### PR TITLE
fix(memory): improve recall relevance

### DIFF
--- a/packages/docs/src/content/docs/extend/memory-plugin.md
+++ b/packages/docs/src/content/docs/extend/memory-plugin.md
@@ -10,7 +10,7 @@ related:
   - /start-here/quickstart/
 ---
 
-The memory plugin uses a Postgres database with the pgvector extension to store and retrieve long-term memories across conversations. Junior recalls relevant memories before each user turn, exposes explicit memory tools (remember, list, search, remove), and passively extracts memories from completed public-channel and local sessions.
+The memory plugin uses a Postgres database with the pgvector extension to store and retrieve long-term memories across conversations. Before each user turn, Junior combines semantic and full-text matches and includes only memories that directly help with the current request. The plugin also exposes explicit memory tools (remember, list, search, remove) and passively extracts memories from completed public-channel and local sessions.
 
 New apps created with `junior init` include `memoryPlugin()` in `plugins.ts` by default.
 
@@ -39,7 +39,7 @@ export const plugins = defineJuniorPlugins([memoryPlugin()]);
 
 Do not register `@sentry/junior-memory` as a bare package-name string. The memory plugin uses `defineJuniorPlugin` with runtime hooks for tool registration and session processing; a bare string skips those hooks and the plugin will not activate its runtime behavior.
 
