### PR TITLE
perf(sandbox): bound ripgrep searches

### DIFF
--- a/packages/junior/src/chat/sandbox/workspace.ts
+++ b/packages/junior/src/chat/sandbox/workspace.ts
@@ -18,6 +18,7 @@ export interface SandboxCommandInput {
   env?: Record<string, string>;
   signal?: AbortSignal;
   sudo?: boolean;
+  timeoutMs?: number;
 }
 
 export interface SandboxFileStat {

--- a/packages/junior/src/chat/tools/sandbox/file-utils.ts
+++ b/packages/junior/src/chat/tools/sandbox/file-utils.ts
@@ -29,6 +29,7 @@ export const RIPGREP_EXCLUDED_GLOBS = [
   "!**/.git/**",
   "!**/node_modules/**",
 ] as const;
+export const DEFAULT_SEARCH_COMMAND_TIMEOUT_MS = 30_000;
 const SKIPPED_DIRECTORIES = new Set([".git", "node_modules"]);
 
 export type TextSearchResultDetails =

--- a/packages/junior/src/chat/tools/sandbox/find-files.ts
+++ b/packages/junior/src/chat/tools/sandbox/find-files.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import {
+  DEFAULT_SEARCH_COMMAND_TIMEOUT_MS,
   MAX_TEXT_CHARS,
   RIPGREP_EXCLUDED_GLOBS,
   collectFiles,
@@ -22,8 +23,9 @@ import {
   type JuniorToolResultEnvelope,
 } from "@/chat/tool-support/structured-result";
 import { zodTool } from "@/chat/tool-support/zod-tool";
+import { ToolInputError } from "@/chat/tools/execution/tool-input-error";
 
-const DEFAULT_FIND_LIMIT = 1000;
+const DEFAULT_FIND_LIMIT = 100;
 
 interface FindFilesSuccessResult {
   content: JuniorToolResultEnvelope["content"];
@@ -143,26 +145,46 @@ async function findFilesWithRipgrep(params: {
   }
 
   const location = getRipgrepSearchLocation(params.root, rootIsDirectory);
-  const args = [
+  const ripgrepArgs = [
     "--files",
     "--null",
     "--hidden",
-    "--sort=path",
     "--glob",
     params.pattern,
   ];
   for (const excludedGlob of RIPGREP_EXCLUDED_GLOBS) {
-    args.push("--glob", excludedGlob);
+    ripgrepArgs.push("--glob", excludedGlob);
   }
-  args.push("--", location.target);
+  ripgrepArgs.push("--", location.target);
   const result = await params.runCommand({
-    cmd: "rg",
-    args,
+    cmd: "bash",
+    args: [
+      "-c",
+      [
+        `rg "$@" | head -z -n ${params.limit + 1}`,
+        'statuses=("${PIPESTATUS[@]}")',
+        "if (( statuses[1] != 0 )); then",
+        '  exit "${statuses[1]}"',
+        "fi",
+        "if (( statuses[0] == 0 || statuses[0] == 1 || statuses[0] == 141 )); then",
+        "  exit 0",
+        "fi",
+        'exit "${statuses[0]}"',
+      ].join("\n"),
+      "find-files",
+      ...ripgrepArgs,
+    ],
     cwd: location.cwd,
+    timeoutMs: DEFAULT_SEARCH_COMMAND_TIMEOUT_MS,
   });
-  if (result.exitCode !== 0 && result.exitCode !== 1) {
+  if (result.exitCode !== 0) {
     const detail =
       result.stderr.trim() || result.stdout.trim() || "command failed";
+    if (/error parsing glob|invalid glob/i.test(detail)) {
+      throw new ToolInputError(`Invalid glob pattern: ${params.pattern}`, {
+        cause: new Error(detail),
+      });
+    }
     throw new Error(`ripgrep file search failed: ${detail}`);
   }
 
@@ -256,7 +278,7 @@ export function createFindFilesTool() {
         .number()
         .int()
         .min(1)
-        .describe("Maximum number of file paths to return. Defaults to 1000.")
+        .describe("Maximum number of file paths to return. Defaults to 100.")
         .optional(),
     }),
     outputSchema: juniorToolResultSchema,

--- a/packages/junior/src/chat/tools/sandbox/grep.ts
+++ b/packages/junior/src/chat/tools/sandbox/grep.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import {
+  DEFAULT_SEARCH_COMMAND_TIMEOUT_MS,
   MAX_TEXT_CHARS,
   RIPGREP_EXCLUDED_GLOBS,
   collectFiles,
@@ -306,7 +307,6 @@ async function grepFilesWithRipgrep(params: {
     "--json",
     "--line-number",
     "--hidden",
-    "--sort=path",
     "--max-count",
     String(params.limit + 1),
   ];
@@ -331,6 +331,7 @@ async function grepFilesWithRipgrep(params: {
     cmd: "rg",
     args,
     cwd: location.cwd,
+    timeoutMs: DEFAULT_SEARCH_COMMAND_TIMEOUT_MS,
   });
   if (result.exitCode !== 0 && result.exitCode !== 1) {
     const detail =

--- a/packages/junior/tests/unit/tools/sandbox/file-tools.test.ts
+++ b/packages/junior/tests/unit/tools/sandbox/file-tools.test.ts
@@ -303,31 +303,34 @@ describe("sandbox file tools", () => {
 
     const result = await findFiles({
       fs: memory.fs,
+      limit: 20,
       path: "src",
       pattern: "nested/*.ts",
       runCommand,
     });
 
-    expect(calls).toEqual([
-      {
-        cmd: "rg",
-        args: [
-          "--files",
-          "--null",
-          "--hidden",
-          "--sort=path",
-          "--glob",
-          "nested/*.ts",
-          "--glob",
-          "!**/.git/**",
-          "--glob",
-          "!**/node_modules/**",
-          "--",
-          ".",
-        ],
-        cwd: workspacePath("src"),
-      },
-    ]);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      cmd: "bash",
+      args: [
+        "-c",
+        expect.stringContaining('rg "$@" | head -z -n 21'),
+        "find-files",
+        "--files",
+        "--null",
+        "--hidden",
+        "--glob",
+        "nested/*.ts",
+        "--glob",
+        "!**/.git/**",
+        "--glob",
+        "!**/node_modules/**",
+        "--",
+        ".",
+      ],
+      cwd: workspacePath("src"),
+      timeoutMs: 30_000,
+    });
     expect(result.details).toMatchObject({
       ok: true,
       data: {
@@ -377,8 +380,11 @@ describe("sandbox file tools", () => {
     expect(calls[0]).toMatchObject({
       cmd: "rg",
       cwd: workspacePath("src"),
+      timeoutMs: 30_000,
     });
     const args = calls[0]?.args ?? [];
+    expect(args).toContain("--max-count");
+    expect(args).toContain("101");
     expect(args).toContain("--fixed-strings");
     expect(args).toContain("--max-count");
     expect(args).toContain("101");
@@ -433,6 +439,25 @@ describe("sandbox file tools", () => {
         },
       }),
     ).rejects.toBe(lifecycleFailure);
+  });
+
+  it("does not accept findFiles pipeline failures as no-match results", async () => {
+    const memory = createMemoryFs({
+      "src/app.ts": "content\n",
+    });
+
+    await expect(
+      findFiles({
+        fs: memory.fs,
+        path: "src",
+        pattern: "*.ts",
+        runCommand: async () => ({
+          exitCode: 1,
+          stderr: "head failed",
+          stdout: "",
+        }),
+      }),
+    ).rejects.toThrow("ripgrep file search failed: head failed");
   });
 
   it("prepares grep string booleans like the previous TypeBox schema", () => {

--- a/packages/junior/tests/unit/tools/sandbox/search-telemetry.test.ts
+++ b/packages/junior/tests/unit/tools/sandbox/search-telemetry.test.ts
@@ -62,7 +62,7 @@ describe("sandbox search telemetry", () => {
 
     expect(onTelemetry).toHaveBeenCalledWith({
       emittedLineCount: 1,
-      limit: 1000,
+      limit: 100,
       limitReached: false,
       parsedRecordCount: 1,
       rawOutputBytes: 11,


### PR DESCRIPTION
Sandbox-backed search now bounds worst-case work instead of paying the full workspace cost. `findFiles` defaults to 100 results, removes full-path sorting, stops ripgrep after `limit + 1` paths, and treats pipeline or invalid-glob failures as errors. `grep` removes full-path sorting and caps matches per file. Both commands use the sandbox SDK's native 30-second process timeout.

This follows the search telemetry added in #1110 and directly addresses the latency and unbounded-command behavior in #1109. Model-provided patterns remain argv values rather than shell-interpolated text.

The exact Junior component CI command passes all 509 tests. Focused search tests, TypeScript, Oxlint, dependency rules, formatting, and commit hooks also pass.

Fixes #1109.
