### PR TITLE
Widen locations runtime column

### DIFF
--- a/packages/junior-dashboard/src/client/pages/locations/LocationDirectory.tsx
+++ b/packages/junior-dashboard/src/client/pages/locations/LocationDirectory.tsx
@@ -54,10 +54,10 @@ export function LocationDirectory(props: {
         />
       </div>
       {props.loading ? (
-        <DirectoryRowsSkeleton />
+        <DirectoryRowsSkeleton wideRuntime />
       ) : props.locations.length ? (
         <div className="min-w-0" role="table">
-          <div className="grid grid-cols-[minmax(14rem,1fr)_repeat(3,minmax(5rem,auto))] items-center gap-4 border-b border-white/[0.06] bg-black/20 px-4 py-2.5 font-mono text-[0.62rem] uppercase tracking-[0.1em] text-dashboard-text-muted max-md:hidden">
+          <div className="grid grid-cols-[minmax(14rem,1fr)_repeat(2,minmax(5rem,auto))_minmax(8rem,auto)] items-center gap-4 border-b border-white/[0.06] bg-black/20 px-4 py-2.5 font-mono text-[0.62rem] uppercase tracking-[0.1em] text-dashboard-text-muted max-md:hidden">
             <div>Location</div>
             <div className="justify-self-end">Conversations</div>
             <div className="justify-self-end">Tokens</div>
@@ -65,7 +65,7 @@ export function LocationDirectory(props: {
           </div>
           {props.locations.map((location) => (
             <Link
-              className="group grid min-w-0 grid-cols-[minmax(14rem,1fr)_repeat(3,minmax(5rem,auto))] items-center gap-4 border-b border-white/[0.055] px-4 py-3.5 text-inherit no-underline transition-colors last:border-b-0 hover:bg-white/[0.035] max-md:grid-cols-3 max-md:gap-x-3 max-md:gap-y-4"
+              className="group grid min-w-0 grid-cols-[minmax(14rem,1fr)_repeat(2,minmax(5rem,auto))_minmax(8rem,auto)] items-center gap-4 border-b border-white/[0.055] px-4 py-3.5 text-inherit no-underline transition-colors last:border-b-0 hover:bg-white/[0.035] max-md:grid-cols-3 max-md:gap-x-3 max-md:gap-y-4"
               key={location.id}
               to={locationPath(location.id)}
             >


### PR DESCRIPTION
The locations directory now reserves a wider runtime column so long multi-day durations do not crowd the conversations and tokens columns. The loading skeleton uses the same column geometry to avoid a layout shift while sorting.

This matches the existing people directory layout and keeps the responsive mobile layout unchanged.
