### PR TITLE
feat(memory): add personal memory REST management

### DIFF
--- a/packages/docs/src/content/docs/extend/build-a-plugin.md
+++ b/packages/docs/src/content/docs/extend/build-a-plugin.md
@@ -184,14 +184,14 @@ rejects non-object replacements before the tool runs.
 
 Use the smallest surface that matches the deterministic boundary your plugin needs:
 
-| Surface                  | Purpose                                                                                                                                                                             |
-| ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `sandboxPrepare(ctx)`    | Prepare files or runtime state inside a sandbox before agent tools run.                                                                                                             |
-| `beforeToolExecute(ctx)` | Deny or rewrite object-shaped tool input and set non-secret env values before a tool runs.                                                                                          |
-| `tools(ctx)`             | Return host-registered tool definitions for the current turn. Tool names must be plugin-local camelCase names.                                                                      |
-| `heartbeat(ctx)`         | Run bounded periodic work from Junior's internal heartbeat route.                                                                                                                   |
-| `apiRoutes(ctx)`         | Return a Hono or fetch-compatible app mounted under `/api/plugins/:pluginName/*` with auth already applied. The app receives sanitized auth context as the second `fetch` argument. |
-| `tasks`                  | Register plugin-owned background tasks. V1 tasks run after completed sessions and load bounded run context with `ctx.run.load()`.                                                   |
+| Surface                  | Purpose                                                                                                                                                                                                                                                                         |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `sandboxPrepare(ctx)`    | Prepare files or runtime state inside a sandbox before agent tools run.                                                                                                                                                                                                         |
+| `beforeToolExecute(ctx)` | Deny or rewrite object-shaped tool input and set non-secret env values before a tool runs.                                                                                                                                                                                      |
+| `tools(ctx)`             | Return host-registered tool definitions for the current turn. Tool names must be plugin-local camelCase names.                                                                                                                                                                  |
+| `heartbeat(ctx)`         | Run bounded periodic work from Junior's internal heartbeat route.                                                                                                                                                                                                               |
+| `apiRoutes(ctx)`         | Return a Hono or fetch-compatible app mounted under `/api/plugins/:pluginName/*` with auth already applied. The app receives sanitized viewer auth as the second `fetch` argument; use `ctx.viewer.actors(email)` only when viewer-owned data spans linked platform identities. |
+| `tasks`                  | Register plugin-owned background tasks. V1 tasks run after completed sessions and load bounded run context with `ctx.run.load()`.                                                                                                                                               |
 
 `tools(ctx)` receives the active turn context, `ctx.state`, and `ctx.log`.
 Return tool definitions keyed by the plugin-local tool names your plugin owns.