-Pass `modelId` to override the model used for memory classification and consolidation:
+Pass `modelId` to override the model used for memory classification, consolidation, and automatic recall relevance:
 
 ```ts title="plugins.ts"
 import { defineJuniorPlugins } from "@sentry/junior";
@@ -57,7 +57,7 @@ export const plugins = defineJuniorPlugins([
 | `DATABASE_URL`                      | Yes      | Postgres connection string for memory storage.                                                                                                                                                               |
 | `JUNIOR_DATABASE_DRIVER`            | No       | SQL client driver: `neon` (default) or `postgres`. Set `postgres` for non-Neon deployments.                                                                                                                  |
 | `AI_EMBEDDING_MODEL`                | No       | Embedding model for vector search. Defaults to `openai/text-embedding-3-small` (1536 dims).                                                                                                                  |
-| `AI_MEMORY_MODEL`                   | No       | Model for memory classification and consolidation. Defaults to the app's structured model.                                                                                                                   |
+| `AI_MEMORY_MODEL`                   | No       | Model for memory classification, consolidation, and automatic recall relevance. Defaults to the app's structured model.                                                                                      |
 | `MEMORY_RECALL_MAX_VECTOR_DISTANCE` | No       | Maximum cosine distance for vector recall candidates. Values 0–1; lower = stricter. Values above 1 are clamped to 1. Default `0.45` suits `text-embedding-3-small`. Tune when changing `AI_EMBEDDING_MODEL`. |
 
 `AI_EMBEDDING_MODEL` must produce 1536-dimensional vectors. Changing this value after memories exist requires flushing the `junior_memory_embeddings` table and re-running to regenerate vectors with the new model.
@@ -105,7 +105,7 @@ Public Slack channel memories are workspace-visible. A durable fact remembered i
 - **`DATABASE_URL` is required**: no database URL is configured. Set it in the deployment environment.
 - **Connection errors on non-Neon Postgres**: set `JUNIOR_DATABASE_DRIVER=postgres` for Railway, Supabase, AWS RDS, or self-hosted Postgres.
 - **Embedding dimension mismatch**: `AI_EMBEDDING_MODEL` was changed after memories were stored with a different model. Flush the `junior_memory_embeddings` table and re-run migrations to regenerate vectors with the new model.
-- **Memories not recalled**: the database migration has not run yet. Run `pnpm junior upgrade` against the production database.
+- **Memories not recalled**: first run `pnpm junior upgrade` against the production database. If migrations are current, the memories may be outside the configured vector distance or may not be directly relevant to the request.
 
 ## Next step
 

--- a/packages/junior-evals/evals/memory/helpers.ts
+++ b/packages/junior-evals/evals/memory/helpers.ts
@@ -43,8 +43,7 @@ export async function seedMemory(args: {
       messageTs: args.thread.thread_ts,
       teamId: memoryTeamId,
       threadTs: args.thread.thread_ts,
-
-      type: "priv",
+      type: args.thread.channel_type === "channel" ? "pub" : "priv",
     }),
   });
   const input = {

--- a/packages/junior-evals/evals/memory/shared.eval.ts
+++ b/packages/junior-evals/evals/memory/shared.eval.ts
@@ -8,10 +8,69 @@ import {
   type MemoryThread,
   memoryPluginOverrides,
   readMemories,
+  seedMemory,
   visibleAssistantText,
 } from "./helpers";
 
 describeEval("Shared Memory", slackEvals, (it) => {
+  const recallRelevanceThread = {
+    channel_type: "channel",
+    id: "thread-memory-recall-relevance",
+    channel_id: "CMEMORYRECALLRELEVANCE",
+    thread_ts: "17000000.000000",
+  } satisfies MemoryThread;
+
+  it("when retrieved memories share generic engineering vocabulary, recall only the directly useful fact", async ({
+    run,
+  }) => {
+    await clearMemories();
+    await seedMemory({
+      content: "getsentry/junior CI runs package tests with pnpm.",
+      idempotencyKey: "eval-memory-recall-relevant",
+      kind: "knowledge",
+      scope: "conversation",
+      thread: recallRelevanceThread,
+    });
+    await seedMemory({
+      content:
+        "getsentry/sentry autofix pull request tests use a dashboard workflow.",
+      idempotencyKey: "eval-memory-recall-vocabulary",
+      kind: "knowledge",
+      scope: "conversation",
+      thread: recallRelevanceThread,
+    });
+    await seedMemory({
+      content:
+        "Single-tenant repository access is configured in the admin dashboard.",
+      idempotencyKey: "eval-memory-recall-unrelated",
+      kind: "knowledge",
+      scope: "conversation",
+      thread: recallRelevanceThread,
+    });
+
+    await run({
+      overrides: memoryPluginOverrides,
+      initialEvents: [
+        mention(
+          "What do you remember about how CI works in getsentry/junior? Reply with a textual answer using only existing conversation context; do not inspect files or use tools.",
+          {
+            thread: recallRelevanceThread,
+          },
+        ),
+      ],
+      criteria: rubric({
+        pass: [
+          "The assistant says getsentry/junior CI runs package tests with pnpm.",
+          "The answer stays scoped to getsentry/junior.",
+        ],
+        fail: [
+          "Do not mention getsentry/sentry autofix, a dashboard workflow, or single-tenant repository access.",
+          "Do not blend generic engineering memories into the answer.",
+        ],
+      }),
+    });
+  });
+
   const explicitTaskProcedureThread = {
     channel_type: "channel",
     id: "thread-memory-explicit-task-procedure",

--- a/packages/junior-memory/README.md
+++ b/packages/junior-memory/README.md
@@ -34,6 +34,8 @@ exported types, tools, and tests are authoritative.
 - Records retain provenance, lifecycle status, supersession relationships, and
   timestamps needed for review and deletion.
 - Embeddings are derived indexes, not independent memory authority.
+- Embedding distance never decides that two memories are duplicates. Exact
+  content and preference review own duplicate and supersession decisions.
 - Writes are idempotent where a completed session or tool retry can repeat.
 - Removal and supersession preserve enough lifecycle information to prevent
   deleted facts from being recalled or silently recreated.
@@ -45,10 +47,15 @@ exported types, tools, and tests are authoritative.
 - Passive extraction creates only durable, reusable facts—not transient tasks,
   conversation summaries, secrets, or speculative interpretation.
 - Candidate review resolves duplicates and supersession before activation.
-- Recall is bounded and relevance-ranked; an empty result contributes no filler
-  prompt text.
-- Model or embedding failures fail the owning hook/task without corrupting
-  existing memory state.
+- Search combines independently ranked vector and PostgreSQL full-text matches
+  with reciprocal rank fusion; provider-specific raw scores are never added
+  together.
+- Automatic recall retrieves a broad candidate window, then uses the
+  memory-owned relevance model to admit at most five directly useful memories.
+  An empty result contributes no filler prompt text.
+- Automatic recall degrades to no prompt contribution when relevance selection
+  fails. Review, extraction, and write failures still fail their owning
+  hook/task without corrupting existing memory state.
 
 ## Configuration
 

--- a/packages/junior-memory/migrations/0005_short_jamie_braddock.sql
+++ b/packages/junior-memory/migrations/0005_short_jamie_braddock.sql
@@ -1,0 +1,1 @@
+CREATE INDEX "junior_memory_memories_search_idx" ON "junior_memory_memories" USING gin (to_tsvector('english', "content")) WHERE "junior_memory_memories"."archived_at_ms" IS NULL AND "junior_memory_memories"."superseded_at_ms" IS NULL AND "junior_memory_memories"."superseded_by_id" IS NULL;

--- a/packages/junior-memory/migrations/meta/0005_snapshot.json
+++ b/packages/junior-memory/migrations/meta/0005_snapshot.json
@@ -1,0 +1,364 @@
+{
+  "id": "6948ea3f-2e44-49ce-aa94-8a993ce61cec",
+  "prevId": "e915b537-996a-488c-a828-7cf4da06be44",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.junior_memory_embeddings": {
+      "name": "junior_memory_embeddings",
+      "schema": "",
+      "columns": {
+        "memory_id": {
+          "name": "memory_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dimensions": {
+          "name": "dimensions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metric": {
+          "name": "metric",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at_ms": {
+          "name": "created_at_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "junior_memory_embeddings_model_idx": {
+          "name": "junior_memory_embeddings_model_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dimensions",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "metric",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "junior_memory_embeddings_memory_id_junior_memory_memories_id_fk": {
+          "name": "junior_memory_embeddings_memory_id_junior_memory_memories_id_fk",
+          "tableFrom": "junior_memory_embeddings",
+          "tableTo": "junior_memory_memories",
+          "columnsFrom": ["memory_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "junior_memory_embeddings_metric_check": {
+          "name": "junior_memory_embeddings_metric_check",
+          "value": "\"junior_memory_embeddings\".\"metric\" IN ('cosine')"
+        },
+        "junior_memory_embeddings_dimensions_check": {
+          "name": "junior_memory_embeddings_dimensions_check",
+          "value": "\"junior_memory_embeddings\".\"dimensions\" = 1536"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.junior_memory_memories": {
+      "name": "junior_memory_memories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_key": {
+          "name": "scope_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_platform": {
+          "name": "source_platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_key": {
+          "name": "source_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_at_ms": {
+          "name": "observed_at_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at_ms": {
+          "name": "created_at_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at_ms": {
+          "name": "expires_at_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "superseded_at_ms": {
+          "name": "superseded_at_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "superseded_by_id": {
+          "name": "superseded_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at_ms": {
+          "name": "archived_at_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archive_reason": {
+          "name": "archive_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "junior_memory_memories_visible_idx": {
+          "name": "junior_memory_memories_visible_idx",
+          "columns": [
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at_ms",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"junior_memory_memories\".\"archived_at_ms\" IS NULL AND \"junior_memory_memories\".\"superseded_at_ms\" IS NULL AND \"junior_memory_memories\".\"superseded_by_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_memory_memories_expiration_idx": {
+          "name": "junior_memory_memories_expiration_idx",
+          "columns": [
+            {
+              "expression": "expires_at_ms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"junior_memory_memories\".\"archived_at_ms\" IS NULL AND \"junior_memory_memories\".\"expires_at_ms\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_memory_memories_search_idx": {
+          "name": "junior_memory_memories_search_idx",
+          "columns": [
+            {
+              "expression": "to_tsvector('english', \"content\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"junior_memory_memories\".\"archived_at_ms\" IS NULL AND \"junior_memory_memories\".\"superseded_at_ms\" IS NULL AND \"junior_memory_memories\".\"superseded_by_id\" IS NULL",
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "junior_memory_memories_idempotency_idx": {
+          "name": "junior_memory_memories_idempotency_idx",
+          "columns": [
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"junior_memory_memories\".\"idempotency_key\" IS NOT NULL AND \"junior_memory_memories\".\"archived_at_ms\" IS NULL AND \"junior_memory_memories\".\"superseded_at_ms\" IS NULL AND \"junior_memory_memories\".\"superseded_by_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "junior_memory_memories_scope_check": {
+          "name": "junior_memory_memories_scope_check",
+          "value": "\"junior_memory_memories\".\"scope\" IN ('personal', 'conversation')"
+        },
+        "junior_memory_memories_kind_check": {
+          "name": "junior_memory_memories_kind_check",
+          "value": "\"junior_memory_memories\".\"type\" IN (\n        'preference',\n        'procedure',\n        'knowledge'\n      )"
+        },
+        "junior_memory_memories_subject_type_check": {
+          "name": "junior_memory_memories_subject_type_check",
+          "value": "\"junior_memory_memories\".\"subject_type\" IN ('user', 'conversation', 'general')"
+        },
+        "junior_memory_memories_subject_key_check": {
+          "name": "junior_memory_memories_subject_key_check",
+          "value": "(\"junior_memory_memories\".\"subject_type\" = 'general' AND \"junior_memory_memories\".\"subject_key\" IS NULL) OR (\"junior_memory_memories\".\"subject_type\" IN ('user', 'conversation') AND \"junior_memory_memories\".\"subject_key\" IS NOT NULL AND length(\"junior_memory_memories\".\"subject_key\") > 0)"
+        },
+        "junior_memory_memories_source_platform_check": {
+          "name": "junior_memory_memories_source_platform_check",
+          "value": "\"junior_memory_memories\".\"source_platform\" IN ('slack', 'local')"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/junior-memory/migrations/meta/_journal.json
+++ b/packages/junior-memory/migrations/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1782676852768,
       "tag": "0004_gigantic_celestials",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1785293874649,
+      "tag": "0005_short_jamie_braddock",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/junior-memory/src/agent.ts
+++ b/packages/junior-memory/src/agent.ts
@@ -23,6 +23,28 @@ const memoryRejectReasonSchema = z.enum([
   "assistant_or_system_detail",
   "unsupported_scope",
 ]);
+const memoryRecallCandidateSchema = z
+  .object({
+    content: z.string().min(1),
+    id: z.string().min(1),
+  })
+  .strict();
+const memoryRecallInputSchema = z
+  .object({
+    candidates: z.array(memoryRecallCandidateSchema).min(1).max(20),
+    userRequest: z.string().min(1),
+  })
+  .strict();
+const memoryRecallDecisionSchema = z
+  .object({
+    relevantIds: z
+      .array(z.string().min(1))
+      .max(20)
+      .describe(
+        "Candidate ids whose memories directly help with the current request, ordered by relevance.",
+      ),
+  })
+  .strict();
 const createMemoryRequestSchema = z
   .object({
     content: z.string().min(1),
@@ -169,6 +191,7 @@ type MemoryReviewResponse = z.output<typeof memoryReviewResponseSchema>;
 type ExtractMemoriesResponse = z.output<typeof extractMemoriesResponseSchema>;
 
 export type MemoryReview = z.output<typeof memoryReviewDecisionSchema>;
+export type MemoryRecallInput = z.output<typeof memoryRecallInputSchema>;
 
 export type CreateMemoryRequest = z.output<typeof createMemoryRequestSchema>;
 export type ExtractSessionRequest = z.output<
@@ -177,6 +200,10 @@ export type ExtractSessionRequest = z.output<
 export type ExtractedMemory = z.output<typeof extractedMemoryResultSchema>;
 
 export interface MemoryAgent {
+  /** Select candidate memories that directly help with the current request. */
+  selectRelevantMemories(
+    request: MemoryRecallInput,
+  ): Promise<string[]> | string[];
   /** Classify a new preference against related active preferences. */
   adjudicateSupersession(
     request: MemorySupersessionInput,
@@ -202,6 +229,13 @@ const MEMORY_EXTRACTION_SYSTEM = [
   "Assistant text is context for interpreting the run, not independent evidence for new facts.",
   "Reject secrets, credentials, private or sensitive personal details, gossip, speculative claims about other people, assistant/system implementation details, vague references, and low-durability chatter.",
   "If no public, durable, self-contained memory remains after rewriting, return an empty memories array.",
+].join("\n");
+const MEMORY_RECALL_SYSTEM = [
+  "You are Junior's memory recall relevance agent.",
+  "Select only memories that would directly help answer the user's current request.",
+  "Reject memories that merely share a company, product family, repository vocabulary, programming language, or general engineering context.",
+  "Prefer specific matches on the exact repository, workflow, command, test, CI setup, project, or user preference being asked about.",
+  "An empty relevantIds array is correct when no candidate is directly helpful.",
 ].join("\n");
 const MEMORY_PREFERENCE_ADJUDICATION_SYSTEM = [
   "You are Junior's memory preference adjudication agent.",
@@ -444,6 +478,22 @@ function sessionExtractionPrompt(request: ExtractSessionRequest): string {
   ].join("\n");
 }
 
+function recallRelevancePrompt(request: MemoryRecallInput): string {
+  return [
+    "<memory-recall-input>",
+    "<user-request>",
+    escapeXml(request.userRequest),
+    "</user-request>",
+    "",
+    "<candidate-memories>",
+    escapeXml(JSON.stringify(request.candidates)),
+    "</candidate-memories>",
+    "",
+    "Return only ids from candidate-memories. Preserve the most relevant candidates first.",
+    "</memory-recall-input>",
+  ].join("\n");
+}
+
 function preferenceAdjudicationPrompt(
   request: MemorySupersessionInput,
 ): string {
@@ -477,9 +527,23 @@ function preferenceAdjudicationPrompt(
   ].join("\n");
 }
 
-/** Create the memory-owned agent that reviews and extracts memory candidates. */
+/** Create the memory-owned agent that reviews, extracts, and recalls memories. */
 export function createMemoryAgent(model: PluginModel): MemoryAgent {
   return {
+    async selectRelevantMemories(rawRequest) {
+      const request = memoryRecallInputSchema.parse(rawRequest);
+      const result = await model.completeObject({
+        schema: memoryRecallDecisionSchema,
+        system: MEMORY_RECALL_SYSTEM,
+        prompt: recallRelevancePrompt(request),
+        maxTokens: 400,
+      });
+      const decision = memoryRecallDecisionSchema.parse(result.object);
+      const candidateIds = new Set(request.candidates.map(({ id }) => id));
+      return [...new Set(decision.relevantIds)].filter((id) =>
+        candidateIds.has(id),
+      );
+    },
     async adjudicateSupersession(rawRequest) {
       const request = memorySupersessionInputSchema.parse(rawRequest);
       const result = await model.completeObject({

--- a/packages/junior-memory/src/db/schema.ts
+++ b/packages/junior-memory/src/db/schema.ts
@@ -58,6 +58,11 @@ export const juniorMemoryMemories = pgTable(
       .where(
         sql`${table.archivedAtMs} IS NULL AND ${table.expiresAtMs} IS NOT NULL`,
       ),
+    index("junior_memory_memories_search_idx")
+      .using("gin", sql`to_tsvector('english', ${table.content})`)
+      .where(
+        sql`${table.archivedAtMs} IS NULL AND ${table.supersededAtMs} IS NULL AND ${table.supersededById} IS NULL`,
+      ),
     uniqueIndex("junior_memory_memories_idempotency_idx")
       .on(table.scope, table.scopeKey, table.idempotencyKey)
       .where(

--- a/packages/junior-memory/src/plugin.ts
+++ b/packages/junior-memory/src/plugin.ts
@@ -135,10 +135,12 @@ export function memoryPlugin(options: MemoryPluginOptions = {}) {
       },
       async userPrompt(ctx) {
         return await createMemoryPromptContributions({
+          agent: createMemoryAgent(ctx.model),
           ...(ctx.conversationId ? { conversationId: ctx.conversationId } : {}),
           ...(ctx.actor ? { actor: ctx.actor } : {}),
           db: ctx.db as MemoryDb,
           embedder: ctx.embedder,
+          log: ctx.log,
           maxVectorDistance: recallMaxVectorDistance(options),
           source: ctx.source,
           text: ctx.text,

--- a/packages/junior-memory/src/ranking.ts
+++ b/packages/junior-memory/src/ranking.ts
@@ -1,0 +1,98 @@
+import type { MemoryRecord } from "./store";
+
+const RECIPROCAL_RANK_FUSION_K = 60;
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+export interface MemoryMatch {
+  exactIdentifier: boolean;
+  lexical?: {
+    rank: number;
+  };
+  memory: MemoryRecord;
+  sourceKey: string;
+  vector?: {
+    rank: number;
+  };
+}
+
+function reciprocalRank(rank: number): number {
+  return 1 / (RECIPROCAL_RANK_FUSION_K + rank);
+}
+
+function matchScore(match: MemoryMatch): number {
+  return (
+    (match.vector ? reciprocalRank(match.vector.rank) : 0) +
+    (match.lexical ? reciprocalRank(match.lexical.rank) : 0)
+  );
+}
+
+function currentChannel(
+  match: Pick<MemoryMatch, "sourceKey">,
+  channelPrefix: string | undefined,
+): boolean {
+  return channelPrefix ? match.sourceKey.startsWith(channelPrefix) : false;
+}
+
+function observedAgeRank(memory: MemoryRecord, nowMs: number): number {
+  const ageMs = Math.max(0, nowMs - memory.observedAtMs);
+  if (ageMs <= 7 * ONE_DAY_MS) {
+    return 3;
+  }
+  if (ageMs <= 30 * ONE_DAY_MS) {
+    return 2;
+  }
+  if (ageMs <= 90 * ONE_DAY_MS) {
+    return 1;
+  }
+  return 0;
+}
+
+/**
+ * Keep exact structured-identifier matches in the strongest relevance tier,
+ * then fuse lexical and vector ranks without comparing provider raw scores.
+ */
+export function rankMemoryMatches(
+  matches: MemoryMatch[],
+  options: {
+    channelPrefix?: string;
+    nowMs: number;
+  },
+): MemoryMatch[] {
+  const byId = new Map<string, MemoryMatch>();
+  for (const match of matches) {
+    const existing = byId.get(match.memory.id);
+    if (!existing) {
+      byId.set(match.memory.id, match);
+      continue;
+    }
+    byId.set(match.memory.id, {
+      ...existing,
+      exactIdentifier: existing.exactIdentifier || match.exactIdentifier,
+      ...(match.lexical ? { lexical: match.lexical } : {}),
+      ...(match.vector ? { vector: match.vector } : {}),
+    });
+  }
+  return [...byId.values()].sort((left, right) => {
+    const identifierDelta =
+      Number(right.exactIdentifier) - Number(left.exactIdentifier);
+    if (identifierDelta !== 0) {
+      return identifierDelta;
+    }
+    const scoreDelta = matchScore(right) - matchScore(left);
+    if (scoreDelta !== 0) {
+      return scoreDelta;
+    }
+    const channelDelta =
+      Number(currentChannel(right, options.channelPrefix)) -
+      Number(currentChannel(left, options.channelPrefix));
+    if (channelDelta !== 0) {
+      return channelDelta;
+    }
+    return (
+      observedAgeRank(right.memory, options.nowMs) -
+        observedAgeRank(left.memory, options.nowMs) ||
+      right.memory.observedAtMs - left.memory.observedAtMs ||
+      left.memory.id.localeCompare(right.memory.id)
+    );
+  });
+}

--- a/packages/junior-memory/src/recall.ts
+++ b/packages/junior-memory/src/recall.ts
@@ -2,9 +2,11 @@ import {
   definePromptContext,
   type UserPromptContribution,
   type Actor,
+  type PluginLogger,
   type Source,
 } from "@sentry/junior-plugin-api";
 import { z } from "zod";
+import type { MemoryAgent } from "./agent";
 import {
   createMemoryStore,
   type MemoryDb,
@@ -14,13 +16,16 @@ import {
 import { memoryRuntimeContextSchema } from "./types";
 
 const DEFAULT_RECALL_LIMIT = 5;
+const RECALL_CANDIDATE_LIMIT = 20;
 const MAX_PROMPT_CHARS = 4_000;
 const MAX_MEMORY_LINE_CHARS = 600;
 
 export interface MemoryRecallContext {
+  agent: Pick<MemoryAgent, "selectRelevantMemories">;
   conversationId?: string;
   db: MemoryDb;
   embedder?: MemoryEmbeddingProvider;
+  log: PluginLogger;
   /** Maximum cosine distance for vector recall. Passed through to the memory store. */
   maxVectorDistance?: number;
   actor?: Actor;
@@ -122,16 +127,38 @@ export async function createMemoryPromptContributions(
     ...(context.actor ? { actor: context.actor } : {}),
     source: context.source,
   });
-  const memories = await createMemoryStore(context.db, runtimeContext, {
+  const candidates = await createMemoryStore(context.db, runtimeContext, {
     ...(context.embedder ? { embedder: context.embedder } : {}),
     ...(context.maxVectorDistance !== undefined
       ? { maxVectorDistance: context.maxVectorDistance }
       : {}),
-  }).searchMemories({
+  }).recallMemories({
     query: context.text,
-    limit: DEFAULT_RECALL_LIMIT,
+    limit: RECALL_CANDIDATE_LIMIT,
   });
-  const selected = selectPromptMemories(memories);
+  if (candidates.length === 0) {
+    return undefined;
+  }
+  let relevantIds: string[];
+  try {
+    relevantIds = await context.agent.selectRelevantMemories({
+      candidates: candidates.map(({ content, id }) => ({ content, id })),
+      userRequest: context.text,
+    });
+  } catch {
+    // Automatic recall is optional context; a relevance-model failure must not
+    // prevent the user's turn from continuing without recalled memory.
+    context.log.warn("memory_recall_selection_failed");
+    return undefined;
+  }
+  const candidatesById = new Map(
+    candidates.map((memory) => [memory.id, memory]),
+  );
+  const relevant = relevantIds
+    .map((id) => candidatesById.get(id))
+    .filter((memory): memory is MemoryRecord => memory !== undefined)
+    .slice(0, DEFAULT_RECALL_LIMIT);
+  const selected = selectPromptMemories(relevant);
   if (selected.length === 0) {
     return undefined;
   }

--- a/packages/junior-memory/src/store.ts
+++ b/packages/junior-memory/src/store.ts
@@ -583,14 +583,14 @@ async function archiveExpiredMemoryBatch(args: {
  * Two-part hyphenated prose such as "long-running" remains ordinary text.
  */
 function structuredQueryIdentifiers(query: string): string[] {
+  const matches =
+    query
+      .toLowerCase()
+      .match(
+        /(?:[a-z0-9][a-z0-9._-]*\/)+[a-z0-9][a-z0-9._-]*|[a-z0-9]+(?:[._][a-z0-9]+)+|[a-z0-9]+(?:-[a-z0-9]+){2,}/g,
+      ) ?? [];
   return [
-    ...new Set(
-      query
-        .toLowerCase()
-        .match(
-          /(?:[a-z0-9][a-z0-9._-]*\/)+[a-z0-9][a-z0-9._-]*|[a-z0-9]+(?:[._][a-z0-9]+)+|[a-z0-9]+(?:-[a-z0-9]+){2,}/g,
-        ) ?? [],
-    ),
+    ...new Set(matches.map((identifier) => identifier.replace(/\.+$/, ""))),
   ];
 }
 
@@ -982,7 +982,15 @@ async function searchVisibleLexicalMemories(args: {
       : undefined;
   const exactIdentifierMatch =
     identifierArray !== undefined
-      ? sql<boolean>`${contentTokens} && ${identifierArray}`
+      ? sql<boolean>`EXISTS (
+          SELECT 1
+          FROM unnest(${contentTokens}) AS content_token(value)
+          CROSS JOIN unnest(${identifierArray}) AS query_identifier(value)
+          WHERE strpos(
+            '/' || regexp_replace(content_token.value, '\\.+$', '') || '/',
+            '/' || query_identifier.value || '/'
+          ) > 0
+        )`
       : sql<boolean>`false`;
   const rows = await args.db
     .select({

--- a/packages/junior-memory/src/store.ts
+++ b/packages/junior-memory/src/store.ts
@@ -12,7 +12,6 @@ import {
   desc,
   eq,
   gt,
-  ilike,
   inArray,
   isNull,
   isNotNull,
@@ -28,6 +27,7 @@ import type { PgQueryResultHKT } from "drizzle-orm/pg-core/session";
 import { z } from "zod";
 import * as memorySqlSchema from "./db/schema";
 import { juniorMemoryEmbeddings, juniorMemoryMemories } from "./db/schema";
+import { rankMemoryMatches, type MemoryMatch } from "./ranking";
 import {
   MEMORY_EMBEDDING_DIMENSIONS,
   MEMORY_SCOPES,
@@ -49,23 +49,13 @@ import {
 const DEFAULT_LIST_LIMIT = 50;
 const DEFAULT_SEARCH_LIMIT = 10;
 const DEFAULT_EXPIRED_ARCHIVE_LIMIT = 100;
-const HIGH_CONFIDENCE_DUPLICATE_DISTANCE = 0.015;
 const PREFERENCE_ADJUDICATION_CANDIDATE_LIMIT = 10;
 const PREFERENCE_ADJUDICATION_VECTOR_LIMIT = 5;
 const VECTOR_SEARCH_OVERFETCH = 4;
 const MAX_MEMORY_CONTENT_CHARS = 4_000;
 const EMBEDDING_METRIC = "cosine";
-const ONE_DAY_MS = 24 * 60 * 60 * 1000;
-const RELEVANCE_NEAR_TIE_DELTA = 0.01;
-const SOURCE_CHANNEL_BOOST = 0.05;
 
 export type MemoryDb = PgDatabase<PgQueryResultHKT, typeof memorySqlSchema>;
-
-interface SearchCandidate {
-  memory: MemoryRecord;
-  score: number;
-  sourceKey: string;
-}
 
 interface MemoryEmbedding {
   model: string;
@@ -326,6 +316,11 @@ export interface MemoryStore {
   listMemories(input: ListMemoriesInput): Promise<MemoryRecord[]>;
   /** List active personal memories owned by the current actor. */
   listPersonalMemories(input: ListMemoriesInput): Promise<MemoryRecord[]>;
+  /**
+   * Retrieve a broad relevance-ranked candidate window for automatic recall.
+   * Prompt admission remains owned by the recall boundary.
+   */
+  recallMemories(input: SearchMemoriesInput): Promise<MemoryRecord[]>;
   /** Search active memories visible in the current runtime context. */
   searchMemories(input: SearchMemoriesInput): Promise<MemoryRecord[]>;
 }
@@ -583,25 +578,36 @@ async function archiveExpiredMemoryBatch(args: {
   return { archivedCount: archivedIds.length };
 }
 
-function searchScore(memory: MemoryRecord, terms: string[]): number {
-  const haystack = memory.content.toLowerCase();
-  // Lexical score is a retrieval fallback signal, not a memory policy decision.
-  return terms.reduce(
-    (score, term) => score + (haystack.includes(term) ? 1 : 0),
-    0,
-  );
-}
-
-function searchTerms(query: string): string[] {
+/**
+ * Find path-like, dotted, underscored, and multi-part hyphenated identifiers.
+ * Two-part hyphenated prose such as "long-running" remains ordinary text.
+ */
+function structuredQueryIdentifiers(query: string): string[] {
   return [
     ...new Set(
       query
         .toLowerCase()
-        .split(/[^a-z0-9_'-]+/)
-        .map((term) => term.trim())
-        .filter((term) => term.length >= 2),
+        .match(
+          /(?:[a-z0-9][a-z0-9._-]*\/)+[a-z0-9][a-z0-9._-]*|[a-z0-9]+(?:[._][a-z0-9]+)+|[a-z0-9]+(?:-[a-z0-9]+){2,}/g,
+        ) ?? [],
     ),
   ];
+}
+
+function denseRanks<T>(
+  values: T[],
+  key: (value: T) => string | number,
+): number[] {
+  let previous: string | number | undefined;
+  let rank = 0;
+  return values.map((value, index) => {
+    const current = key(value);
+    if (index === 0 || current !== previous) {
+      rank = index + 1;
+      previous = current;
+    }
+    return rank;
+  });
 }
 
 async function embedOne(
@@ -733,52 +739,6 @@ async function findExactDuplicateMemory(args: {
     )
     .limit(1);
   return rows[0] ? parseMemoryRow(rows[0]) : undefined;
-}
-
-async function findVectorDuplicateMemory(args: {
-  db: MemoryDb;
-  embedding: MemoryEmbedding;
-  kind: MemoryRecord["kind"];
-  nowMs: number;
-  scope: ResolvedMemoryScope;
-  subject: ResolvedMemorySubject;
-}): Promise<MemoryRecord | undefined> {
-  const distance = cosineDistance(
-    juniorMemoryEmbeddings.embedding,
-    args.embedding.vector,
-  );
-  const rows = await args.db
-    .select({
-      contentHash: juniorMemoryEmbeddings.contentHash,
-      distance,
-      memory: juniorMemoryMemories,
-    })
-    .from(juniorMemoryMemories)
-    .innerJoin(
-      juniorMemoryEmbeddings,
-      eq(juniorMemoryEmbeddings.memoryId, juniorMemoryMemories.id),
-    )
-    .where(
-      and(
-        activeScopedSubjectPredicate(args),
-        eq(juniorMemoryEmbeddings.provider, args.embedding.provider),
-        eq(juniorMemoryEmbeddings.model, args.embedding.model),
-        eq(juniorMemoryEmbeddings.dimensions, MEMORY_EMBEDDING_DIMENSIONS),
-        eq(juniorMemoryEmbeddings.metric, EMBEDDING_METRIC),
-        lte(distance, HIGH_CONFIDENCE_DUPLICATE_DISTANCE),
-      ),
-    )
-    .orderBy(
-      distance,
-      desc(juniorMemoryMemories.createdAtMs),
-      asc(juniorMemoryMemories.id),
-    )
-    .limit(1);
-  const row = rows[0];
-  if (!row || hashEmbeddedContent(row.memory.content) !== row.contentHash) {
-    return undefined;
-  }
-  return parseMemoryRow(row.memory);
 }
 
 async function rememberDuplicateIdempotency(args: {
@@ -989,38 +949,65 @@ async function listVisibleMemories(args: {
   return rows.map(parseMemoryRow);
 }
 
-/** Search active visible records with the V1 lexical matcher. */
-async function searchVisibleMemories(args: {
+/** Search active visible records with PostgreSQL full-text ranking. */
+async function searchVisibleLexicalMemories(args: {
   db: MemoryDb;
+  limit: number;
   nowMs: number;
   query: string;
   scopes: ResolvedMemoryScope[];
-}): Promise<SearchCandidate[]> {
-  const terms = searchTerms(args.query);
-  if (terms.length === 0) {
-    return [];
-  }
+}): Promise<MemoryMatch[]> {
   const predicate = activeVisiblePredicate(args);
   if (!predicate) {
     return [];
   }
+  const queryVector = sql`to_tsvector('english', ${args.query})`;
+  const tsquery = sql`(
+    SELECT COALESCE(
+      string_agg(quote_literal(term), ' | ')::tsquery,
+      ''::tsquery
+    )
+    FROM unnest(tsvector_to_array(${queryVector})) AS query_terms(term)
+  )`;
+  const textsearch = sql`to_tsvector('english', ${juniorMemoryMemories.content})`;
+  const textRank = sql<number>`ts_rank_cd(${textsearch}, ${tsquery})`;
+  const identifiers = structuredQueryIdentifiers(args.query);
+  const contentTokens = sql`regexp_split_to_array(lower(${juniorMemoryMemories.content}), '[^a-z0-9._/-]+')`;
+  const identifierArray =
+    identifiers.length > 0
+      ? sql`ARRAY[${sql.join(
+          identifiers.map((identifier) => sql`${identifier}`),
+          sql`, `,
+        )}]::text[]`
+      : undefined;
+  const exactIdentifierMatch =
+    identifierArray !== undefined
+      ? sql<boolean>`${contentTokens} && ${identifierArray}`
+      : sql<boolean>`false`;
   const rows = await args.db
-    .select()
+    .select({
+      exactIdentifierMatch,
+      memory: juniorMemoryMemories,
+      textRank,
+    })
     .from(juniorMemoryMemories)
-    .where(
-      and(
-        predicate,
-        or(
-          ...terms.map((term) =>
-            ilike(juniorMemoryMemories.content, `%${term}%`),
-          ),
-        ),
-      ),
-    );
-  return rows.map((row) => ({
-    memory: parseMemoryRow(row),
-    score: 0,
-    sourceKey: row.sourceKey,
+    .where(and(predicate, sql`${textsearch} @@ ${tsquery}`))
+    .orderBy(
+      ...(identifiers.length > 0 ? [desc(exactIdentifierMatch)] : []),
+      desc(textRank),
+      desc(juniorMemoryMemories.observedAtMs),
+      asc(juniorMemoryMemories.id),
+    )
+    .limit(args.limit);
+  const ranks = denseRanks(
+    rows,
+    (row) => `${row.exactIdentifierMatch}:${Number(row.textRank)}`,
+  );
+  return rows.map((row, index) => ({
+    exactIdentifier: row.exactIdentifierMatch,
+    lexical: { rank: ranks[index] },
+    memory: parseMemoryRow(row.memory),
+    sourceKey: row.memory.sourceKey,
   }));
 }
 
@@ -1033,7 +1020,7 @@ async function searchVisibleVectorMemories(args: {
   nowMs: number;
   query: string;
   scopes: ResolvedMemoryScope[];
-}): Promise<SearchCandidate[]> {
+}): Promise<MemoryMatch[]> {
   if (!args.embedder) {
     return [];
   }
@@ -1077,7 +1064,8 @@ async function searchVisibleVectorMemories(args: {
       asc(juniorMemoryMemories.id),
     )
     .limit(args.limit);
-  return rows.flatMap((row) => {
+  const ranks = denseRanks(rows, (row) => Number(row.distance));
+  return rows.flatMap((row, index) => {
     const distanceValue = Number(row.distance);
     if (
       row.distance === null ||
@@ -1091,87 +1079,15 @@ async function searchVisibleVectorMemories(args: {
     }
     return [
       {
+        exactIdentifier: false,
         memory: parseMemoryRow(row.memory),
-        score: 1 / (1 + Math.max(0, distanceValue)),
         sourceKey: row.memory.sourceKey,
+        vector: {
+          rank: ranks[index],
+        },
       },
     ];
   });
-}
-
-function sourceBoost(
-  candidate: Pick<SearchCandidate, "sourceKey">,
-  currentChannelPrefix: string | undefined,
-): number {
-  if (!currentChannelPrefix) {
-    return 0;
-  }
-  return candidate.sourceKey.startsWith(currentChannelPrefix)
-    ? SOURCE_CHANNEL_BOOST
-    : 0;
-}
-
-/** Score only observation age for near-tie reranking; this is not lifecycle decay. */
-function observedAgeBoost(memory: MemoryRecord, nowMs: number): number {
-  const ageMs = Math.max(0, nowMs - memory.observedAtMs);
-  if (ageMs <= 7 * ONE_DAY_MS) {
-    return 0.15;
-  }
-  if (ageMs <= 30 * ONE_DAY_MS) {
-    return 0.1;
-  }
-  if (ageMs <= 90 * ONE_DAY_MS) {
-    return 0.05;
-  }
-  return 0;
-}
-
-/** Fuse retrieval candidates while keeping observed age to near-tie reranking. */
-function mergeSearchCandidates(
-  candidates: SearchCandidate[],
-  nowMs: number,
-  currentChannelKey?: string,
-): MemoryRecord[] {
-  const byId = new Map<
-    string,
-    {
-      memory: MemoryRecord;
-      score: number;
-      sourceKey: string;
-    }
-  >();
-  for (const candidate of candidates) {
-    const existing = byId.get(candidate.memory.id);
-    if (existing) {
-      existing.score += candidate.score;
-      continue;
-    }
-    byId.set(candidate.memory.id, {
-      memory: candidate.memory,
-      score: candidate.score,
-      sourceKey: candidate.sourceKey,
-    });
-  }
-  return [...byId.values()]
-    .sort((left, right) => {
-      const scoreDelta = right.score - left.score;
-      if (Math.abs(scoreDelta) > RELEVANCE_NEAR_TIE_DELTA) {
-        return scoreDelta;
-      }
-      const sourceDelta =
-        sourceBoost(right, currentChannelKey) -
-        sourceBoost(left, currentChannelKey);
-      if (sourceDelta !== 0) {
-        return sourceDelta;
-      }
-      return (
-        observedAgeBoost(right.memory, nowMs) -
-          observedAgeBoost(left.memory, nowMs) ||
-        right.memory.observedAtMs - left.memory.observedAtMs ||
-        left.memory.id.localeCompare(right.memory.id)
-      );
-    })
-    .map((candidate) => candidate.memory);
 }
 
 /** Create a context-bound SQL-backed store for explicit memory operations. */
@@ -1294,27 +1210,6 @@ export function createMemoryStore(
         candidateEmbedding = undefined;
       }
     }
-    const vectorDuplicate = candidateEmbedding
-      ? await findVectorDuplicateMemory({
-          db,
-          embedding: candidateEmbedding,
-          kind: input.kind,
-          nowMs,
-          scope,
-          subject,
-        })
-      : undefined;
-    if (vectorDuplicate) {
-      return await reuseDuplicateMemory({
-        content,
-        duplicate: vectorDuplicate,
-        idempotencyKey: input.idempotencyKey,
-        nowMs,
-        scope,
-        subject,
-      });
-    }
-
     let supersededIds: string[] = [];
     if (
       scopeKind === "personal" &&
@@ -1440,6 +1335,49 @@ export function createMemoryStore(
     return { created: false, memory: idempotent };
   }
 
+  async function retrieveVisibleMemories(
+    rawInput: SearchMemoriesInput,
+    vectorMaxDistance: number | undefined,
+  ): Promise<MemoryRecord[]> {
+    const input = searchMemoriesInputSchema.parse(rawInput);
+    const nowMs = getNowMs();
+    const scopes = deriveVisibleMemoryScopes(runtimeContext);
+    await archiveExpiredMemoryBatch({
+      db,
+      nowMs,
+      scopes,
+    });
+    const limit = boundedLimit(input.limit, DEFAULT_SEARCH_LIMIT);
+    const candidateLimit = limit * VECTOR_SEARCH_OVERFETCH;
+    const [vectorMatches, lexicalMatches] = await Promise.all([
+      searchVisibleVectorMemories({
+        db,
+        embedder,
+        limit: candidateLimit,
+        ...(vectorMaxDistance !== undefined
+          ? { maxDistance: vectorMaxDistance }
+          : {}),
+        nowMs,
+        query: input.query,
+        scopes,
+      }),
+      searchVisibleLexicalMemories({
+        db,
+        limit: candidateLimit,
+        nowMs,
+        query: input.query,
+        scopes,
+      }),
+    ]);
+    const channelPrefix = sourceChannelPrefix(runtimeContext);
+    return rankMemoryMatches([...vectorMatches, ...lexicalMatches], {
+      nowMs,
+      ...(channelPrefix ? { channelPrefix } : {}),
+    })
+      .slice(0, limit)
+      .map(({ memory }) => memory);
+  }
+
   return {
     async archiveExpiredMemories(input) {
       return await archiveExpiredVisibleMemories(input, getNowMs());
@@ -1487,45 +1425,12 @@ export function createMemoryStore(
       });
     },
 
+    async recallMemories(input) {
+      return await retrieveVisibleMemories(input, maxVectorDistance);
+    },
+
     async searchMemories(input) {
-      input = searchMemoriesInputSchema.parse(input);
-      const nowMs = getNowMs();
-      const scopes = deriveVisibleMemoryScopes(runtimeContext);
-      await archiveExpiredMemoryBatch({
-        db,
-        nowMs,
-        scopes,
-      });
-      const limit = boundedLimit(input.limit, DEFAULT_SEARCH_LIMIT);
-      const vectorCandidates = await searchVisibleVectorMemories({
-        db,
-        embedder,
-        limit: limit * VECTOR_SEARCH_OVERFETCH,
-        ...(maxVectorDistance !== undefined
-          ? { maxDistance: maxVectorDistance }
-          : {}),
-        nowMs,
-        query: input.query,
-        scopes,
-      });
-      const candidates = await searchVisibleMemories({
-        db,
-        nowMs,
-        query: input.query,
-        scopes,
-      });
-      const terms = searchTerms(input.query);
-      const lexicalCandidates = candidates
-        .map((candidate) => ({
-          ...candidate,
-          score: searchScore(candidate.memory, terms),
-        }))
-        .filter((item) => item.score > 0);
-      return mergeSearchCandidates(
-        [...vectorCandidates, ...lexicalCandidates],
-        nowMs,
-        sourceChannelPrefix(runtimeContext),
-      ).slice(0, limit);
+      return await retrieveVisibleMemories(input, undefined);
     },
 
     async archiveMemory(input) {

--- a/packages/junior-memory/tests/ranking.test.ts
+++ b/packages/junior-memory/tests/ranking.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import { rankMemoryMatches, type MemoryMatch } from "../src/ranking";
+import type { MemoryRecord } from "../src/store";
+
+const NOW_MS = Date.parse("2026-07-28T12:00:00.000Z");
+
+function memory(id: string, observedAtMs = NOW_MS): MemoryRecord {
+  return {
+    content: `Memory ${id}`,
+    createdAtMs: observedAtMs,
+    id,
+    kind: "knowledge",
+    observedAtMs,
+    scope: "conversation",
+    subjectType: "conversation",
+  };
+}
+
+function match(
+  id: string,
+  input: Omit<MemoryMatch, "exactIdentifier" | "memory" | "sourceKey"> & {
+    exactIdentifier?: boolean;
+    observedAtMs?: number;
+    sourceKey?: string;
+  },
+): MemoryMatch {
+  return {
+    ...input,
+    exactIdentifier: input.exactIdentifier ?? false,
+    memory: memory(id, input.observedAtMs),
+    sourceKey: input.sourceKey ?? "slack:T123:C456",
+  };
+}
+
+describe("memory retrieval ranking", () => {
+  it("promotes a memory supported by both retrieval methods", () => {
+    const ranked = rankMemoryMatches(
+      [
+        match("vector-only", { vector: { distance: 0.1, rank: 1 } }),
+        match("supported", { vector: { distance: 0.2, rank: 2 } }),
+        match("supported", { lexical: { rank: 2 } }),
+        match("lexical-only", { lexical: { rank: 1 } }),
+      ],
+      { nowMs: NOW_MS },
+    );
+
+    expect(ranked[0]?.memory.id).toBe("supported");
+    expect(ranked.slice(1).map(({ memory }) => memory.id)).toEqual(
+      expect.arrayContaining(["vector-only", "lexical-only"]),
+    );
+  });
+
+  it("uses source proximity and observation age only after relevance ties", () => {
+    const ranked = rankMemoryMatches(
+      [
+        match("other-channel-new", {
+          lexical: { rank: 1 },
+          sourceKey: "slack:T123:C999",
+        }),
+        match("same-channel-old", {
+          lexical: { rank: 1 },
+          observedAtMs: NOW_MS - 120 * 24 * 60 * 60 * 1000,
+          sourceKey: "slack:T123:C456",
+        }),
+        match("same-channel-new", {
+          lexical: { rank: 1 },
+          sourceKey: "slack:T123:C456",
+        }),
+      ],
+      { channelPrefix: "slack:T123:C456", nowMs: NOW_MS },
+    );
+
+    expect(ranked.map(({ memory }) => memory.id)).toEqual([
+      "same-channel-new",
+      "same-channel-old",
+      "other-channel-new",
+    ]);
+  });
+
+  it("keeps an exact identifier match in a crowded fused candidate window", () => {
+    const matches = [
+      match("exact", {
+        exactIdentifier: true,
+        lexical: { rank: 1 },
+      }),
+      match("exact", {
+        vector: { rank: 20 },
+      }),
+    ];
+    for (let rank = 1; rank <= 20; rank += 1) {
+      matches.push(
+        match(`generic-${rank}`, {
+          lexical: { rank },
+          vector: { rank },
+        }),
+      );
+    }
+
+    const ranked = rankMemoryMatches(matches, { nowMs: NOW_MS });
+
+    expect(ranked[0]?.memory.id).toBe("exact");
+    expect(
+      ranked.slice(0, 20).some(({ memory }) => memory.id === "exact"),
+    ).toBe(true);
+  });
+});

--- a/packages/junior-memory/tests/retrieval-quality.test.ts
+++ b/packages/junior-memory/tests/retrieval-quality.test.ts
@@ -1,0 +1,172 @@
+import { readdir, readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  createLocalPgliteFixture,
+  pgliteVectorExtension,
+  type LocalPgliteFixture,
+} from "@sentry/junior-testing/pglite";
+import { createSlackSource } from "@sentry/junior-plugin-api";
+import { describe, expect, it } from "vitest";
+import * as memorySqlSchema from "../src/db/schema";
+import {
+  createMemoryStore,
+  type MemoryDb,
+  type MemoryEmbeddingProvider,
+} from "../src/store";
+
+const EMBEDDING_DIMENSIONS = 1536;
+const NOW_MS = Date.parse("2026-07-29T12:00:00.000Z");
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+type MemoryFixture = LocalPgliteFixture<MemoryDb>;
+
+function unitEmbedding(index: number): number[] {
+  const embedding = Array.from({ length: EMBEDDING_DIMENSIONS }, () => 0);
+  embedding[index] = 1;
+  return embedding;
+}
+
+function testEmbedder(
+  vectors: Record<string, number[]>,
+): MemoryEmbeddingProvider {
+  return {
+    async embedTexts({ texts }) {
+      return {
+        dimensions: EMBEDDING_DIMENSIONS,
+        model: "retrieval-quality-model",
+        provider: "retrieval-quality-provider",
+        vectors: texts.map((text) => vectors[text] ?? unitEmbedding(10)),
+      };
+    },
+  };
+}
+
+async function createFixture(): Promise<MemoryFixture> {
+  const fixture = await createLocalPgliteFixture<MemoryDb>(memorySqlSchema, {
+    extensions: { vector: pgliteVectorExtension },
+  });
+  const migrationsDir = resolve(__dirname, "../migrations");
+  const migrations = (await readdir(migrationsDir))
+    .filter((filename) => filename.endsWith(".sql"))
+    .sort();
+  for (const filename of migrations) {
+    await fixture.execute(
+      await readFile(resolve(migrationsDir, filename), "utf8"),
+    );
+  }
+  return fixture;
+}
+
+function runtimeContext() {
+  const teamId = "TQUALITY";
+  const channelId = "CQUALITY";
+  const threadTs = "1785326400.000000";
+  return {
+    actor: {
+      platform: "slack" as const,
+      teamId,
+      userId: "UQUALITY",
+    },
+    conversationId: `slack:${channelId}:${threadTs}`,
+    source: createSlackSource({
+      channelId,
+      messageTs: threadTs,
+      teamId,
+      threadTs,
+      type: "pub",
+    }),
+  };
+}
+
+describe("memory retrieval quality", () => {
+  it("keeps exact, lexical, and semantic facts ahead of plausible distractors", async () => {
+    const fixture = await createFixture();
+    const exactContent = "getsentry/junior CI runs package tests with pnpm.";
+    const prefixContent =
+      "getsentry/junior-old CI runs package tests with pnpm.";
+    const genericContent =
+      "Repository CI guidance is available in the engineering dashboard.";
+    const runbookContent = "Release runbooks are documented in Notion.";
+    const semanticContent =
+      "Deployments require canary verification before production rollout.";
+    const exactQuery = "How does CI work in getsentry/junior?";
+    const lexicalQuery = "Where are release runbooks documented?";
+    const semanticQuery = "What is the publishing process?";
+    const embedder = testEmbedder({
+      [exactContent]: unitEmbedding(0),
+      [prefixContent]: unitEmbedding(0),
+      [genericContent]: unitEmbedding(0),
+      [runbookContent]: unitEmbedding(1),
+      [semanticContent]: unitEmbedding(2),
+      [exactQuery]: unitEmbedding(0),
+      [lexicalQuery]: unitEmbedding(1),
+      [semanticQuery]: unitEmbedding(2),
+    });
+    const store = createMemoryStore(fixture.db(), runtimeContext(), {
+      embedder,
+      now: () => NOW_MS,
+    });
+
+    try {
+      const memories = new Map<string, string>();
+      for (const [key, content] of [
+        ["exact", exactContent],
+        ["prefix", prefixContent],
+        ["generic", genericContent],
+        ["lexical", runbookContent],
+        ["semantic", semanticContent],
+      ] as const) {
+        const result = await store.createConversationMemory({
+          content,
+          idempotencyKey: `retrieval-quality:${key}`,
+          kind: "knowledge",
+        });
+        memories.set(key, result.memory.id);
+      }
+
+      const cases = [
+        { expected: memories.get("exact"), query: exactQuery },
+        { expected: memories.get("lexical"), query: lexicalQuery },
+        { expected: memories.get("semantic"), query: semanticQuery },
+      ];
+      const outcomes = await Promise.all(
+        cases.map(async ({ expected, query }) => {
+          const ranked = await store.searchMemories({ limit: 5, query });
+          const rank = ranked.findIndex((memory) => memory.id === expected) + 1;
+          return {
+            hitAt1: rank === 1,
+            reciprocalRank: rank > 0 ? 1 / rank : 0,
+            recallAt5: rank > 0,
+          };
+        }),
+      );
+      const count = outcomes.length;
+      const report = {
+        hitAt1:
+          outcomes.filter(({ hitAt1 }) => hitAt1).length / Math.max(1, count),
+        meanReciprocalRank:
+          outcomes.reduce(
+            (total, { reciprocalRank }) => total + reciprocalRank,
+            0,
+          ) / Math.max(1, count),
+        recallAt5:
+          outcomes.filter(({ recallAt5 }) => recallAt5).length /
+          Math.max(1, count),
+      };
+
+      expect(report).toEqual({
+        hitAt1: 1,
+        meanReciprocalRank: 1,
+        recallAt5: 1,
+      });
+      const exactResults = await store.searchMemories({
+        limit: 1,
+        query: exactQuery,
+      });
+      expect(exactResults[0]?.id).not.toBe(memories.get("prefix"));
+    } finally {
+      await fixture.close();
+    }
+  }, 15_000);
+});

--- a/packages/junior-memory/tests/storage.test.ts
+++ b/packages/junior-memory/tests/storage.test.ts
@@ -2265,6 +2265,55 @@ WHERE id = '${superseded.memory.id}'
     }
   }, 15_000);
 
+  it("matches structured identifiers inside URLs and before sentence punctuation", async () => {
+    const fixture = await createMemoryFixture();
+
+    try {
+      let nowMs = TEST_NOW_MS - 3;
+      const store = createMemoryStore(memoryDb(fixture), slackContext(), {
+        now: () => nowMs,
+      });
+      const url = await store.createConversationMemory({
+        content: "CI docs live at https://github.com/getsentry/junior.",
+        kind: "knowledge",
+        idempotencyKey: "memory-test:identifier-url",
+      });
+      nowMs += 1;
+      await store.createConversationMemory({
+        content: "CI docs for getsentry/junior-old explain package tests.",
+        kind: "knowledge",
+        idempotencyKey: "memory-test:identifier-url-prefix",
+      });
+      nowMs += 1;
+      const sentence = await store.createConversationMemory({
+        content: "Primary service repository is acme/service.",
+        kind: "knowledge",
+        idempotencyKey: "memory-test:identifier-sentence",
+      });
+      nowMs += 1;
+      await store.createConversationMemory({
+        content: "Primary service repository is acme/service-old.",
+        kind: "knowledge",
+        idempotencyKey: "memory-test:identifier-sentence-prefix",
+      });
+
+      await expect(
+        store.searchMemories({
+          limit: 1,
+          query: "How does CI work in getsentry/junior?",
+        }),
+      ).resolves.toEqual([expect.objectContaining({ id: url.memory.id })]);
+      await expect(
+        store.searchMemories({
+          limit: 1,
+          query: "Where is acme/service.",
+        }),
+      ).resolves.toEqual([expect.objectContaining({ id: sentence.memory.id })]);
+    } finally {
+      await fixture.close();
+    }
+  }, 15_000);
+
   it("does not treat a longer repository name as an exact identifier match", async () => {
     const fixture = await createMemoryFixture();
 

--- a/packages/junior-memory/tests/storage.test.ts
+++ b/packages/junior-memory/tests/storage.test.ts
@@ -218,6 +218,36 @@ function createTestEmbedder(
   };
 }
 
+function recallModel(select: (candidates: string[]) => string[]): PluginModel {
+  return {
+    async completeObject(input) {
+      const encoded =
+        /<candidate-memories>\n(.+)\n<\/candidate-memories>/s.exec(
+          input.prompt,
+        )?.[1];
+      const candidates = JSON.parse(
+        (encoded ?? "[]")
+          .replaceAll("&lt;", "<")
+          .replaceAll("&gt;", ">")
+          .replaceAll("&amp;", "&"),
+      ) as Array<{
+        content: string;
+        id: string;
+      }>;
+      return {
+        object: {
+          relevantIds: select(candidates.map(({ content }) => content)).map(
+            (content) =>
+              candidates.find((candidate) => candidate.content === content)!.id,
+          ),
+        },
+      };
+    },
+  };
+}
+
+const selectAllRecallModel = recallModel((candidates) => candidates);
+
 function extractionModel(
   memories: Array<{
     content: string;
@@ -471,6 +501,38 @@ describe("memory plugin storage", () => {
       content: "Uses qa-structured-output in CLI QA.",
     });
     expect(calls[0]?.schema).toBeDefined();
+  });
+
+  it("normalizes recall selection to known unique candidate ids", async () => {
+    const calls: Parameters<PluginModel["completeObject"]>[0][] = [];
+    const model: PluginModel = {
+      async completeObject(input) {
+        calls.push(input);
+        return {
+          object: {
+            relevantIds: ["memory-2", "unknown", "memory-2", "memory-1"],
+          },
+        };
+      },
+    };
+    const agent = createMemoryAgent(model);
+
+    await expect(
+      agent.selectRelevantMemories({
+        candidates: [
+          { content: "Release notes live in Notion.", id: "memory-1" },
+          {
+            content: "getsentry/junior CI runs package tests with pnpm.",
+            id: "memory-2",
+          },
+        ],
+        userRequest: "How does CI work in getsentry/junior?",
+      }),
+    ).resolves.toEqual(["memory-2", "memory-1"]);
+    expect(calls[0]?.system).toContain(
+      "Reject memories that merely share a company",
+    );
+    expect(calls[0]?.prompt).toContain("<candidate-memories>");
   });
 
   it("registers explicit model id as memory plugin model configuration", () => {
@@ -2077,6 +2139,46 @@ WHERE id = '${superseded.memory.id}'
     }
   }, 15_000);
 
+  it("applies the vector cutoff to automatic recall without narrowing explicit search", async () => {
+    const fixture = await createMemoryFixture();
+
+    try {
+      const query = "semantic needle";
+      const closeContent = "Close vector-only memory.";
+      const weakContent = "Weak vector-only memory.";
+      const embedder = createTestEmbedder({
+        [query]: unitEmbedding(0),
+        [closeContent]: cosineEmbedding(0.8),
+        [weakContent]: cosineEmbedding(0.5),
+      });
+      const store = createMemoryStore(memoryDb(fixture), slackContext(), {
+        embedder,
+        maxVectorDistance: 0.45,
+        now: () => TEST_NOW_MS,
+      });
+      const close = await store.createMemory({
+        content: closeContent,
+        kind: "knowledge",
+        idempotencyKey: "memory-test:recall-distance-close",
+      });
+      const weak = await store.createMemory({
+        content: weakContent,
+        kind: "knowledge",
+        idempotencyKey: "memory-test:recall-distance-weak",
+      });
+
+      await expect(store.recallMemories({ limit: 2, query })).resolves.toEqual([
+        expect.objectContaining({ id: close.memory.id }),
+      ]);
+      await expect(store.searchMemories({ limit: 2, query })).resolves.toEqual([
+        expect.objectContaining({ id: close.memory.id }),
+        expect.objectContaining({ id: weak.memory.id }),
+      ]);
+    } finally {
+      await fixture.close();
+    }
+  }, 15_000);
+
   it("fuses vector and lexical matches before applying the search limit", async () => {
     const fixture = await createMemoryFixture();
 
@@ -2085,7 +2187,7 @@ WHERE id = '${superseded.memory.id}'
       const vectorMemories = [
         "Uses server components for dashboard filters.",
         "Keeps migrations generated through drizzle-kit.",
-        "Prefers short-lived QA branches.",
+        "Maintains short-lived QA branches.",
         "Stores runbooks near deploy checklists.",
       ];
       const lexicalMemory = "Exact lexical preference lives in this memory.";
@@ -2126,6 +2228,69 @@ WHERE id = '${superseded.memory.id}'
       await expect(
         vectorStore.searchMemories({ limit: 1, query }),
       ).resolves.toEqual([expect.objectContaining({ id: lexical.memory.id })]);
+    } finally {
+      await fixture.close();
+    }
+  }, 15_000);
+
+  it("keeps exact structured identifiers ahead of generic lexical overlap", async () => {
+    const fixture = await createMemoryFixture();
+
+    try {
+      let nowMs = TEST_NOW_MS - 1;
+      const store = createMemoryStore(memoryDb(fixture), slackContext(), {
+        now: () => nowMs,
+      });
+      const exact = await store.createConversationMemory({
+        content: "getsentry/junior CI runs package tests with pnpm.",
+        kind: "knowledge",
+        idempotencyKey: "memory-test:identifier-exact",
+      });
+      nowMs += 1;
+      await store.createConversationMemory({
+        content:
+          "CI work is documented with repository tests and engineering notes.",
+        kind: "knowledge",
+        idempotencyKey: "memory-test:identifier-generic",
+      });
+
+      await expect(
+        store.searchMemories({
+          limit: 1,
+          query: "How does CI work in getsentry/junior?",
+        }),
+      ).resolves.toEqual([expect.objectContaining({ id: exact.memory.id })]);
+    } finally {
+      await fixture.close();
+    }
+  }, 15_000);
+
+  it("does not treat a longer repository name as an exact identifier match", async () => {
+    const fixture = await createMemoryFixture();
+
+    try {
+      let nowMs = TEST_NOW_MS - 1;
+      const store = createMemoryStore(memoryDb(fixture), slackContext(), {
+        now: () => nowMs,
+      });
+      const exact = await store.createConversationMemory({
+        content: "getsentry/junior CI runs package tests with pnpm.",
+        kind: "knowledge",
+        idempotencyKey: "memory-test:identifier-boundary-exact",
+      });
+      nowMs += 1;
+      await store.createConversationMemory({
+        content: "getsentry/junior-old CI runs package tests with pnpm.",
+        kind: "knowledge",
+        idempotencyKey: "memory-test:identifier-boundary-prefix",
+      });
+
+      await expect(
+        store.searchMemories({
+          limit: 1,
+          query: "How does CI work in getsentry/junior?",
+        }),
+      ).resolves.toEqual([expect.objectContaining({ id: exact.memory.id })]);
     } finally {
       await fixture.close();
     }
@@ -2440,7 +2605,7 @@ WHERE id = '${superseded.memory.id}'
     }
   }, 15_000);
 
-  it("preserves vector duplicate retry identity", async () => {
+  it("preserves retry identity for a distinct semantic neighbor", async () => {
     const fixture = await createMemoryFixture();
 
     try {
@@ -2455,46 +2620,46 @@ WHERE id = '${superseded.memory.id}'
         now: () => TEST_NOW_MS,
       });
 
-      const created = await store.createMemory({
+      const first = await store.createMemory({
         content: firstContent,
         kind: "preference",
         idempotencyKey: "memory-test:vector-dedup-idempotent-original",
       });
-      await expect(
-        store.createMemory({
-          content: duplicateContent,
-          kind: "preference",
-          idempotencyKey: "memory-test:vector-dedup-idempotent-repeat",
-        }),
-      ).resolves.toMatchObject({
-        created: false,
-        memory: { id: created.memory.id, content: firstContent },
+      const second = await store.createMemory({
+        content: duplicateContent,
+        kind: "preference",
+        idempotencyKey: "memory-test:vector-dedup-idempotent-repeat",
       });
+      expect(second).toMatchObject({
+        created: true,
+        memory: { content: duplicateContent },
+      });
+      expect(second.memory.id).not.toBe(first.memory.id);
       await expect(
         store.createMemory({
-          content: "Changed retry content should stay deduped.",
+          content:
+            "Changed retry content should resolve to its original write.",
           kind: "preference",
           idempotencyKey: "memory-test:vector-dedup-idempotent-repeat",
         }),
       ).resolves.toMatchObject({
         created: false,
-        memory: { id: created.memory.id, content: firstContent },
+        memory: { id: second.memory.id, content: duplicateContent },
       });
 
-      await expect(store.listMemories({})).resolves.toEqual([
-        expect.objectContaining({ id: created.memory.id }),
-      ]);
+      await expect(store.listMemories({})).resolves.toHaveLength(2);
     } finally {
       await fixture.close();
     }
   }, 15_000);
 
-  it("returns an existing same-kind memory for high-confidence vector duplicates", async () => {
+  it("does not collapse distinct facts with identical embeddings", async () => {
     const fixture = await createMemoryFixture();
 
     try {
-      const firstContent = "Prefers weekly summaries in bullet form.";
-      const duplicateContent = "Likes weekly updates as bullet lists.";
+      const firstContent = "getsentry/junior CI runs package tests with pnpm.";
+      const duplicateContent =
+        "getsentry/junior-old CI runs package tests with pnpm.";
       const embedder = createTestEmbedder({
         [firstContent]: unitEmbedding(1),
         [duplicateContent]: unitEmbedding(1),
@@ -2506,28 +2671,24 @@ WHERE id = '${superseded.memory.id}'
 
       const created = await store.createMemory({
         content: firstContent,
-        kind: "preference",
+        kind: "knowledge",
         idempotencyKey: "memory-test:vector-dedup-original",
       });
-      await expect(
-        store.createMemory({
-          content: duplicateContent,
-          kind: "preference",
-          idempotencyKey: "memory-test:vector-dedup-repeat",
-        }),
-      ).resolves.toMatchObject({
-        created: false,
-        memory: { id: created.memory.id, content: firstContent },
+      const neighbor = await store.createMemory({
+        content: duplicateContent,
+        kind: "knowledge",
+        idempotencyKey: "memory-test:vector-dedup-repeat",
       });
+      expect(neighbor).toMatchObject({
+        created: true,
+        memory: { content: duplicateContent },
+      });
+      expect(neighbor.memory.id).not.toBe(created.memory.id);
 
-      await expect(store.listMemories({})).resolves.toEqual([
-        expect.objectContaining({ id: created.memory.id }),
-      ]);
+      await expect(store.listMemories({})).resolves.toHaveLength(2);
       await expect(
         memoryDb(fixture).select().from(memorySqlSchema.juniorMemoryEmbeddings),
-      ).resolves.toEqual([
-        expect.objectContaining({ memoryId: created.memory.id }),
-      ]);
+      ).resolves.toHaveLength(2);
     } finally {
       await fixture.close();
     }
@@ -3011,6 +3172,7 @@ WHERE id = '${superseded.memory.id}'
         db: memoryDb(fixture),
         embedder: createTestEmbedder(),
         log: noopLogger,
+        model: selectAllRecallModel,
         plugin: { name: "memory" },
         state: memoryState,
         text: "Draft a PR summary and mention release notes.",
@@ -3053,6 +3215,7 @@ WHERE id = '${superseded.memory.id}'
         db: memoryDb(fixture),
         embedder: createTestEmbedder(),
         log: noopLogger,
+        model: selectAllRecallModel,
         plugin: { name: "memory" },
         state: memoryState,
         text: "Where do release notes live?",
@@ -3091,6 +3254,138 @@ WHERE id = '${superseded.memory.id}'
     }
   }, 15_000);
 
+  it("filters candidates that only share repository and CI vocabulary", async () => {
+    const fixture = await createMemoryFixture();
+
+    try {
+      const context = slackContext();
+      const store = createMemoryStore(memoryDb(fixture), context, {
+        now: () => TEST_NOW_MS,
+      });
+      const relevant = await store.createConversationMemory({
+        content: "getsentry/junior CI runs package tests with pnpm.",
+        kind: "knowledge",
+        idempotencyKey: "memory-test:recall-gate-relevant",
+      });
+      await store.createConversationMemory({
+        content: "getsentry/sentry autofix PR tests use a dashboard workflow.",
+        kind: "knowledge",
+        idempotencyKey: "memory-test:recall-gate-vocabulary",
+      });
+      await store.createConversationMemory({
+        content:
+          "Single-tenant repository access is configured in the admin dashboard.",
+        kind: "knowledge",
+        idempotencyKey: "memory-test:recall-gate-unrelated",
+      });
+
+      const plugin = createMemoryPlugin();
+      const result = await plugin.hooks?.userPrompt?.({
+        ...context,
+        destination: slackDestination(context),
+        db: memoryDb(fixture),
+        embedder: createTestEmbedder(),
+        log: noopLogger,
+        model: recallModel((candidates) =>
+          candidates.filter((content) => content.includes("getsentry/junior")),
+        ),
+        plugin: { name: "memory" },
+        state: memoryState,
+        text: "How does CI work in getsentry/junior?",
+      });
+
+      const contribution = result?.[0];
+      expect(contribution && "context" in contribution).toBe(true);
+      if (!contribution || !("context" in contribution)) {
+        throw new Error("Memory recall did not return structured context");
+      }
+      expect(contribution.context.content).toMatchObject({
+        memories: [{ id: relevant.memory.id }],
+      });
+      expect(contribution.renderPrompt()).not.toContain("autofix");
+      expect(contribution.renderPrompt()).not.toContain("Single-tenant");
+    } finally {
+      await fixture.close();
+    }
+  }, 15_000);
+
+  it("omits memory context when no candidate is directly relevant", async () => {
+    const fixture = await createMemoryFixture();
+
+    try {
+      const context = slackContext();
+      await createMemoryStore(memoryDb(fixture), context, {
+        now: () => TEST_NOW_MS,
+      }).createConversationMemory({
+        content: "getsentry/sentry autofix PR tests use a dashboard workflow.",
+        kind: "knowledge",
+        idempotencyKey: "memory-test:recall-gate-empty",
+      });
+
+      const plugin = createMemoryPlugin();
+      await expect(
+        plugin.hooks?.userPrompt?.({
+          ...context,
+          destination: slackDestination(context),
+          db: memoryDb(fixture),
+          embedder: createTestEmbedder(),
+          log: noopLogger,
+          model: recallModel(() => []),
+          plugin: { name: "memory" },
+          state: memoryState,
+          text: "How does CI work in getsentry/junior?",
+        }),
+      ).resolves.toBeUndefined();
+    } finally {
+      await fixture.close();
+    }
+  }, 15_000);
+
+  it("continues without recalled context when relevance selection fails", async () => {
+    const fixture = await createMemoryFixture();
+    const warnings: string[] = [];
+    const log: PluginLogger = {
+      error() {},
+      info() {},
+      warn(message) {
+        warnings.push(message);
+      },
+    };
+
+    try {
+      const context = slackContext();
+      await createMemoryStore(memoryDb(fixture), context, {
+        now: () => TEST_NOW_MS,
+      }).createConversationMemory({
+        content: "Release notes live in Notion.",
+        kind: "knowledge",
+        idempotencyKey: "memory-test:recall-gate-failure",
+      });
+
+      const plugin = createMemoryPlugin();
+      await expect(
+        plugin.hooks?.userPrompt?.({
+          ...context,
+          destination: slackDestination(context),
+          db: memoryDb(fixture),
+          embedder: createTestEmbedder(),
+          log,
+          model: {
+            async completeObject() {
+              throw new Error("model unavailable");
+            },
+          },
+          plugin: { name: "memory" },
+          state: memoryState,
+          text: "Where do release notes live?",
+        }),
+      ).resolves.toBeUndefined();
+      expect(warnings).toEqual(["memory_recall_selection_failed"]);
+    } finally {
+      await fixture.close();
+    }
+  }, 15_000);
+
   it("skips user prompt memory recall when prompt text is blank", async () => {
     const fixture = await createMemoryFixture();
 
@@ -3110,6 +3405,7 @@ WHERE id = '${superseded.memory.id}'
           db: memoryDb(fixture),
           embedder: createTestEmbedder(),
           log: noopLogger,
+          model: selectAllRecallModel,
           plugin: { name: "memory" },
           state: memoryState,
           text: "   ",
@@ -3147,6 +3443,7 @@ WHERE id = '${superseded.memory.id}'
         db: memoryDb(fixture),
         embedder,
         log: noopLogger,
+        model: selectAllRecallModel,
         plugin: { name: "memory" },
         state: memoryState,
         text: query,

--- a/packages/junior-memory/tests/storage.test.ts
+++ b/packages/junior-memory/tests/storage.test.ts
@@ -3279,7 +3279,7 @@ WHERE id = '${superseded.memory.id}'
         idempotencyKey: "memory-test:recall-gate-unrelated",
       });
 
-      const plugin = createMemoryPlugin();
+      const plugin = memoryPlugin();
       const result = await plugin.hooks?.userPrompt?.({
         ...context,
         destination: slackDestination(context),
@@ -3322,7 +3322,7 @@ WHERE id = '${superseded.memory.id}'
         idempotencyKey: "memory-test:recall-gate-empty",
       });
 
-      const plugin = createMemoryPlugin();
+      const plugin = memoryPlugin();
       await expect(
         plugin.hooks?.userPrompt?.({
           ...context,
@@ -3362,7 +3362,7 @@ WHERE id = '${superseded.memory.id}'
         idempotencyKey: "memory-test:recall-gate-failure",
       });
 
-      const plugin = createMemoryPlugin();
+      const plugin = memoryPlugin();
       await expect(
         plugin.hooks?.userPrompt?.({
           ...context,

--- a/packages/junior-plugin-api/src/prompt.ts
+++ b/packages/junior-plugin-api/src/prompt.ts
@@ -4,6 +4,7 @@ import type {
   Platform,
   PluginContext,
   PluginEmbedder,
+  PluginModel,
   Actor,
   Source,
 } from "./context";
@@ -79,6 +80,7 @@ export type UserPromptContext = Pick<PluginContext, "db" | "log" | "plugin"> & {
   conversationId?: string;
   destination: Destination;
   embedder: PluginEmbedder;
+  model: PluginModel;
   actor?: Actor;
   source: Source;
   state: PluginState;

--- a/packages/junior/src/chat/plugins/agent-hooks.ts
+++ b/packages/junior/src/chat/plugins/agent-hooks.ts
@@ -140,6 +140,7 @@ function invocationPluginContext(
     ...base,
     conversationId: context.conversationId,
     embedder: createPluginEmbedder(plugin.manifest.name),
+    model: createPluginModel(plugin.manifest.name, plugin.model),
     source: context.source,
     text: context.userText ?? "",
     state: createPluginState(plugin.manifest.name),

--- a/packages/junior/tests/unit/plugins/agent-hooks.test.ts
+++ b/packages/junior/tests/unit/plugins/agent-hooks.test.ts
@@ -262,7 +262,7 @@ describe("agent plugin hooks", () => {
             expect(ctx.source).toEqual(LOCAL_SOURCE);
             expect(ctx.text).toBe("remember this");
             expect(ctx).toHaveProperty("embedder");
-            expect(ctx).not.toHaveProperty("model");
+            expect(ctx).toHaveProperty("model");
             return [{ text: "remembered context" }];
           },
         },


### PR DESCRIPTION
Memory recall now builds a broad candidate set from PostgreSQL full-text search and vector search, fuses their independent ranks with reciprocal rank fusion, prioritizes exact structured identifiers, and then asks the memory-owned structured model to admit at most five memories that directly help with the current request. Empty or failed relevance selection contributes no memory context instead of injecting filler.

Previously, nearest embedding matches could surface memories that shared only generic engineering vocabulary, while embedding distance also carried duplicate authority it could not reliably support. This keeps embeddings as a derived retrieval index, leaves exact-content and model review responsible for duplicate and supersession decisions, adds a configurable vector candidate threshold, and adds the GIN expression index needed for lexical retrieval.

The regression coverage includes deterministic ranking and retrieval-quality cases plus a real-model Slack eval where only the `getsentry/junior` CI fact is recalled from plausible distractors; that eval scored 1.00. The memory test suite, workspace typecheck, eval package typecheck, lint checks, and migration upgrade path pass.

Refs #1103
