### PR TITLE
perf(sandbox): reduce and measure search overhead

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -76,6 +76,14 @@ fields=timestamp,trace,span.description,span.duration,gen_ai.conversation.id,err
 sort=-timestamp
 ```
 
+Search tool volume, truncation, and raw output size.
+
+```text
+dataset=spans query='span.op:gen_ai.execute_tool gen_ai.tool.name:[grep,findFiles] app.sandbox.search.raw_output_bytes:*'
+fields=timestamp,trace,gen_ai.tool.name,span.duration,app.sandbox.search.raw_output_bytes,app.sandbox.search.parsed_records,app.sandbox.search.result_count,app.sandbox.search.result_bytes,app.sandbox.search.limit,app.sandbox.search.limit_reached
+sort=-timestamp
+```
+
 Slack delivery failures after the agent turn ran.
 
 ```text
@@ -154,7 +162,11 @@ Spans: `execute_tool <toolName>`, `sandbox.acquire`, `sandbox.create`,
 
 Attributes: `gen_ai.tool.name`, `gen_ai.tool.call.id`, `gen_ai.tool.call.result`, `mcp.method.name`,
 `process.executable.name`, `process.exit.code`, `app.sandbox.source`,
-`app.sandbox.snapshot.resolve_outcome`
+`app.sandbox.snapshot.resolve_outcome`, `app.sandbox.search.raw_output_bytes`,
+`app.sandbox.search.parsed_records`,
+`app.sandbox.search.result_count`, `app.sandbox.search.emitted_lines`,
+`app.sandbox.search.result_bytes`, `app.sandbox.search.limit`,
+`app.sandbox.search.limit_reached`
 
 ### Auth And Resume
 

