### PR TITLE
docs: use Junior mascot across homepage branding

### DIFF
--- a/packages/docs/public/favicon.svg
+++ b/packages/docs/public/favicon.svg
@@ -1,20 +1,11 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Junior favicon">
-  <rect x="0" y="0" width="64" height="64" fill="#111111" />
-  <path
-    d="M24 18V39C24 45 20 48 14 48"
-    fill="none"
-    stroke="#ffffff"
-    stroke-width="6"
-    stroke-linecap="round"
-    stroke-linejoin="round"
-  />
-  <path
-    d="M36 46V28M36 33C36 30 39 28 43 28"
-    fill="none"
-    stroke="#ffffff"
-    stroke-width="6"
-    stroke-linecap="round"
-    stroke-linejoin="round"
-  />
-  <circle cx="49" cy="46" r="3" fill="#39ff14" />
+  <rect width="64" height="64" rx="10" fill="#000" />
+  <path d="M31 14 34 6" fill="none" stroke="#fff7df" stroke-width="4" stroke-linecap="round" />
+  <circle cx="35" cy="5" r="4" fill="#ff3cac" stroke="#000" stroke-width="2" />
+  <path d="M12 27c2-13 12-19 25-18 10 1 17 7 18 18z" fill="#0033ff" stroke="#000" stroke-width="4" stroke-linejoin="round" />
+  <path d="M10 27h45l-4 27c-10 7-28 7-38 0z" fill="#ffd000" stroke="#000" stroke-width="4" stroke-linejoin="round" />
+  <path d="M34 25c10 0 17 6 18 9-5 0-13-2-21-5z" fill="#0033ff" stroke="#000" stroke-width="4" stroke-linejoin="round" />
+  <ellipse cx="31" cy="39" rx="15" ry="11" fill="#fff" stroke="#000" stroke-width="4" />
+  <circle cx="34" cy="39" r="7" fill="#000" />
+  <circle cx="37" cy="36" r="2.5" fill="#fff" />
 </svg>

--- a/packages/docs/public/junior-character.svg
+++ b/packages/docs/public/junior-character.svg
@@ -1,0 +1,37 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 260 280" role="img" aria-labelledby="title desc">
+  <title id="title">Junior</title>
+  <desc id="desc">A cheerful one-eyed robot kid in a blue cap and red hoodie carrying a shovel.</desc>
+
+  <path d="M126 51 133 27" fill="none" stroke="#000" stroke-width="9" stroke-linecap="round" />
+  <circle cx="136" cy="20" r="12" fill="#ff3cac" stroke="#000" stroke-width="7" />
+
+  <path d="M49 113c2-48 35-78 85-78 45 0 75 25 81 72z" fill="#1667d9" stroke="#000" stroke-width="9" stroke-linejoin="round" />
+  <path d="M69 85c13-26 49-36 80-27-19 1-33 8-45 22z" fill="#0033ff" />
+  <path d="M49 111c31-8 104-10 167 18 14 6 24 17 21 25-4 10-19 7-31 0-49-28-107-28-159-15z" fill="#0033ff" stroke="#000" stroke-width="9" stroke-linecap="round" stroke-linejoin="round" />
+
+  <path d="M50 122c-6 16-4 49 5 65 12 20 43 30 76 29 38-1 69-13 79-35 7-15 6-42 0-57-41-17-113-20-160-2z" fill="#ffd000" stroke="#000" stroke-width="9" stroke-linejoin="round" />
+  <path d="M49 130c-13-3-24 8-25 27-1 20 9 34 24 31z" fill="#aeb6bf" stroke="#000" stroke-width="8" />
+  <path d="M213 130c15-2 24 10 23 29-1 20-12 32-26 27z" fill="#aeb6bf" stroke="#000" stroke-width="8" />
+  <path d="M36 143v30m188-30-3 29" stroke="#6d7680" stroke-width="7" stroke-linecap="round" />
+
+  <path d="M63 140c17-22 86-26 120 0 14 10 11 31-1 41-22 18-87 20-116-1-15-11-16-25-3-40z" fill="#fff" stroke="#000" stroke-width="9" stroke-linejoin="round" />
+  <ellipse cx="129" cy="159" rx="25" ry="25" fill="#000" />
+  <circle cx="139" cy="150" r="8" fill="#fff" />
+  <path d="M104 190c16 10 38 9 54-3" fill="none" stroke="#000" stroke-width="7" stroke-linecap="round" />
+
+  <path d="M100 213h59l-4 25c-14 10-35 10-50 1z" fill="#aeb6bf" stroke="#000" stroke-width="8" stroke-linejoin="round" />
+  <path d="M104 222h52m-48 12h45" stroke="#6d7680" stroke-width="5" />
+  <path d="M72 270c4-36 22-54 50-56h22c31 1 49 20 53 56z" fill="#ef3f13" stroke="#000" stroke-width="9" stroke-linejoin="round" />
+  <path d="M92 222c9 17 23 26 38 28 16-2 30-12 39-29" fill="none" stroke="#000" stroke-width="8" stroke-linecap="round" />
+  <path d="M104 229 99 265m58-36 5 36" fill="none" stroke="#fff7df" stroke-width="7" stroke-linecap="round" />
+  <circle cx="99" cy="266" r="5" fill="#000" />
+  <circle cx="162" cy="266" r="5" fill="#000" />
+
+  <path d="M76 225c-19 1-34 13-41 35" fill="none" stroke="#ef3f13" stroke-width="22" stroke-linecap="round" />
+  <path d="M35 259c-5 7 4 17 13 11l15-11-10-13z" fill="#ffd000" stroke="#000" stroke-width="7" stroke-linejoin="round" />
+  <path d="m55 254 162-70" fill="none" stroke="#000" stroke-width="8" stroke-linecap="round" />
+  <path d="m211 187 18-24 21 11-7 29z" fill="#aeb6bf" stroke="#000" stroke-width="8" stroke-linejoin="round" />
+
+  <path d="M188 226c12 2 21 11 24 24" fill="none" stroke="#ef3f13" stroke-width="22" stroke-linecap="round" />
+  <path d="M207 251c4 10 18 9 20-2l1-15-17-2z" fill="#ffd000" stroke="#000" stroke-width="7" stroke-linejoin="round" />
+</svg>

