### PR TITLE
ref(plugins)!: standardize plugin factory names

### DIFF
--- a/apps/example/plugins.ts
+++ b/apps/example/plugins.ts
@@ -1,6 +1,6 @@
 import { defineJuniorPlugins } from "@sentry/junior";
 import { githubPlugin } from "@sentry/junior-github";
-import { createMemoryPlugin } from "@sentry/junior-memory";
+import { memoryPlugin } from "@sentry/junior-memory";
 import { schedulerPlugin } from "@sentry/junior-scheduler";
 import { vercelPlugin } from "@sentry/junior-vercel";
 
@@ -18,7 +18,7 @@ export const plugins = defineJuniorPlugins([
   }),
   "@sentry/junior-hex",
   "@sentry/junior-linear",
-  createMemoryPlugin(),
+  memoryPlugin(),
   "@sentry/junior-notion",
   schedulerPlugin(),
   "@sentry/junior-sentry",

--- a/packages/docs/src/content/docs/cli/init.md
+++ b/packages/docs/src/content/docs/cli/init.md
@@ -27,7 +27,7 @@ The scaffold includes:
 
 - `package.json` with `@sentry/junior`, `@sentry/junior-maintenance`, `@sentry/junior-memory`, `hono`, `nitro`, `typescript`, `jiti`, and `@types/node`
 - `pnpm-workspace.yaml` with a 24-hour dependency release delay and an immediate exception for the `@sentry/*` package scope
-- `plugins.ts` with `@sentry/junior-maintenance` and `createMemoryPlugin()` enabled
+- `plugins.ts` with `@sentry/junior-maintenance` and `memoryPlugin()` enabled
 - `server.ts`
 - `nitro.config.ts` pointing at `./plugins`
 - `tsconfig.json` extending Nitro's TypeScript config
@@ -43,7 +43,7 @@ The scaffold includes:
 
 `SOUL.md` sets Junior's default voice, `WORLD.md` holds operational context, and `DESCRIPTION.md` powers the user-facing app description. Add other `app/*.md` files only when you want optional reference material available to the agent at runtime. `ABOUT.md` is not part of the scaffold and is not supported.
 
-The generated `plugins.ts` enables `@sentry/junior-maintenance` and `createMemoryPlugin()` by default. Maintenance provides the `self-update` skill for keeping Junior packages current, and memory provides long-term recall once you configure Postgres with pgvector. `plugins.ts` is also the place to add other packaged plugins later.
+The generated `plugins.ts` enables `@sentry/junior-maintenance` and `memoryPlugin()` by default. Maintenance provides the `self-update` skill for keeping Junior packages current, and memory provides long-term recall once you configure Postgres with pgvector. `plugins.ts` is also the place to add other packaged plugins later.
 
 This gives you the supported app shape needed to run Junior locally, keep the app updated, and continue with plugin or skill setup.
 

--- a/packages/docs/src/content/docs/extend/_plugin-template.md
+++ b/packages/docs/src/content/docs/extend/_plugin-template.md
@@ -38,6 +38,10 @@ import { examplePlugin } from "@sentry/junior-example";
 export const plugins = defineJuniorPlugins([examplePlugin()]);
 ```
 
+Name a runtime plugin factory `<domain>Plugin`, export it as a function, and
+call it even when it has no options. Do not document a `create<Domain>Plugin`
+alias or a prebuilt plugin registration.
+
 Do not register a factory-based plugin as a bare package-name string. A bare string does not run runtime hooks, so the plugin will not activate its runtime behavior. Check the plugin package's README or setup page to confirm which registration style it requires.
 
 ## Configure environment variables

--- a/packages/docs/src/content/docs/extend/build-a-plugin.md
+++ b/packages/docs/src/content/docs/extend/build-a-plugin.md
@@ -126,7 +126,9 @@ app code; Junior never loads them from `plugin.yaml`.
 Hook contexts include `ctx.plugin` and `ctx.log`. Use `ctx.log` for
 plugin-scoped structured logs instead of writing directly to stdout.
 
-Export a factory from the plugin package:
+Export one factory from the plugin package. Name it after the plugin domain
+followed by `Plugin`, such as `myProviderPlugin`. The factory must remain
+callable even when it accepts no options:
 
 ```ts title="index.ts"
 import { defineJuniorPlugin } from "@sentry/junior-plugin-api";