--- a/packages/docs/src/content/docs/extend/memory-plugin.md
+++ b/packages/docs/src/content/docs/extend/memory-plugin.md
@@ -64,6 +64,23 @@ export const plugins = defineJuniorPlugins([
 
 For non-Neon managed Postgres (Railway, Supabase, AWS RDS, or self-hosted), set `JUNIOR_DATABASE_DRIVER=postgres`. Local URLs (`localhost`, `127.0.0.1`) automatically use the `postgres` driver.
 
+## Manage personal memories
+
+Signed-in users can search, page through, and forget their personal memories
+from **Profile → Memories** in the dashboard. Forgetting archives the memory so
+Junior no longer recalls it.
+
+The plugin also exposes authenticated REST resources:
+
+| Method   | Path                               | Purpose                                       |
+| -------- | ---------------------------------- | --------------------------------------------- |
+| `GET`    | `/api/plugins/memory/memories`     | List memories with `q`, `cursor`, and `limit` |
+| `GET`    | `/api/plugins/memory/memories/:id` | Read one personal memory                      |
+| `DELETE` | `/api/plugins/memory/memories/:id` | Forget one personal memory                    |
+
+Personal API tokens can use the read endpoints. Deletion requires an
+authenticated dashboard browser session.
+
 ## Run migrations
 
 After setting `DATABASE_URL`, run the upgrade command to apply the memory plugin schema:

--- a/packages/junior-dashboard/README.md
+++ b/packages/junior-dashboard/README.md
@@ -12,7 +12,9 @@ state.
   or required configuration is missing.
 - API schemas under `src/api/` define the client/server boundary.
 - Plugin user pages use the core `/api/user-pages` contract and appear under
-  the signed-in user menu at `/settings/plugins/:plugin/:page`.
+  the signed-in user menu at `/settings/plugins/:plugin/:page`. Core-rendered
+  lists own search query state, cursor pagination, destructive confirmation,
+  and authenticated plugin REST actions.
 - Conversation detail is a bounded TanStack Query resource that polls while
   active. Earlier event pages use a separate infinite query loaded on demand.
   The client derives one ordered transcript from those immutable responses;

--- a/packages/junior-dashboard/e2e/harness.ts
+++ b/packages/junior-dashboard/e2e/harness.ts
@@ -119,8 +119,18 @@ export async function mockDashboardApis(page: Page) {
       json: {
         type: "list",
         emptyText: "No personal memories yet.",
+        searchPlaceholder: "Search memories",
         records: [
           {
+            actions: [
+              {
+                confirmation: "Forget this memory?",
+                href: "/api/plugins/memory/memories/memory-1",
+                label: "Forget",
+                method: "DELETE",
+                tone: "danger",
+              },
+            ],
             id: "memory-1",
             title: "I prefer concise summaries.",
             metadata: [{ label: "Type", value: "Preference" }],

--- a/packages/junior-dashboard/e2e/user-pages.spec.ts
+++ b/packages/junior-dashboard/e2e/user-pages.spec.ts
@@ -120,10 +120,21 @@ test("searches, paginates, and forgets plugin page records", async ({
 
   await page.goto(`${server.baseURL}/settings/plugins/memory/memories`);
   await expect(page.getByText("First page memory.")).toBeVisible();
+  const searchbox = page.getByRole("searchbox", { name: "Search memories" });
+  await searchbox.fill("runbook");
+  await expect(page).toHaveURL(/q=runbook/);
+  await expect(
+    page.getByRole("button", { name: "Load more" }),
+  ).not.toBeVisible();
+  await expect(searchbox).toBeFocused();
+  await expect(page.getByText("Deploy runbooks live in Notion.")).toBeVisible();
+
+  await searchbox.fill("");
+  await expect(page).not.toHaveURL(/q=/);
+  await expect(page.getByText("First page memory.")).toBeVisible();
   await page.getByRole("button", { name: "Load more" }).click();
   await expect(page.getByText("Second page memory.")).toBeVisible();
 
-  const searchbox = page.getByRole("searchbox", { name: "Search memories" });
   await searchbox.fill("runbook");
   await expect(page).toHaveURL(/q=runbook/);
   await expect(searchbox).toBeFocused();

--- a/packages/junior-dashboard/e2e/user-pages.spec.ts
+++ b/packages/junior-dashboard/e2e/user-pages.spec.ts
@@ -72,6 +72,9 @@ test("searches, paginates, and forgets plugin page records", async ({
     const url = new URL(route.request().url());
     const query = url.searchParams.get("q");
     const cursor = url.searchParams.get("cursor");
+    if (query) {
+      await new Promise((resolve) => setTimeout(resolve, 400));
+    }
     const records = forgotMemory
       ? []
       : query
@@ -120,10 +123,10 @@ test("searches, paginates, and forgets plugin page records", async ({
   await page.getByRole("button", { name: "Load more" }).click();
   await expect(page.getByText("Second page memory.")).toBeVisible();
 
-  await page
-    .getByRole("searchbox", { name: "Search memories" })
-    .fill("runbook");
+  const searchbox = page.getByRole("searchbox", { name: "Search memories" });
+  await searchbox.fill("runbook");
   await expect(page).toHaveURL(/q=runbook/);
+  await expect(searchbox).toBeFocused();
   await expect(page.getByText("Deploy runbooks live in Notion.")).toBeVisible();
 
   page.once("dialog", (dialog) => dialog.accept());

--- a/packages/junior-dashboard/e2e/user-pages.spec.ts
+++ b/packages/junior-dashboard/e2e/user-pages.spec.ts
@@ -63,3 +63,77 @@ test("renders an empty registered plugin page", async ({ page }) => {
   await expect(page.getByText("No personal memories yet.")).toBeVisible();
   expect(browserErrors).toEqual([]);
 });
+
+test("searches, paginates, and forgets plugin page records", async ({
+  page,
+}) => {
+  let forgotMemory = false;
+  await page.route("**/api/user-pages/memory/memories*", async (route) => {
+    const url = new URL(route.request().url());
+    const query = url.searchParams.get("q");
+    const cursor = url.searchParams.get("cursor");
+    const records = forgotMemory
+      ? []
+      : query
+        ? [
+            {
+              actions: [
+                {
+                  confirmation: "Forget this memory?",
+                  href: "/api/plugins/memory/memories/memory-search",
+                  label: "Forget",
+                  method: "DELETE",
+                  tone: "danger",
+                },
+              ],
+              id: "memory-search",
+              title: "Deploy runbooks live in Notion.",
+            },
+          ]
+        : cursor
+          ? [{ id: "memory-2", title: "Second page memory." }]
+          : [{ id: "memory-1", title: "First page memory." }];
+    await route.fulfill({
+      json: {
+        type: "list",
+        emptyText: query
+          ? "No memories matched your search."
+          : "No personal memories yet.",
+        ...(!query && !cursor ? { nextCursor: "page-2" } : {}),
+        records,
+        searchPlaceholder: "Search memories",
+      },
+    });
+  });
+  await page.route(
+    "**/api/plugins/memory/memories/memory-search",
+    async (route) => {
+      expect(route.request().method()).toBe("DELETE");
+      forgotMemory = true;
+      await route.fulfill({ status: 204 });
+    },
+  );
+  const browserErrors = collectBrowserErrors(page);
+
+  await page.goto(`${server.baseURL}/settings/plugins/memory/memories`);
+  await expect(page.getByText("First page memory.")).toBeVisible();
+  await page.getByRole("button", { name: "Load more" }).click();
+  await expect(page.getByText("Second page memory.")).toBeVisible();
+
+  await page
+    .getByRole("searchbox", { name: "Search memories" })
+    .fill("runbook");
+  await expect(page).toHaveURL(/q=runbook/);
+  await expect(page.getByText("Deploy runbooks live in Notion.")).toBeVisible();
+
+  page.once("dialog", (dialog) => dialog.accept());
+  await page
+    .getByRole("button", {
+      name: "Forget: Deploy runbooks live in Notion.",
+    })
+    .click();
+  await expect(
+    page.getByText("No memories matched your search."),
+  ).toBeVisible();
+  expect(browserErrors).toEqual([]);
+});

--- a/packages/junior-dashboard/src/client/pages/user/PluginUserPage.tsx
+++ b/packages/junior-dashboard/src/client/pages/user/PluginUserPage.tsx
@@ -69,6 +69,7 @@ export function PluginUserPage(props: { pages: PluginUserPageLink[] }) {
       );
     },
     getNextPageParam: (lastPage) => lastPage.nextCursor,
+    placeholderData: (previousData) => previousData,
     retry: false,
   });
   const records = useMemo(
@@ -216,7 +217,7 @@ export function PluginUserPage(props: { pages: PluginUserPageLink[] }) {
             ) : null}
             {action.error ? (
               <p className="m-0 text-center text-sm text-rose-300">
-                Could not update this memory. Try again.
+                Could not complete this action. Try again.
               </p>
             ) : null}
           </div>

--- a/packages/junior-dashboard/src/client/pages/user/PluginUserPage.tsx
+++ b/packages/junior-dashboard/src/client/pages/user/PluginUserPage.tsx
@@ -206,7 +206,7 @@ export function PluginUserPage(props: { pages: PluginUserPageLink[] }) {
                 ) : null}
               </Card>
             ))}
-            {query.hasNextPage ? (
+            {!query.isPlaceholderData && query.hasNextPage ? (
               <Button
                 className="justify-self-center"
                 disabled={query.isFetchingNextPage}

--- a/packages/junior-dashboard/src/client/pages/user/PluginUserPage.tsx
+++ b/packages/junior-dashboard/src/client/pages/user/PluginUserPage.tsx
@@ -1,15 +1,22 @@
-import { useQuery } from "@tanstack/react-query";
-import { Boxes } from "lucide-react";
-import { Navigate, useParams } from "react-router";
+import {
+  useInfiniteQuery,
+  useMutation,
+  useQueryClient,
+} from "@tanstack/react-query";
+import { Boxes, Search, Trash2 } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { Navigate, useParams, useSearchParams } from "react-router";
 import {
   pluginUserPageContentSchema,
+  type PluginUserPageContent,
   type PluginUserPageLink,
 } from "@sentry/junior-plugin-api";
 
+import { Button } from "../../components/Button";
 import { LoadingView } from "../../components/LoadingView";
 import { Card } from "../../components/layout/Card";
 import { PageHeader } from "../../components/layout/PageHeader";
-import { fetchDashboardJson } from "../../http";
+import { deleteDashboardResource, fetchDashboardJson } from "../../http";
 import { dashboardContainerClass } from "../../styles";
 
 /** Build the dashboard route for a plugin-owned user page. */
@@ -20,18 +27,81 @@ export function pluginUserPagePath(pluginName: string, pageId: string): string {
 /** Render a plugin-owned user page from its bounded list response. */
 export function PluginUserPage(props: { pages: PluginUserPageLink[] }) {
   const { pageId, pluginName } = useParams();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const queryClient = useQueryClient();
   const page = props.pages.find(
     (item) => item.pluginName === pluginName && item.id === pageId,
   );
-  const query = useQuery({
+  const searchQuery = searchParams.get("q")?.trim() ?? "";
+  const [searchText, setSearchText] = useState(searchQuery);
+  useEffect(() => {
+    setSearchText(searchQuery);
+  }, [searchQuery]);
+  useEffect(() => {
+    const timeout = window.setTimeout(() => {
+      const normalized = searchText.trim();
+      if (normalized === searchQuery) return;
+      setSearchParams(normalized ? { q: normalized } : {}, { replace: true });
+    }, 250);
+    return () => window.clearTimeout(timeout);
+  }, [searchQuery, searchText, setSearchParams]);
+
+  const queryKey = [
+    "dashboard",
+    "plugin-user-page",
+    pluginName,
+    pageId,
+    searchQuery,
+  ] as const;
+  const query = useInfiniteQuery({
     enabled: Boolean(page),
-    queryKey: ["dashboard", "plugin-user-page", pluginName, pageId],
-    queryFn: () =>
-      fetchDashboardJson(
+    initialPageParam: undefined as string | undefined,
+    queryKey,
+    queryFn: ({ pageParam, signal }) => {
+      const params = new URLSearchParams();
+      if (searchQuery) params.set("q", searchQuery);
+      if (pageParam) params.set("cursor", pageParam);
+      const search = params.toString();
+      return fetchDashboardJson(
         pluginUserPageContentSchema,
-        `/api/user-pages/${encodeURIComponent(pluginName!)}/${encodeURIComponent(pageId!)}`,
-      ),
+        `/api/user-pages/${encodeURIComponent(pluginName!)}/${encodeURIComponent(pageId!)}${search ? `?${search}` : ""}`,
+        signal,
+      );
+    },
+    getNextPageParam: (lastPage) => lastPage.nextCursor,
     retry: false,
+  });
+  const records = useMemo(
+    () => [
+      ...new Map(
+        (query.data?.pages ?? [])
+          .flatMap((content) => content.records)
+          .map((record) => [record.id, record]),
+      ).values(),
+    ],
+    [query.data?.pages],
+  );
+  const content = query.data?.pages[0];
+  const action = useMutation({
+    mutationFn: async (
+      recordAction: NonNullable<
+        PluginUserPageContent["records"][number]["actions"]
+      >[number],
+    ) => {
+      if (
+        recordAction.confirmation &&
+        !window.confirm(recordAction.confirmation)
+      ) {
+        return false;
+      }
+      await deleteDashboardResource(recordAction.href);
+      return true;
+    },
+    onSuccess: async (changed) => {
+      if (changed) {
+        await queryClient.resetQueries({ queryKey });
+      }
+    },
   });
 
   if (!page) return <Navigate replace to="/" />;
@@ -47,30 +117,73 @@ export function PluginUserPage(props: { pages: PluginUserPageLink[] }) {
           eyebrow={page.pluginDisplayName}
           title={page.label}
         />
+        {content?.searchPlaceholder ? (
+          <label className="relative block">
+            <Search
+              aria-hidden="true"
+              className="pointer-events-none absolute top-1/2 left-3 -translate-y-1/2 text-dashboard-text-muted"
+              size={15}
+            />
+            <span className="sr-only">{content.searchPlaceholder}</span>
+            <input
+              className="w-full rounded border border-white/15 bg-black py-2 pr-3 pl-9 text-sm text-dashboard-text placeholder:text-dashboard-text-muted focus:border-cyan-300/50 focus:outline-none"
+              onChange={(event) => setSearchText(event.target.value)}
+              placeholder={content.searchPlaceholder}
+              type="search"
+              value={searchText}
+            />
+          </label>
+        ) : null}
         {query.error ? (
           <Card padding="md">
             <p className="m-0 text-sm text-rose-300">
               Could not load {page.label.toLowerCase()}. Try again.
             </p>
           </Card>
-        ) : query.data!.records.length === 0 ? (
+        ) : records.length === 0 ? (
           <Card padding="md">
             <div className="flex items-center gap-4">
               <div className="grid size-10 shrink-0 place-items-center rounded border border-white/[0.07] bg-white/[0.025] text-dashboard-text-muted">
                 <Boxes aria-hidden="true" size={17} />
               </div>
               <p className="m-0 text-sm text-dashboard-text-muted">
-                {query.data!.emptyText ?? `No ${page.label.toLowerCase()}.`}
+                {content?.emptyText ?? `No ${page.label.toLowerCase()}.`}
               </p>
             </div>
           </Card>
         ) : (
           <div className="grid gap-3">
-            {query.data!.records.map((record) => (
+            {records.map((record) => (
               <Card key={record.id} padding="md">
-                <h2 className="m-0 font-display text-base font-medium text-dashboard-text">
-                  {record.title}
-                </h2>
+                <div className="flex items-start gap-3">
+                  <h2 className="m-0 min-w-0 flex-1 font-display text-base font-medium text-dashboard-text">
+                    {record.title}
+                  </h2>
+                  {record.actions?.map((recordAction) => (
+                    <button
+                      aria-label={`${recordAction.label}: ${record.title}`}
+                      className={`cursor-pointer border-0 bg-transparent p-1 text-dashboard-text-muted transition-colors ${
+                        recordAction.tone === "danger"
+                          ? "hover:text-rose-300"
+                          : "hover:text-dashboard-text"
+                      }`}
+                      disabled={
+                        action.isPending &&
+                        action.variables?.href === recordAction.href
+                      }
+                      key={`${recordAction.method}:${recordAction.href}`}
+                      onClick={() => action.mutate(recordAction)}
+                      title={recordAction.label}
+                      type="button"
+                    >
+                      {recordAction.tone === "danger" ? (
+                        <Trash2 aria-hidden="true" size={16} />
+                      ) : (
+                        recordAction.label
+                      )}
+                    </button>
+                  ))}
+                </div>
                 {record.description ? (
                   <p className="mt-2 mb-0 text-sm text-dashboard-text-muted">
                     {record.description}
@@ -92,6 +205,20 @@ export function PluginUserPage(props: { pages: PluginUserPageLink[] }) {
                 ) : null}
               </Card>
             ))}
+            {query.hasNextPage ? (
+              <Button
+                className="justify-self-center"
+                disabled={query.isFetchingNextPage}
+                onClick={() => void query.fetchNextPage()}
+              >
+                {query.isFetchingNextPage ? "Loading…" : "Load more"}
+              </Button>
+            ) : null}
+            {action.error ? (
+              <p className="m-0 text-center text-sm text-rose-300">
+                Could not update this memory. Try again.
+              </p>
+            ) : null}
           </div>
         )}
       </section>

--- a/packages/junior-dashboard/tests/dashboard-routes.test.ts
+++ b/packages/junior-dashboard/tests/dashboard-routes.test.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createApp, defineJuniorPlugins } from "@sentry/junior";
+import * as juniorApi from "@sentry/junior/api";
 import { defineJuniorPlugin } from "@sentry/junior-plugin-api";
 import { createDashboardApp } from "../src/app";
 import {
@@ -77,6 +78,7 @@ describe("dashboard routes", () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     vi.doUnmock("#junior/config");
     for (const name of dashboardEnvNames) {
       delete process.env[name];
@@ -792,6 +794,34 @@ describe("dashboard routes", () => {
       path: "/memories",
       ok: true,
     });
+  });
+
+  it("rejects personal bearer token writes before plugin dispatch", async () => {
+    const authenticateToken = vi
+      .spyOn(juniorApi, "authenticatePersonalToken")
+      .mockResolvedValue("person@sentry.io");
+    let dispatched = false;
+    const pluginApp = new Hono();
+    pluginApp.delete("/memories/:id", (c) => {
+      dispatched = true;
+      return c.body(null, 204);
+    });
+    const app = createDashboardApp({
+      allowedGoogleDomains: ["sentry.io"],
+      auth: auth(null),
+      pluginRoutes: [{ app: pluginApp, pluginName: "memory" }],
+    });
+
+    const response = await app.fetch(
+      new Request("http://localhost/api/plugins/memory/memories/memory-1", {
+        headers: { authorization: "Bearer jr_pat_valid" },
+        method: "DELETE",
+      }),
+    );
+
+    expect(response.status).toBe(401);
+    expect(authenticateToken).not.toHaveBeenCalled();
+    expect(dispatched).toBe(false);
   });
 
   it("passes sanitized auth context to plugin API route apps", async () => {

--- a/packages/junior-dashboard/tests/dashboard-routes.test.ts
+++ b/packages/junior-dashboard/tests/dashboard-routes.test.ts
@@ -1,7 +1,6 @@
 import { Hono } from "hono";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createApp, defineJuniorPlugins } from "@sentry/junior";
-import * as juniorApi from "@sentry/junior/api";
 import { defineJuniorPlugin } from "@sentry/junior-plugin-api";
 import { createDashboardApp } from "../src/app";
 import {
@@ -9,6 +8,14 @@ import {
   type DashboardAuth,
   type DashboardSession,
 } from "../src/auth";
+
+const { authenticatePersonalToken } = vi.hoisted(() => ({
+  authenticatePersonalToken: vi.fn(),
+}));
+vi.mock("@sentry/junior/api", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@sentry/junior/api")>()),
+  authenticatePersonalToken,
+}));
 
 const dashboardEnvNames = [
   "BETTER_AUTH_SECRET",
@@ -72,13 +79,13 @@ function mockDashboardVirtualConfig() {
 describe("dashboard routes", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    authenticatePersonalToken.mockReset();
     for (const name of dashboardEnvNames) {
       delete process.env[name];
     }
   });
 
   afterEach(() => {
-    vi.restoreAllMocks();
     vi.doUnmock("#junior/config");
     for (const name of dashboardEnvNames) {
       delete process.env[name];
@@ -797,9 +804,7 @@ describe("dashboard routes", () => {
   });
 
   it("rejects personal bearer token writes before plugin dispatch", async () => {
-    const authenticateToken = vi
-      .spyOn(juniorApi, "authenticatePersonalToken")
-      .mockResolvedValue("person@sentry.io");
+    authenticatePersonalToken.mockResolvedValue("person@sentry.io");
     let dispatched = false;
     const pluginApp = new Hono();
     pluginApp.delete("/memories/:id", (c) => {
@@ -820,7 +825,7 @@ describe("dashboard routes", () => {
     );
 
     expect(response.status).toBe(401);
-    expect(authenticateToken).not.toHaveBeenCalled();
+    expect(authenticatePersonalToken).not.toHaveBeenCalled();
     expect(dispatched).toBe(false);
   });
 

--- a/packages/junior-memory/README.md
+++ b/packages/junior-memory/README.md
@@ -13,13 +13,22 @@ exported types, tools, and tests are authoritative.
   learning.
 - The `memory` CLI namespace provides explicit administrative search and
   inspection.
-- The dashboard exposes a read-only **Memories** user page for personal
-  memories owned by actors linked to the signed-in user.
+- The dashboard exposes a searchable, paginated **Memories** user page for
+  personal memories owned by actors linked to the signed-in viewer. Its
+  **Forget** action archives the selected memory.
+- Authenticated REST clients can list and search personal memories through
+  `GET /api/plugins/memory/memories`, read one through
+  `GET /api/plugins/memory/memories/:id`, and archive one through
+  `DELETE /api/plugins/memory/memories/:id`. Personal bearer tokens remain
+  read-only, so mutations require a dashboard browser session.
 
 ## Scope And Visibility
 
 - Memory scope is derived from the active actor and source, never from
   model-supplied ownership fields.
+- Dashboard and REST requests authorize one verified viewer, then resolve every
+  linked platform actor internally so one arbitrary actor is never treated as
+  the viewer's canonical identity.
 - Private conversations and local sources remain private by default.
 - Recall filters candidates by actor, source, visibility, status, and relevance
   before content reaches the model.

--- a/packages/junior-memory/src/api.ts
+++ b/packages/junior-memory/src/api.ts
@@ -1,0 +1,168 @@
+/**
+ * Authenticated REST resources for personal memories.
+ *
+ * HTTP identity is one verified viewer. Linked platform actors are resolved
+ * behind the route boundary and used only to authorize personal scopes.
+ */
+import { z } from "zod";
+import {
+  pluginApiRouteRequestContextSchema,
+  type PluginApiRouteRequestContext,
+  type PluginRouteApp,
+  type PluginUserPageActor,
+} from "@sentry/junior-plugin-api";
+import type { MemoryDb, MemoryRecord } from "./store";
+import {
+  createViewerMemories,
+  InvalidMemoryCursorError,
+  PersonalMemoryNotFoundError,
+} from "./personal";
+
+export const memoryApiSchema = z
+  .object({
+    content: z.string().min(1),
+    createdAt: z.iso.datetime(),
+    expiresAt: z.iso.datetime().optional(),
+    id: z.string().min(1),
+    kind: z.enum(["preference", "procedure", "knowledge"]),
+    observedAt: z.iso.datetime(),
+  })
+  .strict();
+
+export const memoryListResponseSchema = z
+  .object({
+    memories: z.array(memoryApiSchema),
+    nextCursor: z.string().min(1).optional(),
+  })
+  .strict();
+
+export type MemoryApi = z.output<typeof memoryApiSchema>;
+export type MemoryListResponse = z.output<typeof memoryListResponseSchema>;
+
+const memoryListQuerySchema = z
+  .object({
+    cursor: z.string().min(1).max(1_000).optional(),
+    limit: z.coerce.number().int().min(1).max(50).default(25),
+    q: z.string().trim().max(200).optional(),
+  })
+  .strict();
+
+interface MemoryApiOptions {
+  actors(email: string): Promise<PluginUserPageActor[]>;
+  db: MemoryDb;
+}
+
+function json(body: unknown, status = 200): Response {
+  return Response.json(body, {
+    headers: { "cache-control": "no-store" },
+    status,
+  });
+}
+
+function apiMemory(memory: MemoryRecord): z.output<typeof memoryApiSchema> {
+  return {
+    content: memory.content,
+    createdAt: new Date(memory.createdAtMs).toISOString(),
+    ...(memory.expiresAtMs !== undefined
+      ? { expiresAt: new Date(memory.expiresAtMs).toISOString() }
+      : {}),
+    id: memory.id,
+    kind: memory.kind,
+    observedAt: new Date(memory.observedAtMs).toISOString(),
+  };
+}
+
+function viewerEmail(
+  context: PluginApiRouteRequestContext | undefined,
+): string | undefined {
+  const parsed = pluginApiRouteRequestContextSchema.safeParse(context);
+  if (!parsed.success || parsed.data.auth.user.emailVerified !== true) {
+    return undefined;
+  }
+  return parsed.data.auth.user.email?.trim().toLowerCase() || undefined;
+}
+
+/** Create the authenticated personal-memory REST app. */
+export function createMemoryApi(options: MemoryApiOptions): PluginRouteApp {
+  return {
+    async fetch(request, context) {
+      const email = viewerEmail(context);
+      if (!email) {
+        return json({ error: "Authentication required." }, 401);
+      }
+
+      const url = new URL(request.url);
+      const memoryPath = /^\/memories\/([^/]+)$/.exec(url.pathname);
+      const isCollection = url.pathname === "/memories";
+      if (!isCollection && !memoryPath) {
+        return json({ error: "Not found." }, 404);
+      }
+
+      const actors = await options.actors(email);
+      const memories = createViewerMemories(options.db, actors);
+      try {
+        if (
+          isCollection &&
+          (request.method === "GET" || request.method === "HEAD")
+        ) {
+          const query = memoryListQuerySchema.parse({
+            cursor: url.searchParams.get("cursor") ?? undefined,
+            limit: url.searchParams.get("limit") ?? undefined,
+            q: url.searchParams.get("q") ?? undefined,
+          });
+          const page = await memories.list({
+            cursor: query.cursor,
+            limit: query.limit,
+            ...(query.q ? { query: query.q } : {}),
+          });
+          const body = memoryListResponseSchema.parse({
+            memories: page.memories.map(apiMemory),
+            ...(page.nextCursor ? { nextCursor: page.nextCursor } : {}),
+          });
+          return request.method === "HEAD"
+            ? new Response(null, {
+                headers: { "cache-control": "no-store" },
+                status: 200,
+              })
+            : json(body);
+        }
+
+        if (
+          memoryPath &&
+          (request.method === "GET" || request.method === "HEAD")
+        ) {
+          const memory = memoryApiSchema.parse(
+            apiMemory(await memories.get(decodeURIComponent(memoryPath[1]!))),
+          );
+          return request.method === "HEAD"
+            ? new Response(null, {
+                headers: { "cache-control": "no-store" },
+                status: 200,
+              })
+            : json(memory);
+        }
+
+        if (memoryPath && request.method === "DELETE") {
+          await memories.archive(decodeURIComponent(memoryPath[1]!));
+          return new Response(null, {
+            headers: { "cache-control": "no-store" },
+            status: 204,
+          });
+        }
+      } catch (error) {
+        if (
+          error instanceof z.ZodError ||
+          error instanceof InvalidMemoryCursorError
+        ) {
+          return json({ error: "Invalid memory request." }, 400);
+        }
+        if (error instanceof PersonalMemoryNotFoundError) {
+          return json({ error: error.message }, 404);
+        }
+        throw error;
+      }
+
+      return json({ error: "Method not allowed." }, 405);
+    },
+  };
+}

--- a/packages/junior-memory/src/index.ts
+++ b/packages/junior-memory/src/index.ts
@@ -1,4 +1,10 @@
 export { memoryPlugin } from "./plugin";
+export {
+  memoryApiSchema,
+  memoryListResponseSchema,
+  type MemoryApi,
+  type MemoryListResponse,
+} from "./api";
 export type { MemoryPluginOptions } from "./plugin";
 export { createMemoryStore } from "./store";
 export type {

--- a/packages/junior-memory/src/personal-store.ts
+++ b/packages/junior-memory/src/personal-store.ts
@@ -1,0 +1,195 @@
+/**
+ * SQL operations over personal memories owned by one authenticated viewer.
+ *
+ * A viewer may resolve to several runtime actors. This store combines their
+ * personal scopes without treating one actor as the canonical identity.
+ */
+import { and, asc, desc, eq, gt, ilike, lt, or, sql } from "drizzle-orm";
+import { z } from "zod";
+import { juniorMemoryEmbeddings, juniorMemoryMemories } from "./db/schema";
+import { deriveMemoryScope, type ResolvedMemoryScope } from "./scope";
+import {
+  activeVisiblePredicate,
+  archiveExpiredMemoryBatch,
+  parseMemoryRow,
+  type MemoryDb,
+  type MemoryRecord,
+} from "./store";
+import type { MemoryRuntimeContext } from "./types";
+
+const nonEmptyStringSchema = z.string().min(1);
+const personalMemoryCursorSchema = z
+  .object({
+    createdAtMs: z.number().finite(),
+    id: nonEmptyStringSchema,
+  })
+  .strict();
+const personalMemoryPageInputSchema = z
+  .object({
+    cursor: personalMemoryCursorSchema.optional(),
+    limit: z.number().int().min(1).max(50),
+    query: z.string().max(200).optional(),
+  })
+  .strict();
+
+export type PersonalMemoryCursor = z.output<typeof personalMemoryCursorSchema>;
+
+export type PersonalMemoryPageInput = z.output<
+  typeof personalMemoryPageInputSchema
+>;
+
+export interface PersonalMemoryPage {
+  memories: MemoryRecord[];
+  nextCursor?: PersonalMemoryCursor;
+}
+
+/** Expected failure when a viewer does not own the requested memory. */
+export class PersonalMemoryNotFoundError extends Error {
+  constructor() {
+    super("Memory was not found for the authenticated viewer.");
+    this.name = "PersonalMemoryNotFoundError";
+  }
+}
+
+/** Viewer-scoped personal memory operations shared by dashboard and REST. */
+export interface PersonalMemoryCollection {
+  /** Archive one exact personal memory owned by a linked actor. */
+  archive(id: string): Promise<MemoryRecord>;
+  /** Read one exact personal memory owned by a linked actor. */
+  get(id: string): Promise<MemoryRecord>;
+  /** List one stable page across every linked personal scope. */
+  list(input: PersonalMemoryPageInput): Promise<PersonalMemoryPage>;
+}
+
+function personalScopes(
+  runtimeContexts: MemoryRuntimeContext[],
+): ResolvedMemoryScope[] {
+  return [
+    ...new Map(
+      runtimeContexts.map((context) => {
+        const scope = deriveMemoryScope(context, "personal");
+        return [`${scope.scope}:${scope.scopeKey}`, scope] as const;
+      }),
+    ).values(),
+  ];
+}
+
+function searchTerms(query: string): string[] {
+  return [
+    ...new Set(
+      query
+        .toLowerCase()
+        .split(/[^a-z0-9_'-]+/)
+        .map((term) => term.trim())
+        .filter((term) => term.length >= 2),
+    ),
+  ];
+}
+
+/** Build storage operations for every personal scope linked to one viewer. */
+export function createPersonalMemoryCollection(
+  db: MemoryDb,
+  runtimeContexts: MemoryRuntimeContext[],
+  options: { now?: () => number } = {},
+): PersonalMemoryCollection {
+  const scopes = personalScopes(runtimeContexts);
+  const getNowMs = () => options.now?.() ?? Date.now();
+
+  return {
+    async archive(id) {
+      const memoryId = nonEmptyStringSchema.parse(id);
+      const nowMs = getNowMs();
+      const predicate = activeVisiblePredicate({ nowMs, scopes });
+      if (!predicate) {
+        throw new PersonalMemoryNotFoundError();
+      }
+      const updated = await db
+        .update(juniorMemoryMemories)
+        .set({
+          archivedAtMs: nowMs,
+          archiveReason: "user_removed",
+        })
+        .where(and(predicate, eq(juniorMemoryMemories.id, memoryId)))
+        .returning();
+      if (!updated[0]) {
+        throw new PersonalMemoryNotFoundError();
+      }
+      await db
+        .delete(juniorMemoryEmbeddings)
+        .where(eq(juniorMemoryEmbeddings.memoryId, memoryId));
+      return parseMemoryRow(updated[0]);
+    },
+
+    async get(id) {
+      const memoryId = nonEmptyStringSchema.parse(id);
+      const nowMs = getNowMs();
+      const predicate = activeVisiblePredicate({ nowMs, scopes });
+      if (!predicate) {
+        throw new PersonalMemoryNotFoundError();
+      }
+      const rows = await db
+        .select()
+        .from(juniorMemoryMemories)
+        .where(and(predicate, eq(juniorMemoryMemories.id, memoryId)))
+        .limit(1);
+      if (!rows[0]) {
+        throw new PersonalMemoryNotFoundError();
+      }
+      return parseMemoryRow(rows[0]);
+    },
+
+    async list(input) {
+      input = personalMemoryPageInputSchema.parse(input);
+      const nowMs = getNowMs();
+      await archiveExpiredMemoryBatch({ db, nowMs, scopes });
+      const active = activeVisiblePredicate({ nowMs, scopes });
+      if (!active) {
+        return { memories: [] };
+      }
+
+      const cursor = input.cursor
+        ? or(
+            lt(juniorMemoryMemories.createdAtMs, input.cursor.createdAtMs),
+            and(
+              eq(juniorMemoryMemories.createdAtMs, input.cursor.createdAtMs),
+              gt(juniorMemoryMemories.id, input.cursor.id),
+            ),
+          )
+        : undefined;
+      const terms = input.query ? searchTerms(input.query) : [];
+      const search =
+        input.query === undefined
+          ? undefined
+          : terms.length === 0
+            ? sql`false`
+            : or(
+                ...terms.map((term) =>
+                  ilike(juniorMemoryMemories.content, `%${term}%`),
+                ),
+              );
+      const rows = await db
+        .select()
+        .from(juniorMemoryMemories)
+        .where(and(active, cursor, search))
+        .orderBy(
+          desc(juniorMemoryMemories.createdAtMs),
+          asc(juniorMemoryMemories.id),
+        )
+        .limit(input.limit + 1);
+      const hasNextPage = rows.length > input.limit;
+      const memories = rows.slice(0, input.limit).map(parseMemoryRow);
+      const last = memories.at(-1);
+      return {
+        memories,
+        ...(hasNextPage && last
+          ? {
+              nextCursor: {
+                createdAtMs: last.createdAtMs,
+                id: last.id,
+              },
+            }
+          : {}),
+      };
+    },
+  };
+}

--- a/packages/junior-memory/src/personal.ts
+++ b/packages/junior-memory/src/personal.ts
@@ -1,0 +1,120 @@
+/**
+ * Authenticated-viewer memory access shared by REST and dashboard projections.
+ *
+ * Viewer identity may resolve to multiple platform actors. This module keeps
+ * that federation behind one personal-memory collection.
+ */
+import { z } from "zod";
+import type { PluginUserPageActor } from "@sentry/junior-plugin-api";
+import { createPersonalMemoryCollection } from "./personal-store";
+import type { MemoryDb, MemoryRecord } from "./store";
+import type { MemoryRuntimeContext } from "./types";
+
+const cursorSchema = z
+  .object({
+    createdAtMs: z.number().finite(),
+    id: z.string().min(1),
+    query: z.string().max(200).optional(),
+    version: z.literal(1),
+  })
+  .strict();
+
+export interface ViewerMemoryPage {
+  memories: MemoryRecord[];
+  nextCursor?: string;
+}
+
+export interface ViewerMemoryPageInput {
+  cursor?: string;
+  limit: number;
+  query?: string;
+}
+
+export class InvalidMemoryCursorError extends Error {
+  constructor() {
+    super("Memory cursor is invalid.");
+    this.name = "InvalidMemoryCursorError";
+  }
+}
+
+export { PersonalMemoryNotFoundError } from "./personal-store";
+
+function runtimeContext(actor: PluginUserPageActor): MemoryRuntimeContext {
+  if (actor.platform === "slack") {
+    return {
+      actor,
+      source: {
+        platform: "slack",
+        type: "priv",
+        teamId: actor.teamId,
+        channelId: "DDASHBOARD",
+      },
+    };
+  }
+  return {
+    actor,
+    source: {
+      platform: "local",
+      type: "priv",
+      conversationId: "local:dashboard:memories",
+    },
+  };
+}
+
+function decodeCursor(value: string | undefined, query: string | undefined) {
+  if (!value) return undefined;
+  try {
+    const parsed = cursorSchema.parse(
+      JSON.parse(Buffer.from(value, "base64url").toString("utf8")),
+    );
+    if (parsed.query !== query) {
+      throw new InvalidMemoryCursorError();
+    }
+    return { createdAtMs: parsed.createdAtMs, id: parsed.id };
+  } catch {
+    throw new InvalidMemoryCursorError();
+  }
+}
+
+function encodeCursor(
+  cursor: { createdAtMs: number; id: string },
+  query: string | undefined,
+): string {
+  return Buffer.from(
+    JSON.stringify({ ...cursor, ...(query ? { query } : {}), version: 1 }),
+    "utf8",
+  ).toString("base64url");
+}
+
+/** Build personal-memory operations authorized by a viewer's linked actors. */
+export function createViewerMemories(
+  db: MemoryDb,
+  actors: PluginUserPageActor[],
+) {
+  const collection = createPersonalMemoryCollection(
+    db,
+    actors.map(runtimeContext),
+  );
+  return {
+    async archive(id: string): Promise<MemoryRecord> {
+      return await collection.archive(id);
+    },
+    async get(id: string): Promise<MemoryRecord> {
+      return await collection.get(id);
+    },
+    async list(input: ViewerMemoryPageInput): Promise<ViewerMemoryPage> {
+      const query = input.query?.trim() || undefined;
+      const page = await collection.list({
+        cursor: decodeCursor(input.cursor, query),
+        limit: input.limit,
+        ...(query ? { query } : {}),
+      });
+      return {
+        memories: page.memories,
+        ...(page.nextCursor
+          ? { nextCursor: encodeCursor(page.nextCursor, query) }
+          : {}),
+      };
+    },
+  };
+}

--- a/packages/junior-memory/src/plugin.ts
+++ b/packages/junior-memory/src/plugin.ts
@@ -1,5 +1,6 @@
 import { defineJuniorPlugin } from "@sentry/junior-plugin-api";
 import { createMemoryAgent } from "./agent";
+import { createMemoryApi } from "./api";
 import { createMemoryCliCommand } from "./cli";
 import {
   createMemoryCreateTool,
@@ -110,6 +111,12 @@ export function memoryPlugin(options: MemoryPluginOptions = {}) {
     },
     userPages: [createMemoryUserPage()],
     hooks: {
+      apiRoutes(ctx) {
+        return createMemoryApi({
+          actors: ctx.viewer.actors,
+          db: ctx.db as MemoryDb,
+        });
+      },
       tools(ctx) {
         const agent = createMemoryAgent(ctx.model);
         const context = memoryToolContext({

--- a/packages/junior-memory/src/store.ts
+++ b/packages/junior-memory/src/store.ts
@@ -384,7 +384,8 @@ function sourceChannelPrefix(ctx: MemoryRuntimeContext): string | undefined {
 }
 
 /** Parse one SQL row into the public memory record projection. */
-function parseMemoryRow(row: unknown): MemoryRecord {
+/** Parse one SQL row into the public memory projection. */
+export function parseMemoryRow(row: unknown): MemoryRecord {
   const parsed = memoryRowSchema.parse(row);
   return memoryRecordSchema.parse({
     id: parsed.id,
@@ -423,7 +424,8 @@ function visibleScopePredicate(scopes: ResolvedMemoryScope[]): SQL | undefined {
   );
 }
 
-function activeVisiblePredicate(args: {
+/** Build the active-row predicate for already-authorized memory scopes. */
+export function activeVisiblePredicate(args: {
   nowMs: number;
   scopes: ResolvedMemoryScope[];
 }): SQL | undefined {
@@ -525,7 +527,7 @@ async function findByIdempotencyKey(args: {
 /**
  * Archive a bounded batch of expired active rows and remove their derived vectors.
  */
-async function archiveExpiredMemoryBatch(args: {
+export async function archiveExpiredMemoryBatch(args: {
   db: MemoryDb;
   idempotencyKey?: string;
   limit?: number;

--- a/packages/junior-memory/src/user-pages.ts
+++ b/packages/junior-memory/src/user-pages.ts
@@ -1,36 +1,7 @@
-/** Project actor-owned memories into Junior's core-rendered user page. */
-import type {
-  PluginUserPageActor,
-  PluginUserPageDefinition,
-} from "@sentry/junior-plugin-api";
-import { createMemoryStore, type MemoryDb, type MemoryRecord } from "./store";
-import type { MemoryRuntimeContext } from "./types";
-
-const MEMORY_PAGE_LIMIT = 100;
-
-function runtimeContext(
-  actor: PluginUserPageActor,
-): MemoryRuntimeContext | undefined {
-  if (actor.platform === "slack") {
-    return {
-      actor,
-      source: {
-        platform: "slack",
-        type: "priv",
-        teamId: actor.teamId,
-        channelId: "DDASHBOARD",
-      },
-    };
-  }
-  return {
-    actor,
-    source: {
-      platform: "local",
-      type: "priv",
-      conversationId: "local:dashboard:memories",
-    },
-  };
-}
+/** Project viewer-owned memories into Junior's core-rendered user page. */
+import type { PluginUserPageDefinition } from "@sentry/junior-plugin-api";
+import { createViewerMemories } from "./personal";
+import type { MemoryDb, MemoryRecord } from "./store";
 
 function memoryKindLabel(kind: MemoryRecord["kind"]): string {
   return kind.charAt(0).toUpperCase() + kind.slice(1);
@@ -43,44 +14,38 @@ function rememberedDate(createdAtMs: number): string {
   }).format(new Date(createdAtMs));
 }
 
-async function readPersonalMemories(
-  db: MemoryDb,
-  actors: PluginUserPageActor[],
-): Promise<MemoryRecord[]> {
-  const memories = await Promise.all(
-    actors.flatMap((actor) => {
-      const context = runtimeContext(actor);
-      return context
-        ? [
-            createMemoryStore(db, context).listPersonalMemories({
-              limit: MEMORY_PAGE_LIMIT,
-            }),
-          ]
-        : [];
-    }),
-  );
-  return [
-    ...new Map(memories.flat().map((memory) => [memory.id, memory])).values(),
-  ]
-    .sort((left, right) => right.createdAtMs - left.createdAtMs)
-    .slice(0, MEMORY_PAGE_LIMIT);
-}
-
-/** Create the read-only personal Memories dashboard page. */
+/** Create the interactive personal Memories dashboard page. */
 export function createMemoryUserPage(): PluginUserPageDefinition {
   return {
     id: "memories",
     label: "Memories",
     description: "Personal facts and preferences Junior remembers about you.",
-    async read(ctx) {
-      const memories = await readPersonalMemories(
+    async read(ctx, input) {
+      const page = await createViewerMemories(
         ctx.db as MemoryDb,
         ctx.viewer.actors,
-      );
+      ).list({
+        cursor: input.cursor,
+        limit: input.limit,
+        ...(input.query ? { query: input.query } : {}),
+      });
       return {
         type: "list",
-        emptyText: "No personal memories yet.",
-        records: memories.map((memory) => ({
+        emptyText: input.query
+          ? "No memories matched your search."
+          : "No personal memories yet.",
+        ...(page.nextCursor ? { nextCursor: page.nextCursor } : {}),
+        searchPlaceholder: "Search memories",
+        records: page.memories.map((memory) => ({
+          actions: [
+            {
+              confirmation: "Forget this memory?",
+              href: `/api/plugins/memory/memories/${encodeURIComponent(memory.id)}`,
+              label: "Forget",
+              method: "DELETE" as const,
+              tone: "danger" as const,
+            },
+          ],
           id: memory.id,
           title: memory.content,
           metadata: [

--- a/packages/junior-memory/tests/storage.test.ts
+++ b/packages/junior-memory/tests/storage.test.ts
@@ -9,6 +9,7 @@ import {
 import {
   createLocalSource,
   createSlackSource,
+  pluginApiRouteRequestContextSchema,
   pluginUserPageContentSchema,
   PluginToolInputError,
   type PluginLogger,
@@ -22,6 +23,11 @@ import { Command, CommanderError } from "commander";
 import { eq } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
 import * as memorySqlSchema from "../src/db/schema";
+import {
+  createMemoryApi,
+  memoryApiSchema,
+  memoryListResponseSchema,
+} from "../src/api";
 import { createMemoryAgent, type CreateMemoryRequest } from "../src/agent";
 import { createMemoryCliCommand } from "../src/cli";
 import { memoryPlugin } from "../src/plugin";
@@ -1809,20 +1815,33 @@ ORDER BY created_at_ms ASC
       if (!memoryPage || !actorContext.actor) {
         throw new Error("Expected Memory dashboard page and actor context");
       }
-      const memoryContent = await memoryPage.read({
-        db: memoryDb(fixture),
-        log: noopLogger,
-        plugin: { name: "memory" },
-        viewer: {
-          actors: [actorContext.actor],
-          email: "person@example.com",
+      const memoryContent = await memoryPage.read(
+        {
+          db: memoryDb(fixture),
+          log: noopLogger,
+          plugin: { name: "memory" },
+          viewer: {
+            actors: [actorContext.actor],
+            email: "person@example.com",
+          },
         },
-      });
+        { limit: 20 },
+      );
       expect(pluginUserPageContentSchema.parse(memoryContent)).toEqual({
         type: "list",
         emptyText: "No personal memories yet.",
+        searchPlaceholder: "Search memories",
         records: [
           {
+            actions: [
+              {
+                confirmation: "Forget this memory?",
+                href: `/api/plugins/memory/memories/${personal.memory.id}`,
+                label: "Forget",
+                method: "DELETE",
+                tone: "danger",
+              },
+            ],
             id: personal.memory.id,
             title: "Prefers short PR summaries.",
             metadata: [
@@ -1833,15 +1852,19 @@ ORDER BY created_at_ms ASC
         ],
       });
       await expect(
-        memoryPage.read({
-          db: memoryDb(fixture),
-          log: noopLogger,
-          plugin: { name: "memory" },
-          viewer: { actors: [], email: "new@example.com" },
-        }),
+        memoryPage.read(
+          {
+            db: memoryDb(fixture),
+            log: noopLogger,
+            plugin: { name: "memory" },
+            viewer: { actors: [], email: "new@example.com" },
+          },
+          { limit: 20 },
+        ),
       ).resolves.toEqual({
         type: "list",
         emptyText: "No personal memories yet.",
+        searchPlaceholder: "Search memories",
         records: [],
       });
       const otherConversationStore = createMemoryStore(
@@ -1892,6 +1915,137 @@ ORDER BY created_at_ms ASC
       await expect(
         store.searchMemories({ query: "summaries" }),
       ).resolves.toEqual([]);
+    } finally {
+      await fixture.close();
+    }
+  }, 15_000);
+
+  it("serves viewer-scoped personal memories through the REST resource", async () => {
+    const fixture = await createMemoryFixture();
+
+    try {
+      const firstContext = slackContext({ teamId: "T123", userId: "U123" });
+      const secondContext = slackContext({ teamId: "T456", userId: "U456" });
+      const hiddenContext = slackContext({ teamId: "T999", userId: "U999" });
+      const firstStore = createMemoryStore(memoryDb(fixture), firstContext, {
+        now: () => TEST_NOW_MS,
+      });
+      const secondStore = createMemoryStore(memoryDb(fixture), secondContext, {
+        now: () => TEST_NOW_MS + 1,
+      });
+      const hiddenStore = createMemoryStore(memoryDb(fixture), hiddenContext, {
+        now: () => TEST_NOW_MS + 2,
+      });
+      const first = await firstStore.createMemory({
+        content: "Prefers concise release notes.",
+        idempotencyKey: "api:first",
+        kind: "preference",
+      });
+      const second = await secondStore.createMemory({
+        content: "Deploy runbooks live in Notion.",
+        idempotencyKey: "api:second",
+        kind: "knowledge",
+      });
+      const hidden = await hiddenStore.createMemory({
+        content: "Hidden viewer memory.",
+        idempotencyKey: "api:hidden",
+        kind: "knowledge",
+      });
+      const actors = [firstContext.actor!, secondContext.actor!];
+      const api = createMemoryApi({
+        actors: async () => actors,
+        db: memoryDb(fixture),
+      });
+      const requestContext = pluginApiRouteRequestContextSchema.parse({
+        auth: {
+          user: {
+            email: "person@example.com",
+            emailVerified: true,
+          },
+        },
+        pluginName: "memory",
+      });
+
+      const firstPageResponse = await api.fetch(
+        new Request("http://localhost/memories?limit=1"),
+        requestContext,
+      );
+      expect(firstPageResponse.status).toBe(200);
+      const firstPage = memoryListResponseSchema.parse(
+        await firstPageResponse.json(),
+      );
+      expect(firstPage.memories).toEqual([
+        expect.objectContaining({
+          content: "Deploy runbooks live in Notion.",
+          id: second.memory.id,
+        }),
+      ]);
+      expect(firstPage.nextCursor).toEqual(expect.any(String));
+
+      const secondPageResponse = await api.fetch(
+        new Request(
+          `http://localhost/memories?limit=1&cursor=${encodeURIComponent(firstPage.nextCursor!)}`,
+        ),
+        requestContext,
+      );
+      expect(secondPageResponse.status).toBe(200);
+      expect(
+        memoryListResponseSchema.parse(await secondPageResponse.json()),
+      ).toEqual({
+        memories: [
+          expect.objectContaining({
+            content: "Prefers concise release notes.",
+            id: first.memory.id,
+          }),
+        ],
+      });
+
+      const mismatchedCursorResponse = await api.fetch(
+        new Request(
+          `http://localhost/memories?q=runbooks&cursor=${encodeURIComponent(firstPage.nextCursor!)}`,
+        ),
+        requestContext,
+      );
+      expect(mismatchedCursorResponse.status).toBe(400);
+
+      const searchResponse = await api.fetch(
+        new Request("http://localhost/memories?q=runbooks"),
+        requestContext,
+      );
+      expect(searchResponse.status).toBe(200);
+      expect(
+        memoryListResponseSchema.parse(await searchResponse.json()).memories,
+      ).toEqual([expect.objectContaining({ id: second.memory.id })]);
+
+      const detailResponse = await api.fetch(
+        new Request(`http://localhost/memories/${first.memory.id}`),
+        requestContext,
+      );
+      expect(detailResponse.status).toBe(200);
+      expect(memoryApiSchema.parse(await detailResponse.json())).toMatchObject({
+        content: "Prefers concise release notes.",
+        id: first.memory.id,
+      });
+
+      const deleteResponse = await api.fetch(
+        new Request(`http://localhost/memories/${second.memory.id}`, {
+          method: "DELETE",
+        }),
+        requestContext,
+      );
+      expect(deleteResponse.status).toBe(204);
+      await expect(secondStore.listPersonalMemories({})).resolves.toEqual([]);
+
+      const hiddenDeleteResponse = await api.fetch(
+        new Request(`http://localhost/memories/${hidden.memory.id}`, {
+          method: "DELETE",
+        }),
+        requestContext,
+      );
+      expect(hiddenDeleteResponse.status).toBe(404);
+      await expect(hiddenStore.listPersonalMemories({})).resolves.toEqual([
+        expect.objectContaining({ id: hidden.memory.id }),
+      ]);
     } finally {
       await fixture.close();
     }

--- a/packages/junior-plugin-api/README.md
+++ b/packages/junior-plugin-api/README.md
@@ -45,6 +45,9 @@ reports, and other typed hook surfaces exported by this package.
 - Tool hooks return model-visible schemas aligned with their executor inputs.
 - Host-owned structured model and embedding calls do not expose provider
   credentials to plugins.
+- Authenticated API route apps receive one verified viewer in their request
+  context. The registration hook exposes actor resolution for plugins whose
+  viewer-owned data spans platform identities.
 - User page readers receive the signed-in email plus runtime-owned actors linked
   to that user. Plugins return bounded data and do not mount their own page
   routes or browser code.
@@ -52,11 +55,12 @@ reports, and other typed hook surfaces exported by this package.
 ## User Pages
 
 Register signed-in pages through `userPages` beside `hooks`, `tasks`, and `cli`.
-Each definition owns its navigation metadata and `read(ctx)` function, so a
-page cannot be advertised without an implementation. Core owns discovery,
-authentication, actor resolution, routing, response validation, and rendering.
-The initial response type is the bounded `list` page; add another core-rendered
-type only when a concrete product need proves it.
+Each definition owns its navigation metadata and `read(ctx, input)` function,
+so a page cannot be advertised without an implementation. List readers receive
+validated search and cursor input and may return an opaque continuation cursor.
+Records may expose bounded `DELETE` actions inside their own authenticated
+plugin API namespace. Core owns discovery, authentication, actor resolution,
+routing, response validation, rendering, confirmation, and query state.
 
 ## Durable Work
 

--- a/packages/junior-plugin-api/src/operations.ts
+++ b/packages/junior-plugin-api/src/operations.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { PluginContext } from "./context";
+import type { LocalActor, PluginContext, SlackActor } from "./context";
 import type { Dispatch, DispatchOptions, DispatchResult } from "./dispatch";
 import { nonBlankStringSchema } from "./schemas";
 import type { PluginReadState, PluginState } from "./state";
@@ -119,7 +119,12 @@ export interface RouteRegistrationHookContext extends PluginContext {
   resourceEvents: ResourceEventPublisher;
 }
 
-export interface ApiRouteRegistrationHookContext extends PluginContext {}
+export interface ApiRouteRegistrationHookContext extends PluginContext {
+  viewer: {
+    /** Resolve every runtime actor linked to one authenticated viewer email. */
+    actors(email: string): Promise<Array<LocalActor | SlackActor>>;
+  };
+}
 
 /** Per-request context Junior passes to authenticated plugin product API routes. */
 export const pluginApiRouteRequestContextSchema = z

--- a/packages/junior-plugin-api/src/user-pages.ts
+++ b/packages/junior-plugin-api/src/user-pages.ts
@@ -21,8 +21,21 @@ const pluginUserPageMetadataSchema = z
   })
   .strict();
 
+const pluginUserPageActionSchema = z
+  .object({
+    confirmation: nonBlankStringSchema.max(500).optional(),
+    href: nonBlankStringSchema
+      .max(500)
+      .regex(/^\/api\/plugins\/[a-z][a-z0-9-]*(?:\/|$)/),
+    label: nonBlankStringSchema.max(80),
+    method: z.literal("DELETE"),
+    tone: z.enum(["danger", "neutral"]).optional(),
+  })
+  .strict();
+
 const pluginUserPageRecordSchema = z
   .object({
+    actions: z.array(pluginUserPageActionSchema).max(4).optional(),
     description: nonBlankStringSchema.max(1_000).optional(),
     id: nonBlankStringSchema.max(128),
     metadata: z.array(pluginUserPageMetadataSchema).max(8).optional(),
@@ -34,7 +47,9 @@ const pluginUserPageRecordSchema = z
 export const pluginUserPageContentSchema = z
   .object({
     emptyText: nonBlankStringSchema.max(500).optional(),
+    nextCursor: nonBlankStringSchema.max(1_000).optional(),
     records: z.array(pluginUserPageRecordSchema).max(100),
+    searchPlaceholder: nonBlankStringSchema.max(120).optional(),
     type: z.literal("list"),
   })
   .strict();
@@ -59,6 +74,17 @@ export const pluginUserPageLinksSchema = z.array(pluginUserPageLinkSchema);
 /** Safe navigation metadata for one registered plugin user page. */
 export type PluginUserPageLink = z.output<typeof pluginUserPageLinkSchema>;
 
+/** Validated query state passed to one plugin user page reader. */
+export const pluginUserPageInputSchema = z
+  .object({
+    cursor: nonBlankStringSchema.max(1_000).optional(),
+    limit: z.number().int().min(1).max(50),
+    query: z.string().trim().max(200).optional(),
+  })
+  .strict();
+
+export type PluginUserPageInput = z.output<typeof pluginUserPageInputSchema>;
+
 /** Runtime-owned actor shapes that may belong to an authenticated viewer. */
 export type PluginUserPageActor = SlackActor | LocalActor;
 
@@ -77,5 +103,6 @@ export interface PluginUserPageDefinition {
   label: string;
   read(
     ctx: PluginUserPageContext,
+    input: PluginUserPageInput,
   ): Promise<PluginUserPageContent> | PluginUserPageContent;
 }

--- a/packages/junior/src/api/user-pages/routes.ts
+++ b/packages/junior/src/api/user-pages/routes.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import {
   pluginUserPageContentSchema,
+  pluginUserPageInputSchema,
   pluginUserPageLinksSchema,
 } from "@sentry/junior-plugin-api";
 import {
@@ -27,10 +28,25 @@ export function createUserPageRoutes(): Hono<JuniorApiEnv> {
         { status: 401 },
       );
     }
+    const pageInput = pluginUserPageInputSchema.safeParse({
+      cursor: context.req.query("cursor") || undefined,
+      limit: context.req.query("limit")
+        ? Number(context.req.query("limit"))
+        : 20,
+      query: context.req.query("q") || undefined,
+    });
+    if (!pageInput.success) {
+      return jsonResponse(
+        apiErrorSchema,
+        { error: "Invalid user page query." },
+        { status: 400 },
+      );
+    }
     const page = await readPluginUserPage({
       email,
       pageId: context.req.param("pageId"),
       pluginName: context.req.param("pluginName"),
+      query: pageInput.data,
     });
     return page
       ? jsonResponse(pluginUserPageContentSchema, page)

--- a/packages/junior/src/chat/plugins/agent-hooks.ts
+++ b/packages/junior/src/chat/plugins/agent-hooks.ts
@@ -30,6 +30,7 @@ import { SANDBOX_WORKSPACE_ROOT } from "@/chat/sandbox/paths";
 import type { AnyToolDefinition } from "@/chat/tools/definition";
 import { getDashboardConversationLink } from "@/chat/slack/dashboard-link";
 import { getSlackToolContext } from "@/chat/slack/tools/context";
+import { readViewerActors } from "@/chat/plugins/viewer-actors";
 import type { ToolRuntimeContext } from "@/chat/tools/types";
 import type {
   SandboxCommandInput,
@@ -705,6 +706,9 @@ export function getPluginApiRoutes(): PluginApiRouteRegistration[] {
     }
     const app = hook({
       ...basePluginContext(plugin),
+      viewer: {
+        actors: readViewerActors,
+      },
     });
     if (app === undefined) {
       continue;

--- a/packages/junior/src/chat/plugins/user-pages.ts
+++ b/packages/junior/src/chat/plugins/user-pages.ts
@@ -8,6 +8,7 @@ import {
   pluginUserPageContentSchema,
   pluginUserPageLinksSchema,
   type PluginUserPageContent,
+  type PluginUserPageInput,
   type PluginUserPageLink,
 } from "@sentry/junior-plugin-api";
 import { getDb } from "@/chat/db";
@@ -30,11 +31,23 @@ export function readPluginUserPageLinks(): PluginUserPageLink[] {
   );
 }
 
+function actionBelongsToPlugin(href: string, pluginName: string): boolean {
+  const parsed = new URL(href, "http://junior.local");
+  return (
+    parsed.origin === "http://junior.local" &&
+    parsed.pathname === href &&
+    parsed.pathname.startsWith(`/api/plugins/${pluginName}/`) &&
+    !parsed.search &&
+    !parsed.hash
+  );
+}
+
 /** Read one registered plugin user page for the authenticated viewer. */
 export async function readPluginUserPage(input: {
   email: string;
   pageId: string;
   pluginName: string;
+  query: PluginUserPageInput;
 }): Promise<PluginUserPageContent | undefined> {
   const plugin = getPlugins().find(
     (candidate) => candidate.manifest.name === input.pluginName,
@@ -44,15 +57,30 @@ export async function readPluginUserPage(input: {
   );
   if (!plugin || !page) return undefined;
 
-  return pluginUserPageContentSchema.parse(
-    await page.read({
-      db: getDb(),
-      log: createPluginLogger(plugin.manifest.name),
-      plugin: { name: plugin.manifest.name },
-      viewer: {
-        actors: await readViewerActors(input.email),
-        email: input.email,
+  const content = pluginUserPageContentSchema.parse(
+    await page.read(
+      {
+        db: getDb(),
+        log: createPluginLogger(plugin.manifest.name),
+        plugin: { name: plugin.manifest.name },
+        viewer: {
+          actors: await readViewerActors(input.email),
+          email: input.email,
+        },
       },
-    }),
+      input.query,
+    ),
   );
+  if (
+    content.records.some((record) =>
+      record.actions?.some(
+        (action) => !actionBelongsToPlugin(action.href, plugin.manifest.name),
+      ),
+    )
+  ) {
+    throw new Error(
+      `Plugin user page "${plugin.manifest.name}/${page.id}" returned an action outside its API namespace.`,
+    );
+  }
+  return content;
 }

--- a/packages/junior/tests/integration/api/user-pages.test.ts
+++ b/packages/junior/tests/integration/api/user-pages.test.ts
@@ -81,6 +81,49 @@ describe("plugin user page API", () => {
     expect(response.status).toBe(401);
   });
 
+  test("passes validated search and pagination state to the page reader", async () => {
+    let receivedInput: unknown;
+    setPlugins([
+      defineJuniorPlugin({
+        manifest: {
+          name: "memory",
+          displayName: "Memory",
+          description: "Long-term memory storage and recall.",
+        },
+        userPages: [
+          {
+            id: "memories",
+            label: "Memories",
+            description: "Personal facts Junior remembers about you.",
+            read(_ctx, input) {
+              receivedInput = input;
+              return {
+                type: "list",
+                records: [],
+              };
+            },
+          },
+        ],
+      }),
+    ]);
+
+    const response = await authenticatedApi("viewer@example.com").request(
+      "http://localhost/api/user-pages/memory/memories?q=runbooks&cursor=next-page&limit=12",
+    );
+
+    expect(response.status).toBe(200);
+    expect(receivedInput).toEqual({
+      cursor: "next-page",
+      limit: 12,
+      query: "runbooks",
+    });
+
+    const invalid = await authenticatedApi("viewer@example.com").request(
+      "http://localhost/api/user-pages/memory/memories?limit=500",
+    );
+    expect(invalid.status).toBe(400);
+  });
+
   test("passes only actors linked to the authenticated viewer", async () => {
     const fixture = createConfiguredJuniorSqlFixture();
     const store = createSqlStore(fixture.sql);

--- a/packages/junior/tests/unit/plugins/agent-hooks.test.ts
+++ b/packages/junior/tests/unit/plugins/agent-hooks.test.ts
@@ -918,6 +918,7 @@ describe("agent plugin hooks", () => {
   });
 
   it("collects API route apps from configured plugins", async () => {
+    let hasViewerActorResolver = false;
     const previous = setPlugins([
       defineJuniorPlugin({
         manifest: {
@@ -926,7 +927,8 @@ describe("agent plugin hooks", () => {
           description: "Agent demo",
         },
         hooks: {
-          apiRoutes() {
+          apiRoutes(ctx) {
+            hasViewerActorResolver = typeof ctx.viewer.actors === "function";
             return {
               fetch: () => new Response("api demo"),
             };
@@ -939,6 +941,7 @@ describe("agent plugin hooks", () => {
 
       expect(routes).toHaveLength(1);
       expect(routes[0]?.pluginName).toBe("agent-demo");
+      expect(hasViewerActorResolver).toBe(true);
       const response = await routes[0]!.app.fetch(
         new Request("http://localhost/demo"),
       );


### PR DESCRIPTION
Personal memories are now available through authenticated plugin REST resources for listing, detail reads, and archival, with server-side search and opaque cursor pagination. The dashboard Memories page adds debounced search, incremental pagination, and a confirmed **Forget** action backed by the REST `DELETE` endpoint.

API requests remain viewer-based. Core resolves the platform actors linked to the verified viewer only to authorize personal-memory scopes, so no arbitrary Slack or local actor becomes the viewer’s canonical identity. Personal bearer tokens remain read-only; deletion requires a dashboard browser session.

This also extends core-rendered plugin lists with validated query and cursor input plus namespace-constrained `DELETE` action metadata. Regression coverage exercises linked-actor isolation, cursor validation, delete authorization, and the browser search, pagination, and forget flow.
