### PR TITLE
fix(slack): normalize Canvas markdown

### DIFF
--- a/packages/junior/src/chat/slack/tools/canvas/api.ts
+++ b/packages/junior/src/chat/slack/tools/canvas/api.ts
@@ -9,6 +9,10 @@ import {
   withSlackRetries,
 } from "@/chat/slack/client";
 import { extractCanvasId } from "@/chat/slack/canvas-references";
+import {
+  normalizeCanvasMarkdown,
+  type CanvasMarkdownNormalization,
+} from "@/chat/slack/tools/canvas/markdown";
 
 export { extractCanvasId } from "@/chat/slack/canvas-references";
 
@@ -26,28 +30,6 @@ export interface CanvasReadResult {
   filetype?: string;
   content: string;
   byteLength: number;
-}
-
-/** Clamp headings deeper than h3 to h3 (Slack canvas limitation). */
-export function normalizeCanvasMarkdown(markdown: string): {
-  markdown: string;
-  normalizedHeadingCount: number;
-} {
-  let normalizedHeadingCount = 0;
-  const normalized = markdown
-    .split("\n")
-    .map((line) =>
-      line.replace(/^(#{4,})(?=\s)/, () => {
-        normalizedHeadingCount += 1;
-        return "###";
-      }),
-    )
-    .join("\n");
-
-  return {
-    markdown: normalized,
-    normalizedHeadingCount,
-  };
 }
 
 /**
@@ -83,9 +65,13 @@ export async function createCanvas(
         "app.slack.canvas.title_length": input.title.length,
         "app.slack.canvas.markdown_length": normalizedContent.markdown.length,
         "app.slack.canvas.markdown_normalized":
-          normalizedContent.normalizedHeadingCount > 0,
+          normalizedContent.normalizedCount > 0,
         "app.slack.canvas.normalized_heading_count":
           normalizedContent.normalizedHeadingCount,
+        "app.slack.canvas.flattened_mixed_list_count":
+          normalizedContent.flattenedMixedListCount,
+        "app.slack.canvas.flattened_blockquote_count":
+          normalizedContent.flattenedBlockquoteCount,
       },
     },
   );
@@ -159,7 +145,7 @@ async function grantChannelCanvasAccess(
 export async function writeCanvasMarkdown(input: {
   canvasId: string;
   markdown: string;
-}): Promise<{ markdown: string; normalizedHeadingCount: number }> {
+}): Promise<CanvasMarkdownNormalization> {
   const client = getSlackClient();
   const normalizedContent = normalizeCanvasMarkdown(input.markdown);
 
@@ -185,9 +171,13 @@ export async function writeCanvasMarkdown(input: {
         "app.slack.canvas.operation": "replace",
         "app.slack.canvas.markdown_length": normalizedContent.markdown.length,
         "app.slack.canvas.markdown_normalized":
-          normalizedContent.normalizedHeadingCount > 0,
+          normalizedContent.normalizedCount > 0,
         "app.slack.canvas.normalized_heading_count":
           normalizedContent.normalizedHeadingCount,
+        "app.slack.canvas.flattened_mixed_list_count":
+          normalizedContent.flattenedMixedListCount,
+        "app.slack.canvas.flattened_blockquote_count":
+          normalizedContent.flattenedBlockquoteCount,
       },
     },
   );

--- a/packages/junior/src/chat/slack/tools/canvas/api.ts
+++ b/packages/junior/src/chat/slack/tools/canvas/api.ts
@@ -68,10 +68,10 @@ export async function createCanvas(
           normalizedContent.normalizedCount > 0,
         "app.slack.canvas.normalized_heading_count":
           normalizedContent.normalizedHeadingCount,
-        "app.slack.canvas.flattened_mixed_list_count":
-          normalizedContent.flattenedMixedListCount,
-        "app.slack.canvas.flattened_blockquote_count":
-          normalizedContent.flattenedBlockquoteCount,
+        "app.slack.canvas.normalized_mixed_list_count":
+          normalizedContent.normalizedMixedListCount,
+        "app.slack.canvas.unwrapped_blockquote_count":
+          normalizedContent.unwrappedBlockquoteCount,
       },
     },
   );
@@ -174,10 +174,10 @@ export async function writeCanvasMarkdown(input: {
           normalizedContent.normalizedCount > 0,
         "app.slack.canvas.normalized_heading_count":
           normalizedContent.normalizedHeadingCount,
-        "app.slack.canvas.flattened_mixed_list_count":
-          normalizedContent.flattenedMixedListCount,
-        "app.slack.canvas.flattened_blockquote_count":
-          normalizedContent.flattenedBlockquoteCount,
+        "app.slack.canvas.normalized_mixed_list_count":
+          normalizedContent.normalizedMixedListCount,
+        "app.slack.canvas.unwrapped_blockquote_count":
+          normalizedContent.unwrappedBlockquoteCount,
       },
     },
   );

--- a/packages/junior/src/chat/slack/tools/canvas/edit.ts
+++ b/packages/junior/src/chat/slack/tools/canvas/edit.ts
@@ -1,10 +1,10 @@
 import { logWarn } from "@/chat/logging";
 import {
-  normalizeCanvasMarkdown,
   readCanvas,
   writeCanvasMarkdown,
 } from "@/chat/slack/tools/canvas/api";
 import { resolveCanvasTarget } from "@/chat/slack/tools/canvas/context";
+import { normalizeCanvasMarkdown } from "@/chat/slack/tools/canvas/markdown";
 import { z } from "zod";
 import { juniorToolResultSchema } from "@/chat/tool-support/structured-result";
 import { zodTool } from "@/chat/tool-support/zod-tool";

--- a/packages/junior/src/chat/slack/tools/canvas/markdown.ts
+++ b/packages/junior/src/chat/slack/tools/canvas/markdown.ts
@@ -1,0 +1,133 @@
+type ListType = "bullet" | "numbered";
+
+interface ListItem {
+  indent: number;
+  type: ListType;
+}
+
+interface Fence {
+  marker: "`" | "~";
+  length: number;
+}
+
+export interface CanvasMarkdownNormalization {
+  markdown: string;
+  normalizedCount: number;
+  normalizedHeadingCount: number;
+  flattenedMixedListCount: number;
+  flattenedBlockquoteCount: number;
+}
+
+function getListType(marker: string): ListType {
+  return /^\d/.test(marker) ? "numbered" : "bullet";
+}
+
+function getFence(line: string): { fence: Fence; suffix: string } | undefined {
+  const match = line.match(/^ {0,3}(`{3,}|~{3,})(.*)$/);
+  const run = match?.[1];
+  if (!run) return undefined;
+  return {
+    fence: {
+      marker: run[0] as Fence["marker"],
+      length: run.length,
+    },
+    suffix: match[2] ?? "",
+  };
+}
+
+/** Normalize Markdown constructs known to be rejected by Slack Canvas. */
+export function normalizeCanvasMarkdown(
+  markdown: string,
+): CanvasMarkdownNormalization {
+  let normalizedHeadingCount = 0;
+  let flattenedMixedListCount = 0;
+  let flattenedBlockquoteCount = 0;
+  let openFence: Fence | undefined;
+  const listItems: ListItem[] = [];
+
+  const lines = markdown.split("\n").map((originalLine) => {
+    const fenceLine = getFence(originalLine);
+    if (openFence) {
+      if (
+        fenceLine?.fence.marker === openFence.marker &&
+        fenceLine.fence.length >= openFence.length &&
+        !fenceLine.suffix.trim()
+      ) {
+        openFence = undefined;
+      }
+      return originalLine;
+    }
+    if (fenceLine) {
+      openFence = fenceLine.fence;
+      return originalLine;
+    }
+
+    const listMatch = originalLine.match(
+      /^([ \t]*)([-+*]|\d+[.)])([ \t]+)(.*)$/,
+    );
+    if (listMatch) {
+      const [, whitespace = "", marker = "", gap = "", content = ""] =
+        listMatch;
+      const indent = whitespace.length;
+      const type = getListType(marker);
+
+      while (
+        listItems.length > 0 &&
+        listItems[listItems.length - 1]!.indent >= indent
+      ) {
+        listItems.pop();
+      }
+
+      const parent = listItems[listItems.length - 1];
+      // Slack rejects a list nested under a different list type.
+      if (parent && parent.type !== type) {
+        const rootIndent = listItems[0]?.indent ?? 0;
+        listItems.length = 0;
+        listItems.push({ indent: rootIndent, type });
+        flattenedMixedListCount += 1;
+        return `${" ".repeat(rootIndent)}${marker}${gap}${content}`;
+      }
+
+      listItems.push({ indent, type });
+      return originalLine;
+    }
+
+    const blockquoteMatch = originalLine.match(/^([ \t]+)(>+.*)$/);
+    const rootListIndent = listItems[0]?.indent;
+    // Slack rejects blockquotes nested inside list items.
+    if (
+      blockquoteMatch &&
+      rootListIndent !== undefined &&
+      blockquoteMatch[1]!.length > rootListIndent
+    ) {
+      flattenedBlockquoteCount += 1;
+      return `${" ".repeat(rootListIndent)}${blockquoteMatch[2]}`;
+    }
+
+    if (
+      rootListIndent !== undefined &&
+      originalLine.trim() &&
+      originalLine.search(/\S/) <= rootListIndent
+    ) {
+      listItems.length = 0;
+    }
+
+    return originalLine.replace(/^( {0,3})#{4,}(?=[ \t])/, (_, indent) => {
+      normalizedHeadingCount += 1;
+      return `${indent}###`;
+    });
+  });
+
+  const normalizedCount =
+    normalizedHeadingCount +
+    flattenedMixedListCount +
+    flattenedBlockquoteCount;
+
+  return {
+    markdown: lines.join("\n"),
+    normalizedCount,
+    normalizedHeadingCount,
+    flattenedMixedListCount,
+    flattenedBlockquoteCount,
+  };
+}