@@ -155,6 +157,11 @@ export function myProviderPlugin() {
   });
 }
 ```
+
+Do not prefix the public factory with `create` or export a prebuilt registration
+under the domain name. A single callable `<domain>Plugin(options?)` export keeps
+registration consistent across plugins. Call it as `myProviderPlugin()` when it
+has no configuration, or pass options when the package defines them.
 
 Do not ship `plugin.yaml` for the same plugin. The JavaScript definition owns
 both the manifest surface and the hooks. If the same package also ships

--- a/packages/docs/src/content/docs/extend/memory-plugin.md
+++ b/packages/docs/src/content/docs/extend/memory-plugin.md
@@ -12,7 +12,7 @@ related:
 
 The memory plugin uses a Postgres database with the pgvector extension to store and retrieve long-term memories across conversations. Junior recalls relevant memories before each user turn, exposes explicit memory tools (remember, list, search, remove), and passively extracts memories from completed public-channel and local sessions.
 
-New apps created with `junior init` include `createMemoryPlugin()` in `plugins.ts` by default.
+New apps created with `junior init` include `memoryPlugin()` in `plugins.ts` by default.
 
 ## Prerequisites
 
@@ -28,13 +28,13 @@ pnpm add @sentry/junior @sentry/junior-memory
 
 ## Runtime setup
 
-The memory plugin requires a factory function call to register its tools and session hooks. Add `createMemoryPlugin()` to the plugin set exported from `plugins.ts`:
+The memory plugin requires a factory function call to register its tools and session hooks. Add `memoryPlugin()` to the plugin set exported from `plugins.ts`:
 
 ```ts title="plugins.ts"
 import { defineJuniorPlugins } from "@sentry/junior";
-import { createMemoryPlugin } from "@sentry/junior-memory";
+import { memoryPlugin } from "@sentry/junior-memory";
 
-export const plugins = defineJuniorPlugins([createMemoryPlugin()]);
+export const plugins = defineJuniorPlugins([memoryPlugin()]);
 ```
 
 Do not register `@sentry/junior-memory` as a bare package-name string. The memory plugin uses `defineJuniorPlugin` with runtime hooks for tool registration and session processing; a bare string skips those hooks and the plugin will not activate its runtime behavior.
@@ -43,10 +43,10 @@ Pass `modelId` to override the model used for memory classification and consolid
 
 ```ts title="plugins.ts"
 import { defineJuniorPlugins } from "@sentry/junior";
-import { createMemoryPlugin } from "@sentry/junior-memory";
+import { memoryPlugin } from "@sentry/junior-memory";
 
 export const plugins = defineJuniorPlugins([
-  createMemoryPlugin({ modelId: "anthropic/claude-sonnet-4-5" }),
+  memoryPlugin({ modelId: "anthropic/claude-sonnet-4-5" }),
 ]);
 ```
 
@@ -100,7 +100,7 @@ Public Slack channel memories are workspace-visible. A durable fact remembered i
 
 ## Failure modes
 
-- **Plugin not active after registration**: `@sentry/junior-memory` was registered as a bare string instead of `createMemoryPlugin()`. Switch to the factory call and redeploy.
+- **Plugin not active after registration**: `@sentry/junior-memory` was registered as a bare string instead of `memoryPlugin()`. Switch to the factory call and redeploy.
 - **Migration error — extension "vector" does not exist**: the Postgres database does not have pgvector available. Use a provider that supports pgvector or install it manually with `CREATE EXTENSION vector`.
 - **`DATABASE_URL` is required**: no database URL is configured. Set it in the deployment environment.
 - **Connection errors on non-Neon Postgres**: set `JUNIOR_DATABASE_DRIVER=postgres` for Railway, Supabase, AWS RDS, or self-hosted Postgres.

--- a/packages/docs/src/content/docs/start-here/quickstart.mdx
+++ b/packages/docs/src/content/docs/start-here/quickstart.mdx
@@ -131,13 +131,13 @@ Add them to the plugin set in `plugins.ts`:
 
 ```ts title="plugins.ts"
 import { defineJuniorPlugins } from "@sentry/junior";
