### PR TITLE
feat(docs): redesign Junior homepage

### DIFF
--- a/packages/docs/astro.config.mjs
+++ b/packages/docs/astro.config.mjs
@@ -45,7 +45,7 @@ export default defineConfig({
       description:
         "Production docs for Junior, the Slack bot runtime for Hono and Nitro apps.",
       favicon: "/favicon.svg",
-      customCss: ["./src/styles/custom.css"],
+      customCss: ["./src/styles/custom.css", "./src/styles/homepage-mocks.css"],
       social: [
         {
           icon: "github",
@@ -191,10 +191,7 @@ export default defineConfig({
           ],
         },
       ],
-      plugins: [
-        sentryStarlightTheme(),
-        sentryAgentMarkdown(),
-      ],
+      plugins: [sentryStarlightTheme(), sentryAgentMarkdown()],
     }),
   ],
   markdown: {

--- a/packages/docs/src/content/docs/index.mdx
+++ b/packages/docs/src/content/docs/index.mdx
@@ -1,111 +1,299 @@
 ---
 title: Junior
-description: Junior brings your tools into Slack. Ask in a thread and get answers backed by live context from Sentry, GitHub, Linear, and whatever else you've connected.
+description: Junior investigates issues, gathers company context, and takes action with your connected tools from a Slack thread.
 template: splash
 hero:
-  title: '<span class="jr-home-mega-inline">Junior</span><span class="jr-home-headline">Your company''s tools, <span class="jr-highlight">inside Slack.</span></span>'
-  tagline: "Ask in a thread. Junior figures out the rest — pulling context from Sentry, GitHub, Linear, and whatever else you've connected."
+  title: '<span class="jr-home-mega" aria-label="Junior">JUNIOR</span>'
+  tagline: "Drop a question in Slack. Junior digs through your tools, brings receipts, and handles the next annoying step."
   actions:
-    - text: Get Started
+    - text: Set Up Junior
       link: /start-here/quickstart/
       icon: right-arrow
-    - text: Use Junior
+    - text: See Junior Cook
       link: /start-here/using-junior/
       icon: right-arrow
 ---
 
 <div class="jr-home">
-<section class="slk-window">
-  <header class="slk-header">
-    <div class="slk-header-left">
-      <svg class="slk-thread-icon" aria-hidden="true" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
-        <path d="M2 5.5A2.5 2.5 0 014.5 3h11A2.5 2.5 0 0118 5.5v6a2.5 2.5 0 01-2.5 2.5H11l-3.5 3v-3H4.5A2.5 2.5 0 012 11.5v-6z" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"/>
+  <div class="jr-scribble jr-scribble-star" aria-hidden="true">★</div>
+  <div class="jr-scribble jr-scribble-arrow" aria-hidden="true">↘</div>
+  <div class="jr-scribble jr-scribble-wow" aria-hidden="true">WOW!</div>
+
+  <section class="jr-sticker-scene" aria-label="Junior connects Slack to your tools">
+    <div class="jr-sticker jr-sticker-slack">
+      <span class="jr-sticker-kicker">YELL HERE</span>
+      <svg aria-hidden="true" viewBox="0 0 120 96" xmlns="http://www.w3.org/2000/svg">
+        <path d="M10 12h100v58H65L43 88V70H10z" fill="#ff3cac" stroke="#000" stroke-width="7" stroke-linejoin="round" />
+        <circle cx="35" cy="41" r="6" fill="#000" />
+        <circle cx="59" cy="41" r="6" fill="#000" />
+        <circle cx="83" cy="41" r="6" fill="#000" />
       </svg>
-      <span class="slk-header-title">Thread</span>
+      <strong>Slack</strong>
     </div>
-    <span class="slk-header-channel"># incident-ops</span>
+
+    <div class="jr-flow-arrow jr-flow-arrow-blue" aria-hidden="true">
+      <span>the vague ask</span>
+      <svg viewBox="0 0 180 78" xmlns="http://www.w3.org/2000/svg">
+        <path d="M8 42c50-27 101-26 151-5" fill="none" stroke="currentColor" stroke-width="10" stroke-linecap="round" />
+        <path d="m139 17 31 23-37 13" fill="none" stroke="currentColor" stroke-width="10" stroke-linecap="round" stroke-linejoin="round" />
+      </svg>
+    </div>
+
+    <div class="jr-gremlin" aria-label="Junior, a mischievous robot gremlin">
+      <span class="jr-gremlin-note">goes digging</span>
+      <svg viewBox="0 0 230 250" role="img" xmlns="http://www.w3.org/2000/svg">
+        <path d="m54 54-30-36 49 10m103 26 31-36-50 10" fill="#0033ff" stroke="#000" stroke-width="8" stroke-linecap="round" stroke-linejoin="round" />
+        <path d="M44 61c18-31 124-36 145 8l-4 118c-19 35-111 48-145 5z" fill="#695cff" stroke="#000" stroke-width="9" stroke-linejoin="round" />
+        <path d="m47 87-31 39 34 5m133-45 31 32-32 10" fill="#ff3cac" stroke="#000" stroke-width="8" stroke-linecap="round" stroke-linejoin="round" />
+        <rect x="61" y="77" width="105" height="66" rx="15" fill="#ccff00" stroke="#000" stroke-width="8" />
+        <circle cx="91" cy="106" r="12" fill="#000" />
+        <circle cx="139" cy="106" r="12" fill="#000" />
+        <circle cx="95" cy="102" r="4" fill="#fff" />
+        <circle cx="143" cy="102" r="4" fill="#fff" />
+        <path d="M91 130c15 10 31 10 48-2" fill="none" stroke="#000" stroke-width="7" stroke-linecap="round" />
+        <path d="m76 203-7 30m87-31 10 29" fill="none" stroke="#000" stroke-width="10" stroke-linecap="round" />
+        <path d="m54 235 30-2m67 0 31 2" fill="none" stroke="#000" stroke-width="12" stroke-linecap="round" />
+        <path d="M105 44v-19" stroke="#000" stroke-width="8" stroke-linecap="round" />
+        <circle cx="105" cy="18" r="10" fill="#ff3cac" stroke="#000" stroke-width="6" />
+      </svg>
+    </div>
+
+    <div class="jr-flow-arrow jr-flow-arrow-green" aria-hidden="true">
+      <span>receipts + buttons</span>
+      <svg viewBox="0 0 180 78" xmlns="http://www.w3.org/2000/svg">
+        <path d="M8 42c50-27 101-26 151-5" fill="none" stroke="currentColor" stroke-width="10" stroke-linecap="round" />
+        <path d="m139 17 31 23-37 13" fill="none" stroke="currentColor" stroke-width="10" stroke-linecap="round" stroke-linejoin="round" />
+      </svg>
+    </div>
+
+    <div class="jr-tool-pile">
+      <div class="jr-sticker jr-sticker-github">
+        <span class="jr-cat-ears" aria-hidden="true"></span>
+        <span class="jr-cat-face" aria-hidden="true">•ᴗ•</span>
+        <strong>GitHub</strong>
+      </div>
+      <div class="jr-sticker jr-sticker-sentry">
+        <span aria-hidden="true">△</span>
+        <strong>Sentry</strong>
+      </div>
+      <div class="jr-sticker jr-sticker-more">
+        <span aria-hidden="true">+∞</span>
+        <strong>your stuff</strong>
+      </div>
+    </div>
+
+  </section>
+
+<div
+  class="jr-ticker"
+  aria-label="Ask the question, let Junior dig, get the receipts, and ship the fix"
+>
+  <span>ASK THE QUESTION</span>
+  <i>★</i>
+  <span>LET JUNIOR DIG</span>
+  <i>★</i>
+  <span>GET THE RECEIPTS</span>
+  <i>★</i>
+  <span>SHIP THE FIX</span>
+</div>
+
+  <section class="jr-proof" aria-labelledby="jr-proof-title">
+    <div class="jr-proof-copy">
+      <p class="jr-section-number">ONE SLACK MESSAGE</p>
+      <h2 id="jr-proof-title">Junior digs.<br />You ship.</h2>
+      <p>Junior snoops through Sentry, GitHub, Linear, docs, dashboards — whatever you plugged in. Then it comes back with receipts and can actually do the next thing.</p>
+      <div class="jr-proof-stamp">FINDS IT<br />EXPLAINS IT<br />DOES IT</div>
+    </div>
+
+    <div class="jr-slack-wrap">
+      <span class="jr-tape jr-tape-top" aria-hidden="true"></span>
+      <span class="jr-tape jr-tape-bottom" aria-hidden="true"></span>
+      <section class="slk-window" aria-label="Example Slack conversation with Junior">
+        <header class="slk-header">
+          <div class="slk-header-left">
+            <svg class="slk-thread-icon" aria-hidden="true" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="M2 5.5A2.5 2.5 0 014.5 3h11A2.5 2.5 0 0118 5.5v6a2.5 2.5 0 01-2.5 2.5H11l-3.5 3v-3H4.5A2.5 2.5 0 012 11.5v-6z" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round" />
+            </svg>
+            <span class="slk-header-title">Thread</span>
+          </div>
+          <span class="slk-header-channel"># incident-ops</span>
+        </header>
+
+        <div class="slk-messages">
+          <div class="slk-msg">
+            <div class="slk-avatar slk-avatar-user" aria-hidden="true">DC</div>
+            <div class="slk-msg-body">
+              <div class="slk-msg-meta"><span class="slk-name">David C.</span><span class="slk-time">12:03 PM</span></div>
+              <p class="slk-text"><span class="slk-mention slk-mention-user">@jr</span> why is prod on fire? if auth did it, undo it and write the update.</p>
+            </div>
+          </div>
+
+          <div class="slk-msg slk-msg-junior">
+            <div class="slk-avatar slk-avatar-bot" aria-hidden="true">J</div>
+            <div class="slk-msg-body">
+              <div class="slk-msg-meta"><span class="slk-name">Junior</span><span class="slk-app-badge">App</span><span class="slk-time">12:04 PM</span></div>
+              <p class="slk-text">yep, auth did it. <code class="slk-code">9f4e2c</code> broke webhook verification. rolled it back, the graph is chilling out, and the update is drafted.</p>
+              <div class="slk-tool-call">↳ Sentry snitched · GitHub confirmed · rollback shipped</div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+
+  </section>
+
+<section class="jr-real-work" aria-labelledby="jr-real-work-title">
+  <header class="jr-real-work-heading">
+    <p>REAL STUFF. ALREADY SHIPPED.</p>
+    <h2 id="jr-real-work-title">Junior does more than yap.</h2>
+    <span>These mocks map to plugins and workflows in the repo right now. No roadmap fanfic.</span>
   </header>
 
-  <div class="slk-messages">
-
-    <div class="slk-msg">
-      <div class="slk-avatar slk-avatar-user" aria-hidden="true">DC</div>
-      <div class="slk-msg-body">
-        <div class="slk-msg-meta">
-          <span class="slk-name">David C.</span>
-          <span class="slk-time">12:03 PM</span>
+  <div class="jr-mock-grid">
+    <article class="jr-product-mock jr-product-mock-incident">
+      <header class="jr-product-mock-label">
+        <span>01</span>
+        <div>
+          <small>SENTRY + GITHUB + VERCEL</small>
+          <h3>Prod is on fire</h3>
         </div>
-        <p class="slk-text"><span class="slk-mention slk-mention-user">@jr</span> need context on the 5xx spike after deploy. Pull the likely cause and give me a rollback call if this is the auth change.</p>
+      </header>
+      <div class="jr-mock-window jr-incident-window">
+        <div class="jr-mock-window-bar">
+          <span># incident-ops</span>
+          <i>LIVE</i>
+        </div>
+        <div class="jr-mini-message">
+          <b>DC</b>
+          <p><strong>@jr</strong> why are checkouts dying? find it and fix it if the deploy did it.</p>
+        </div>
+        <div class="jr-mini-message jr-mini-message-bot">
+          <b>J</b>
+          <div>
+            <span class="jr-mock-status">CAUSE FOUND</span>
+            <p><code>9f4e2c</code> broke signature checks. rolled back. errors are dropping.</p>
+          </div>
+        </div>
+        <div class="jr-receipt-list">
+          <span>✓ Sentry spike matched</span>
+          <span>✓ GitHub diff checked</span>
+          <span>✓ Vercel rollback shipped</span>
+        </div>
       </div>
-    </div>
+      <p class="jr-product-mock-caption">Ask for the answer and the fix in the same sentence. Wild concept.</p>
+    </article>
 
-    <div class="slk-divider">
-      <span class="slk-divider-label">4 replies</span>
-    </div>
-
-    <div class="slk-msg">
-      <div class="slk-avatar slk-avatar-bot" aria-hidden="true">J</div>
-      <div class="slk-msg-body">
-        <div class="slk-msg-meta">
-          <span class="slk-name">Junior</span>
-          <span class="slk-app-badge">App</span>
-          <span class="slk-time">12:03 PM</span>
+    <article class="jr-product-mock jr-product-mock-linear">
+      <header class="jr-product-mock-label">
+        <span>02</span>
+        <div>
+          <small>LINEAR</small>
+          <h3>Make the ticket</h3>
         </div>
-        <p class="slk-text">On it. Pulling deploy diff, recent error groups, and queue callback failures for the last 30 min.</p>
-        <div class="slk-tool-call">
-          <svg aria-hidden="true" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M8 1.5v5h4.5L8 14.5v-5H3.5L8 1.5z" fill="currentColor"/></svg>
-          Queried Sentry error groups · Fetched deploy diff · Scanned queue callbacks
+      </header>
+      <div class="jr-mock-window jr-linear-window">
+        <div class="jr-linear-prompt">“turn this thread into a Linear issue, keep the links, assign the on-call”</div>
+        <div class="jr-linear-issue">
+          <div class="jr-linear-issue-top">
+            <span>ENG-482</span>
+            <i>IN PROGRESS</i>
+          </div>
+          <h4>Webhook verification rejects valid checkout events</h4>
+          <p>Regression started after <code>9f4e2c</code>. Includes Sentry issue, deploy, and reproduction notes from Slack.</p>
+          <div class="jr-linear-meta">
+            <span>◉ on-call</span>
+            <span>▲ urgent</span>
+            <span>↗ 3 links</span>
+          </div>
         </div>
+        <div class="jr-linear-done">created from the thread · context survived</div>
       </div>
-    </div>
+      <p class="jr-product-mock-caption">No copy-paste pilgrimage. The useful thread bits come with it.</p>
+    </article>
 
-    <div class="slk-msg">
-      <div class="slk-avatar slk-avatar-bot" aria-hidden="true">J</div>
-      <div class="slk-msg-body">
-        <div class="slk-msg-meta">
-          <span class="slk-name">Junior</span>
-          <span class="slk-app-badge">App</span>
-          <span class="slk-time">12:04 PM</span>
+    <article class="jr-product-mock jr-product-mock-browser">
+      <header class="jr-product-mock-label">
+        <span>03</span>
+        <div>
+          <small>AGENT BROWSER</small>
+          <h3>Check the website</h3>
         </div>
-        <p class="slk-text">Found it. Error rate jumped 7x immediately after commit <code class="slk-code">9f4e2c</code> in auth middleware. 87% of failures are <code class="slk-code">invalid_signature</code> from webhook verification.</p>
-      </div>
-    </div>
-
-    <div class="slk-msg">
-      <div class="slk-avatar slk-avatar-user" aria-hidden="true">DC</div>
-      <div class="slk-msg-body">
-        <div class="slk-msg-meta">
-          <span class="slk-name">David C.</span>
-          <span class="slk-time">12:04 PM</span>
+      </header>
+      <div class="jr-mock-window jr-browser-window">
+        <div class="jr-browser-bar">
+          <span></span><span></span><span></span>
+          <p>preview.example.com</p>
         </div>
-        <p class="slk-text">Roll it back and drop the status update text for <span class="slk-mention">#eng-incidents</span>.</p>
-      </div>
-    </div>
-
-    <div class="slk-msg">
-      <div class="slk-avatar slk-avatar-bot" aria-hidden="true">J</div>
-      <div class="slk-msg-body">
-        <div class="slk-msg-meta">
-          <span class="slk-name">Junior</span>
-          <span class="slk-app-badge">App</span>
-          <span class="slk-time">12:05 PM</span>
+        <div class="jr-browser-preview">
+          <div class="jr-browser-preview-nav"></div>
+          <div class="jr-browser-preview-title"></div>
+          <div class="jr-browser-preview-grid"><i></i><i></i><i></i></div>
         </div>
-        <p class="slk-text">Done. Rollback is live. Error rate is trending down. Draft posted to <span class="slk-mention">#eng-incidents</span>: <em>"Rolled back auth middleware regression from <code class="slk-code">9f4e2c</code>; webhook 5xx recovering."</em></p>
+        <div class="jr-browser-checks">
+          <span>✓ desktop checked</span>
+          <span>✓ mobile checked</span>
+          <span>✓ console clean</span>
+          <span>✓ screenshots attached</span>
+        </div>
+        <div class="jr-browser-verdict"><b>SHIP IT</b><span>nothing cursed found</span></div>
       </div>
-    </div>
+      <p class="jr-product-mock-caption">Junior can open the real page, click around, and bring visual receipts.</p>
+    </article>
 
   </div>
+</section>
+
+<section class="jr-cards" aria-label="What Junior does">
+  <article class="jr-card jr-card-blue">
+    <span>01</span>
+    <h2>Find it.</h2>
+    <p>
+      Errors, deploys, logs, code changes, owners. Junior digs through the pile
+      so you do not have to.
+    </p>
+  </article>
+  <article class="jr-card jr-card-pink">
+    <span>02</span>
+    <h2>Prove it.</h2>
+    <p>
+      No mystery vibes. Junior shows its work and brings the useful bits back
+      from every tool it checked.
+    </p>
+  </article>
+  <article class="jr-card jr-card-cream">
+    <span>03</span>
+    <h2>Do it.</h2>
+    <p>
+      Draft the update. Open the issue. Make the approved change. Anything but
+      another giant blob of advice.
+    </p>
+  </article>
 </section>
 
 <section class="jr-customers" aria-labelledby="jr-customers-title">
-  <p class="jr-customers-eyebrow" id="jr-customers-title">Sort of trusted by</p>
-  <div class="jr-customer-logos" aria-label="Companies using Junior">
-    <a class="jr-customer-logo" href="https://sentry.io" aria-label="Sentry">
-      <svg viewBox="0 0 222 66" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
-        <path d="M29,2.26a4.67,4.67,0,0,0-8,0L14.42,13.53A32.21,32.21,0,0,1,32.17,40.19H27.55A27.68,27.68,0,0,0,12.09,17.47L6,28a15.92,15.92,0,0,1,9.23,12.17H4.62A.76.76,0,0,1,4,39.06l2.94-5a10.74,10.74,0,0,0-3.36-1.9l-2.91,5a4.54,4.54,0,0,0,1.69,6.24A4.66,4.66,0,0,0,4.62,44H19.15a19.4,19.4,0,0,0-8-17.31l2.31-4A23.87,23.87,0,0,1,23.76,44H36.07a35.88,35.88,0,0,0-16.41-31.8l4.67-8a.77.77,0,0,1,1.05-.27c.53.29,20.29,34.77,20.66,35.17a.76.76,0,0,1-.68,1.13H40.6q.09,1.91,0,3.81h4.78A4.59,4.59,0,0,0,50,39.43a4.49,4.49,0,0,0-.62-2.28Z M124.32,28.28,109.56,9.22h-3.68V34.77h3.73V15.19l15.18,19.58h3.26V9.22h-3.73ZM87.15,23.54h13.23V20.22H87.14V12.53h14.93V9.21H83.34V34.77h18.92V31.45H87.14ZM71.59,20.3h0C66.44,19.06,65,18.08,65,15.7c0-2.14,1.89-3.59,4.71-3.59a12.06,12.06,0,0,1,7.07,2.55l2-2.83a14.1,14.1,0,0,0-9-3c-5.06,0-8.59,3-8.59,7.27,0,4.6,3,6.19,8.46,7.52C74.51,24.74,76,25.78,76,28.11s-2,3.77-5.09,3.77a12.34,12.34,0,0,1-8.3-3.26l-2.25,2.69a15.94,15.94,0,0,0,10.42,3.85c5.48,0,9-2.95,9-7.51C79.75,23.79,77.47,21.72,71.59,20.3ZM195.7,9.22l-7.69,12-7.64-12h-4.46L186,24.67V34.78h3.84V24.55L200,9.22Zm-64.63,3.46h8.37v22.1h3.84V12.68h8.37V9.22H131.08ZM169.41,24.8c3.86-1.07,6-3.77,6-7.63,0-4.91-3.59-8-9.38-8H154.67V34.76h3.8V25.58h6.45l6.48,9.2h4.44l-7-9.82Zm-10.95-2.5V12.6h7.17c3.74,0,5.88,1.77,5.88,4.84s-2.29,4.86-5.84,4.86Z" transform="translate(11, 11)" fill="currentColor" />
-      </svg>
-    </a>
-  </div>
-  <a class="jr-customers-cta" href="https://github.com/getsentry/junior/issues/new?title=Add%20our%20company%20to%20the%20Junior%20homepage">Add your company</a>
+  <p class="jr-customers-eyebrow" id="jr-customers-title">
+    BUILT AT SENTRY. YES, WE ACTUALLY USE IT.
+  </p>
+  <a class="jr-customer-logo" href="https://sentry.io" aria-label="Sentry">
+    <svg
+      viewBox="0 0 222 66"
+      aria-hidden="true"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M29,2.26a4.67,4.67,0,0,0-8,0L14.42,13.53A32.21,32.21,0,0,1,32.17,40.19H27.55A27.68,27.68,0,0,0,12.09,17.47L6,28a15.92,15.92,0,0,1,9.23,12.17H4.62A.76.76,0,0,1,4,39.06l2.94-5a10.74,10.74,0,0,0-3.36-1.9l-2.91,5a4.54,4.54,0,0,0,1.69,6.24A4.66,4.66,0,0,0,4.62,44H19.15a19.4,19.4,0,0,0-8-17.31l2.31-4A23.87,23.87,0,0,1,23.76,44H36.07a35.88,35.88,0,0,0-16.41-31.8l4.67-8a.77.77,0,0,1,1.05-.27c.53.29,20.29,34.77,20.66,35.17a.76.76,0,0,1-.68,1.13H40.6q.09,1.91,0,3.81h4.78A4.59,4.59,0,0,0,50,39.43a4.49,4.49,0,0,0-.62-2.28Z M124.32,28.28,109.56,9.22h-3.68V34.77h3.73V15.19l15.18,19.58h3.26V9.22h-3.73ZM87.15,23.54h13.23V20.22H87.14V12.53h14.93V9.21H83.34V34.77h18.92V31.45H87.14ZM71.59,20.3h0C66.44,19.06,65,18.08,65,15.7c0-2.14,1.89-3.59,4.71-3.59a12.06,12.06,0,0,1,7.07,2.55l2-2.83a14.1,14.1,0,0,0-9-3c-5.06,0-8.59,3-8.59,7.27,0,4.6,3,6.19,8.46,7.52C74.51,24.74,76,25.78,76,28.11s-2,3.77-5.09,3.77a12.34,12.34,0,0,1-8.3-3.26l-2.25,2.69a15.94,15.94,0,0,0,10.42,3.85c5.48,0,9-2.95,9-7.51C79.75,23.79,77.47,21.72,71.59,20.3ZM195.7,9.22l-7.69,12-7.64-12h-4.46L186,24.67V34.78h3.84V24.55L200,9.22Zm-64.63,3.46h8.37v22.1h3.84V12.68h8.37V9.22H131.08ZM169.41,24.8c3.86-1.07,6-3.77,6-7.63,0-4.91-3.59-8-9.38-8H154.67V34.76h3.8V25.58h6.45l6.48,9.2h4.44l-7-9.82Zm-10.95-2.5V12.6h7.17c3.74,0,5.88,1.77,5.88,4.84s-2.29,4.86-5.84,4.86Z"
+        transform="translate(11, 11)"
+        fill="currentColor"
+      />
+    </svg>
+  </a>
+  <a
+    class="jr-customers-cta"
+    href="https://github.com/getsentry/junior/issues/new?title=Add%20our%20company%20to%20the%20Junior%20homepage"
+  >
+    Got Junior running? Flex on us →
+  </a>
 </section>
+
+  <p class="jr-made-this"><b>*</b> yes, Junior made this homepage too.</p>
 </div>

--- a/packages/docs/src/content/docs/index.mdx
+++ b/packages/docs/src/content/docs/index.mdx
@@ -99,7 +99,7 @@ hero:
 
   <section class="jr-proof" aria-labelledby="jr-proof-title">
     <div class="jr-proof-copy">
-      <p class="jr-section-number">ONE SLACK MESSAGE</p>
+      <div class="jr-section-number">ONE SLACK MESSAGE</div>
       <h2 id="jr-proof-title">Junior digs.<br />You ship.</h2>
       <p>Junior snoops through Sentry, GitHub, Linear, docs, dashboards — whatever you plugged in. Then it comes back with receipts and can actually do the next thing.</p>
       <div class="jr-proof-stamp">FINDS IT<br />EXPLAINS IT<br />DOES IT</div>
@@ -180,7 +180,7 @@ hero:
           <span>✓ Vercel rollback shipped</span>
         </div>
       </div>
-      <p class="jr-product-mock-caption">Ask for the answer and the fix in the same sentence. Wild concept.</p>
+      <div class="jr-product-mock-caption">Ask for the answer and the fix in the same sentence. Wild concept.</div>
     </article>
 
     <article class="jr-product-mock jr-product-mock-linear">
@@ -208,7 +208,7 @@ hero:
         </div>
         <div class="jr-linear-done">created from the thread · context survived</div>
       </div>
-      <p class="jr-product-mock-caption">No copy-paste pilgrimage. The useful thread bits come with it.</p>
+      <div class="jr-product-mock-caption">No copy-paste pilgrimage. The useful thread bits come with it.</div>
     </article>
 
     <article class="jr-product-mock jr-product-mock-browser">
@@ -237,7 +237,7 @@ hero:
         </div>
         <div class="jr-browser-verdict"><b>SHIP IT</b><span>nothing cursed found</span></div>
       </div>
-      <p class="jr-product-mock-caption">Junior can open the real page, click around, and bring visual receipts.</p>
+      <div class="jr-product-mock-caption">Junior can open the real page, click around, and bring visual receipts.</div>
     </article>
 
   </div>
@@ -271,9 +271,9 @@ hero:
 </section>
 
 <section class="jr-customers" aria-labelledby="jr-customers-title">
-  <p class="jr-customers-eyebrow" id="jr-customers-title">
+  <span class="jr-customers-eyebrow" id="jr-customers-title">
     BUILT AT SENTRY. YES, WE ACTUALLY USE IT.
-  </p>
+  </span>
   <a class="jr-customer-logo" href="https://sentry.io" aria-label="Sentry">
     <svg
       viewBox="0 0 222 66"
@@ -291,9 +291,9 @@ hero:
     class="jr-customers-cta"
     href="https://github.com/getsentry/junior/issues/new?title=Add%20our%20company%20to%20the%20Junior%20homepage"
   >
-    Got Junior running? Flex on us →
+    <span>Got Junior running? Flex on us →</span>
   </a>
 </section>
 
-  <p class="jr-made-this"><b>*</b> yes, Junior made this homepage too.</p>
+  <div class="jr-made-this"><b>*</b> yes, Junior made this homepage too.</div>
 </div>

--- a/packages/docs/src/styles/custom.css
+++ b/packages/docs/src/styles/custom.css
@@ -5,6 +5,40 @@
   --jr-cream: #fff7df;
   --jr-black: #000;
   --jr-purple: #695cff;
+  --ve-accent-soft: rgba(204, 255, 0, 0.16);
+  --ve-heading-accent: rgba(204, 255, 0, 0.42);
+}
+
+html:root,
+html:root[data-theme="dark"],
+html:root[data-theme="light"] {
+  --ve-accent-soft: rgba(204, 255, 0, 0.16);
+  --ve-heading-accent: rgba(204, 255, 0, 0.42);
+}
+
+::selection {
+  background: var(--jr-acid);
+  color: var(--jr-black);
+}
+
+:focus-visible {
+  outline-color: var(--jr-acid);
+}
+
+.sidebar [aria-current="page"],
+.sidebar [aria-current="page"]:hover,
+.sidebar [aria-current="page"]:focus {
+  background: var(--jr-acid);
+  color: var(--jr-black);
+}
+
+.sl-markdown-content a:not(:where(.not-content *)) {
+  text-decoration-color: rgba(204, 255, 0, 0.65);
+}
+
+.sl-markdown-content a:hover:not(:where(.not-content *)) {
+  color: var(--jr-acid);
+  text-decoration-color: var(--jr-acid);
 }
 
 .site-title {

--- a/packages/docs/src/styles/custom.css
+++ b/packages/docs/src/styles/custom.css
@@ -406,7 +406,7 @@ body:has(.jr-home) main {
 }
 
 .jr-section-number {
-  color: var(--jr-black);
+  color: var(--jr-black) !important;
   font-family: "Arial Black", Impact, sans-serif;
   font-size: 0.8rem;
   font-weight: 900;
@@ -590,7 +590,7 @@ body:has(.jr-home) main {
 }
 
 .slk-text {
-  color: #e7e8ea;
+  color: #e7e8ea !important;
   line-height: 1.5;
   margin: 0;
 }
@@ -711,12 +711,17 @@ body:has(.jr-home) main {
 }
 
 .jr-customers-eyebrow {
-  color: var(--jr-black);
+  color: var(--jr-black) !important;
   font-family: "Arial Black", Impact, sans-serif;
   font-size: 0.8rem;
   font-weight: 900;
   letter-spacing: 0.12em;
   margin: 0 0 1rem;
+}
+
+.jr-customers-eyebrow p {
+  color: var(--jr-black) !important;
+  margin: 0;
 }
 
 .jr-customer-logo {
@@ -742,7 +747,7 @@ body:has(.jr-home) main {
 }
 
 .jr-made-this {
-  color: var(--jr-black);
+  color: var(--jr-black) !important;
   font-size: 0.8rem;
   font-style: italic;
   margin: 0 0 1rem auto;

--- a/packages/docs/src/styles/custom.css
+++ b/packages/docs/src/styles/custom.css
@@ -1,10 +1,10 @@
 :root {
-  --jr-accent: #39ff14;
-  --jr-accent-soft: rgba(57, 255, 20, 0.16);
-  --jr-accent-line: rgba(57, 255, 20, 0.34);
-  --jr-slack-bg: #1a1d21;
-  --jr-slack-line: rgba(255, 255, 255, 0.09);
-  --jr-radius: 8px;
+  --jr-acid: #ccff00;
+  --jr-blue: #0033ff;
+  --jr-pink: #ff3cac;
+  --jr-cream: #fff7df;
+  --jr-black: #000;
+  --jr-purple: #695cff;
 }
 
 .site-title {
@@ -22,80 +22,489 @@
   width: 2rem;
 }
 
+body:has(.jr-home) {
+  background: var(--jr-acid);
+  color: var(--jr-black);
+}
+
+body:has(.jr-home) .header {
+  background: var(--jr-cream);
+  border-bottom: 4px solid var(--jr-black);
+}
+
+body:has(.jr-home) .site-title,
+body:has(.jr-home) .social-icons a,
+body:has(.jr-home) starlight-theme-select label,
+body:has(.jr-home) site-search button {
+  color: var(--jr-black);
+}
+
+body:has(.jr-home) site-search button {
+  background: #fff;
+  border: 3px solid var(--jr-black);
+  border-radius: 0;
+  box-shadow: 4px 4px 0 var(--jr-black);
+}
+
+body:has(.jr-home) .page {
+  background-color: var(--jr-acid);
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='17' height='17' viewBox='0 0 17 17'%3E%3Ccircle cx='1.5' cy='1.5' r='1.2' fill='%23000' fill-opacity='.17'/%3E%3C/svg%3E");
+}
+
+body:has(.jr-home) main {
+  overflow: hidden;
+}
+
 :root:not([data-has-sidebar]) .hero {
-  padding-block: clamp(1.5rem, 0.5rem + 5vmin, 5rem);
+  box-sizing: border-box;
+  margin-inline: calc(50% - 50vw);
+  max-width: none;
+  min-height: min(76vw, 54rem);
+  padding: clamp(2rem, 5vw, 5rem) max(1.25rem, calc((100vw - 86rem) / 2));
+  position: relative;
+  width: 100vw;
+}
+
+:root:not([data-has-sidebar]) .hero::before,
+:root:not([data-has-sidebar]) .hero::after {
+  color: var(--jr-pink);
+  font-family: "Arial Black", Impact, sans-serif;
+  font-weight: 900;
+  position: absolute;
+  -webkit-text-stroke: 3px var(--jr-black);
+  z-index: 2;
+}
+
+:root:not([data-has-sidebar]) .hero::before {
+  content: "★";
+  font-size: clamp(3rem, 8vw, 8rem);
+  left: 4vw;
+  top: 18%;
+  transform: rotate(-16deg);
+}
+
+:root:not([data-has-sidebar]) .hero::after {
+  content: "↗";
+  font-size: clamp(4rem, 10vw, 10rem);
+  right: 4vw;
+  top: 15%;
+  transform: rotate(9deg);
+}
+
+:root:not([data-has-sidebar]) .hero > div {
+  box-sizing: border-box;
+  margin-inline: auto;
+  max-width: none;
+  position: relative;
+  width: min(calc(100vw - 2.5rem), 86rem);
+  z-index: 3;
+}
+
+:root:not([data-has-sidebar]) .hero .copy {
+  align-items: center;
+  width: 100%;
 }
 
 :root:not([data-has-sidebar]) .hero :is(h1, [data-page-title]) {
-  max-width: 46rem;
+  margin: 0;
+  max-width: none;
+  width: 100%;
 }
 
-:root:not([data-has-sidebar])
-  .hero
-  :is(h1, [data-page-title])
-  .jr-home-mega-inline {
+.jr-home-mega {
+  color: var(--jr-black);
   display: block;
-  font-size: 4.8rem;
-  font-weight: 700;
-  line-height: 0.95;
-  margin-bottom: 0.25rem;
+  font-family: "Arial Black", Impact, Haettenschweiler, sans-serif;
+  font-size: clamp(5.2rem, 18vw, 16rem);
+  font-stretch: condensed;
+  font-weight: 950;
+  letter-spacing: -0.09em;
+  line-height: 0.72;
+  margin-inline: auto;
+  text-shadow: clamp(8px, 1.5vw, 22px) clamp(8px, 1.5vw, 22px) 0 var(--jr-blue);
+  transform: scaleX(1.08);
+  transform-origin: center;
+  width: max-content;
+  white-space: nowrap;
 }
 
-:root:not([data-has-sidebar])
-  .hero
-  :is(h1, [data-page-title])
-  .jr-home-headline {
-  display: block;
+:root:not([data-has-sidebar]) .hero .tagline {
+  background: var(--jr-cream);
+  border: 4px solid var(--jr-black);
+  box-shadow: 8px 8px 0 var(--jr-black);
+  color: var(--jr-black);
+  font-family: "Arial Black", Impact, sans-serif;
+  font-size: clamp(1rem, 2.2vw, 1.65rem);
+  font-weight: 900;
+  line-height: 1.05;
+  margin: clamp(2rem, 5vw, 4rem) auto 0;
+  max-width: 34rem;
+  padding: 1rem 1.25rem;
+  text-transform: uppercase;
+  transform: rotate(-2deg);
 }
 
-:root:not([data-has-sidebar]) .jr-highlight {
-  color: var(--ve-text);
-  display: inline;
-  position: relative;
-  z-index: 0;
+:root:not([data-has-sidebar]) .hero .actions {
+  gap: 1.25rem;
+  justify-content: center;
+  margin-top: 1.75rem;
 }
 
-:root:not([data-has-sidebar]) .jr-highlight::before {
-  background: var(--ve-heading-accent);
-  bottom: 0.06em;
-  content: "";
-  height: 0.42em;
-  left: -0.08em;
-  pointer-events: none;
-  position: absolute;
-  right: -0.08em;
-  transform: rotate(-3deg);
-  z-index: -1;
+:root:not([data-has-sidebar]) .hero .sl-link-button {
+  border: 4px solid var(--jr-black);
+  border-radius: 0;
+  box-shadow: 7px 7px 0 var(--jr-black);
+  color: var(--jr-black);
+  font-family: "Arial Black", Impact, sans-serif;
+  font-size: 0.95rem;
+  font-weight: 900;
+  letter-spacing: 0.02em;
+  padding: 0.8rem 1.1rem;
+  text-transform: uppercase;
+  transition:
+    transform 100ms ease,
+    box-shadow 100ms ease;
+}
+
+:root:not([data-has-sidebar]) .hero .sl-link-button:first-child {
+  background: var(--jr-pink);
+}
+
+:root:not([data-has-sidebar]) .hero .sl-link-button:last-child {
+  background: var(--jr-cream);
+}
+
+:root:not([data-has-sidebar]) .hero .sl-link-button:hover {
+  box-shadow: 3px 3px 0 var(--jr-black);
+  transform: translate(4px, 4px);
 }
 
 .jr-home {
-  margin-top: 1rem;
+  color: var(--jr-black);
+  margin: -4rem auto 0;
+  max-width: 86rem;
+  padding: 0 1.25rem 4rem;
+  position: relative;
+}
+
+.jr-scribble {
+  font-family: "Arial Black", Impact, sans-serif;
+  font-weight: 900;
+  pointer-events: none;
+  position: absolute;
+  z-index: 4;
+}
+
+.jr-scribble-star {
+  color: var(--jr-pink);
+  font-size: clamp(3rem, 7vw, 6rem);
+  left: 42%;
+  top: -5rem;
+  transform: rotate(17deg);
+  -webkit-text-stroke: 3px var(--jr-black);
+}
+
+.jr-scribble-arrow {
+  color: var(--jr-blue);
+  font-size: clamp(5rem, 10vw, 9rem);
+  left: 8%;
+  top: -3rem;
+  transform: rotate(12deg);
+  -webkit-text-stroke: 3px var(--jr-black);
+}
+
+.jr-scribble-wow {
+  background: var(--jr-pink);
+  border: 3px solid var(--jr-black);
+  box-shadow: 5px 5px 0 var(--jr-black);
+  font-size: clamp(0.9rem, 2vw, 1.4rem);
+  padding: 0.35rem 0.6rem;
+  right: 7%;
+  top: -1rem;
+  transform: rotate(11deg);
+}
+
+.jr-sticker-scene {
+  align-items: center;
+  display: grid;
+  grid-template-columns: 0.9fr 0.8fr 1.2fr 0.8fr 1fr;
+  min-height: 25rem;
+  padding: 2rem 0 4rem;
+  position: relative;
+}
+
+.jr-sticker {
+  align-items: center;
+  border: 5px solid var(--jr-black);
+  box-shadow: 9px 9px 0 var(--jr-black);
+  display: flex;
+  flex-direction: column;
+  font-family: "Arial Black", Impact, sans-serif;
+  font-weight: 900;
+  justify-content: center;
+  line-height: 1;
+  position: relative;
+  text-transform: uppercase;
+}
+
+.jr-sticker-slack {
+  background: var(--jr-cream);
+  padding: 1rem;
+  transform: rotate(-6deg);
+}
+
+.jr-sticker-slack svg {
+  margin: 0;
+  width: 7rem;
+}
+
+.jr-sticker-slack strong {
+  font-size: 1.5rem;
+  margin-top: -0.25rem;
+}
+
+.jr-sticker-kicker {
+  background: var(--jr-blue);
+  border: 3px solid var(--jr-black);
+  color: #fff;
+  font-size: 0.72rem;
+  left: -1.2rem;
+  padding: 0.35rem 0.5rem;
+  position: absolute;
+  top: -1.2rem;
+  transform: rotate(-5deg);
+}
+
+.jr-flow-arrow {
+  color: var(--jr-blue);
+  font-family: "Arial Black", Impact, sans-serif;
+  font-size: 0.75rem;
+  font-weight: 900;
+  text-align: center;
+  text-transform: uppercase;
+  transform: rotate(-4deg);
+}
+
+.jr-flow-arrow svg {
+  display: block;
+  margin: -0.6rem auto 0;
+  overflow: visible;
+  width: 100%;
+}
+
+.jr-flow-arrow-green {
+  color: #5ca800;
+  transform: rotate(6deg);
+}
+
+.jr-gremlin {
+  filter: drop-shadow(10px 10px 0 var(--jr-black));
+  margin: 0 auto;
+  max-width: 17rem;
+  position: relative;
+  transform: rotate(3deg);
+}
+
+.jr-gremlin svg {
+  display: block;
+  width: 100%;
+}
+
+.jr-gremlin-note {
+  background: var(--jr-pink);
+  border: 4px solid var(--jr-black);
+  font-family: "Arial Black", Impact, sans-serif;
+  font-size: 0.75rem;
+  font-weight: 900;
+  padding: 0.45rem 0.6rem;
+  position: absolute;
+  right: -1.5rem;
+  text-transform: uppercase;
+  top: 1rem;
+  transform: rotate(9deg);
+  z-index: 2;
+}
+
+.jr-tool-pile {
+  display: grid;
+  gap: 1rem;
+  justify-items: center;
+  position: relative;
+}
+
+.jr-sticker-github {
+  background: var(--jr-black);
+  color: #fff;
+  padding: 1.7rem 1.5rem 1rem;
+  transform: rotate(5deg);
+  width: 9rem;
+}
+
+.jr-cat-face {
+  font-size: 1.8rem;
+  letter-spacing: 0.1em;
+  white-space: nowrap;
+}
+
+.jr-cat-ears {
+  border-bottom: 28px solid var(--jr-black);
+  border-left: 30px solid transparent;
+  border-right: 30px solid transparent;
+  height: 0;
+  left: 0.65rem;
+  position: absolute;
+  top: -1.9rem;
+  width: 7rem;
+}
+
+.jr-sticker-sentry {
+  background: var(--jr-pink);
+  flex-direction: row;
+  gap: 0.4rem;
+  padding: 0.65rem 1rem;
+  transform: rotate(-4deg);
+}
+
+.jr-sticker-more {
+  background: var(--jr-cream);
+  flex-direction: row;
+  font-size: 0.78rem;
+  gap: 0.4rem;
+  padding: 0.55rem 0.8rem;
+  transform: rotate(7deg);
+}
+
+.jr-ticker {
+  background: var(--jr-black);
+  border-block: 5px solid var(--jr-black);
+  color: var(--jr-acid);
+  display: flex;
+  font-family: "Arial Black", Impact, sans-serif;
+  font-size: clamp(1.15rem, 2.5vw, 2rem);
+  font-weight: 900;
+  gap: 1.25rem;
+  justify-content: center;
+  margin-inline: calc(50% - 50vw);
+  overflow: hidden;
+  padding: 0.65rem 1rem;
+  text-transform: uppercase;
+  transform: rotate(-1deg);
+  white-space: nowrap;
+}
+
+.jr-ticker i {
+  color: var(--jr-pink);
+  font-style: normal;
+}
+
+.jr-proof {
+  align-items: center;
+  display: grid;
+  gap: clamp(3rem, 7vw, 7rem);
+  grid-template-columns: 0.75fr 1.25fr;
+  padding: clamp(6rem, 10vw, 10rem) 0;
+}
+
+.jr-section-number {
+  color: var(--jr-black);
+  font-family: "Arial Black", Impact, sans-serif;
+  font-size: 0.8rem;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  margin: 0 0 1rem;
+}
+
+.jr-proof-copy h2,
+.jr-card h2 {
+  color: var(--jr-black);
+  font-family: "Arial Black", Impact, sans-serif;
+  font-weight: 950;
+  letter-spacing: -0.055em;
+  line-height: 0.9;
+  margin: 0;
+  text-transform: uppercase;
+}
+
+.jr-proof-copy h2 {
+  font-size: clamp(3rem, 6vw, 5.5rem);
+}
+
+.jr-proof-copy > p:not(.jr-section-number) {
+  color: var(--jr-black);
+  font-size: 1.05rem;
+  font-weight: 700;
+  line-height: 1.5;
+  margin: 1.75rem 0;
+  max-width: 34rem;
+}
+
+.jr-proof-stamp {
+  align-items: center;
+  aspect-ratio: 1;
+  background: var(--jr-pink);
+  border: 4px solid var(--jr-black);
+  border-radius: 50%;
+  display: flex;
+  font-family: "Arial Black", Impact, sans-serif;
+  font-size: 0.78rem;
+  font-weight: 900;
+  justify-content: center;
+  line-height: 1.05;
+  text-align: center;
+  transform: rotate(-10deg);
+  width: 7.5rem;
+}
+
+.jr-slack-wrap {
+  position: relative;
+  transform: rotate(2deg);
+}
+
+.jr-tape {
+  background: rgba(255, 247, 223, 0.9);
+  border: 3px solid var(--jr-black);
+  height: 2.2rem;
+  position: absolute;
+  width: 8rem;
+  z-index: 3;
+}
+
+.jr-tape-top {
+  right: 20%;
+  top: -1.5rem;
+  transform: rotate(-7deg);
+}
+
+.jr-tape-bottom {
+  bottom: -1.4rem;
+  left: 12%;
+  transform: rotate(8deg);
 }
 
 .slk-window {
-  background: var(--jr-slack-bg);
-  border: 1px solid var(--ve-line-soft);
-  border-radius: var(--jr-radius);
-  box-shadow: 0 24px 48px -16px rgba(0, 0, 0, 0.68);
+  background: #1a1d21;
+  border: 5px solid var(--jr-black);
+  border-radius: 0;
+  box-shadow: 14px 14px 0 var(--jr-blue);
   color: #c9cdd1;
   font-size: 0.9375rem;
   line-height: 1.46668;
-  margin-top: 0;
   overflow: hidden;
 }
 
 .slk-header {
   align-items: center;
-  background: var(--jr-slack-bg);
-  border-bottom: 1px solid var(--jr-slack-line);
+  background: #24272b;
+  border-bottom: 2px solid #000;
   display: flex;
   gap: 0.5rem;
   justify-content: space-between;
   margin: 0;
-  padding: 0.7rem 1rem;
+  padding: 0.9rem 1rem;
 }
 
-.slk-header-left {
+.slk-header-left,
+.slk-msg-meta {
   align-items: center;
   display: flex;
   gap: 0.4rem;
@@ -103,61 +512,60 @@
 }
 
 .slk-thread-icon {
-  color: #c9cdd1;
-  flex: 0 0 auto;
+  color: #fff;
   height: 1rem;
   width: 1rem;
 }
 
-.slk-header-title {
-  color: #d9d9d9;
-  font-size: 0.9375rem;
-  font-weight: 700;
+.slk-header-title,
+.slk-name {
+  color: #fff;
+  font-weight: 800;
 }
 
-.slk-header-channel {
-  color: #848d97;
-  font-size: 0.8125rem;
+.slk-header-channel,
+.slk-time {
+  color: #9299a1;
+  font-size: 0.78rem;
 }
 
 .slk-messages {
   margin: 0;
-  padding: 0.5rem 0;
+  padding: 0.7rem 0;
 }
 
 .slk-msg {
   align-items: flex-start;
   display: flex;
-  gap: 0.625rem;
-  padding: 0.35rem 1rem;
-  transition: background 120ms ease;
+  gap: 0.75rem;
+  padding: 0.7rem 1rem;
 }
 
-.slk-msg:hover {
-  background: rgba(255, 255, 255, 0.04);
+.slk-msg-junior {
+  background: rgba(105, 92, 255, 0.13);
+  border-left: 6px solid var(--jr-pink);
 }
 
 .slk-avatar {
   align-items: center;
-  border-radius: 6px;
+  border: 2px solid #000;
   display: flex;
   flex: 0 0 auto;
-  font-size: 0.8125rem;
-  font-weight: 700;
-  height: 2.25rem;
+  font-size: 0.8rem;
+  font-weight: 900;
+  height: 2.35rem;
   justify-content: center;
-  width: 2.25rem;
+  width: 2.35rem;
 }
 
 .slk-avatar-user {
-  background: #4a154b;
-  color: #fff;
+  background: var(--jr-pink);
+  color: #000;
 }
 
 .slk-avatar-bot {
-  background: #1d2a1d;
-  border: 1px solid var(--jr-accent-line);
-  color: var(--jr-accent);
+  background: var(--jr-acid);
+  color: #000;
 }
 
 .slk-msg-body {
@@ -168,183 +576,323 @@
 
 .slk-msg-meta {
   align-items: baseline;
-  display: flex;
   flex-wrap: wrap;
-  gap: 0.35rem;
-  margin: 0 0 0.1rem;
-}
-
-.slk-name {
-  color: #d9d9d9;
-  font-size: 0.9375rem;
-  font-weight: 700;
-  line-height: 1.2;
+  margin-bottom: 0.15rem;
 }
 
 .slk-app-badge {
-  align-items: center;
-  background: #383a3d;
-  border-radius: 3px;
-  color: #868686;
-  display: inline-flex;
-  font-size: 0.6875rem;
-  font-weight: 600;
-  line-height: 1.4;
-  padding: 0.05rem 0.3rem;
-}
-
-.slk-time {
-  color: #848d97;
-  font-size: 0.75rem;
+  background: var(--jr-blue);
+  color: #fff;
+  font-size: 0.65rem;
+  font-weight: 800;
+  padding: 0.05rem 0.25rem;
+  text-transform: uppercase;
 }
 
 .slk-text {
-  color: #c9cdd1;
-  font-size: 0.9375rem;
-  line-height: 1.46668;
+  color: #e7e8ea;
+  line-height: 1.5;
   margin: 0;
 }
 
-.slk-text em {
-  color: #a8abb0;
-}
-
 .slk-code {
-  background: rgba(255, 255, 255, 0.09);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  border-radius: 3px;
-  color: #c9cdd1;
+  background: var(--jr-cream);
+  border: 2px solid #000;
+  color: #000;
   font-family: var(--__sl-font-mono);
   font-size: 0.875em;
-  padding: 0.08em 0.32em;
+  padding: 0.05em 0.25em;
 }
 
 .slk-mention {
-  background: rgba(29, 155, 209, 0.1);
-  border-radius: 3px;
-  color: #1d9bd1;
-  font-weight: 500;
+  background: rgba(0, 51, 255, 0.24);
+  color: #8e9fff;
+  font-weight: 700;
   padding: 0 0.12em;
 }
 
 .slk-mention-user {
-  background: rgba(233, 194, 106, 0.12);
-  color: #e9c26a;
+  background: var(--jr-acid);
+  color: #000;
 }
 
 .slk-tool-call {
-  align-items: center;
-  color: #8d96a0;
-  display: flex;
-  font-size: 0.8125rem;
-  gap: 0.35rem;
-  line-height: 1.4;
-  margin: 0;
-  padding-top: 0.3rem;
-}
-
-.slk-tool-call svg {
-  color: #8d96a0;
-  flex: 0 0 auto;
-  height: 0.75rem;
-  width: 0.75rem;
-}
-
-.slk-divider {
-  align-items: center;
-  display: flex;
-  gap: 0.6rem;
-  padding: 0.5rem 1rem;
-}
-
-.slk-divider::before,
-.slk-divider::after {
-  background: var(--jr-slack-line);
-  content: "";
-  flex: 1;
-  height: 1px;
-}
-
-.slk-divider-label {
-  color: #1d9bd1;
-  font-size: 0.8125rem;
+  color: var(--jr-acid);
+  font-size: 0.78rem;
   font-weight: 700;
-  white-space: nowrap;
+  margin-top: 0.45rem;
+}
+
+.jr-cards {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(3, 1fr);
+  padding-bottom: clamp(5rem, 9vw, 9rem);
+}
+
+.jr-card {
+  border: 5px solid var(--jr-black);
+  box-shadow: 10px 10px 0 var(--jr-black);
+  min-height: 18rem;
+  min-width: 0;
+  overflow: hidden;
+  padding: 1.5rem;
+  position: relative;
+}
+
+.jr-card:nth-child(1) {
+  transform: rotate(-2deg);
+}
+
+.jr-card:nth-child(2) {
+  transform: translateY(1.5rem) rotate(2deg);
+}
+
+.jr-card:nth-child(3) {
+  transform: rotate(-1deg);
+}
+
+.jr-card-blue {
+  background: var(--jr-blue);
+  color: #fff;
+}
+
+.jr-card-pink {
+  background: var(--jr-pink);
+}
+
+.jr-card-cream {
+  background: var(--jr-cream);
+}
+
+.jr-card > span {
+  background: var(--jr-black);
+  color: var(--jr-acid);
+  display: inline-block;
+  font-family: "Arial Black", Impact, sans-serif;
+  font-size: 1.3rem;
+  font-weight: 900;
+  margin-bottom: 3rem;
+  padding: 0.4rem 0.55rem;
+}
+
+.jr-card h2 {
+  font-size: clamp(2.2rem, 4vw, 3.7rem);
+  hyphens: none;
+  overflow-wrap: normal;
+  word-break: normal;
+}
+
+.jr-card-blue h2,
+.jr-card-blue p {
+  color: #fff !important;
+}
+
+.jr-card p {
+  color: var(--jr-black);
+  font-size: 0.95rem;
+  font-weight: 800;
+  line-height: 1.4;
+  margin: 1rem 0 0;
 }
 
 .jr-customers {
   align-items: center;
+  background: var(--jr-cream);
+  border: 5px solid var(--jr-black);
+  box-shadow: 12px 12px 0 var(--jr-pink);
   display: flex;
   flex-direction: column;
-  margin: clamp(3.5rem, 8vw, 6rem) auto 1rem;
+  margin: 2rem auto 5rem;
+  max-width: 36rem;
+  padding: 2rem;
   text-align: center;
+  transform: rotate(1deg);
 }
 
 .jr-customers-eyebrow {
-  color: var(--ve-text-light);
-  font-size: 0.75rem;
-  font-weight: 700;
-  letter-spacing: 0.14em;
-  margin: 0 0 1.5rem;
-  text-transform: uppercase;
-}
-
-.jr-customer-logos {
-  align-items: center;
-  display: flex;
-  justify-content: center;
-  margin: 0;
-  min-height: 4rem;
+  color: var(--jr-black);
+  font-family: "Arial Black", Impact, sans-serif;
+  font-size: 0.8rem;
+  font-weight: 900;
+  letter-spacing: 0.12em;
+  margin: 0 0 1rem;
 }
 
 .jr-customer-logo {
-  align-items: center;
-  color: var(--ve-text-light);
+  color: var(--jr-black) !important;
   display: inline-flex;
-  font-size: 1.35rem;
-  font-weight: 700;
-  gap: 0.6rem;
-  letter-spacing: 0.05em;
   text-decoration: none;
-  transition: color 120ms ease;
-}
-
-.jr-customer-logo:hover {
-  color: var(--ve-text);
 }
 
 .jr-customer-logo svg {
-  height: 3.75rem;
+  height: 4.5rem;
   width: auto;
 }
 
 .jr-customers-cta {
-  color: var(--ve-text-light);
-  font-size: 0.875rem;
-  margin-top: 1.25rem;
-  text-underline-offset: 0.2em;
+  color: var(--jr-black) !important;
+  font-family: "Arial Black", Impact, sans-serif;
+  font-size: 0.8rem;
+  font-weight: 900;
+  margin-top: 1rem;
+  text-decoration-thickness: 3px;
+  text-underline-offset: 0.25em;
+  text-transform: uppercase;
 }
 
-.jr-customers-cta:hover {
-  color: var(--ve-text);
+.jr-made-this {
+  color: var(--jr-black);
+  font-size: 0.8rem;
+  font-style: italic;
+  margin: 0 0 1rem auto;
+  text-align: right;
 }
 
-@media (max-width: 44rem) {
-  :root:not([data-has-sidebar])
-    .hero
-    :is(h1, [data-page-title])
-    .jr-home-mega-inline {
-    font-size: 3.2rem;
+.jr-made-this b {
+  color: var(--jr-pink);
+  font-size: 1.2em;
+  -webkit-text-stroke: 1px var(--jr-black);
+}
+
+body:has(.jr-home) footer {
+  color: var(--jr-black);
+}
+
+@media (max-width: 64rem) {
+  :root:not([data-has-sidebar]) .hero {
+    min-height: auto;
+  }
+
+  .jr-home {
+    margin-top: 1rem;
+  }
+
+  .jr-sticker-scene {
+    grid-template-columns: 1fr 0.6fr 1.2fr 0.6fr 1fr;
+  }
+
+  .jr-gremlin-note {
+    right: -0.5rem;
+  }
+}
+
+@media (max-width: 48rem) {
+  :root:not([data-has-sidebar]) .hero::before,
+  :root:not([data-has-sidebar]) .hero::after {
+    display: none;
+  }
+
+  .jr-home-mega {
+    font-size: clamp(4rem, 22vw, 8rem);
+    letter-spacing: -0.1em;
+    text-shadow: 8px 8px 0 var(--jr-blue);
+  }
+
+  :root:not([data-has-sidebar]) .hero .tagline {
+    margin-left: 0;
+  }
+
+  :root:not([data-has-sidebar]) .hero .actions {
+    justify-content: flex-start;
+  }
+
+  .jr-scribble {
+    display: none;
+  }
+
+  .jr-sticker-scene {
+    gap: 2.5rem 1rem;
+    grid-template-columns: 1fr 1fr;
+    padding-top: 3rem;
+  }
+
+  .jr-sticker-slack,
+  .jr-tool-pile {
+    justify-self: center;
+  }
+
+  .jr-flow-arrow {
+    display: none;
+  }
+
+  .jr-gremlin {
+    grid-column: 1 / -1;
+    grid-row: 1;
+  }
+
+  .jr-sticker-slack {
+    grid-column: 1;
+    grid-row: 2;
+  }
+
+  .jr-tool-pile {
+    grid-column: 2;
+    grid-row: 2;
+  }
+
+  .jr-proof {
+    grid-template-columns: 1fr;
+  }
+
+  .jr-cards {
+    grid-template-columns: 1fr;
+  }
+
+  .jr-card,
+  .jr-card:nth-child(2) {
+    min-height: 15rem;
+    transform: none;
+  }
+}
+
+@media (max-width: 30rem) {
+  .jr-home-mega {
+    font-size: 19vw;
+  }
+
+  :root:not([data-has-sidebar]) .hero .actions {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  :root:not([data-has-sidebar]) .hero .sl-link-button {
+    justify-content: center;
+  }
+
+  .jr-sticker-scene {
+    grid-template-columns: 1fr;
+  }
+
+  .jr-sticker-slack,
+  .jr-tool-pile,
+  .jr-gremlin {
+    grid-column: 1;
+  }
+
+  .jr-gremlin {
+    grid-row: 1;
+  }
+
+  .jr-sticker-slack {
+    grid-row: 2;
+  }
+
+  .jr-tool-pile {
+    grid-row: 3;
+  }
+
+  .jr-ticker {
+    font-size: 1rem;
   }
 
   .slk-msg {
     gap: 0.5rem;
-    padding: 0.25rem 0.75rem;
+    padding: 0.65rem;
   }
 
   .slk-avatar {
-    font-size: 0.7rem;
-    height: 1.75rem;
-    width: 1.75rem;
+    height: 1.9rem;
+    width: 1.9rem;
   }
 }

--- a/packages/docs/src/styles/homepage-mocks.css
+++ b/packages/docs/src/styles/homepage-mocks.css
@@ -1,0 +1,463 @@
+.jr-real-work {
+  margin-inline: calc(50% - 50vw);
+  padding: clamp(5rem, 9vw, 9rem) max(1.25rem, calc((100vw - 86rem) / 2));
+  position: relative;
+}
+
+.jr-real-work::before {
+  background: var(--jr-cream);
+  border-block: 5px solid var(--jr-black);
+  content: "";
+  inset: 0;
+  position: absolute;
+  transform: rotate(0.6deg);
+}
+
+.jr-real-work-heading,
+.jr-mock-grid {
+  position: relative;
+  z-index: 1;
+}
+
+.jr-real-work-heading {
+  margin: 0 auto clamp(3rem, 6vw, 5rem);
+  max-width: 58rem;
+  text-align: center;
+}
+
+.jr-real-work-heading p {
+  color: var(--jr-blue);
+  font-family: "Arial Black", Impact, sans-serif;
+  font-size: 0.8rem;
+  font-weight: 900;
+  letter-spacing: 0.1em;
+  margin: 0 0 0.8rem;
+}
+
+.jr-real-work-heading h2 {
+  color: var(--jr-black);
+  font-family: "Arial Black", Impact, sans-serif;
+  font-size: clamp(3rem, 7vw, 6.5rem);
+  font-weight: 950;
+  letter-spacing: -0.065em;
+  line-height: 0.86;
+  margin: 0;
+  text-transform: uppercase;
+}
+
+.jr-real-work-heading span {
+  color: var(--jr-black);
+  display: block;
+  font-size: 1rem;
+  font-weight: 800;
+  margin: 1.5rem auto 0;
+  max-width: 38rem;
+}
+
+.jr-mock-grid {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.jr-product-mock {
+  min-width: 0;
+}
+
+.jr-product-mock:nth-child(1) {
+  transform: rotate(-1.3deg);
+}
+
+.jr-product-mock:nth-child(2) {
+  transform: translateY(1.5rem) rotate(1deg);
+}
+
+.jr-product-mock:nth-child(3) {
+  transform: rotate(-0.5deg);
+}
+
+.jr-product-mock-label {
+  align-items: center;
+  display: flex;
+  gap: 0.75rem;
+  margin: 0 0 0.8rem;
+}
+
+.jr-product-mock-label > span {
+  align-items: center;
+  background: var(--jr-black);
+  color: var(--jr-acid);
+  display: flex;
+  flex: 0 0 auto;
+  font-family: "Arial Black", Impact, sans-serif;
+  font-size: 1rem;
+  font-weight: 900;
+  height: 2.5rem;
+  justify-content: center;
+  width: 2.5rem;
+}
+
+.jr-product-mock-label div {
+  margin: 0;
+}
+
+.jr-product-mock-label small {
+  color: var(--jr-black);
+  display: block;
+  font-family: "Arial Black", Impact, sans-serif;
+  font-size: 0.62rem;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  line-height: 1;
+  margin-bottom: 0.2rem;
+}
+
+.jr-product-mock-label h3 {
+  color: var(--jr-black);
+  font-family: "Arial Black", Impact, sans-serif;
+  font-size: clamp(1.6rem, 3vw, 2.35rem);
+  font-weight: 950;
+  letter-spacing: -0.045em;
+  line-height: 0.9;
+  margin: 0;
+  text-transform: uppercase;
+}
+
+.jr-mock-window {
+  border: 5px solid var(--jr-black);
+  box-shadow: 10px 10px 0 var(--jr-black);
+  box-sizing: border-box;
+  min-height: 28rem;
+  overflow: hidden;
+}
+
+.jr-product-mock-caption {
+  color: var(--jr-black);
+  font-size: 0.82rem;
+  font-weight: 800;
+  line-height: 1.35;
+  margin: 1.25rem 0 0;
+  padding-inline: 0.25rem;
+}
+
+.jr-incident-window {
+  background: #181a1f;
+  color: #fff;
+}
+
+.jr-mock-window-bar {
+  align-items: center;
+  background: #292c33;
+  border-bottom: 3px solid var(--jr-black);
+  display: flex;
+  font-size: 0.75rem;
+  font-weight: 900;
+  justify-content: space-between;
+  padding: 0.8rem 0.9rem;
+}
+
+.jr-mock-window-bar i {
+  background: var(--jr-pink);
+  color: var(--jr-black);
+  font-style: normal;
+  padding: 0.2rem 0.4rem;
+}
+
+.jr-mini-message {
+  align-items: flex-start;
+  display: flex;
+  gap: 0.65rem;
+  padding: 1rem;
+}
+
+.jr-mini-message > b {
+  align-items: center;
+  background: var(--jr-pink);
+  border: 2px solid var(--jr-black);
+  color: var(--jr-black);
+  display: flex;
+  flex: 0 0 auto;
+  font-size: 0.68rem;
+  height: 2rem;
+  justify-content: center;
+  width: 2rem;
+}
+
+.jr-mini-message p {
+  color: #f4f4f4;
+  font-size: 0.8rem;
+  line-height: 1.45;
+  margin: 0;
+}
+
+.jr-mini-message p strong {
+  background: var(--jr-acid);
+  color: var(--jr-black);
+  padding: 0 0.15rem;
+}
+
+.jr-mini-message-bot {
+  background: rgba(105, 92, 255, 0.15);
+  border-block: 2px solid rgba(255, 255, 255, 0.1);
+}
+
+.jr-mini-message-bot > b {
+  background: var(--jr-acid);
+}
+
+.jr-mock-status {
+  background: var(--jr-blue);
+  color: #fff;
+  display: inline-block;
+  font-family: "Arial Black", Impact, sans-serif;
+  font-size: 0.62rem;
+  font-weight: 900;
+  margin-bottom: 0.45rem;
+  padding: 0.25rem 0.4rem;
+}
+
+.jr-mini-message-bot code,
+.jr-linear-issue code {
+  background: var(--jr-cream);
+  color: var(--jr-black);
+  font-size: 0.85em;
+  padding: 0.05rem 0.22rem;
+}
+
+.jr-receipt-list {
+  display: grid;
+  gap: 0.55rem;
+  padding: 1rem;
+}
+
+.jr-receipt-list span {
+  background: var(--jr-black);
+  border: 2px solid var(--jr-acid);
+  color: var(--jr-acid);
+  font-size: 0.72rem;
+  font-weight: 800;
+  padding: 0.45rem 0.55rem;
+}
+
+.jr-linear-window {
+  background: var(--jr-pink);
+  padding: 1rem;
+}
+
+.jr-linear-prompt {
+  background: var(--jr-black);
+  color: #fff;
+  font-size: 0.82rem;
+  font-weight: 800;
+  line-height: 1.35;
+  padding: 0.8rem;
+  transform: rotate(-1deg);
+}
+
+.jr-linear-issue {
+  background: var(--jr-cream);
+  border: 4px solid var(--jr-black);
+  box-shadow: 7px 7px 0 var(--jr-black);
+  margin: 1.5rem 0 1.25rem;
+  padding: 1rem;
+  transform: rotate(1deg);
+}
+
+.jr-linear-issue-top {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+}
+
+.jr-linear-issue-top span,
+.jr-linear-issue-top i {
+  font-family: "Arial Black", Impact, sans-serif;
+  font-size: 0.67rem;
+  font-style: normal;
+  font-weight: 900;
+}
+
+.jr-linear-issue-top i {
+  background: var(--jr-blue);
+  color: #fff;
+  padding: 0.25rem 0.35rem;
+}
+
+.jr-linear-issue h4 {
+  color: var(--jr-black);
+  font-family: "Arial Black", Impact, sans-serif;
+  font-size: 1.35rem;
+  font-weight: 900;
+  letter-spacing: -0.035em;
+  line-height: 1;
+  margin: 1rem 0;
+  text-transform: uppercase;
+}
+
+.jr-linear-issue p {
+  color: var(--jr-black);
+  font-size: 0.75rem;
+  font-weight: 700;
+  line-height: 1.45;
+  margin: 0;
+}
+
+.jr-linear-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-top: 1rem;
+}
+
+.jr-linear-meta span {
+  border: 2px solid var(--jr-black);
+  font-size: 0.63rem;
+  font-weight: 900;
+  padding: 0.25rem 0.35rem;
+}
+
+.jr-linear-done {
+  background: var(--jr-acid);
+  border: 3px solid var(--jr-black);
+  color: var(--jr-black);
+  font-size: 0.7rem;
+  font-weight: 900;
+  padding: 0.55rem;
+  text-align: center;
+  transform: rotate(-2deg);
+}
+
+.jr-browser-window {
+  background: var(--jr-blue);
+  padding-bottom: 1rem;
+}
+
+.jr-browser-bar {
+  align-items: center;
+  background: var(--jr-black);
+  display: flex;
+  gap: 0.35rem;
+  padding: 0.7rem;
+}
+
+.jr-browser-bar > span {
+  background: var(--jr-pink);
+  border-radius: 50%;
+  height: 0.55rem;
+  width: 0.55rem;
+}
+
+.jr-browser-bar p {
+  background: #fff;
+  color: var(--jr-black);
+  flex: 1;
+  font-size: 0.6rem;
+  margin: 0 0 0 0.35rem;
+  padding: 0.35rem 0.5rem;
+}
+
+.jr-browser-preview {
+  background: var(--jr-acid);
+  border: 4px solid var(--jr-black);
+  box-shadow: 7px 7px 0 var(--jr-black);
+  height: 12rem;
+  margin: 1rem;
+  padding: 0.8rem;
+  transform: rotate(-1deg);
+}
+
+.jr-browser-preview-nav {
+  background: var(--jr-black);
+  height: 0.8rem;
+  width: 100%;
+}
+
+.jr-browser-preview-title {
+  background: var(--jr-pink);
+  border: 3px solid var(--jr-black);
+  box-shadow: 4px 4px 0 var(--jr-black);
+  height: 3rem;
+  margin: 1.2rem 0;
+  width: 72%;
+}
+
+.jr-browser-preview-grid {
+  display: grid;
+  gap: 0.4rem;
+  grid-template-columns: repeat(3, 1fr);
+}
+
+.jr-browser-preview-grid i {
+  background: var(--jr-cream);
+  border: 3px solid var(--jr-black);
+  height: 4rem;
+}
+
+.jr-browser-checks {
+  display: grid;
+  gap: 0.35rem;
+  grid-template-columns: 1fr 1fr;
+  margin: 0 1rem;
+}
+
+.jr-browser-checks span {
+  background: #fff;
+  border: 2px solid var(--jr-black);
+  color: var(--jr-black);
+  font-size: 0.62rem;
+  font-weight: 900;
+  padding: 0.4rem;
+}
+
+.jr-browser-verdict {
+  align-items: center;
+  background: var(--jr-pink);
+  border: 3px solid var(--jr-black);
+  box-shadow: 5px 5px 0 var(--jr-black);
+  display: flex;
+  justify-content: space-between;
+  margin: 1rem;
+  padding: 0.6rem 0.75rem;
+  transform: rotate(1deg);
+}
+
+.jr-browser-verdict b {
+  font-family: "Arial Black", Impact, sans-serif;
+  font-size: 1.15rem;
+}
+
+.jr-browser-verdict span {
+  font-size: 0.62rem;
+  font-weight: 900;
+}
+
+@media (max-width: 64rem) {
+  .jr-mock-grid {
+    grid-template-columns: 1fr;
+    margin-inline: auto;
+    max-width: 38rem;
+  }
+
+  .jr-product-mock,
+  .jr-product-mock:nth-child(2) {
+    transform: none;
+  }
+
+  .jr-mock-window {
+    min-height: 0;
+  }
+}
+
+@media (max-width: 30rem) {
+  .jr-real-work-heading {
+    text-align: left;
+  }
+
+  .jr-real-work-heading h2 {
+    font-size: 3.2rem;
+  }
+
+  .jr-browser-checks {
+    grid-template-columns: 1fr;
+  }
+}

--- a/packages/docs/src/styles/homepage-mocks.css
+++ b/packages/docs/src/styles/homepage-mocks.css
@@ -132,7 +132,7 @@
 }
 
 .jr-product-mock-caption {
-  color: var(--jr-black);
+  color: var(--jr-black) !important;
   font-size: 0.82rem;
   font-weight: 800;
   line-height: 1.35;


### PR DESCRIPTION
Redesigns the Junior docs homepage as a bold neo-brutalist product landing page with a centered hero, sharper Junior voice, responsive layouts, and clearer calls to action.

The page now includes concrete workflow mocks grounded in shipped functionality: incident investigation and rollback with Sentry, GitHub, and Vercel; creating a Linear issue from Slack context; and Agent Browser visual QA with desktop/mobile evidence. Review should focus on the visual hierarchy, tone, and whether the mocks explain Junior quickly without overpromising.