--- a/packages/docs/public/junior-mark.svg
+++ b/packages/docs/public/junior-mark.svg
@@ -1,20 +1,12 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Junior mark">
-  <rect x="4" y="4" width="56" height="56" fill="#111111" />
-  <path
-    d="M24 18V39C24 45 20 48 14 48"
-    fill="none"
-    stroke="#ffffff"
-    stroke-width="6"
-    stroke-linecap="round"
-    stroke-linejoin="round"
-  />
-  <path
-    d="M36 46V28M36 33C36 30 39 28 43 28"
-    fill="none"
-    stroke="#ffffff"
-    stroke-width="6"
-    stroke-linecap="round"
-    stroke-linejoin="round"
-  />
-  <circle cx="49" cy="46" r="3" fill="#39ff14" />
+  <rect x="2" y="2" width="60" height="60" rx="13" fill="#fff7df" stroke="#000" stroke-width="4" />
+  <path d="M30 15 33 7" fill="none" stroke="#000" stroke-width="4" stroke-linecap="round" />
+  <circle cx="34" cy="6" r="4" fill="#ff3cac" stroke="#000" stroke-width="2" />
+  <path d="M11 27c2-12 12-18 24-18 11 1 18 7 19 18z" fill="#0033ff" stroke="#000" stroke-width="4" stroke-linejoin="round" />
+  <path d="M10 28h44l-3 25c-10 7-27 7-38 0z" fill="#ffd000" stroke="#000" stroke-width="4" stroke-linejoin="round" />
+  <path d="M33 25c10 0 17 6 19 9-6 0-13-2-21-5z" fill="#0033ff" stroke="#000" stroke-width="4" stroke-linejoin="round" />
+  <ellipse cx="30" cy="39" rx="15" ry="11" fill="#fff" stroke="#000" stroke-width="4" />
+  <circle cx="33" cy="39" r="7" fill="#000" />
+  <circle cx="36" cy="36" r="2.5" fill="#fff" />
+  <path d="M27 52c4 2 8 2 12-1" fill="none" stroke="#000" stroke-width="3" stroke-linecap="round" />
 </svg>

--- a/packages/docs/src/content/docs/index.mdx
+++ b/packages/docs/src/content/docs/index.mdx
@@ -39,23 +39,9 @@ hero:
       </svg>
     </div>
 