-import { createMemoryPlugin } from "@sentry/junior-memory";
+import { memoryPlugin } from "@sentry/junior-memory";
 import { githubPlugin } from "@sentry/junior-github";
 import { schedulerPlugin } from "@sentry/junior-scheduler";
 import { vercelPlugin } from "@sentry/junior-vercel";
 
 export const plugins = defineJuniorPlugins([
-  createMemoryPlugin(),
+  memoryPlugin(),
   "@sentry/junior-maintenance",
   "@sentry/junior-agent-browser",
   "@sentry/junior-amplitude",

--- a/packages/junior-evals/src/behavior-harness.ts
+++ b/packages/junior-evals/src/behavior-harness.ts
@@ -68,7 +68,7 @@ import {
   type SchedulerDb,
 } from "@sentry/junior-scheduler";
 import { githubPlugin } from "@sentry/junior-github";
-import { createMemoryPlugin } from "@sentry/junior-memory";
+import { memoryPlugin } from "@sentry/junior-memory";
 import { runPluginHeartbeats } from "@/chat/agent-dispatch/heartbeat";
 import {
   buildDispatchRoutingContext,
@@ -1545,7 +1545,7 @@ function runtimePluginsForScenario(
     ...(packages.has("@sentry/junior-github")
       ? [githubPlugin({ appPermissions: { deployments: "read" } })]
       : []),
-    ...(packages.has("@sentry/junior-memory") ? [createMemoryPlugin()] : []),
+    ...(packages.has("@sentry/junior-memory") ? [memoryPlugin()] : []),
   ];
 }
 

--- a/packages/junior-memory/README.md
+++ b/packages/junior-memory/README.md
@@ -52,7 +52,7 @@ exported types, tools, and tests are authoritative.
 
 ## Configuration
 
-- `AI_MEMORY_MODEL` or `createMemoryPlugin({ modelId })` selects the structured
+- `AI_MEMORY_MODEL` or `memoryPlugin({ modelId })` selects the structured
   review model.
 - `MEMORY_RECALL_MAX_VECTOR_DISTANCE` or
   `recallMaxVectorDistance` configures the vector candidate threshold.

--- a/packages/junior-memory/src/index.ts
+++ b/packages/junior-memory/src/index.ts
@@ -1,4 +1,4 @@
-export { createMemoryPlugin, memoryPlugin } from "./plugin";
+export { memoryPlugin } from "./plugin";
 export type { MemoryPluginOptions } from "./plugin";
 export { createMemoryStore } from "./store";
 export type {

--- a/packages/junior-memory/src/plugin.ts
+++ b/packages/junior-memory/src/plugin.ts
@@ -85,8 +85,8 @@ function memoryCreateToolContext(ctx: {
   };
 }
 
-/** Create Junior's long-term memory plugin registration. */
-export function createMemoryPlugin(options: MemoryPluginOptions = {}) {
+/** Register Junior's long-term memory plugin. */
+export function memoryPlugin(options: MemoryPluginOptions = {}) {
   const modelId = memoryModelId(options);
   return defineJuniorPlugin({
     manifest: {
@@ -147,5 +147,3 @@ export function createMemoryPlugin(options: MemoryPluginOptions = {}) {
     },
   });
 }
-
-export const memoryPlugin = createMemoryPlugin();

--- a/packages/junior-memory/tests/storage.test.ts
+++ b/packages/junior-memory/tests/storage.test.ts
@@ -24,7 +24,7 @@ import { describe, expect, it } from "vitest";
 import * as memorySqlSchema from "../src/db/schema";
 import { createMemoryAgent, type CreateMemoryRequest } from "../src/agent";
 import { createMemoryCliCommand } from "../src/cli";
-import { createMemoryPlugin } from "../src/plugin";
+import { memoryPlugin } from "../src/plugin";
 import { processMemorySession } from "../src/process-session";
 import {
   createMemoryCreateTool,
@@ -474,7 +474,7 @@ describe("memory plugin storage", () => {
   });
 
   it("registers explicit model id as memory plugin model configuration", () => {
-    const plugin = createMemoryPlugin({
+    const plugin = memoryPlugin({
       modelId: "anthropic/claude-sonnet-4.6",
     });
 
@@ -488,7 +488,7 @@ describe("memory plugin storage", () => {
     delete process.env.AI_MEMORY_MODEL;
 
     try {
-      const plugin = createMemoryPlugin();
+      const plugin = memoryPlugin();
       expect(plugin.model).toEqual({
         structuredModel: "default",
       });
@@ -643,7 +643,7 @@ describe("memory plugin storage", () => {
     process.env.AI_MEMORY_MODEL = "anthropic/claude-sonnet-4.6";
 
     try {
-      const plugin = createMemoryPlugin();
+      const plugin = memoryPlugin();
       expect(plugin.model).toEqual({
         structuredModelId: "anthropic/claude-sonnet-4.6",
       });
@@ -1805,7 +1805,7 @@ ORDER BY created_at_ms ASC
         [],
       );
 
-      const memoryPage = createMemoryPlugin().userPages?.[0];
+      const memoryPage = memoryPlugin().userPages?.[0];
       if (!memoryPage || !actorContext.actor) {
         throw new Error("Expected Memory dashboard page and actor context");
       }
@@ -3004,7 +3004,7 @@ WHERE id = '${superseded.memory.id}'
         idempotencyKey: "memory-test:recall-other-user",
       });
 
-      const plugin = createMemoryPlugin();
+      const plugin = memoryPlugin();
       const result = await plugin.hooks?.userPrompt?.({
         ...context,
         destination: slackDestination(context),
@@ -3046,7 +3046,7 @@ WHERE id = '${superseded.memory.id}'
         idempotencyKey: "memory-test:recall-conversation-context",
       });
 
-      const plugin = createMemoryPlugin();
+      const plugin = memoryPlugin();
       const result = await plugin.hooks?.userPrompt?.({
         ...context,
         destination: slackDestination(context),
@@ -3102,7 +3102,7 @@ WHERE id = '${superseded.memory.id}'
         idempotencyKey: "memory-test:recall-blank",
       });
 
-      const plugin = createMemoryPlugin();
+      const plugin = memoryPlugin();
       await expect(
         plugin.hooks?.userPrompt?.({
           ...context,
@@ -3140,7 +3140,7 @@ WHERE id = '${superseded.memory.id}'
         idempotencyKey: "memory-test:recall-semantic",
       });
 
-      const plugin = createMemoryPlugin();
+      const plugin = memoryPlugin();
       const result = await plugin.hooks?.userPrompt?.({
         ...context,
         destination: slackDestination(context),

--- a/packages/junior-plugin-api/README.md
+++ b/packages/junior-plugin-api/README.md
@@ -8,6 +8,11 @@ exported TypeScript types and runtime validators are authoritative.
 Use `defineJuniorPlugin({ manifest, hooks, tasks, cli, model })`. A plugin name
 is a lowercase identifier and is unique within the enabled app plugin set.
 
+Packages with JavaScript registration export one callable factory named
+`<domain>Plugin`, such as `githubPlugin(options?)`. Do not use a public
+`create<Domain>Plugin` alias or export a prebuilt registration. Call the factory
+even when it accepts no options.
+
 A plugin may instead be a declarative `plugin.yaml` package when it has no
 host-executed hooks. Do not combine an inline manifest with a second YAML
 definition for the same plugin.

--- a/packages/junior-scheduler/src/index.ts
+++ b/packages/junior-scheduler/src/index.ts
@@ -1,4 +1,4 @@
-export { createSchedulerPlugin, schedulerPlugin } from "./plugin";
+export { schedulerPlugin } from "./plugin";
 export {
   createSlackScheduleCreateTaskTool,
   createSlackScheduleDeleteTaskTool,

--- a/packages/junior-scheduler/src/plugin.ts
+++ b/packages/junior-scheduler/src/plugin.ts
@@ -414,8 +414,8 @@ async function buildSchedulerOperationalReport(args: {
   };
 }
 
-/** Create Junior's built-in trusted scheduler plugin. */
-export function createSchedulerPlugin() {
+/** Register Junior's built-in trusted scheduler plugin. */
+export function schedulerPlugin() {
   return defineJuniorPlugin({
     manifest: {
       name: "scheduler",
@@ -584,6 +584,3 @@ export function createSchedulerPlugin() {
     },
   });
 }
-
-/** Register scheduler runtime hooks for scheduled Junior tasks. */
-export const schedulerPlugin = createSchedulerPlugin;

--- a/packages/junior/src/cli/init.ts
+++ b/packages/junior/src/cli/init.ts
@@ -24,10 +24,10 @@ function writePluginsFile(targetDir: string): void {
   fs.writeFileSync(
     path.join(targetDir, "plugins.ts"),
     `import { defineJuniorPlugins } from "@sentry/junior";
-import { createMemoryPlugin } from "@sentry/junior-memory";
+import { memoryPlugin } from "@sentry/junior-memory";
 
 export const plugins = defineJuniorPlugins([
-  createMemoryPlugin(),
+  memoryPlugin(),
   "@sentry/junior-maintenance",
 ]);
 `,

--- a/packages/junior/tests/component/memory-plugin-storage.test.ts
+++ b/packages/junior/tests/component/memory-plugin-storage.test.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 import { readdirSync } from "node:fs";
 import { afterAll, describe, expect, it, vi } from "vitest";
 import {
-  createMemoryPlugin,
+  memoryPlugin,
   createMemoryStore,
   type MemoryDb,
 } from "@sentry/junior-memory";
@@ -196,7 +196,7 @@ CREATE TABLE junior_schema_migrations (
       }).length;
       await expect(
         migratePluginsToSql({
-          pluginSet: defineJuniorPlugins([createMemoryPlugin()]),
+          pluginSet: defineJuniorPlugins([memoryPlugin()]),
           sqlExecutor: fixture.sql,
         }),
       ).resolves.toEqual({
@@ -234,7 +234,7 @@ WHERE table_name = 'junior_memory_memories'
       const totalMigrationCount = coreMigrationCount + memoryMigrationCount;
       const lines: string[] = [];
       const pluginSet = defineJuniorPlugins([
-        createMemoryPlugin(),
+        memoryPlugin(),
         defineJuniorPlugin({
           manifest: {
             description: "Plugin without SQL migrations",
@@ -268,7 +268,7 @@ WHERE table_name = 'junior_memory_memories'
 
   it("registers memory tools with runtime-provided plugin DB access", async () => {
     const fixture = await createLocalJuniorSqlFixture();
-    const previousPlugins = setPlugins([createMemoryPlugin()]);
+    const previousPlugins = setPlugins([memoryPlugin()]);
     NEON.sql = fixture.sql;
 
     try {

--- a/packages/junior/tests/unit/cli/init-cli.test.ts
+++ b/packages/junior/tests/unit/cli/init-cli.test.ts
@@ -137,10 +137,10 @@ describe("init cli", () => {
       'import { defineJuniorPlugins } from "@sentry/junior";',
     );
     expect(pluginsFile).toContain(
-      'import { createMemoryPlugin } from "@sentry/junior-memory";',
+      'import { memoryPlugin } from "@sentry/junior-memory";',
     );
     expect(pluginsFile).toContain("defineJuniorPlugins(");
-    expect(pluginsFile).toContain("createMemoryPlugin()");
+    expect(pluginsFile).toContain("memoryPlugin()");
     expect(pluginsFile).toContain('"@sentry/junior-maintenance"');
 
     const pkg = readJsonFile<{


### PR DESCRIPTION
Runtime-backed plugin packages now expose one callable `<domain>Plugin(options?)` factory. Memory moves from `createMemoryPlugin(...)` to `memoryPlugin(...)`, while scheduler removes the redundant `createSchedulerPlugin` export in favor of `schedulerPlugin()`. App scaffolding, examples, evals, tests, package documentation, and the public authoring guide now use and specify this convention.

This is a breaking API change for consumers importing the old names. Replace `createMemoryPlugin(...)` with `memoryPlugin(...)` and `createSchedulerPlugin()` with `schedulerPlugin()`. Manifest-only plugins remain registered by package-name string.
