### PR TITLE
fix(dashboard): forward token and stats routes

### DIFF
--- a/packages/junior-dashboard/tests/dashboard-host-routes.test.ts
+++ b/packages/junior-dashboard/tests/dashboard-host-routes.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, expect, it, vi } from "vitest";
+import { createApp, defineJuniorPlugins } from "@sentry/junior";
+import { createDashboardApp } from "../src/app";
+
+function concreteRoutePath(path: string): string | undefined {
+  if (path === "*" || path === "/*") {
+    return undefined;
+  }
+  return path.replaceAll(/:[^/]+/g, "contract").replace(/\*$/, "contract");
+}
+
+afterEach(() => {
+  vi.doUnmock("#junior/config");
+});
+
+it("forwards every dashboard route through the Junior app", async () => {
+  const registeredDashboard = createDashboardApp({
+    authRequired: false,
+    componentGallery: true,
+  });
+  const registeredRoutes = registeredDashboard.routes
+    .map((route) => ({
+      method: route.method === "ALL" ? "GET" : route.method,
+      path: concreteRoutePath(route.path),
+    }))
+    .filter(
+      (route): route is { method: string; path: string } =>
+        route.path !== undefined,
+    );
+  const createForwardingDashboard = vi.fn(() => ({
+    fetch(request: Request) {
+      return new Response(`dashboard:${new URL(request.url).pathname}`);
+    },
+  }));
+  vi.doMock("#junior/config", () => ({
+    createDashboardApp: createForwardingDashboard,
+    functionMaxDurationSeconds: undefined,
+    dashboard: {
+      authRequired: false,
+      componentGallery: true,
+    },
+    pluginRuntimeRegistrations: [],
+    pluginSet: defineJuniorPlugins([]),
+    plugins: undefined,
+  }));
+  const app = await createApp();
+
+  for (const route of registeredRoutes) {
+    const response = await app.fetch(
+      new Request(`http://localhost${route.path}`, {
+        method: route.method,
+      }),
+    );
+    expect(
+      await response.text(),
+      `${route.method} ${route.path} was not forwarded`,
+    ).toBe(`dashboard:${route.path}`);
+  }
+});

--- a/packages/junior/src/app.ts
+++ b/packages/junior/src/app.ts
@@ -388,6 +388,7 @@ function dashboardHostRoutePaths(dashboard: JuniorDashboardOptions): string[] {
     `${pagePath("system")}/*`,
     pagePath("settings/plugins"),
     `${pagePath("settings/plugins")}/*`,
+    pagePath("settings/api-tokens"),
   ];
   if (dashboard.componentGallery) {
     pagePaths.push(pagePath("dev"), `${pagePath("dev")}/*`);
@@ -408,12 +409,15 @@ function dashboardHostRoutePaths(dashboard: JuniorDashboardOptions): string[] {
     "/api/user-pages",
     "/api/user-pages/*",
     "/api/skills",
+    "/api/stats",
     "/api/conversations",
     "/api/conversations/*",
     "/api/locations",
     "/api/locations/*",
     "/api/people",
     "/api/people/*",
+    "/api/personal-tokens",
+    "/api/personal-tokens/*",
     "/api/config",
     "/api/me",
     authPath,


### PR DESCRIPTION
Direct requests to newly added dashboard routes now reach the dashboard app instead of falling through the outer Junior app. This forwards the API token settings page, personal token API routes, and the previously omitted stats endpoint.

The root cause was duplicated route ownership: the dashboard Hono app registered routes while `createApp()` maintained a separate forwarding list. The regression test now reads the real dashboard route table and verifies that every registered page, API, asset, method, and nested route is forwarded, so future mismatches fail in CI.