--- a/packages/junior/src/chat/sandbox/sandbox.ts
+++ b/packages/junior/src/chat/sandbox/sandbox.ts
@@ -6,6 +6,7 @@ import {
   setSpanStatus,
   withSpan,
   type LogContext,
+  type SetSpanAttributes,
 } from "@/chat/logging";
 import {
   buildSandboxEgressNetworkPolicy,
@@ -48,6 +49,7 @@ import {
   positiveInteger,
   resolveWorkspacePath,
   type SandboxCommandRunner,
+  type SandboxSearchTelemetry,
 } from "@/chat/tools/sandbox/file-utils";
 import { grepFiles } from "@/chat/tools/sandbox/grep";
 import { listDir } from "@/chat/tools/sandbox/list-dir";
@@ -63,6 +65,8 @@ export interface SandboxToolCall {
   toolName: string;
   input: unknown;
   signal?: AbortSignal;
+  /** Add safe sandbox measurements to the caller-owned tool span. */
+  setToolCallSpanAttributes?: SetSpanAttributes;
 }
 
 export interface SandboxTools {
@@ -92,6 +96,7 @@ export interface SandboxOptions {
 
 interface SandboxToolCallContext {
   readonly signal?: AbortSignal;
+  readonly setToolCallSpanAttributes?: SetSpanAttributes;
   fileSystem(): Promise<SandboxFileSystem>;
   commandRunner(): Promise<SandboxCommandRunner>;
 }
@@ -213,12 +218,14 @@ export function createSandbox(options: SandboxOptions): SandboxAccess {
   });
   const createToolCallContext = (
     signal?: AbortSignal,
+    setToolCallSpanAttributes?: SetSpanAttributes,
   ): SandboxToolCallContext => {
     let fileSystemPromise: Promise<SandboxFileSystem> | undefined;
     let commandRunnerPromise: Promise<SandboxCommandRunner> | undefined;
 
     return {
       signal,
+      setToolCallSpanAttributes,
       fileSystem() {
         signal?.throwIfAborted();
         return (fileSystemPromise ??= runtime.tools().then(({ fs }) => {
@@ -246,7 +253,7 @@ export function createSandbox(options: SandboxOptions): SandboxAccess {
     name: string,
     op: string,
     attributes: Record<string, unknown>,
-    callback: () => Promise<T>,
+    callback: (setSpanAttributes: SetSpanAttributes) => Promise<T>,
   ): Promise<T> => withSpan(name, op, traceContext, callback, attributes);
 
   // Network-policy header transforms need the current tool span's trace headers.
@@ -254,12 +261,42 @@ export function createSandbox(options: SandboxOptions): SandboxAccess {
     name: string,
     op: string,
     attributes: Record<string, unknown>,
-    callback: () => Promise<T>,
+    callback: (setSpanAttributes: SetSpanAttributes) => Promise<T>,
   ): Promise<T> =>
-    withSandboxSpan(name, op, attributes, async () => {
+    withSandboxSpan(name, op, attributes, async (setSpanAttributes) => {
       await runtime.refreshNetworkPolicy(getTracePropagationHeaders());
-      return await callback();
+      return await callback(setSpanAttributes);
     });
+
+  const searchTelemetryAttributes = (
+    telemetry: SandboxSearchTelemetry,
+  ): Record<string, number | boolean> => ({
+    "app.sandbox.search.raw_output_bytes": telemetry.rawOutputBytes,
+    "app.sandbox.search.parsed_records": telemetry.parsedRecordCount,
+    "app.sandbox.search.result_count": telemetry.resultCount,
+    "app.sandbox.search.emitted_lines": telemetry.emittedLineCount,
+    "app.sandbox.search.result_bytes": telemetry.resultBytes,
+    "app.sandbox.search.limit": telemetry.limit,
+    "app.sandbox.search.limit_reached": telemetry.limitReached,
+  });
+
+  const recordSearchTelemetry = (
+    telemetry: SandboxSearchTelemetry,
+    setSearchSpanAttributes: SetSpanAttributes,
+    setToolCallSpanAttributes?: SetSpanAttributes,
+  ): void => {
+    const attributes = searchTelemetryAttributes(telemetry);
+    for (const setAttributes of [
+      setSearchSpanAttributes,
+      setToolCallSpanAttributes,
+    ]) {
+      try {
+        setAttributes?.(attributes);
+      } catch {
+        // Search telemetry is a best-effort observer.
+      }
+    }
+  };
 
   const logSandboxBootRequest = (
     trigger: string,
@@ -555,10 +592,16 @@ export function createSandbox(options: SandboxOptions): SandboxAccess {
       {
         "app.sandbox.pattern.length": pattern.length,
       },
-      async () => {
+      async (setSearchSpanAttributes) => {
         const response = await grepFiles({
           fs: fileSystem,
           runCommand: await context.commandRunner(),
+          onTelemetry: (telemetry) =>
+            recordSearchTelemetry(
+              telemetry,
+              setSearchSpanAttributes,
+              context.setToolCallSpanAttributes,
+            ),
           pattern,
           ...(typeof rawInput.path === "string" ? { path: rawInput.path } : {}),
           ...(typeof rawInput.glob === "string" ? { glob: rawInput.glob } : {}),
@@ -597,10 +640,16 @@ export function createSandbox(options: SandboxOptions): SandboxAccess {
       {
         "app.sandbox.pattern.length": pattern.length,
       },
-      async () => {
+      async (setSearchSpanAttributes) => {
         const response = await findFiles({
           fs: fileSystem,
           runCommand: await context.commandRunner(),
+          onTelemetry: (telemetry) =>
+            recordSearchTelemetry(
+              telemetry,
+              setSearchSpanAttributes,
+              context.setToolCallSpanAttributes,
+            ),
           pattern,
           ...(typeof rawInput.path === "string" ? { path: rawInput.path } : {}),
           ...(limit ? { limit } : {}),
@@ -640,7 +689,10 @@ export function createSandbox(options: SandboxOptions): SandboxAccess {
 
   const execute = async <T>(params: SandboxToolCall): Promise<T> => {
     const rawInput = (params.input ?? {}) as Record<string, unknown>;
-    const context = createToolCallContext(params.signal);
+    const context = createToolCallContext(
+      params.signal,
+      params.setToolCallSpanAttributes,
+    );
     const bashCommand =
       params.toolName === "bash"
         ? String(rawInput.command ?? "").trim()

--- a/packages/junior/src/chat/sandbox/skill-sync.ts
+++ b/packages/junior/src/chat/sandbox/skill-sync.ts
@@ -18,6 +18,8 @@ interface SkillSyncFile {
   content: Buffer;
 }
 
+const DIRECTORY_CREATE_CONCURRENCY = 8;
+
 function toPosixRelative(base: string, absolute: string): string {
   return path.relative(base, absolute).split(path.sep).join("/");
 }
@@ -117,6 +119,19 @@ function collectDirectories(
         directory.startsWith(`${workspaceRoot}/`),
     )
     .sort((a, b) => a.length - b.length);
+}
+
+function groupDirectoriesByDepth(directories: string[]): string[][] {
+  const groups = new Map<number, string[]>();
+  for (const directory of directories) {
+    const depth = directory.split("/").filter(Boolean).length;
+    const group = groups.get(depth) ?? [];
+    group.push(directory);
+    groups.set(depth, group);
+  }
+  return [...groups.entries()]
+    .sort(([left], [right]) => left - right)
+    .map(([, group]) => group);
 }
 
 /** Resolve a virtual sandbox skill path back to the host filesystem when no sandbox exists yet. */
@@ -237,13 +252,28 @@ export async function syncSkillsToSandbox(params: {
         },
         async () => {
           try {
-            for (const directory of directories) {
-              try {
-                await params.sandbox.mkDir(directory);
-              } catch (error) {
-                if (!isAlreadyExistsError(error)) {
-                  throw error;
-                }
+            // Finish each parent depth before creating child directories.
+            for (const directoriesAtDepth of groupDirectoriesByDepth(
+              directories,
+            )) {
+              for (
+                let offset = 0;
+                offset < directoriesAtDepth.length;
+                offset += DIRECTORY_CREATE_CONCURRENCY
+              ) {
+                await Promise.all(
+                  directoriesAtDepth
+                    .slice(offset, offset + DIRECTORY_CREATE_CONCURRENCY)
+                    .map(async (directory) => {
+                      try {
+                        await params.sandbox.mkDir(directory);
+                      } catch (error) {
+                        if (!isAlreadyExistsError(error)) {
+                          throw error;
+                        }
+                      }
+                    }),
+                );
               }
             }
 

--- a/packages/junior/src/chat/tool-support/pi-tool-adapter.ts
+++ b/packages/junior/src/chat/tool-support/pi-tool-adapter.ts
@@ -157,6 +157,9 @@ export function createPiAgentTools(
           toolName,
           input: sandboxInput,
           ...(signal ? { signal } : {}),
+          ...(toolName === "grep" || toolName === "findFiles"
+            ? { setToolCallSpanAttributes: setSpanAttributes }
+            : {}),
         })
       : await toolDef.execute(toolInput, {
           experimental_context: sandbox,

--- a/packages/junior/src/chat/tools/sandbox/file-utils.ts
+++ b/packages/junior/src/chat/tools/sandbox/file-utils.ts
@@ -13,6 +13,17 @@ export type SandboxCommandRunner = (
   input: SandboxCommandInput,
 ) => Promise<SandboxCommandResult>;
 
+/** Safe measurements produced by one sandbox-backed search operation. */
+export interface SandboxSearchTelemetry {
+  emittedLineCount: number;
+  limit: number;
+  limitReached: boolean;
+  parsedRecordCount: number;
+  rawOutputBytes: number;
+  resultCount: number;
+  resultBytes: number;
+}
+
 export const MAX_TEXT_CHARS = 60_000;
 export const RIPGREP_EXCLUDED_GLOBS = [
   "!**/.git/**",

--- a/packages/junior/src/chat/tools/sandbox/find-files.ts
+++ b/packages/junior/src/chat/tools/sandbox/find-files.ts
@@ -11,6 +11,7 @@ import {
   truncateText,
   type SandboxCommandRunner,
   type SandboxFileSystem,
+  type SandboxSearchTelemetry,
   type TextSearchResultDetails,
   type TextSearchToolResult,
 } from "@/chat/tools/sandbox/file-utils";
@@ -43,6 +44,7 @@ type FindFilesResult = FindFilesSuccessResult | TextSearchToolResult;
 export async function findFiles(params: {
   fs: SandboxFileSystem;
   limit?: unknown;
+  onTelemetry?: (telemetry: SandboxSearchTelemetry) => void;
   path?: string;
   pattern: string;
   runCommand?: SandboxCommandRunner;
@@ -57,6 +59,7 @@ export async function findFiles(params: {
     return await findFilesWithRipgrep({
       fs: params.fs,
       limit,
+      onTelemetry: params.onTelemetry,
       path: params.path,
       pattern: params.pattern,
       root,
@@ -120,6 +123,7 @@ export async function findFiles(params: {
 async function findFilesWithRipgrep(params: {
   fs: SandboxFileSystem;
   limit: number;
+  onTelemetry?: (telemetry: SandboxSearchTelemetry) => void;
   path?: string;
   pattern: string;
   root: string;
@@ -194,7 +198,7 @@ async function findFilesWithRipgrep(params: {
       ? `${bounded.content}\n\n[${notices.join(" ")}]`
       : bounded.content;
 
-  return makeStructuredToolResult(
+  const response = makeStructuredToolResult(
     {
       ok: true,
       status: "success",
@@ -211,6 +215,21 @@ async function findFilesWithRipgrep(params: {
     },
     { content: [{ type: "text", text }] },
   ) as FindFilesResult;
+  params.onTelemetry?.({
+    emittedLineCount: relativePaths.length,
+    limit: params.limit,
+    limitReached,
+    parsedRecordCount: allPaths.length,
+    rawOutputBytes: Buffer.byteLength(result.stdout, "utf8"),
+    resultBytes: response.content.reduce(
+      (total, item) =>
+        total +
+        (item.type === "text" ? Buffer.byteLength(item.text, "utf8") : 0),
+      0,
+    ),
+    resultCount: relativePaths.length,
+  });
+  return response;
 }
 
 /** Create the sandbox file discovery tool definition exposed to the agent. */

--- a/packages/junior/src/chat/tools/sandbox/grep.ts
+++ b/packages/junior/src/chat/tools/sandbox/grep.ts
@@ -12,6 +12,7 @@ import {
   truncateText,
   type SandboxCommandRunner,
   type SandboxFileSystem,
+  type SandboxSearchTelemetry,
   type TextSearchResultDetails,
   type TextSearchToolResult,
 } from "@/chat/tools/sandbox/file-utils";
@@ -91,6 +92,7 @@ export async function grepFiles(params: {
   ignoreCase?: boolean;
   limit?: unknown;
   literal?: boolean;
+  onTelemetry?: (telemetry: SandboxSearchTelemetry) => void;
   path?: string;
   pattern: string;
   runCommand?: SandboxCommandRunner;
@@ -110,6 +112,7 @@ export async function grepFiles(params: {
       ignoreCase: params.ignoreCase,
       limit,
       literal: params.literal,
+      onTelemetry: params.onTelemetry,
       path: params.path,
       pattern: params.pattern,
       root,
@@ -279,6 +282,7 @@ async function grepFilesWithRipgrep(params: {
   ignoreCase?: boolean;
   limit: number;
   literal?: boolean;
+  onTelemetry?: (telemetry: SandboxSearchTelemetry) => void;
   path?: string;
   pattern: string;
   root: string;
@@ -298,7 +302,14 @@ async function grepFilesWithRipgrep(params: {
   }
 
   const location = getRipgrepSearchLocation(params.root, rootIsDirectory);
-  const args = ["--json", "--line-number", "--hidden", "--sort=path"];
+  const args = [
+    "--json",
+    "--line-number",
+    "--hidden",
+    "--sort=path",
+    "--max-count",
+    String(params.limit + 1),
+  ];
   if (params.ignoreCase) {
     args.push("--ignore-case");
   }
@@ -338,6 +349,7 @@ async function grepFilesWithRipgrep(params: {
   >();
   const pathOrder: string[] = [];
   let totalMatches = 0;
+  let parsedRecordCount = 0;
   for (const rawLine of normalizeToLf(result.stdout).split("\n")) {
     if (!rawLine) {
       continue;
@@ -348,6 +360,7 @@ async function grepFilesWithRipgrep(params: {
     } catch (error) {
       throw new Error("ripgrep returned invalid JSON output", { cause: error });
     }
+    parsedRecordCount += 1;
     if (record.type !== "match" && record.type !== "context") {
       continue;
     }
@@ -436,7 +449,7 @@ async function grepFilesWithRipgrep(params: {
     notices.push(`${MAX_TEXT_CHARS} character output limit reached.`);
   }
 
-  return makeStructuredToolResult({
+  const response = makeStructuredToolResult({
     ok: true,
     status: "success",
     target: params.path ?? ".",
@@ -458,6 +471,21 @@ async function grepFilesWithRipgrep(params: {
     ...(matchLimitReached ? { match_limit_reached: params.limit } : {}),
     ...(lineTruncated ? { line_truncated: true } : {}),
   });
+  params.onTelemetry?.({
+    emittedLineCount: output.length,
+    limit: params.limit,
+    limitReached: matchLimitReached,
+    parsedRecordCount,
+    rawOutputBytes: Buffer.byteLength(result.stdout, "utf8"),
+    resultBytes: response.content.reduce(
+      (total, item) =>
+        total +
+        (item.type === "text" ? Buffer.byteLength(item.text, "utf8") : 0),
+      0,
+    ),
+    resultCount: matchCount,
+  });
+  return response;
 }
 
 /** Create the sandbox grep tool definition exposed to the agent. */

--- a/packages/junior/tests/unit/sandbox/skill-sync.test.ts
+++ b/packages/junior/tests/unit/sandbox/skill-sync.test.ts
@@ -1,0 +1,95 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { syncSkillsToSandbox } from "@/chat/sandbox/skill-sync";
+import type { SandboxSession } from "@/chat/sandbox/workspace";
+
+const temporaryDirectories: string[] = [];
+
+async function makeSkill(): Promise<string> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "junior-skill-sync-"));
+  temporaryDirectories.push(root);
+  await fs.mkdir(path.join(root, "references", "nested"), { recursive: true });
+  await fs.mkdir(path.join(root, "scripts"), { recursive: true });
+  await fs.writeFile(path.join(root, "SKILL.md"), "skill", "utf8");
+  await fs.writeFile(
+    path.join(root, "references", "nested", "note.md"),
+    "note",
+    "utf8",
+  );
+  await fs.writeFile(path.join(root, "scripts", "run.sh"), "run", "utf8");
+  return root;
+}
+
+function immediateSpan<T>(
+  _name: string,
+  _op: string,
+  _attributes: Record<string, unknown>,
+  callback: () => Promise<T>,
+): Promise<T> {
+  return callback();
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories.splice(0).map(async (directory) => {
+      await fs.rm(directory, { recursive: true, force: true });
+    }),
+  );
+});
+
+describe("sandbox skill sync", () => {
+  it("creates sibling directories concurrently after their parents", async () => {
+    const skillPath = await makeSkill();
+    let parentMissing = false;
+    const createdDirectories = new Set<string>();
+    const siblingDirectories = new Set<string>();
+    let reportFirstSibling: (() => void) | undefined;
+    const firstSiblingStarted = new Promise<void>((resolve) => {
+      reportFirstSibling = resolve;
+    });
+    let releaseSiblings: (() => void) | undefined;
+    const siblingsStarted = new Promise<void>((resolve) => {
+      releaseSiblings = resolve;
+    });
+    const sandbox = {
+      async mkDir(directory: string) {
+        const parent = path.posix.dirname(directory);
+        if (
+          parent.startsWith("/vercel/sandbox") &&
+          !createdDirectories.has(parent)
+        ) {
+          parentMissing = true;
+        }
+        if (
+          directory.endsWith("/references") ||
+          directory.endsWith("/scripts")
+        ) {
+          siblingDirectories.add(directory);
+          reportFirstSibling?.();
+          if (siblingDirectories.size < 2) {
+            await siblingsStarted;
+          }
+        }
+        createdDirectories.add(directory);
+      },
+      async readFileToBuffer() {
+        return null;
+      },
+      async writeFiles() {},
+    } as unknown as SandboxSession;
+
+    const sync = syncSkillsToSandbox({
+      sandbox,
+      skills: [{ name: "demo", description: "Demo", skillPath }],
+      withSpan: immediateSpan,
+    });
+
+    await firstSiblingStarted;
+    expect(siblingDirectories.size).toBe(2);
+    releaseSiblings?.();
+    await sync;
+    expect(parentMissing).toBe(false);
+  });
+});

--- a/packages/junior/tests/unit/tool-support/pi-tool-adapter-telemetry.test.ts
+++ b/packages/junior/tests/unit/tool-support/pi-tool-adapter-telemetry.test.ts
@@ -1,4 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SkillSandbox } from "@/chat/sandbox/skill-sandbox";
+import type { SandboxTools } from "@/chat/sandbox/sandbox";
 import type { AnyToolDefinition } from "@/chat/tools/definition";
 
 const { endAttributes, startAttributes } = vi.hoisted(() => ({
@@ -73,5 +75,38 @@ describe("createPiAgentTools telemetry", () => {
     expect(endAttributes.value["gen_ai.tool.call.result.keys"]).toContain(
       "secret",
     );
+  });
+
+  it("lets sandbox tools add safe attributes to the tool call span", async () => {
+    const tools: Record<string, AnyToolDefinition> = {
+      grep: {
+        description: "Search files.",
+        inputSchema: { type: "object", properties: {} },
+        execute: async () => ({ ok: true }),
+      },
+    };
+    const sandboxTools: SandboxTools = {
+      supports: () => true,
+      execute: async (params) => {
+        params.setToolCallSpanAttributes?.({
+          "app.sandbox.search.result_count": 3,
+        });
+        return {
+          content: [{ type: "text", text: "matches" }],
+          details: { ok: true, status: "success" },
+        };
+      },
+    };
+    const [tool] = createPiAgentTools(
+      tools,
+      new SkillSandbox([], []),
+      {},
+      undefined,
+      sandboxTools,
+    );
+
+    await tool!.execute!("call-1", { pattern: "needle" });
+
+    expect(endAttributes.value["app.sandbox.search.result_count"]).toBe(3);
   });
 });

--- a/packages/junior/tests/unit/tools/sandbox/file-tools.test.ts
+++ b/packages/junior/tests/unit/tools/sandbox/file-tools.test.ts
@@ -380,6 +380,8 @@ describe("sandbox file tools", () => {
     });
     const args = calls[0]?.args ?? [];
     expect(args).toContain("--fixed-strings");
+    expect(args).toContain("--max-count");
+    expect(args).toContain("101");
     expect(args).toContain("nested/*.ts");
     expect(args).toContain("needle'; exit 9; '");
     expect(args.indexOf("nested/*.ts")).toBeLessThan(

--- a/packages/junior/tests/unit/tools/sandbox/search-telemetry.test.ts
+++ b/packages/junior/tests/unit/tools/sandbox/search-telemetry.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from "vitest";
+import { findFiles } from "@/chat/tools/sandbox/find-files";
+import {
+  type SandboxCommandRunner,
+  type SandboxFileSystem,
+} from "@/chat/tools/sandbox/file-utils";
+import { grepFiles } from "@/chat/tools/sandbox/grep";
+
+const directoryStat = { isDirectory: () => true };
+const fs = {
+  stat: async () => directoryStat,
+} as unknown as SandboxFileSystem;
+
+describe("sandbox search telemetry", () => {
+  it("reports bounded grep measurements", async () => {
+    const onTelemetry = vi.fn();
+    const runCommand: SandboxCommandRunner = async () => ({
+      exitCode: 0,
+      stderr: "",
+      stdout: JSON.stringify({
+        type: "match",
+        data: {
+          path: { text: "app.ts" },
+          lines: { text: "needle\n" },
+          line_number: 1,
+        },
+      }),
+    });
+
+    await grepFiles({
+      fs,
+      onTelemetry,
+      pattern: "needle",
+      runCommand,
+    });
+
+    expect(onTelemetry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        emittedLineCount: 1,
+        limit: 100,
+        limitReached: false,
+        parsedRecordCount: 1,
+        resultCount: 1,
+      }),
+    );
+  });
+
+  it("reports bounded findFiles measurements", async () => {
+    const onTelemetry = vi.fn();
+    const runCommand: SandboxCommandRunner = async () => ({
+      exitCode: 0,
+      stderr: "",
+      stdout: "src/app.ts\0",
+    });
+
+    await findFiles({
+      fs,
+      onTelemetry,
+      pattern: "*.ts",
+      runCommand,
+    });
+
+    expect(onTelemetry).toHaveBeenCalledWith({
+      emittedLineCount: 1,
+      limit: 1000,
+      limitReached: false,
+      parsedRecordCount: 1,
+      rawOutputBytes: 11,
+      resultCount: 1,
+      resultBytes: expect.any(Number),
+    });
+  });
+});


### PR DESCRIPTION
Sandbox-backed `grep` and `findFiles` now cap per-file ripgrep matches and record safe search volume and truncation measurements on their existing sandbox and tool-call spans. Cold sandbox preparation creates independent skill directories in bounded parallel batches while preserving mandatory parent-first skill sync.

This follows production traces showing current ripgrep execution is sub-second while cold skill sync dominates slow searches. Tool results and agent-visible data are unchanged; telemetry is best-effort and contains counts, limits, and byte sizes only.

The full required CI suite passes, including package builds, type checks, lint, skills and docs checks, and Junior unit, component, and integration tests.