-    <div class="jr-gremlin" aria-label="Junior, a mischievous robot gremlin">
-      <span class="jr-gremlin-note">goes digging</span>
-      <svg viewBox="0 0 230 250" role="img" xmlns="http://www.w3.org/2000/svg">
-        <path d="m54 54-30-36 49 10m103 26 31-36-50 10" fill="#0033ff" stroke="#000" stroke-width="8" stroke-linecap="round" stroke-linejoin="round" />
-        <path d="M44 61c18-31 124-36 145 8l-4 118c-19 35-111 48-145 5z" fill="#695cff" stroke="#000" stroke-width="9" stroke-linejoin="round" />
-        <path d="m47 87-31 39 34 5m133-45 31 32-32 10" fill="#ff3cac" stroke="#000" stroke-width="8" stroke-linecap="round" stroke-linejoin="round" />
-        <rect x="61" y="77" width="105" height="66" rx="15" fill="#ccff00" stroke="#000" stroke-width="8" />
-        <circle cx="91" cy="106" r="12" fill="#000" />
-        <circle cx="139" cy="106" r="12" fill="#000" />
-        <circle cx="95" cy="102" r="4" fill="#fff" />
-        <circle cx="143" cy="102" r="4" fill="#fff" />
-        <path d="M91 130c15 10 31 10 48-2" fill="none" stroke="#000" stroke-width="7" stroke-linecap="round" />
-        <path d="m76 203-7 30m87-31 10 29" fill="none" stroke="#000" stroke-width="10" stroke-linecap="round" />
-        <path d="m54 235 30-2m67 0 31 2" fill="none" stroke="#000" stroke-width="12" stroke-linecap="round" />
-        <path d="M105 44v-19" stroke="#000" stroke-width="8" stroke-linecap="round" />
-        <circle cx="105" cy="18" r="10" fill="#ff3cac" stroke="#000" stroke-width="6" />
-      </svg>
+    <div class="jr-mascot">
+      <span class="jr-mascot-note">goes digging</span>
+      <img src="/junior-character.svg" alt="Junior, a one-eyed robot kid carrying a shovel" />
     </div>
 
     <div class="jr-flow-arrow jr-flow-arrow-green" aria-hidden="true">
@@ -129,7 +115,7 @@ hero:
           </div>
 
           <div class="slk-msg slk-msg-junior">
-            <div class="slk-avatar slk-avatar-bot" aria-hidden="true">J</div>
+            <div class="slk-avatar slk-avatar-bot" aria-hidden="true"><img src="/junior-mark.svg" alt="" /></div>
             <div class="slk-msg-body">
               <div class="slk-msg-meta"><span class="slk-name">Junior</span><span class="slk-app-badge">App</span><span class="slk-time">12:04 PM</span></div>
               <p class="slk-text">yep, auth did it. <code class="slk-code">9f4e2c</code> broke webhook verification. rolled it back, the graph is chilling out, and the update is drafted.</p>

--- a/packages/docs/src/styles/custom.css
+++ b/packages/docs/src/styles/custom.css
@@ -331,20 +331,21 @@ body:has(.jr-home) main {
   transform: rotate(6deg);
 }
 
-.jr-gremlin {
+.jr-mascot {
   filter: drop-shadow(10px 10px 0 var(--jr-black));
   margin: 0 auto;
-  max-width: 17rem;
+  max-width: 18rem;
   position: relative;
   transform: rotate(3deg);
 }
 
-.jr-gremlin svg {
+.jr-mascot img {
   display: block;
+  margin: 0;
   width: 100%;
 }
 
-.jr-gremlin-note {
+.jr-mascot-note {
   background: var(--jr-pink);
   border: 4px solid var(--jr-black);
   font-family: "Arial Black", Impact, sans-serif;
@@ -598,8 +599,16 @@ body:has(.jr-home) main {
 }
 
 .slk-avatar-bot {
-  background: var(--jr-acid);
-  color: #000;
+  background: var(--jr-cream);
+  overflow: hidden;
+  padding: 0;
+}
+
+.slk-avatar-bot img {
+  display: block;
+  height: 100%;
+  margin: 0;
+  width: 100%;
 }
 
 .slk-msg-body {
@@ -811,7 +820,7 @@ body:has(.jr-home) footer {
     grid-template-columns: 1fr 0.6fr 1.2fr 0.6fr 1fr;
   }
 
-  .jr-gremlin-note {
+  .jr-mascot-note {
     right: -0.5rem;
   }
 }
@@ -855,7 +864,7 @@ body:has(.jr-home) footer {
     display: none;
   }
 
-  .jr-gremlin {
+  .jr-mascot {
     grid-column: 1 / -1;
     grid-row: 1;
   }
@@ -905,11 +914,11 @@ body:has(.jr-home) footer {
 
   .jr-sticker-slack,
   .jr-tool-pile,
-  .jr-gremlin {
+  .jr-mascot {
     grid-column: 1;
   }
 
-  .jr-gremlin {
+  .jr-mascot {
     grid-row: 1;
   }
 


### PR DESCRIPTION
Carries Junior’s existing one-eyed robot identity into the redesigned docs homepage instead of introducing a separate two-eyed character. The “goes digging” scene now uses a full-character SVG with the blue cap, antenna, yellow face, red hoodie, and a shovel; the header, favicon, and Slack mock use simplified versions tuned for their smaller sizes.

This keeps one recognizable Junior character across the page while preserving the neo-brutalist palette and responsive layout. Review should focus on recognition at favicon and header sizes, plus the mascot’s fit in the desktop and mobile scenes.