--- a/packages/junior/src/chat/slack/tools/canvas/markdown.ts
+++ b/packages/junior/src/chat/slack/tools/canvas/markdown.ts
@@ -13,7 +13,7 @@ interface Fence {
 }
 
 interface OpenFence extends Fence {
-  unwrapNestedQuote: boolean;
+  quoteDepth: number;
 }
 
 interface FenceLine {
@@ -71,23 +71,33 @@ function isListBlockIndent(indent: number, listItems: ListItem[]): boolean {
 }
 
 function canOpenFence(fenceLine: FenceLine, listItems: ListItem[]) {
-  return fenceLine.indent <= 3 || isListBlockIndent(fenceLine.indent, listItems);
+  return (
+    fenceLine.indent <= 3 || isListBlockIndent(fenceLine.indent, listItems)
+  );
 }
 
 function unwrapNestedBlockquote(
   line: string,
   listItems: ListItem[],
-): { line: string; unwrapped: boolean } {
-  const match = line.match(/^([ \t]+)(?:>[ \t]*)+(.*)$/);
-  if (
-    !match ||
-    !isListBlockIndent(getIndentWidth(match[1] ?? ""), listItems)
-  ) {
-    return { line, unwrapped: false };
+  maxQuoteDepth = Number.POSITIVE_INFINITY,
+): { line: string; quoteDepth: number } {
+  const match = line.match(/^([ \t]+)((?:>[ \t]*)+)(.*)$/);
+  if (!match || !isListBlockIndent(getIndentWidth(match[1] ?? ""), listItems)) {
+    return { line, quoteDepth: 0 };
   }
+
+  let quotePrefix = match[2] ?? "";
+  const quoteDepth = Math.min(
+    quotePrefix.match(/>/g)?.length ?? 0,
+    maxQuoteDepth,
+  );
+  for (let index = 0; index < quoteDepth; index += 1) {
+    quotePrefix = quotePrefix.replace(/^>[ \t]*/, "");
+  }
+
   return {
-    line: `${match[1]}${match[2]}`,
-    unwrapped: true,
+    line: `${match[1]}${quotePrefix}${match[3]}`,
+    quoteDepth,
   };
 }
 
@@ -103,10 +113,15 @@ export function normalizeCanvasMarkdown(
 
   const lines = markdown.split("\n").map((originalLine) => {
     if (openFence) {
-      const unwrapped = openFence.unwrapNestedQuote
-        ? unwrapNestedBlockquote(originalLine, listItems)
-        : { line: originalLine, unwrapped: false };
-      if (unwrapped.unwrapped) {
+      const unwrapped =
+        openFence.quoteDepth > 0
+          ? unwrapNestedBlockquote(
+              originalLine,
+              listItems,
+              openFence.quoteDepth,
+            )
+          : { line: originalLine, quoteDepth: 0 };
+      if (unwrapped.quoteDepth > 0) {
         unwrappedBlockquoteCount += 1;
       }
       const fenceLine = getFence(unwrapped.line);
@@ -123,7 +138,7 @@ export function normalizeCanvasMarkdown(
     const unwrapped = unwrapNestedBlockquote(originalLine, listItems);
     // Slack rejects blockquotes nested inside list items. Unwrap every quote
     // marker before processing syntax that the quote may have hidden.
-    if (unwrapped.unwrapped) {
+    if (unwrapped.quoteDepth > 0) {
       unwrappedBlockquoteCount += 1;
     }
     const line = unwrapped.line;
@@ -139,14 +154,12 @@ export function normalizeCanvasMarkdown(
       }
       openFence = {
         ...fenceLine.fence,
-        unwrapNestedQuote: unwrapped.unwrapped,
+        quoteDepth: unwrapped.quoteDepth,
       };
       return line;
     }
 
-    const listMatch = line.match(
-      /^([ \t]*)([-+*]|\d+[.)])([ \t]+)(.*)$/,
-    );
+    const listMatch = line.match(/^([ \t]*)([-+*]|\d+[.)])([ \t]+)(.*)$/);
     if (listMatch) {
       const [, whitespace = "", marker = "", gap = "", rawContent = ""] =
         listMatch;
@@ -181,9 +194,7 @@ export function normalizeCanvasMarkdown(
       }
 
       listItems.push({ contentIndent, indent, type, unwrapped: false });
-      return contentMatch
-        ? `${whitespace}${marker}${gap}${content}`
-        : line;
+      return contentMatch ? `${whitespace}${marker}${gap}${content}` : line;
     }
 
     const rootListContentIndent = listItems[0]?.contentIndent;
@@ -202,8 +213,7 @@ export function normalizeCanvasMarkdown(
     if (
       headingMatch &&
       headingIndent !== undefined &&
-      (headingIndent <= 3 ||
-        isListBlockIndent(headingIndent, listItems))
+      (headingIndent <= 3 || isListBlockIndent(headingIndent, listItems))
     ) {
       normalizedHeadingCount += 1;
       return line.replace(

--- a/packages/junior/src/chat/slack/tools/canvas/markdown.ts
+++ b/packages/junior/src/chat/slack/tools/canvas/markdown.ts
@@ -1,13 +1,25 @@
 type ListType = "bullet" | "numbered";
 
 interface ListItem {
+  contentIndent: number;
   indent: number;
   type: ListType;
+  unwrapped: boolean;
 }
 
 interface Fence {
   marker: "`" | "~";
   length: number;
+}
+
+interface OpenFence extends Fence {
+  unwrapNestedQuote: boolean;
+}
+
+interface FenceLine {
+  fence: Fence;
+  indent: number;
+  suffix: string;
 }
 
 export interface CanvasMarkdownNormalization {
@@ -22,16 +34,65 @@ function getListType(marker: string): ListType {
   return /^\d/.test(marker) ? "numbered" : "bullet";
 }
 
-function getFence(line: string): { fence: Fence; suffix: string } | undefined {
-  const match = line.match(/^ {0,3}(`{3,}|~{3,})(.*)$/);
-  const run = match?.[1];
+function getPlainListMarker(marker: string, type: ListType): string {
+  return type === "numbered" ? `${marker.match(/^\d+/)?.[0] ?? "1"}:` : "•";
+}
+
+function getIndentWidth(whitespace: string): number {
+  let width = 0;
+  for (const character of whitespace) {
+    width += character === "\t" ? 4 - (width % 4) : 1;
+  }
+  return width;
+}
+
+function getLineIndent(line: string): number {
+  return getIndentWidth(line.match(/^[ \t]*/)?.[0] ?? "");
+}
+
+function getFence(line: string): FenceLine | undefined {
+  const match = line.match(/^([ \t]*)(`{3,}|~{3,})(.*)$/);
+  const run = match?.[2];
   if (!run) return undefined;
   return {
     fence: {
       marker: run[0] as Fence["marker"],
       length: run.length,
     },
-    suffix: match[2] ?? "",
+    indent: getIndentWidth(match[1] ?? ""),
+    suffix: match[3] ?? "",
+  };
+}
+
+function isInsideListItem(indent: number, listItems: ListItem[]): boolean {
+  return listItems.some((item) => indent >= item.contentIndent);
+}
+
+function canOpenFence(fenceLine: FenceLine, listItems: ListItem[]) {
+  return (
+    fenceLine.indent <= 3 ||
+    listItems.some(
+      (item) =>
+        fenceLine.indent >= item.contentIndent &&
+        fenceLine.indent <= item.contentIndent + 3,
+    )
+  );
+}
+
+function unwrapNestedBlockquote(
+  line: string,
+  listItems: ListItem[],
+): { line: string; unwrapped: boolean } {
+  const match = line.match(/^([ \t]+)(?:>[ \t]*)+(.*)$/);
+  if (
+    !match ||
+    !isInsideListItem(getIndentWidth(match[1] ?? ""), listItems)
+  ) {
+    return { line, unwrapped: false };
+  }
+  return {
+    line: `${match[1]}${match[2]}`,
+    unwrapped: true,
   };
 }
 
@@ -42,12 +103,18 @@ export function normalizeCanvasMarkdown(
   let normalizedHeadingCount = 0;
   let normalizedMixedListCount = 0;
   let unwrappedBlockquoteCount = 0;
-  let openFence: Fence | undefined;
+  let openFence: OpenFence | undefined;
   const listItems: ListItem[] = [];
 
   const lines = markdown.split("\n").map((originalLine) => {
-    const fenceLine = getFence(originalLine);
     if (openFence) {
+      const unwrapped = openFence.unwrapNestedQuote
+        ? unwrapNestedBlockquote(originalLine, listItems)
+        : { line: originalLine, unwrapped: false };
+      if (unwrapped.unwrapped) {
+        unwrappedBlockquoteCount += 1;
+      }
+      const fenceLine = getFence(unwrapped.line);
       if (
         fenceLine?.fence.marker === openFence.marker &&
         fenceLine.fence.length >= openFence.length &&
@@ -55,25 +122,31 @@ export function normalizeCanvasMarkdown(
       ) {
         openFence = undefined;
       }
-      return originalLine;
-    }
-    if (fenceLine) {
-      openFence = fenceLine.fence;
-      return originalLine;
+      return unwrapped.line;
     }
 
-    let line = originalLine;
-    const rootListIndent = listItems[0]?.indent;
-    const blockquoteMatch = line.match(/^([ \t]+)(?:>[ \t]*)+(.*)$/);
+    const unwrapped = unwrapNestedBlockquote(originalLine, listItems);
     // Slack rejects blockquotes nested inside list items. Unwrap every quote
     // marker before processing syntax that the quote may have hidden.
-    if (
-      blockquoteMatch &&
-      rootListIndent !== undefined &&
-      blockquoteMatch[1]!.length > rootListIndent
-    ) {
+    if (unwrapped.unwrapped) {
       unwrappedBlockquoteCount += 1;
-      line = `${blockquoteMatch[1]}${blockquoteMatch[2]}`;
+    }
+    const line = unwrapped.line;
+
+    const fenceLine = getFence(line);
+    if (fenceLine && canOpenFence(fenceLine, listItems)) {
+      const rootListContentIndent = listItems[0]?.contentIndent;
+      if (
+        rootListContentIndent !== undefined &&
+        fenceLine.indent < rootListContentIndent
+      ) {
+        listItems.length = 0;
+      }
+      openFence = {
+        ...fenceLine.fence,
+        unwrapNestedQuote: unwrapped.unwrapped,
+      };
+      return line;
     }
 
     const listMatch = line.match(
@@ -82,8 +155,10 @@ export function normalizeCanvasMarkdown(
     if (listMatch) {
       const [, whitespace = "", marker = "", gap = "", content = ""] =
         listMatch;
-      const indent = whitespace.length;
+      const indent = getIndentWidth(whitespace);
       const type = getListType(marker);
+      const contentIndent =
+        indent + getIndentWidth(marker) + getIndentWidth(gap);
 
       while (
         listItems.length > 0 &&
@@ -94,29 +169,48 @@ export function normalizeCanvasMarkdown(
 
       const parent = listItems[listItems.length - 1];
       // Slack rejects a list nested under a different list type.
-      if (parent && parent.type !== type) {
-        const normalizedMarker = parent.type === "numbered" ? "1." : "-";
-        listItems.push({ indent, type: parent.type });
+      if (parent && (parent.unwrapped || parent.type !== type)) {
+        listItems.push({
+          contentIndent,
+          indent,
+          type: parent.type,
+          unwrapped: true,
+        });
         normalizedMixedListCount += 1;
-        return `${whitespace}${normalizedMarker}${gap}${content}`;
+        return `${whitespace}${getPlainListMarker(marker, type)}${gap}${content}`;
       }
 
-      listItems.push({ indent, type });
+      listItems.push({ contentIndent, indent, type, unwrapped: false });
       return line;
     }
 
+    const rootListContentIndent = listItems[0]?.contentIndent;
     if (
-      rootListIndent !== undefined &&
+      rootListContentIndent !== undefined &&
       line.trim() &&
-      line.search(/\S/) <= rootListIndent
+      getLineIndent(line) < rootListContentIndent
     ) {
       listItems.length = 0;
     }
 
-    return line.replace(/^( {0,3})#{4,}(?=[ \t])/, (_, indent) => {
+    const headingMatch = line.match(/^([ \t]*)#{4,}(?=[ \t])/);
+    const headingIndent = headingMatch
+      ? getIndentWidth(headingMatch[1] ?? "")
+      : undefined;
+    if (
+      headingMatch &&
+      headingIndent !== undefined &&
+      (headingIndent <= 3 ||
+        isInsideListItem(headingIndent, listItems))
+    ) {
       normalizedHeadingCount += 1;
-      return `${indent}###`;
-    });
+      return line.replace(
+        /^([ \t]*)#{4,}(?=[ \t])/,
+        (_, indent) => `${indent}###`,
+      );
+    }
+
+    return line;
   });
 
   const normalizedCount =

--- a/packages/junior/src/chat/slack/tools/canvas/markdown.ts
+++ b/packages/junior/src/chat/slack/tools/canvas/markdown.ts
@@ -38,12 +38,12 @@ function getPlainListMarker(marker: string, type: ListType): string {
   return type === "numbered" ? `${marker.match(/^\d+/)?.[0] ?? "1"}:` : "•";
 }
 
-function getIndentWidth(whitespace: string): number {
-  let width = 0;
+function getIndentWidth(whitespace: string, startColumn = 0): number {
+  let column = startColumn;
   for (const character of whitespace) {
-    width += character === "\t" ? 4 - (width % 4) : 1;
+    column += character === "\t" ? 4 - (column % 4) : 1;
   }
-  return width;
+  return column - startColumn;
 }
 
 function getLineIndent(line: string): number {
@@ -165,8 +165,8 @@ export function normalizeCanvasMarkdown(
         listMatch;
       const indent = getIndentWidth(whitespace);
       const type = getListType(marker);
-      const contentIndent =
-        indent + getIndentWidth(marker) + getIndentWidth(gap);
+      const markerEnd = indent + getIndentWidth(marker);
+      const contentIndent = markerEnd + getIndentWidth(gap, markerEnd);
       const contentMatch = rawContent.match(/^(?:>[ \t]*)+(.*)$/);
       const content = contentMatch?.[1] ?? rawContent;
       if (contentMatch) {

--- a/packages/junior/src/chat/slack/tools/canvas/markdown.ts
+++ b/packages/junior/src/chat/slack/tools/canvas/markdown.ts
@@ -14,8 +14,8 @@ export interface CanvasMarkdownNormalization {
   markdown: string;
   normalizedCount: number;
   normalizedHeadingCount: number;
-  flattenedMixedListCount: number;
-  flattenedBlockquoteCount: number;
+  normalizedMixedListCount: number;
+  unwrappedBlockquoteCount: number;
 }
 
 function getListType(marker: string): ListType {
@@ -40,8 +40,8 @@ export function normalizeCanvasMarkdown(
   markdown: string,
 ): CanvasMarkdownNormalization {
   let normalizedHeadingCount = 0;
-  let flattenedMixedListCount = 0;
-  let flattenedBlockquoteCount = 0;
+  let normalizedMixedListCount = 0;
+  let unwrappedBlockquoteCount = 0;
   let openFence: Fence | undefined;
   const listItems: ListItem[] = [];
 
@@ -81,18 +81,17 @@ export function normalizeCanvasMarkdown(
       const parent = listItems[listItems.length - 1];
       // Slack rejects a list nested under a different list type.
       if (parent && parent.type !== type) {
-        const rootIndent = listItems[0]?.indent ?? 0;
-        listItems.length = 0;
-        listItems.push({ indent: rootIndent, type });
-        flattenedMixedListCount += 1;
-        return `${" ".repeat(rootIndent)}${marker}${gap}${content}`;
+        const normalizedMarker = parent.type === "numbered" ? "1." : "-";
+        listItems.push({ indent, type: parent.type });
+        normalizedMixedListCount += 1;
+        return `${whitespace}${normalizedMarker}${gap}${content}`;
       }
 
       listItems.push({ indent, type });
       return originalLine;
     }
 
-    const blockquoteMatch = originalLine.match(/^([ \t]+)(>+.*)$/);
+    const blockquoteMatch = originalLine.match(/^([ \t]+)>+[ \t]?(.*)$/);
     const rootListIndent = listItems[0]?.indent;
     // Slack rejects blockquotes nested inside list items.
     if (
@@ -100,8 +99,8 @@ export function normalizeCanvasMarkdown(
       rootListIndent !== undefined &&
       blockquoteMatch[1]!.length > rootListIndent
     ) {
-      flattenedBlockquoteCount += 1;
-      return `${" ".repeat(rootListIndent)}${blockquoteMatch[2]}`;
+      unwrappedBlockquoteCount += 1;
+      return `${blockquoteMatch[1]}${blockquoteMatch[2]}`;
     }
 
     if (
@@ -120,14 +119,14 @@ export function normalizeCanvasMarkdown(
 
   const normalizedCount =
     normalizedHeadingCount +
-    flattenedMixedListCount +
-    flattenedBlockquoteCount;
+    normalizedMixedListCount +
+    unwrappedBlockquoteCount;
 
   return {
     markdown: lines.join("\n"),
     normalizedCount,
     normalizedHeadingCount,
-    flattenedMixedListCount,
-    flattenedBlockquoteCount,
+    normalizedMixedListCount,
+    unwrappedBlockquoteCount,
   };
 }

--- a/packages/junior/src/chat/slack/tools/canvas/markdown.ts
+++ b/packages/junior/src/chat/slack/tools/canvas/markdown.ts
@@ -62,7 +62,21 @@ export function normalizeCanvasMarkdown(
       return originalLine;
     }
 
-    const listMatch = originalLine.match(
+    let line = originalLine;
+    const rootListIndent = listItems[0]?.indent;
+    const blockquoteMatch = line.match(/^([ \t]+)(?:>[ \t]*)+(.*)$/);
+    // Slack rejects blockquotes nested inside list items. Unwrap every quote
+    // marker before processing syntax that the quote may have hidden.
+    if (
+      blockquoteMatch &&
+      rootListIndent !== undefined &&
+      blockquoteMatch[1]!.length > rootListIndent
+    ) {
+      unwrappedBlockquoteCount += 1;
+      line = `${blockquoteMatch[1]}${blockquoteMatch[2]}`;
+    }
+
+    const listMatch = line.match(
       /^([ \t]*)([-+*]|\d+[.)])([ \t]+)(.*)$/,
     );
     if (listMatch) {
@@ -88,30 +102,18 @@ export function normalizeCanvasMarkdown(
       }
 
       listItems.push({ indent, type });
-      return originalLine;
-    }
-
-    const blockquoteMatch = originalLine.match(/^([ \t]+)>+[ \t]?(.*)$/);
-    const rootListIndent = listItems[0]?.indent;
-    // Slack rejects blockquotes nested inside list items.
-    if (
-      blockquoteMatch &&
-      rootListIndent !== undefined &&
-      blockquoteMatch[1]!.length > rootListIndent
-    ) {
-      unwrappedBlockquoteCount += 1;
-      return `${blockquoteMatch[1]}${blockquoteMatch[2]}`;
+      return line;
     }
 
     if (
       rootListIndent !== undefined &&
-      originalLine.trim() &&
-      originalLine.search(/\S/) <= rootListIndent
+      line.trim() &&
+      line.search(/\S/) <= rootListIndent
     ) {
       listItems.length = 0;
     }
 
-    return originalLine.replace(/^( {0,3})#{4,}(?=[ \t])/, (_, indent) => {
+    return line.replace(/^( {0,3})#{4,}(?=[ \t])/, (_, indent) => {
       normalizedHeadingCount += 1;
       return `${indent}###`;
     });

--- a/packages/junior/src/chat/slack/tools/canvas/markdown.ts
+++ b/packages/junior/src/chat/slack/tools/canvas/markdown.ts
@@ -64,19 +64,14 @@ function getFence(line: string): FenceLine | undefined {
   };
 }
 
-function isInsideListItem(indent: number, listItems: ListItem[]): boolean {
-  return listItems.some((item) => indent >= item.contentIndent);
+function isListBlockIndent(indent: number, listItems: ListItem[]): boolean {
+  return listItems.some(
+    (item) => indent >= item.contentIndent && indent <= item.contentIndent + 3,
+  );
 }
 
 function canOpenFence(fenceLine: FenceLine, listItems: ListItem[]) {
-  return (
-    fenceLine.indent <= 3 ||
-    listItems.some(
-      (item) =>
-        fenceLine.indent >= item.contentIndent &&
-        fenceLine.indent <= item.contentIndent + 3,
-    )
-  );
+  return fenceLine.indent <= 3 || isListBlockIndent(fenceLine.indent, listItems);
 }
 
 function unwrapNestedBlockquote(
@@ -86,7 +81,7 @@ function unwrapNestedBlockquote(
   const match = line.match(/^([ \t]+)(?:>[ \t]*)+(.*)$/);
   if (
     !match ||
-    !isInsideListItem(getIndentWidth(match[1] ?? ""), listItems)
+    !isListBlockIndent(getIndentWidth(match[1] ?? ""), listItems)
   ) {
     return { line, unwrapped: false };
   }
@@ -153,12 +148,17 @@ export function normalizeCanvasMarkdown(
       /^([ \t]*)([-+*]|\d+[.)])([ \t]+)(.*)$/,
     );
     if (listMatch) {
-      const [, whitespace = "", marker = "", gap = "", content = ""] =
+      const [, whitespace = "", marker = "", gap = "", rawContent = ""] =
         listMatch;
       const indent = getIndentWidth(whitespace);
       const type = getListType(marker);
       const contentIndent =
         indent + getIndentWidth(marker) + getIndentWidth(gap);
+      const contentMatch = rawContent.match(/^(?:>[ \t]*)+(.*)$/);
+      const content = contentMatch?.[1] ?? rawContent;
+      if (contentMatch) {
+        unwrappedBlockquoteCount += 1;
+      }
 
       while (
         listItems.length > 0 &&
@@ -181,7 +181,9 @@ export function normalizeCanvasMarkdown(
       }
 
       listItems.push({ contentIndent, indent, type, unwrapped: false });
-      return line;
+      return contentMatch
+        ? `${whitespace}${marker}${gap}${content}`
+        : line;
     }
 
     const rootListContentIndent = listItems[0]?.contentIndent;
@@ -201,7 +203,7 @@ export function normalizeCanvasMarkdown(
       headingMatch &&
       headingIndent !== undefined &&
       (headingIndent <= 3 ||
-        isInsideListItem(headingIndent, listItems))
+        isListBlockIndent(headingIndent, listItems))
     ) {
       normalizedHeadingCount += 1;
       return line.replace(

--- a/packages/junior/tests/integration/slack-canvases.test.ts
+++ b/packages/junior/tests/integration/slack-canvases.test.ts
@@ -185,7 +185,7 @@ describe("createCanvas", () => {
       document_content: {
         type: "markdown",
         markdown:
-          "### Deep heading\n1. Parent\n   1. Child\n   Quoted child",
+          "### Deep heading\n1. Parent\n   • Child\n   Quoted child",
       },
     });
   });

--- a/packages/junior/tests/integration/slack-canvases.test.ts
+++ b/packages/junior/tests/integration/slack-canvases.test.ts
@@ -158,7 +158,7 @@ describe("createCanvas", () => {
     expect(getCapturedSlackApiCalls("canvases.access.set")).toHaveLength(0);
   });
 
-  it("normalizes unsupported heading depth before canvas create", async () => {
+  it("normalizes rejected markdown before canvas create", async () => {
     queueSlackApiResponse("canvases.create", {
       body: canvasesCreateOk({ canvasId: "F_NORM" }),
     });
@@ -174,7 +174,8 @@ describe("createCanvas", () => {
 
     await createCanvas({
       title: "Title",
-      markdown: "#### Deep heading\nBody",
+      markdown:
+        "#### Deep heading\n1. Parent\n   - Child\n   > Quoted child",
       channelId: "C12345",
     });
 
@@ -183,7 +184,7 @@ describe("createCanvas", () => {
     expect(canvasCreateCalls[0]?.params).toMatchObject({
       document_content: {
         type: "markdown",
-        markdown: "### Deep heading\nBody",
+        markdown: "### Deep heading\n1. Parent\n- Child\n> Quoted child",
       },
     });
   });

--- a/packages/junior/tests/integration/slack-canvases.test.ts
+++ b/packages/junior/tests/integration/slack-canvases.test.ts
@@ -184,7 +184,8 @@ describe("createCanvas", () => {
     expect(canvasCreateCalls[0]?.params).toMatchObject({
       document_content: {
         type: "markdown",
-        markdown: "### Deep heading\n1. Parent\n- Child\n> Quoted child",
+        markdown:
+          "### Deep heading\n1. Parent\n   1. Child\n   Quoted child",
       },
     });
   });

--- a/packages/junior/tests/unit/slack/slack-canvas-markdown.test.ts
+++ b/packages/junior/tests/unit/slack/slack-canvas-markdown.test.ts
@@ -47,18 +47,18 @@ describe("normalizeCanvasMarkdown", () => {
     expect(normalizeCanvasMarkdown(markdown).markdown).toBe(markdown);
   });
 
-  it("uses numbered markers for bullet items nested inside numbered lists", () => {
+  it("uses plain bullet markers inside numbered lists", () => {
     const normalized = normalizeCanvasMarkdown(
       "1. Parent\n   - Child\n2. Next",
     );
-    expect(normalized.markdown).toBe("1. Parent\n   1. Child\n2. Next");
+    expect(normalized.markdown).toBe("1. Parent\n   • Child\n2. Next");
     expect(normalized.normalizedMixedListCount).toBe(1);
     expect(normalized.normalizedCount).toBe(1);
   });
 
-  it("uses bullet markers for numbered items nested inside bullet lists", () => {
+  it("uses plain numbered markers inside bullet lists", () => {
     const normalized = normalizeCanvasMarkdown("- Parent\n  1. Child");
-    expect(normalized.markdown).toBe("- Parent\n  - Child");
+    expect(normalized.markdown).toBe("- Parent\n  1: Child");
     expect(normalized.normalizedMixedListCount).toBe(1);
   });
 
@@ -67,7 +67,7 @@ describe("normalizeCanvasMarkdown", () => {
       "1. Parent\n   - First\n   - Second\n2. Next",
     );
     expect(normalized.markdown).toBe(
-      "1. Parent\n   1. First\n   1. Second\n2. Next",
+      "1. Parent\n   • First\n   • Second\n2. Next",
     );
     expect(normalized.normalizedMixedListCount).toBe(2);
   });
@@ -77,7 +77,7 @@ describe("normalizeCanvasMarkdown", () => {
       "1. Root\n   - Child\n     - Grandchild\n2. Next",
     );
     expect(normalized.markdown).toBe(
-      "1. Root\n   1. Child\n     1. Grandchild\n2. Next",
+      "1. Root\n   • Child\n     • Grandchild\n2. Next",
     );
     expect(normalized.normalizedMixedListCount).toBe(2);
   });
@@ -103,7 +103,7 @@ describe("normalizeCanvasMarkdown", () => {
       "1. Parent\n   > - Child\n2. Next",
     );
     expect(normalized.markdown).toBe(
-      "1. Parent\n   1. Child\n2. Next",
+      "1. Parent\n   • Child\n2. Next",
     );
     expect(normalized.unwrappedBlockquoteCount).toBe(1);
     expect(normalized.normalizedMixedListCount).toBe(1);
@@ -120,6 +120,39 @@ describe("normalizeCanvasMarkdown", () => {
     expect(normalized.unwrappedBlockquoteCount).toBe(1);
     expect(normalized.normalizedHeadingCount).toBe(1);
     expect(normalized.normalizedCount).toBe(2);
+  });
+
+  it("normalizes deeply indented headings inside list items", () => {
+    const normalized = normalizeCanvasMarkdown(
+      "1. Parent\n     #### Deep heading\n2. Next",
+    );
+    expect(normalized.markdown).toBe(
+      "1. Parent\n     ### Deep heading\n2. Next",
+    );
+    expect(normalized.normalizedHeadingCount).toBe(1);
+  });
+
+  it("preserves deeply indented heading syntax outside lists", () => {
+    const markdown = "    #### Indented code";
+    expect(normalizeCanvasMarkdown(markdown).markdown).toBe(markdown);
+  });
+
+  it("preserves syntax inside deeply indented list code fences", () => {
+    const markdown =
+      "1. Parent\n     ```markdown\n     1. Example\n        - Keep bullet\n     #### Keep heading\n     ```\n2. Next";
+    expect(normalizeCanvasMarkdown(markdown).markdown).toBe(markdown);
+  });
+
+  it("unwraps quote-wrapped list code fences without changing their content", () => {
+    const normalized = normalizeCanvasMarkdown(
+      "1. Parent\n   > ```markdown\n   > #### Keep heading\n   > - Keep bullet\n   > ```\n2. Next",
+    );
+    expect(normalized.markdown).toBe(
+      "1. Parent\n   ```markdown\n   #### Keep heading\n   - Keep bullet\n   ```\n2. Next",
+    );
+    expect(normalized.unwrappedBlockquoteCount).toBe(4);
+    expect(normalized.normalizedHeadingCount).toBe(0);
+    expect(normalized.normalizedMixedListCount).toBe(0);
   });
 
   it("preserves top-level blockquotes", () => {

--- a/packages/junior/tests/unit/slack/slack-canvas-markdown.test.ts
+++ b/packages/junior/tests/unit/slack/slack-canvas-markdown.test.ts
@@ -98,6 +98,14 @@ describe("normalizeCanvasMarkdown", () => {
     expect(normalized.normalizedCount).toBe(2);
   });
 
+  it("unwraps blockquotes that start in same-line list content", () => {
+    const normalized = normalizeCanvasMarkdown(
+      "1. > > Same-line quote\n2. Next",
+    );
+    expect(normalized.markdown).toBe("1. Same-line quote\n2. Next");
+    expect(normalized.unwrappedBlockquoteCount).toBe(1);
+  });
+
   it("normalizes list syntax revealed by unwrapped blockquotes", () => {
     const normalized = normalizeCanvasMarkdown(
       "1. Parent\n   > - Child\n2. Next",
@@ -134,6 +142,16 @@ describe("normalizeCanvasMarkdown", () => {
 
   it("preserves deeply indented heading syntax outside lists", () => {
     const markdown = "    #### Indented code";
+    expect(normalizeCanvasMarkdown(markdown).markdown).toBe(markdown);
+  });
+
+  it("preserves headings in list-item indented code", () => {
+    const markdown = "1. Parent\n       #### Indented code\n2. Next";
+    expect(normalizeCanvasMarkdown(markdown).markdown).toBe(markdown);
+  });
+
+  it("preserves quote markers in list-item indented code", () => {
+    const markdown = "1. Parent\n       > Indented code\n2. Next";
     expect(normalizeCanvasMarkdown(markdown).markdown).toBe(markdown);
   });
 

--- a/packages/junior/tests/unit/slack/slack-canvas-markdown.test.ts
+++ b/packages/junior/tests/unit/slack/slack-canvas-markdown.test.ts
@@ -110,9 +110,7 @@ describe("normalizeCanvasMarkdown", () => {
     const normalized = normalizeCanvasMarkdown(
       "1. Parent\n   > - Child\n2. Next",
     );
-    expect(normalized.markdown).toBe(
-      "1. Parent\n   • Child\n2. Next",
-    );
+    expect(normalized.markdown).toBe("1. Parent\n   • Child\n2. Next");
     expect(normalized.unwrappedBlockquoteCount).toBe(1);
     expect(normalized.normalizedMixedListCount).toBe(1);
     expect(normalized.normalizedCount).toBe(2);
@@ -122,9 +120,7 @@ describe("normalizeCanvasMarkdown", () => {
     const normalized = normalizeCanvasMarkdown(
       "1. Parent\n   > > #### Deep heading\n2. Next",
     );
-    expect(normalized.markdown).toBe(
-      "1. Parent\n   ### Deep heading\n2. Next",
-    );
+    expect(normalized.markdown).toBe("1. Parent\n   ### Deep heading\n2. Next");
     expect(normalized.unwrappedBlockquoteCount).toBe(1);
     expect(normalized.normalizedHeadingCount).toBe(1);
     expect(normalized.normalizedCount).toBe(2);
@@ -169,6 +165,18 @@ describe("normalizeCanvasMarkdown", () => {
       "1. Parent\n   ```markdown\n   #### Keep heading\n   - Keep bullet\n   ```\n2. Next",
     );
     expect(normalized.unwrappedBlockquoteCount).toBe(4);
+    expect(normalized.normalizedHeadingCount).toBe(0);
+    expect(normalized.normalizedMixedListCount).toBe(0);
+  });
+
+  it("preserves inner quotes in quote-wrapped list code fences", () => {
+    const normalized = normalizeCanvasMarkdown(
+      "1. Parent\n   > > ```markdown\n   > > > Quoted example\n   > > ```\n2. Next",
+    );
+    expect(normalized.markdown).toBe(
+      "1. Parent\n   ```markdown\n   > Quoted example\n   ```\n2. Next",
+    );
+    expect(normalized.unwrappedBlockquoteCount).toBe(3);
     expect(normalized.normalizedHeadingCount).toBe(0);
     expect(normalized.normalizedMixedListCount).toBe(0);
   });

--- a/packages/junior/tests/unit/slack/slack-canvas-markdown.test.ts
+++ b/packages/junior/tests/unit/slack/slack-canvas-markdown.test.ts
@@ -98,6 +98,30 @@ describe("normalizeCanvasMarkdown", () => {
     expect(normalized.normalizedCount).toBe(2);
   });
 
+  it("normalizes list syntax revealed by unwrapped blockquotes", () => {
+    const normalized = normalizeCanvasMarkdown(
+      "1. Parent\n   > - Child\n2. Next",
+    );
+    expect(normalized.markdown).toBe(
+      "1. Parent\n   1. Child\n2. Next",
+    );
+    expect(normalized.unwrappedBlockquoteCount).toBe(1);
+    expect(normalized.normalizedMixedListCount).toBe(1);
+    expect(normalized.normalizedCount).toBe(2);
+  });
+
+  it("normalizes headings revealed by spaced nested quote markers", () => {
+    const normalized = normalizeCanvasMarkdown(
+      "1. Parent\n   > > #### Deep heading\n2. Next",
+    );
+    expect(normalized.markdown).toBe(
+      "1. Parent\n   ### Deep heading\n2. Next",
+    );
+    expect(normalized.unwrappedBlockquoteCount).toBe(1);
+    expect(normalized.normalizedHeadingCount).toBe(1);
+    expect(normalized.normalizedCount).toBe(2);
+  });
+
   it("preserves top-level blockquotes", () => {
     const markdown = "> Quote\n> More detail";
     expect(normalizeCanvasMarkdown(markdown).markdown).toBe(markdown);
@@ -105,7 +129,7 @@ describe("normalizeCanvasMarkdown", () => {
 
   it("is idempotent after normalizing rejected markdown", () => {
     const first = normalizeCanvasMarkdown(
-      "#### Heading\n1. Parent\n   - Child\n   > Quote",
+      "#### Heading\n1. Parent\n   > - Child\n   > > #### Deep heading",
     );
     const second = normalizeCanvasMarkdown(first.markdown);
 

--- a/packages/junior/tests/unit/slack/slack-canvas-markdown.test.ts
+++ b/packages/junior/tests/unit/slack/slack-canvas-markdown.test.ts
@@ -98,6 +98,14 @@ describe("normalizeCanvasMarkdown", () => {
     expect(normalized.normalizedCount).toBe(2);
   });
 
+  it("uses absolute tab stops for list content indentation", () => {
+    const normalized = normalizeCanvasMarkdown(
+      "1.\tParent\n    > Quoted child\n2. Next",
+    );
+    expect(normalized.markdown).toBe("1.\tParent\n    Quoted child\n2. Next");
+    expect(normalized.unwrappedBlockquoteCount).toBe(1);
+  });
+
   it("unwraps blockquotes that start in same-line list content", () => {
     const normalized = normalizeCanvasMarkdown(
       "1. > > Same-line quote\n2. Next",

--- a/packages/junior/tests/unit/slack/slack-canvas-markdown.test.ts
+++ b/packages/junior/tests/unit/slack/slack-canvas-markdown.test.ts
@@ -8,8 +8,8 @@ describe("normalizeCanvasMarkdown", () => {
       markdown: "### Deep heading\nBody",
       normalizedCount: 1,
       normalizedHeadingCount: 1,
-      flattenedMixedListCount: 0,
-      flattenedBlockquoteCount: 0,
+      normalizedMixedListCount: 0,
+      unwrappedBlockquoteCount: 0,
     });
   });
 
@@ -19,8 +19,8 @@ describe("normalizeCanvasMarkdown", () => {
       markdown: "# H1\n## H2\n### H3",
       normalizedCount: 0,
       normalizedHeadingCount: 0,
-      flattenedMixedListCount: 0,
-      flattenedBlockquoteCount: 0,
+      normalizedMixedListCount: 0,
+      unwrappedBlockquoteCount: 0,
     });
   });
 
@@ -32,8 +32,8 @@ describe("normalizeCanvasMarkdown", () => {
       markdown: "Text\n### Too deep\n`#### code`",
       normalizedCount: 1,
       normalizedHeadingCount: 1,
-      flattenedMixedListCount: 0,
-      flattenedBlockquoteCount: 0,
+      normalizedMixedListCount: 0,
+      unwrappedBlockquoteCount: 0,
     });
   });
 
@@ -47,19 +47,39 @@ describe("normalizeCanvasMarkdown", () => {
     expect(normalizeCanvasMarkdown(markdown).markdown).toBe(markdown);
   });
 
-  it("flattens bullet lists nested inside numbered lists", () => {
+  it("uses numbered markers for bullet items nested inside numbered lists", () => {
     const normalized = normalizeCanvasMarkdown(
       "1. Parent\n   - Child\n2. Next",
     );
-    expect(normalized.markdown).toBe("1. Parent\n- Child\n2. Next");
-    expect(normalized.flattenedMixedListCount).toBe(1);
+    expect(normalized.markdown).toBe("1. Parent\n   1. Child\n2. Next");
+    expect(normalized.normalizedMixedListCount).toBe(1);
     expect(normalized.normalizedCount).toBe(1);
   });
 
-  it("flattens numbered lists nested inside bullet lists", () => {
+  it("uses bullet markers for numbered items nested inside bullet lists", () => {
     const normalized = normalizeCanvasMarkdown("- Parent\n  1. Child");
-    expect(normalized.markdown).toBe("- Parent\n1. Child");
-    expect(normalized.flattenedMixedListCount).toBe(1);
+    expect(normalized.markdown).toBe("- Parent\n  - Child");
+    expect(normalized.normalizedMixedListCount).toBe(1);
+  });
+
+  it("preserves sibling hierarchy when normalizing mixed nested lists", () => {
+    const normalized = normalizeCanvasMarkdown(
+      "1. Parent\n   - First\n   - Second\n2. Next",
+    );
+    expect(normalized.markdown).toBe(
+      "1. Parent\n   1. First\n   1. Second\n2. Next",
+    );
+    expect(normalized.normalizedMixedListCount).toBe(2);
+  });
+
+  it("uses the normalized parent type for deeper descendants", () => {
+    const normalized = normalizeCanvasMarkdown(
+      "1. Root\n   - Child\n     - Grandchild\n2. Next",
+    );
+    expect(normalized.markdown).toBe(
+      "1. Root\n   1. Child\n     1. Grandchild\n2. Next",
+    );
+    expect(normalized.normalizedMixedListCount).toBe(2);
   });
 
   it("preserves nested lists with the same list type", () => {
@@ -67,14 +87,14 @@ describe("normalizeCanvasMarkdown", () => {
     expect(normalizeCanvasMarkdown(markdown).markdown).toBe(markdown);
   });
 
-  it("moves blockquotes out of list items", () => {
+  it("unwraps blockquotes inside list items without changing indentation", () => {
     const normalized = normalizeCanvasMarkdown(
       "1. Parent\n   > Quoted child\n   > More detail\n2. Next",
     );
     expect(normalized.markdown).toBe(
-      "1. Parent\n> Quoted child\n> More detail\n2. Next",
+      "1. Parent\n   Quoted child\n   More detail\n2. Next",
     );
-    expect(normalized.flattenedBlockquoteCount).toBe(2);
+    expect(normalized.unwrappedBlockquoteCount).toBe(2);
     expect(normalized.normalizedCount).toBe(2);
   });
 

--- a/packages/junior/tests/unit/slack/slack-canvas-markdown.test.ts
+++ b/packages/junior/tests/unit/slack/slack-canvas-markdown.test.ts
@@ -1,12 +1,15 @@
 import { describe, expect, it } from "vitest";
-import { normalizeCanvasMarkdown } from "@/chat/slack/tools/canvas/api";
+import { normalizeCanvasMarkdown } from "@/chat/slack/tools/canvas/markdown";
 
 describe("normalizeCanvasMarkdown", () => {
   it("downgrades unsupported heading depth to h3", () => {
     const normalized = normalizeCanvasMarkdown("#### Deep heading\nBody");
     expect(normalized).toEqual({
       markdown: "### Deep heading\nBody",
+      normalizedCount: 1,
       normalizedHeadingCount: 1,
+      flattenedMixedListCount: 0,
+      flattenedBlockquoteCount: 0,
     });
   });
 
@@ -14,7 +17,10 @@ describe("normalizeCanvasMarkdown", () => {
     const normalized = normalizeCanvasMarkdown("# H1\n## H2\n### H3");
     expect(normalized).toEqual({
       markdown: "# H1\n## H2\n### H3",
+      normalizedCount: 0,
       normalizedHeadingCount: 0,
+      flattenedMixedListCount: 0,
+      flattenedBlockquoteCount: 0,
     });
   });
 
@@ -24,7 +30,66 @@ describe("normalizeCanvasMarkdown", () => {
     );
     expect(normalized).toEqual({
       markdown: "Text\n### Too deep\n`#### code`",
+      normalizedCount: 1,
       normalizedHeadingCount: 1,
+      flattenedMixedListCount: 0,
+      flattenedBlockquoteCount: 0,
     });
+  });
+
+  it("preserves markdown syntax inside fenced code blocks", () => {
+    const markdown = "```markdown\n#### Heading\n1. Parent\n   - Child\n```";
+    expect(normalizeCanvasMarkdown(markdown).markdown).toBe(markdown);
+  });
+
+  it("does not close a longer fence with a shorter fence", () => {
+    const markdown = "````markdown\n```\n#### Heading\n```\n````";
+    expect(normalizeCanvasMarkdown(markdown).markdown).toBe(markdown);
+  });
+
+  it("flattens bullet lists nested inside numbered lists", () => {
+    const normalized = normalizeCanvasMarkdown(
+      "1. Parent\n   - Child\n2. Next",
+    );
+    expect(normalized.markdown).toBe("1. Parent\n- Child\n2. Next");
+    expect(normalized.flattenedMixedListCount).toBe(1);
+    expect(normalized.normalizedCount).toBe(1);
+  });
+
+  it("flattens numbered lists nested inside bullet lists", () => {
+    const normalized = normalizeCanvasMarkdown("- Parent\n  1. Child");
+    expect(normalized.markdown).toBe("- Parent\n1. Child");
+    expect(normalized.flattenedMixedListCount).toBe(1);
+  });
+
+  it("preserves nested lists with the same list type", () => {
+    const markdown = "1. Parent\n   1. Child\n- Parent\n  - Child";
+    expect(normalizeCanvasMarkdown(markdown).markdown).toBe(markdown);
+  });
+
+  it("moves blockquotes out of list items", () => {
+    const normalized = normalizeCanvasMarkdown(
+      "1. Parent\n   > Quoted child\n   > More detail\n2. Next",
+    );
+    expect(normalized.markdown).toBe(
+      "1. Parent\n> Quoted child\n> More detail\n2. Next",
+    );
+    expect(normalized.flattenedBlockquoteCount).toBe(2);
+    expect(normalized.normalizedCount).toBe(2);
+  });
+
+  it("preserves top-level blockquotes", () => {
+    const markdown = "> Quote\n> More detail";
+    expect(normalizeCanvasMarkdown(markdown).markdown).toBe(markdown);
+  });
+
+  it("is idempotent after normalizing rejected markdown", () => {
+    const first = normalizeCanvasMarkdown(
+      "#### Heading\n1. Parent\n   - Child\n   > Quote",
+    );
+    const second = normalizeCanvasMarkdown(first.markdown);
+
+    expect(second.markdown).toBe(first.markdown);
+    expect(second.normalizedCount).toBe(0);
   });
 });


### PR DESCRIPTION
Slack Canvas writes now normalize Markdown structures that Slack rejects: mixed nested list types, blockquotes inside list items, and headings deeper than H3. The normalizer is a pure feature-local module shared by Canvas create and write paths, while preserving supported same-type nesting and fenced code.

The previous normalizer only handled heading depth, so model-generated long-form content could reach `canvases.create` with unsupported nested blocks and fail with `canvas_creation_failed`. Regression coverage now owns the local normalization rules in unit tests and verifies the outgoing Slack API payload through the integration harness.

Fixes #1108
