### PR TITLE
fix(chat): order agent history before visible replies

### DIFF
--- a/packages/junior-evals/package.json
+++ b/packages/junior-evals/package.json
@@ -11,6 +11,7 @@
   },
   "devDependencies": {
     "@chat-adapter/slack": "4.29.0",
+    "@earendil-works/pi-ai": "0.80.6",
     "@sentry/junior": "workspace:*",
     "@sentry/junior-github": "workspace:*",
     "@sentry/junior-memory": "workspace:*",

--- a/packages/junior-evals/src/behavior-harness.ts
+++ b/packages/junior-evals/src/behavior-harness.ts
@@ -50,7 +50,7 @@ import { buildSlackInboundMessage } from "@/chat/task-execution/slack-work";
 import { appendAndEnqueueInboundMessage } from "@/chat/task-execution/store";
 import { deleteConversationState } from "@/chat/task-execution/state";
 import { executeAgentRun } from "@/chat/agent";
-import { actorFromRouting, type Reply } from "@/chat/agent/request";
+import { actorFromRouting, type AgentRunDelivery } from "@/chat/agent/request";
 import { renderCurrentInstruction } from "@/chat/current-instruction";
 import { standardModelId } from "@/chat/model-profile";
 import type { PiMessage } from "@/chat/pi/messages";
@@ -1904,9 +1904,8 @@ function buildRuntimeServices(
           const mockImageGeneration = scenario.overrides?.mock_image_generation;
           const replyText = replyTexts[replyState.successfulCount];
           if (typeof replyText === "string") {
-            await runRequest.durability?.onInputCommitted?.();
             const nowMs = Date.now();
-            const message: Reply["message"] = {
+            const message: Parameters<AgentRunDelivery>[0] = {
               role: "assistant",
               content: [{ type: "text", text: replyText }],
               api: "eval-canned-reply",
@@ -1949,7 +1948,8 @@ function buildRuntimeServices(
               conversationId: runRequest.conversationId,
               messages: history.slice(0, -1),
             });
-            await runRequest.delivery?.({ message, text: replyText });
+            await runRequest.durability?.onInputCommitted?.();
+            await runRequest.delivery?.(message);
             replyState.successfulCount += 1;
             return completedAgentRun({
               text: replyText,

--- a/packages/junior-evals/src/behavior-harness.ts
+++ b/packages/junior-evals/src/behavior-harness.ts
@@ -50,12 +50,13 @@ import { buildSlackInboundMessage } from "@/chat/task-execution/slack-work";
 import { appendAndEnqueueInboundMessage } from "@/chat/task-execution/store";
 import { deleteConversationState } from "@/chat/task-execution/state";
 import { executeAgentRun } from "@/chat/agent";
-import { actorFromRouting } from "@/chat/agent/request";
+import { actorFromRouting, type Reply } from "@/chat/agent/request";
 import { renderCurrentInstruction } from "@/chat/current-instruction";
 import { standardModelId } from "@/chat/model-profile";
 import type { PiMessage } from "@/chat/pi/messages";
 import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 import type { AgentRunner } from "@/chat/runtime/agent-runner";
+import { commitMessages } from "@/chat/conversations/projection";
 import { addAgentTurnUsage, type AgentTurnUsage } from "@/chat/usage";
 import { resumeAwaitingSlackContinuation } from "@/chat/runtime/agent-continue-runner";
 import { scheduleAgentContinue } from "@/chat/services/agent-continue";
@@ -1904,10 +1905,55 @@ function buildRuntimeServices(
           const replyText = replyTexts[replyState.successfulCount];
           if (typeof replyText === "string") {
             await runRequest.durability?.onInputCommitted?.();
-            await runRequest.delivery?.onAssistantMessage({ text: replyText });
+            const nowMs = Date.now();
+            const message: Reply["message"] = {
+              role: "assistant",
+              content: [{ type: "text", text: replyText }],
+              api: "eval-canned-reply",
+              provider: "eval",
+              model: "eval-reply-text",
+              usage: {
+                input: 0,
+                output: 0,
+                cacheRead: 0,
+                cacheWrite: 0,
+                totalTokens: 0,
+                cost: {
+                  input: 0,
+                  output: 0,
+                  cacheRead: 0,
+                  cacheWrite: 0,
+                  total: 0,
+                },
+              },
+              stopReason: "stop",
+              timestamp: nowMs,
+            };
+            const history = [
+              ...(runRequest.input.piMessages ?? []),
+              {
+                role: "user",
+                content: [
+                  {
+                    type: "text",
+                    text: renderCurrentInstruction(
+                      runRequest.input.messageText,
+                    ),
+                  },
+                ],
+                timestamp: nowMs,
+              },
+              message,
+            ] as PiMessage[];
+            await commitMessages({
+              conversationId: runRequest.conversationId,
+              messages: history.slice(0, -1),
+            });
+            await runRequest.delivery?.({ message, text: replyText });
             replyState.successfulCount += 1;
             return completedAgentRun({
               text: replyText,
+              piMessages: history,
               diagnostics: {
                 assistantMessageCount: 1,
                 modelId: "eval-reply-text",

--- a/packages/junior-evals/src/behavior-harness.ts
+++ b/packages/junior-evals/src/behavior-harness.ts
@@ -16,6 +16,10 @@ import type {
 } from "@sentry/junior-plugin-api";
 import { executeWithReplay } from "vitest-evals/replay";
 import type { JsonValue } from "vitest-evals/harness";
+import {
+  createFauxCore,
+  fauxAssistantMessage,
+} from "@earendil-works/pi-ai/providers/faux";
 import { createSlackRuntime } from "@/chat/app/factory";
 import { botConfig } from "@/chat/config";
 import { getConversationEventStore, getDb } from "@/chat/db";
@@ -50,13 +54,12 @@ import { buildSlackInboundMessage } from "@/chat/task-execution/slack-work";
 import { appendAndEnqueueInboundMessage } from "@/chat/task-execution/store";
 import { deleteConversationState } from "@/chat/task-execution/state";
 import { executeAgentRun } from "@/chat/agent";
-import { actorFromRouting, type AgentRunDelivery } from "@/chat/agent/request";
+import { actorFromRouting } from "@/chat/agent/request";
 import { renderCurrentInstruction } from "@/chat/current-instruction";
 import { standardModelId } from "@/chat/model-profile";
 import type { PiMessage } from "@/chat/pi/messages";
 import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 import type { AgentRunner } from "@/chat/runtime/agent-runner";
-import { commitMessages } from "@/chat/conversations/projection";
 import { addAgentTurnUsage, type AgentTurnUsage } from "@/chat/usage";
 import { resumeAwaitingSlackContinuation } from "@/chat/runtime/agent-continue-runner";
 import { scheduleAgentContinue } from "@/chat/services/agent-continue";
@@ -1903,67 +1906,13 @@ function buildRuntimeServices(
           }
           const mockImageGeneration = scenario.overrides?.mock_image_generation;
           const replyText = replyTexts[replyState.successfulCount];
+          let scriptedStream: ReturnType<typeof createFauxCore> | undefined;
           if (typeof replyText === "string") {
-            const nowMs = Date.now();
-            const message: Parameters<AgentRunDelivery>[0] = {
-              role: "assistant",
-              content: [{ type: "text", text: replyText }],
-              api: "eval-canned-reply",
+            scriptedStream = createFauxCore({
+              api: "eval",
               provider: "eval",
-              model: "eval-reply-text",
-              usage: {
-                input: 0,
-                output: 0,
-                cacheRead: 0,
-                cacheWrite: 0,
-                totalTokens: 0,
-                cost: {
-                  input: 0,
-                  output: 0,
-                  cacheRead: 0,
-                  cacheWrite: 0,
-                  total: 0,
-                },
-              },
-              stopReason: "stop",
-              timestamp: nowMs,
-            };
-            const history = [
-              ...(runRequest.input.piMessages ?? []),
-              {
-                role: "user",
-                content: [
-                  {
-                    type: "text",
-                    text: renderCurrentInstruction(
-                      runRequest.input.messageText,
-                    ),
-                  },
-                ],
-                timestamp: nowMs,
-              },
-              message,
-            ] as PiMessage[];
-            await commitMessages({
-              conversationId: runRequest.conversationId,
-              messages: history.slice(0, -1),
             });
-            await runRequest.durability?.onInputCommitted?.();
-            await runRequest.delivery?.(message);
-            replyState.successfulCount += 1;
-            return completedAgentRun({
-              text: replyText,
-              piMessages: history,
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "eval-reply-text",
-                outcome: "success",
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            });
+            scriptedStream.setResponses([fauxAssistantMessage(replyText)]);
           }
 
           const gatewaySnapshot = snapshotEnv([
@@ -2008,50 +1957,54 @@ function buildRuntimeServices(
               AbortSignal.timeout(replyTimeoutMs),
             ]);
             const outcome = await raceWithAbort(replySignal, () =>
-              executeAgentRun({
-                ...runRequest,
-                policy: {
-                  ...runRequest.policy,
-                  signal: replySignal,
-                  turnDeadlineAtMs: Math.min(
-                    runRequest.policy?.turnDeadlineAtMs ??
-                      Number.POSITIVE_INFINITY,
-                    Date.now() + replyTimeoutMs,
-                  ),
-                  ...(env.configuredSkillDirs.length > 0
-                    ? { skillDirs: env.configuredSkillDirs }
-                    : {}),
-                  toolOverrides,
-                },
-                observers: {
-                  ...runRequest.observers,
-                  onToolInvocation: (invocation) => {
-                    const evalInvocation = toEvalToolInvocation(invocation);
-                    observations.toolInvocations.push(evalInvocation);
-                    pendingToolInvocations.push(evalInvocation);
+              executeAgentRun(
+                {
+                  ...runRequest,
+                  policy: {
+                    ...runRequest.policy,
+                    signal: replySignal,
+                    turnDeadlineAtMs: Math.min(
+                      runRequest.policy?.turnDeadlineAtMs ??
+                        Number.POSITIVE_INFINITY,
+                      Date.now() + replyTimeoutMs,
+                    ),
+                    ...(env.configuredSkillDirs.length > 0
+                      ? { skillDirs: env.configuredSkillDirs }
+                      : {}),
+                    toolOverrides,
                   },
-                  onToolResult: (result) => {
-                    const pendingIndex = pendingToolInvocations.findIndex(
-                      (candidate) => candidate.toolCallId === result.toolCallId,
-                    );
-                    if (pendingIndex === -1) {
-                      return;
-                    }
-                    const [invocation] = pendingToolInvocations.splice(
-                      pendingIndex,
-                      1,
-                    );
-                    invocation.completed = true;
-                    invocation.ok = result.ok;
-                    if (result.error) {
-                      invocation.error = result.error;
-                    }
-                    if (result.result !== undefined) {
-                      invocation.result = result.result;
-                    }
+                  observers: {
+                    ...runRequest.observers,
+                    onToolInvocation: (invocation) => {
+                      const evalInvocation = toEvalToolInvocation(invocation);
+                      observations.toolInvocations.push(evalInvocation);
+                      pendingToolInvocations.push(evalInvocation);
+                    },
+                    onToolResult: (result) => {
+                      const pendingIndex = pendingToolInvocations.findIndex(
+                        (candidate) =>
+                          candidate.toolCallId === result.toolCallId,
+                      );
+                      if (pendingIndex === -1) {
+                        return;
+                      }
+                      const [invocation] = pendingToolInvocations.splice(
+                        pendingIndex,
+                        1,
+                      );
+                      invocation.completed = true;
+                      invocation.ok = result.ok;
+                      if (result.error) {
+                        invocation.error = result.error;
+                      }
+                      if (result.result !== undefined) {
+                        invocation.result = result.result;
+                      }
+                    },
                   },
                 },
-              }),
+                scriptedStream?.stream,
+              ),
             );
             const usage =
               outcome.status === "completed"

--- a/packages/junior-evals/tests/unit/harness/behavior-harness.test.ts
+++ b/packages/junior-evals/tests/unit/harness/behavior-harness.test.ts
@@ -114,6 +114,7 @@ import {
 } from "../../../src/behavior-harness";
 import type { AgentRunDelivery } from "@/chat/agent/request";
 import { renderCurrentInstruction } from "@/chat/current-instruction";
+import { loadProjection } from "@/chat/conversations/projection";
 import { getPlugins } from "@/chat/plugins/agent-hooks";
 import { resolveSandboxEgressProviderForHost } from "@/chat/sandbox/egress/policy";
 
@@ -163,7 +164,12 @@ describe("behavior harness", () => {
       initialEvents: [],
       overrides: { reply_texts: ["Canned reply"] },
     });
-    const delivery = vi.fn<AgentRunDelivery>(async () => {});
+    let historyAtDelivery: Awaited<ReturnType<typeof loadProjection>> = [];
+    const delivery = vi.fn<AgentRunDelivery>(async () => {
+      historyAtDelivery = await loadProjection({
+        conversationId: "eval:test:canned-delivery",
+      });
+    });
     const result = await runtimeState.agentRunner?.run({
       conversationId: "eval:test:canned-delivery",
       turnId: "turn-canned-delivery",
@@ -176,15 +182,23 @@ describe("behavior harness", () => {
     });
 
     expect(delivery).toHaveBeenCalledOnce();
-    const reply = delivery.mock.calls[0]?.[0];
-    expect(reply).toMatchObject({
-      text: "Canned reply",
-      message: {
-        role: "assistant",
-        content: [{ type: "text", text: "Canned reply" }],
-        stopReason: "stop",
-      },
+    const message = delivery.mock.calls[0]?.[0];
+    expect(message).toMatchObject({
+      role: "assistant",
+      content: [{ type: "text", text: "Canned reply" }],
+      stopReason: "stop",
     });
+    expect(historyAtDelivery).toMatchObject([
+      {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: renderCurrentInstruction("Current instruction"),
+          },
+        ],
+      },
+    ]);
     expect(result).toMatchObject({
       status: "completed",
       result: {
@@ -198,7 +212,7 @@ describe("behavior harness", () => {
               },
             ],
           },
-          reply?.message,
+          message,
         ],
       },
     });

--- a/packages/junior-evals/tests/unit/harness/behavior-harness.test.ts
+++ b/packages/junior-evals/tests/unit/harness/behavior-harness.test.ts
@@ -112,9 +112,6 @@ import {
   collectSlackArtifactsFromCapturedCalls,
   runEvalScenario,
 } from "../../../src/behavior-harness";
-import type { AgentRunDelivery } from "@/chat/agent/request";
-import { renderCurrentInstruction } from "@/chat/current-instruction";
-import { loadProjection } from "@/chat/conversations/projection";
 import { getPlugins } from "@/chat/plugins/agent-hooks";
 import { resolveSandboxEgressProviderForHost } from "@/chat/sandbox/egress/policy";
 
@@ -157,65 +154,6 @@ describe("behavior harness", () => {
     expect(forwardedSignal).not.toBe(controller.signal);
     controller.abort();
     expect(forwardedSignal?.aborted).toBe(true);
-  });
-
-  it("returns agent history containing the delivered canned reply", async () => {
-    await runEvalScenario({
-      initialEvents: [],
-      overrides: { reply_texts: ["Canned reply"] },
-    });
-    let historyAtDelivery: Awaited<ReturnType<typeof loadProjection>> = [];
-    const delivery = vi.fn<AgentRunDelivery>(async () => {
-      historyAtDelivery = await loadProjection({
-        conversationId: "eval:test:canned-delivery",
-      });
-    });
-    const result = await runtimeState.agentRunner?.run({
-      conversationId: "eval:test:canned-delivery",
-      turnId: "turn-canned-delivery",
-      input: {
-        messageText: "Current instruction",
-        piMessages: [],
-      },
-      policy: {},
-      delivery,
-    });
-
-    expect(delivery).toHaveBeenCalledOnce();
-    const message = delivery.mock.calls[0]?.[0];
-    expect(message).toMatchObject({
-      role: "assistant",
-      content: [{ type: "text", text: "Canned reply" }],
-      stopReason: "stop",
-    });
-    expect(historyAtDelivery).toMatchObject([
-      {
-        role: "user",
-        content: [
-          {
-            type: "text",
-            text: renderCurrentInstruction("Current instruction"),
-          },
-        ],
-      },
-    ]);
-    expect(result).toMatchObject({
-      status: "completed",
-      result: {
-        piMessages: [
-          {
-            role: "user",
-            content: [
-              {
-                type: "text",
-                text: renderCurrentInstruction("Current instruction"),
-              },
-            ],
-          },
-          message,
-        ],
-      },
-    });
   });
 
   it("aborts eval replies at the configured timeout", async () => {

--- a/packages/junior-evals/tests/unit/harness/behavior-harness.test.ts
+++ b/packages/junior-evals/tests/unit/harness/behavior-harness.test.ts
@@ -112,6 +112,8 @@ import {
   collectSlackArtifactsFromCapturedCalls,
   runEvalScenario,
 } from "../../../src/behavior-harness";
+import type { AgentRunDelivery } from "@/chat/agent/request";
+import { renderCurrentInstruction } from "@/chat/current-instruction";
 import { getPlugins } from "@/chat/plugins/agent-hooks";
 import { resolveSandboxEgressProviderForHost } from "@/chat/sandbox/egress/policy";
 
@@ -154,6 +156,52 @@ describe("behavior harness", () => {
     expect(forwardedSignal).not.toBe(controller.signal);
     controller.abort();
     expect(forwardedSignal?.aborted).toBe(true);
+  });
+
+  it("returns agent history containing the delivered canned reply", async () => {
+    await runEvalScenario({
+      initialEvents: [],
+      overrides: { reply_texts: ["Canned reply"] },
+    });
+    const delivery = vi.fn<AgentRunDelivery>(async () => {});
+    const result = await runtimeState.agentRunner?.run({
+      conversationId: "eval:test:canned-delivery",
+      turnId: "turn-canned-delivery",
+      input: {
+        messageText: "Current instruction",
+        piMessages: [],
+      },
+      policy: {},
+      delivery,
+    });
+
+    expect(delivery).toHaveBeenCalledOnce();
+    const reply = delivery.mock.calls[0]?.[0];
+    expect(reply).toMatchObject({
+      text: "Canned reply",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Canned reply" }],
+        stopReason: "stop",
+      },
+    });
+    expect(result).toMatchObject({
+      status: "completed",
+      result: {
+        piMessages: [
+          {
+            role: "user",
+            content: [
+              {
+                type: "text",
+                text: renderCurrentInstruction("Current instruction"),
+              },
+            ],
+          },
+          reply?.message,
+        ],
+      },
+    });
   });
 
   it("aborts eval replies at the configured timeout", async () => {

--- a/packages/junior/src/chat/README.md
+++ b/packages/junior/src/chat/README.md
@@ -16,8 +16,10 @@ file.
 5. Tools, plugins, credentials, sandbox, and MCP operate within harness-owned
    actor and destination context.
 6. `agent/` emits every completed, tool-free visible assistant message through
-   one awaited delivery port; provider adapters deliver and record each message
-   in order. Tool-bearing assistant text remains internal to the agent loop.
+   one awaited delivery port with the completed Pi message that produced it;
+   provider adapters deliver, then commit that agent message before the visible
+   reply in one transaction. Tool-bearing assistant text remains internal to
+   the agent loop.
 7. The completed run result supplies diagnostics and artifacts; successful
    delivery or intentional no-reply completion commits the durable turn outcome.
 

--- a/packages/junior/src/chat/agent/index.ts
+++ b/packages/junior/src/chat/agent/index.ts
@@ -10,7 +10,11 @@
  * diagnostics, artifacts, and transcript state for destination-owned
  * completion.
  */
-import { Agent, type AgentLoopTurnUpdate } from "@earendil-works/pi-agent-core";
+import {
+  Agent,
+  type AgentLoopTurnUpdate,
+  type StreamFn,
+} from "@earendil-works/pi-agent-core";
 import type { FileUpload } from "chat";
 import { botConfig } from "@/chat/config";
 import {
@@ -176,9 +180,15 @@ function waitForAbortSettlement(
   });
 }
 
-/** Run a full agent turn: discover skills, execute tools, and return the assistant reply. */
+/**
+ * Run a full agent turn, optionally using a caller-provided model stream.
+ *
+ * The stream changes model output only; prompt assembly, persistence, tools,
+ * delivery, and completion still use the normal agent runtime.
+ */
 export async function executeAgentRun(
   request: AgentRunRequest,
+  streamFn?: StreamFn,
 ): Promise<AgentRunOutcome> {
   if (!request.routing.destination) {
     throw new TypeError("Assistant reply generation requires a destination");
@@ -232,6 +242,7 @@ export async function executeAgentRun(
         request,
         conversationPrivacy,
         runLogContext,
+        streamFn,
       ),
     ),
   );
@@ -241,6 +252,7 @@ async function executeAgentRunInPrivacyContext(
   request: AgentRunRequest,
   conversationPrivacy: ConversationPrivacy | undefined,
   runLogContext: LogContext,
+  streamFn: StreamFn | undefined,
 ): Promise<AgentRunOutcome> {
   const { conversationId, input, routing, runId, turnId } = request;
   const policy = request.policy ?? {};
@@ -986,7 +998,10 @@ async function executeAgentRunInPrivacyContext(
     let pendingPiHookError: Error | undefined;
     agent = new Agent({
       ...(apiKeyOverride ? { getApiKey: () => apiKeyOverride } : {}),
-      streamFn: createTracedStreamFn({ conversationPrivacy }),
+      streamFn: createTracedStreamFn({
+        conversationPrivacy,
+        ...(streamFn ? { base: streamFn } : {}),
+      }),
       steeringMode: "all",
       beforeToolCall: async ({ assistantMessage }) => {
         const toolCalls = assistantMessage.content.filter(

--- a/packages/junior/src/chat/agent/index.ts
+++ b/packages/junior/src/chat/agent/index.ts
@@ -905,7 +905,7 @@ async function executeAgentRunInPrivacyContext(
         return;
       }
       try {
-        await delivery({ message, text });
+        await delivery(message);
       } catch (error) {
         assistantMessageDeliveryError = new AssistantMessageDeliveryError(
           error,

--- a/packages/junior/src/chat/agent/index.ts
+++ b/packages/junior/src/chat/agent/index.ts
@@ -905,7 +905,7 @@ async function executeAgentRunInPrivacyContext(
         return;
       }
       try {
-        await delivery.onAssistantMessage({ text });
+        await delivery({ message, text });
       } catch (error) {
         assistantMessageDeliveryError = new AssistantMessageDeliveryError(
           error,

--- a/packages/junior/src/chat/agent/request.ts
+++ b/packages/junior/src/chat/agent/request.ts
@@ -145,19 +145,15 @@ export interface AgentRunObservers {
   onStatus?: (status: AssistantStatusSpec) => void | Promise<void>;
 }
 
-/** One completed tool-free reply ready for destination delivery. */
-export interface Reply {
-  message: AssistantMessage;
-  text: string;
-}
-
 /**
  * Delivers completed tool-free assistant messages in model order.
  *
  * The runner must commit the preceding agent boundary before invoking this
- * port; the accepted reply transaction appends only `reply.message`.
+ * port; the accepted reply transaction appends only this message.
  */
-export type AgentRunDelivery = (reply: Reply) => void | Promise<void>;
+export type AgentRunDelivery = (
+  message: AssistantMessage,
+) => void | Promise<void>;
 
 /** Resume the agent turn after a transient or ambiguous delivery failure. */
 export class RetryableDeliveryError extends Error {

--- a/packages/junior/src/chat/agent/request.ts
+++ b/packages/junior/src/chat/agent/request.ts
@@ -37,6 +37,7 @@ import type {
   WebFetchToolDeps,
   WebSearchToolDeps,
 } from "@/chat/tools/types";
+import type { AssistantMessage } from "@earendil-works/pi-ai";
 
 export interface AgentRunAttachment {
   data?: Buffer;
@@ -144,15 +145,19 @@ export interface AgentRunObservers {
   onStatus?: (status: AssistantStatusSpec) => void | Promise<void>;
 }
 
-/** One completed tool-free assistant message ready for destination delivery. */
-export interface AgentAssistantMessage {
+/** One completed tool-free reply ready for destination delivery. */
+export interface Reply {
+  message: AssistantMessage;
   text: string;
 }
 
-/** Delivers completed tool-free assistant messages in model order. */
-export interface AgentRunDelivery {
-  onAssistantMessage: (message: AgentAssistantMessage) => void | Promise<void>;
-}
+/**
+ * Delivers completed tool-free assistant messages in model order.
+ *
+ * The runner must commit the preceding agent boundary before invoking this
+ * port; the accepted reply transaction appends only `reply.message`.
+ */
+export type AgentRunDelivery = (reply: Reply) => void | Promise<void>;
 
 /** Resume the agent turn after a transient or ambiguous delivery failure. */
 export class RetryableDeliveryError extends Error {

--- a/packages/junior/src/chat/conversations/messages.ts
+++ b/packages/junior/src/chat/conversations/messages.ts
@@ -11,6 +11,7 @@ import type {
   ConversationMessage,
   ThreadConversationState,
 } from "@/chat/state/conversation";
+import type { ConversationEventStore } from "./history";
 
 /** Author role of a visible conversation message. */
 export type ConversationMessageRole = "user" | "assistant" | "system";
@@ -88,9 +89,24 @@ export async function persistConversationMessages(args: {
 }): Promise<void> {
   if (!args.conversationId || args.conversation.messages.length === 0) return;
 
-  const history = await getConversationEventStore().loadMessageHistory(
-    args.conversationId,
-  );
+  await appendConversationMessages(getConversationEventStore(), {
+    ...args,
+    conversationId: args.conversationId,
+  });
+}
+
+/** Append visible message facts through a caller-owned event-store transaction. */
+export async function appendConversationMessages(
+  eventStore: ConversationEventStore,
+  args: {
+    conversation: ThreadConversationState;
+    conversationId: string;
+    repliedAtMs?: number;
+  },
+): Promise<void> {
+  if (args.conversation.messages.length === 0) return;
+
+  const history = await eventStore.loadMessageHistory(args.conversationId);
   const existingMessages = new Map(
     projectConversationMessages(history).map((message) => [
       message.id,
@@ -155,5 +171,5 @@ export async function persistConversationMessages(args: {
         : []),
     ];
   });
-  await getConversationEventStore().append(args.conversationId, events);
+  await eventStore.append(args.conversationId, events);
 }

--- a/packages/junior/src/chat/conversations/projection.ts
+++ b/packages/junior/src/chat/conversations/projection.ts
@@ -30,6 +30,9 @@ import { sanitizePostgresJson } from "@/db/postgres-json";
 import type { ModelProfile } from "@/chat/model-profile";
 import type { TurnReasoningLevel } from "@/chat/reasoning-level";
 import type { PluginTurnContext } from "@/chat/plugins/prompt";
+import type { ThreadConversationState } from "@/chat/state/conversation";
+import type { AssistantMessage } from "@earendil-works/pi-ai";
+import { appendConversationMessages } from "./messages";
 
 /** Distinct MCP providers durably connected in the given events, sorted. */
 function connectedMcpProvidersFromEvents(
@@ -250,6 +253,48 @@ export async function commitMessages(args: {
       executor.transaction(
         async () => await commitMessagesLocked(args, executor),
       ),
+  );
+}
+
+/**
+ * Commit an accepted agent reply and its visible message in causal order.
+ *
+ * The destination has already accepted the reply. One transaction prevents
+ * reporting from observing the visible reply before the agent message that
+ * produced it.
+ */
+export async function commitAcceptedReply(args: {
+  agentMessage: AssistantMessage;
+  conversation: ThreadConversationState;
+  conversationMessageId: string;
+  conversationId: string;
+  repliedAtMs?: number;
+}): Promise<void> {
+  const executor = getSqlExecutor();
+  await withConversationEventLock(executor, args.conversationId, async () =>
+    executor.transaction(async () => {
+      const agentMessage = normalizeDurableMessage(args.agentMessage);
+      await createSqlConversationEventStore(executor).append(
+        args.conversationId,
+        [
+          {
+            idempotencyKey: `message:${args.conversationMessageId}:agent`,
+            data: historyItemFromPiMessage(agentMessage, contextProvenance),
+            createdAtMs: messageTimestamp(agentMessage),
+          },
+        ],
+      );
+      await appendConversationMessages(
+        createSqlConversationEventStore(executor),
+        {
+          conversation: args.conversation,
+          conversationId: args.conversationId,
+          ...(args.repliedAtMs === undefined
+            ? {}
+            : { repliedAtMs: args.repliedAtMs }),
+        },
+      );
+    }),
   );
 }
 

--- a/packages/junior/src/chat/local/runner.ts
+++ b/packages/junior/src/chat/local/runner.ts
@@ -9,6 +9,7 @@
 import type { AgentRunResult } from "@/chat/services/turn-result";
 import { randomUUID } from "node:crypto";
 import type { AgentRunner } from "@/chat/runtime/agent-runner";
+import type { Reply } from "@/chat/agent/request";
 import type { PiMessage } from "@/chat/pi/messages";
 import {
   createLocalSource,
@@ -45,7 +46,10 @@ import {
 import { coerceThreadArtifactsState } from "@/chat/state/artifacts";
 import { coerceThreadConversationState } from "@/chat/state/conversation";
 import { hydrateConversationMessages } from "@/chat/conversations/messages";
-import { loadProjection } from "@/chat/conversations/projection";
+import {
+  commitAcceptedReply,
+  loadProjection,
+} from "@/chat/conversations/projection";
 import { getConversationEventStore } from "@/chat/db";
 import {
   ConversationTurnLifecycleService,
@@ -250,6 +254,7 @@ export async function runLocalAgentTurn(
   let assistantMessageDelivered = false;
   /** Print and record one completed assistant message in local conversation order. */
   const deliverAssistantMessage = async (message: {
+    message?: Reply["message"];
     text: string;
   }): Promise<void> => {
     if (!message.text.trim()) {
@@ -258,7 +263,7 @@ export async function runLocalAgentTurn(
     failureCode = "delivery_failed";
     await deps.deliverReply({ text: message.text });
     assistantMessageDelivered = true;
-    recordDeliveredAssistantMessage({
+    const recordedMessageId = recordDeliveredAssistantMessage({
       conversation,
       sessionId: turnId,
       text: message.text,
@@ -266,10 +271,17 @@ export async function runLocalAgentTurn(
     });
     try {
       await persistWithRetry(() =>
-        persistConversationMessages({
-          conversation,
-          conversationId: input.conversationId,
-        }),
+        message.message
+          ? commitAcceptedReply({
+              agentMessage: message.message,
+              conversation,
+              conversationMessageId: recordedMessageId,
+              conversationId: input.conversationId,
+            })
+          : persistConversationMessages({
+              conversation,
+              conversationId: input.conversationId,
+            }),
       );
     } catch (error) {
       logException(
@@ -339,9 +351,7 @@ export async function runLocalAgentTurn(
             await deps.onToolResult?.(result);
           },
         },
-        delivery: {
-          onAssistantMessage: deliverAssistantMessage,
-        },
+        delivery: deliverAssistantMessage,
         durability: {
           onArtifactStateUpdated: async (nextArtifacts) => {
             artifacts = nextArtifacts;

--- a/packages/junior/src/chat/local/runner.ts
+++ b/packages/junior/src/chat/local/runner.ts
@@ -6,11 +6,14 @@
  * a local destination, and only commits assistant delivery after the CLI sink
  * accepts each completed tool-free assistant message.
  */
-import type { AgentRunResult } from "@/chat/services/turn-result";
+import {
+  getAssistantMessageText,
+  type AgentRunResult,
+} from "@/chat/services/turn-result";
 import { randomUUID } from "node:crypto";
 import type { AgentRunner } from "@/chat/runtime/agent-runner";
-import type { Reply } from "@/chat/agent/request";
 import type { PiMessage } from "@/chat/pi/messages";
+import type { AssistantMessage } from "@earendil-works/pi-ai";
 import {
   createLocalSource,
   localDestinationSchema,
@@ -253,27 +256,29 @@ export async function runLocalAgentTurn(
   };
   let assistantMessageDelivered = false;
   /** Print and record one completed assistant message in local conversation order. */
-  const deliverAssistantMessage = async (message: {
-    message?: Reply["message"];
-    text: string;
-  }): Promise<void> => {
-    if (!message.text.trim()) {
+  const deliverAssistantMessage = async (
+    reply: AssistantMessage | string,
+  ): Promise<void> => {
+    const message = typeof reply === "string" ? undefined : reply;
+    const text =
+      typeof reply === "string" ? reply : getAssistantMessageText(reply);
+    if (!text?.trim()) {
       return;
     }
     failureCode = "delivery_failed";
-    await deps.deliverReply({ text: message.text });
+    await deps.deliverReply({ text });
     assistantMessageDelivered = true;
     const recordedMessageId = recordDeliveredAssistantMessage({
       conversation,
       sessionId: turnId,
-      text: message.text,
+      text,
       userMessageId,
     });
     try {
       await persistWithRetry(() =>
-        message.message
+        message
           ? commitAcceptedReply({
-              agentMessage: message.message,
+              agentMessage: message,
               conversation,
               conversationMessageId: recordedMessageId,
               conversationId: input.conversationId,
@@ -432,7 +437,7 @@ export async function runLocalAgentTurn(
     modelFailureEventId = finalized.eventId;
 
     if (reply.diagnostics.outcome !== "success") {
-      await deliverAssistantMessage({ text: reply.text });
+      await deliverAssistantMessage(reply.text);
     }
 
     completedState = buildDeliveredTurnStatePatch({

--- a/packages/junior/src/chat/runtime/reply-executor.ts
+++ b/packages/junior/src/chat/runtime/reply-executor.ts
@@ -40,6 +40,7 @@ import {
 import { buildSteeringPiMessage } from "@/chat/agent/prompt";
 import {
   RetryableDeliveryError,
+  type Reply,
   type AgentRunSteeringMessage,
 } from "@/chat/agent/request";
 import type { AgentRunner } from "@/chat/runtime/agent-runner";
@@ -135,6 +136,7 @@ import {
   type ConversationMessageProvenance,
 } from "@/chat/conversations/provenance";
 import {
+  commitAcceptedReply,
   commitMessages,
   loadConversationProjection,
 } from "@/chat/conversations/projection";
@@ -1080,7 +1082,10 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
         };
         /** Post and record one completed assistant message in the active thread. */
         const deliverAssistantMessage = async (
-          assistantMessage: { text: string },
+          assistantMessage: {
+            message?: Reply["message"];
+            text: string;
+          },
           terminalDispatchOutcome?: "blocked" | "failed",
         ): Promise<void> => {
           if (!assistantMessage.text.trim()) {
@@ -1143,10 +1148,17 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
           }
           try {
             await persistWithRetry(() =>
-              persistConversationMessages({
-                conversation: preparedState.conversation,
-                conversationId,
-              }),
+              assistantMessage.message && conversationId
+                ? commitAcceptedReply({
+                    agentMessage: assistantMessage.message,
+                    conversation: preparedState.conversation,
+                    conversationMessageId: recordedMessageId,
+                    conversationId,
+                  })
+                : persistConversationMessages({
+                    conversation: preparedState.conversation,
+                    conversationId,
+                  }),
             );
           } catch (error) {
             logException(
@@ -1430,9 +1442,7 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
               onStatus: (nextStatus) => status.update(nextStatus),
               onToolInvocation: options.onToolInvocation,
             },
-            delivery: {
-              onAssistantMessage: deliverAssistantMessage,
-            },
+            delivery: deliverAssistantMessage,
             durability: {
               onInputCommitted: options.ack,
               drainSteeringMessages,

--- a/packages/junior/src/chat/runtime/reply-executor.ts
+++ b/packages/junior/src/chat/runtime/reply-executor.ts
@@ -40,7 +40,6 @@ import {
 import { buildSteeringPiMessage } from "@/chat/agent/prompt";
 import {
   RetryableDeliveryError,
-  type Reply,
   type AgentRunSteeringMessage,
 } from "@/chat/agent/request";
 import type { AgentRunner } from "@/chat/runtime/agent-runner";
@@ -122,6 +121,8 @@ import { AuthorizationFlowDisabledError } from "@/chat/services/auth-pause";
 import { PluginCredentialFailureError } from "@/chat/services/plugin-auth-orchestration";
 import { maybeApplyProviderDefaultConfigRequest } from "@/chat/services/provider-default-config";
 import type { PiMessage } from "@/chat/pi/messages";
+import type { AssistantMessage } from "@earendil-works/pi-ai";
+import { getAssistantMessageText } from "@/chat/services/turn-result";
 import {
   abandonAgentTurnSessionRecord,
   failAgentTurnSessionRecord,
@@ -1082,13 +1083,13 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
         };
         /** Post and record one completed assistant message in the active thread. */
         const deliverAssistantMessage = async (
-          assistantMessage: {
-            message?: Reply["message"];
-            text: string;
-          },
+          reply: AssistantMessage | string,
           terminalDispatchOutcome?: "blocked" | "failed",
         ): Promise<void> => {
-          if (!assistantMessage.text.trim()) {
+          const agentMessage = typeof reply === "string" ? undefined : reply;
+          const text =
+            typeof reply === "string" ? reply : getAssistantMessageText(reply);
+          if (!text?.trim()) {
             return;
           }
           boundaryFailureCode = "delivery_failed";
@@ -1101,12 +1102,12 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
               slackTs = await sendSlackReply({
                 channelId,
                 conversationId,
-                text: assistantMessage.text,
+                text,
                 ...(threadTs ? { threadTs } : {}),
               });
             } else {
-              for (const text of splitSlackReplyText(assistantMessage.text)) {
-                slackTs = (await thread.post(buildSlackOutputMessage(text))).id;
+              for (const part of splitSlackReplyText(text)) {
+                slackTs = (await thread.post(buildSlackOutputMessage(part))).id;
               }
             }
           } catch (error) {
@@ -1136,7 +1137,7 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
           const recordedMessageId = recordDeliveredAssistantMessage({
             conversation: preparedState.conversation,
             sessionId: turnId,
-            text: assistantMessage.text,
+            text,
             userMessageId: preparedState.userMessageId,
           });
           if (slackTs) {
@@ -1148,9 +1149,9 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
           }
           try {
             await persistWithRetry(() =>
-              assistantMessage.message && conversationId
+              agentMessage && conversationId
                 ? commitAcceptedReply({
-                    agentMessage: assistantMessage.message,
+                    agentMessage,
                     conversation: preparedState.conversation,
                     conversationMessageId: recordedMessageId,
                     conversationId,
@@ -1483,7 +1484,7 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
                 "Subscribed Slack turn could not continue without user authorization",
               );
               const text = `I could not act on this subscribed event because ${outcome.providerDisplayName} needs user authorization. Ask me in this thread to connect ${outcome.providerDisplayName} before retrying.`;
-              await deliverAssistantMessage({ text });
+              await deliverAssistantMessage(text);
               markTurnClosed({
                 conversation: preparedState.conversation,
                 nowMs: Date.now(),
@@ -1585,7 +1586,7 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
             });
             reply = finalized.reply;
             finalizedFailureEventId = finalized.eventId;
-            await deliverAssistantMessage({ text: reply.text });
+            await deliverAssistantMessage(reply.text);
           }
           const turnResult: DispatchTurnResult =
             reply.diagnostics.outcome === "success"
@@ -1841,10 +1842,7 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
                 ? failureCause.message
                 : "Agent turn failed after creating a canvas";
             const recoveryText = buildCanvasRecoveryReply(createdCanvasUrl);
-            await deliverAssistantMessage(
-              { text: recoveryText },
-              dispatchOutcome,
-            );
+            await deliverAssistantMessage(recoveryText, dispatchOutcome);
             if (conversationId) {
               const sessionRecord = await getAgentTurnSessionRecord(
                 conversationId,

--- a/packages/junior/src/chat/runtime/slack-resume.ts
+++ b/packages/junior/src/chat/runtime/slack-resume.ts
@@ -11,9 +11,12 @@ import type { ChannelConfigurationService } from "@/chat/configuration/types";
 import {
   RetryableDeliveryError,
   type AgentRunRequest,
-  type Reply,
 } from "@/chat/agent/request";
-import type { AgentRunResult } from "@/chat/services/turn-result";
+import {
+  getAssistantMessageText,
+  type AgentRunResult,
+} from "@/chat/services/turn-result";
+import type { AssistantMessage } from "@earendil-works/pi-ai";
 import type { AgentRunner } from "@/chat/runtime/agent-runner";
 import { scheduleSessionCompletedPluginTasks } from "@/chat/plugins/task-runner";
 import {
@@ -548,11 +551,13 @@ export async function resumeSlackTurn(
       };
     };
     /** Post and record one completed assistant message for the resumed turn. */
-    const deliverAssistantMessage = async (assistantMessage: {
-      message?: Reply["message"];
-      text: string;
-    }): Promise<void> => {
-      if (!assistantMessage.text.trim()) {
+    const deliverAssistantMessage = async (
+      reply: AssistantMessage | string,
+    ): Promise<void> => {
+      const message = typeof reply === "string" ? undefined : reply;
+      const text =
+        typeof reply === "string" ? reply : getAssistantMessageText(reply);
+      if (!text?.trim()) {
         return;
       }
       failureCode = "delivery_failed";
@@ -562,7 +567,7 @@ export async function resumeSlackTurn(
         messageTs = await sendSlackReply({
           channelId: runArgs.channelId,
           conversationId: runArgs.conversationId,
-          text: assistantMessage.text,
+          text,
           threadTs: runArgs.threadTs,
         });
       } catch (error) {
@@ -576,7 +581,7 @@ export async function resumeSlackTurn(
       const recordedMessageId = recordDeliveredAssistantMessage({
         conversation: deliveryState.conversation,
         sessionId: deliveryState.sessionId,
-        text: assistantMessage.text,
+        text,
         userMessageId: deliveryState.userMessageId,
       });
       if (messageTs) {
@@ -586,9 +591,9 @@ export async function resumeSlackTurn(
       }
       try {
         await persistWithRetry(() =>
-          assistantMessage.message
+          message
             ? commitAcceptedReply({
-                agentMessage: assistantMessage.message,
+                agentMessage: message,
                 conversation: deliveryState.conversation,
                 conversationMessageId: recordedMessageId,
                 conversationId,
@@ -724,7 +729,7 @@ export async function resumeSlackTurn(
             `Agent turn ended with ${reply.diagnostics.outcome}.`)
           : undefined;
       if (reply.diagnostics.outcome !== "success") {
-        await deliverAssistantMessage({ text: reply.text });
+        await deliverAssistantMessage(reply.text);
       }
       runResultHandled = true;
 

--- a/packages/junior/src/chat/runtime/slack-resume.ts
+++ b/packages/junior/src/chat/runtime/slack-resume.ts
@@ -11,6 +11,7 @@ import type { ChannelConfigurationService } from "@/chat/configuration/types";
 import {
   RetryableDeliveryError,
   type AgentRunRequest,
+  type Reply,
 } from "@/chat/agent/request";
 import type { AgentRunResult } from "@/chat/services/turn-result";
 import type { AgentRunner } from "@/chat/runtime/agent-runner";
@@ -58,6 +59,7 @@ import {
   hydrateConversationMessages,
   persistConversationMessages,
 } from "@/chat/conversations/messages";
+import { commitAcceptedReply } from "@/chat/conversations/projection";
 import {
   getPersistedThreadState,
   persistThreadStateById,
@@ -547,6 +549,7 @@ export async function resumeSlackTurn(
     };
     /** Post and record one completed assistant message for the resumed turn. */
     const deliverAssistantMessage = async (assistantMessage: {
+      message?: Reply["message"];
       text: string;
     }): Promise<void> => {
       if (!assistantMessage.text.trim()) {
@@ -583,10 +586,17 @@ export async function resumeSlackTurn(
       }
       try {
         await persistWithRetry(() =>
-          persistConversationMessages({
-            conversation: deliveryState.conversation,
-            conversationId,
-          }),
+          assistantMessage.message
+            ? commitAcceptedReply({
+                agentMessage: assistantMessage.message,
+                conversation: deliveryState.conversation,
+                conversationMessageId: recordedMessageId,
+                conversationId,
+              })
+            : persistConversationMessages({
+                conversation: deliveryState.conversation,
+                conversationId,
+              }),
         );
       } catch (error) {
         logException(
@@ -632,9 +642,11 @@ export async function resumeSlackTurn(
       deliveryState.conversation,
       sessionId,
     );
-    const replyContext = createResumeReplyContext(runArgs, status, {
-      onAssistantMessage: deliverAssistantMessage,
-    });
+    const replyContext = createResumeReplyContext(
+      runArgs,
+      status,
+      deliverAssistantMessage,
+    );
     if (runArgs.inputMessageIds?.length) {
       await turnLifecycle.start({
         conversationId: runArgs.conversationId,

--- a/packages/junior/tests/component/runtime/agent-run-model-handoff.test.ts
+++ b/packages/junior/tests/component/runtime/agent-run-model-handoff.test.ts
@@ -1,7 +1,9 @@
 import { Buffer } from "node:buffer";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createLocalSource } from "@sentry/junior-plugin-api";
-import type { Reply } from "@/chat/agent/request";
+import type { AssistantMessage } from "@earendil-works/pi-ai";
+import { getAssistantMessageText } from "@/chat/services/turn-result";
+import type { AgentRunRequest } from "@/chat/agent/request";
 
 const observations = vi.hoisted(() => ({
   afterHandoffModelId: "",
@@ -651,7 +653,7 @@ describe("model handoff composition", () => {
   it("delivers only the tool-free assistant message after tool use", async () => {
     observations.progressTool = true;
     const delivered: Array<{ text: string }> = [];
-    let deliveredMessage: Reply["message"] | undefined;
+    let deliveredMessage: AssistantMessage | undefined;
     const conversationId = "local:test:assistant-message-delivery";
 
     const outcome = await executeAgentRun({
@@ -662,8 +664,9 @@ describe("model handoff composition", () => {
         destination: { platform: "local", conversationId },
         source: createLocalSource(conversationId),
       },
-      delivery: ({ message, text }) => {
-        delivered.push({ text });
+      delivery: (message) => {
+        const text = getAssistantMessageText(message);
+        if (text) delivered.push({ text });
         deliveredMessage = message;
       },
     });
@@ -710,7 +713,7 @@ describe("model handoff composition", () => {
     const turnId = "turn-assistant-message-delivery-retry";
     const delivered: Array<{ text: string }> = [];
     let deliveryAttempts = 0;
-    const request = {
+    const request: AgentRunRequest = {
       conversationId,
       turnId,
       input: { messageText: "Check the details." },
@@ -718,12 +721,13 @@ describe("model handoff composition", () => {
         destination: { platform: "local" as const, conversationId },
         source: createLocalSource(conversationId),
       },
-      delivery: ({ text }: Reply) => {
+      delivery: (message) => {
         deliveryAttempts += 1;
         if (deliveryAttempts === 1) {
           throw new RetryableDeliveryError(new Error("Slack unavailable"));
         }
-        delivered.push({ text });
+        const text = getAssistantMessageText(message);
+        if (text) delivered.push({ text });
       },
     };
 

--- a/packages/junior/tests/component/runtime/agent-run-model-handoff.test.ts
+++ b/packages/junior/tests/component/runtime/agent-run-model-handoff.test.ts
@@ -1,6 +1,7 @@
 import { Buffer } from "node:buffer";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createLocalSource } from "@sentry/junior-plugin-api";
+import type { Reply } from "@/chat/agent/request";
 
 const observations = vi.hoisted(() => ({
   afterHandoffModelId: "",
@@ -650,6 +651,7 @@ describe("model handoff composition", () => {
   it("delivers only the tool-free assistant message after tool use", async () => {
     observations.progressTool = true;
     const delivered: Array<{ text: string }> = [];
+    let deliveredMessage: Reply["message"] | undefined;
     const conversationId = "local:test:assistant-message-delivery";
 
     const outcome = await executeAgentRun({
@@ -660,15 +662,18 @@ describe("model handoff composition", () => {
         destination: { platform: "local", conversationId },
         source: createLocalSource(conversationId),
       },
-      delivery: {
-        onAssistantMessage: (message) => {
-          delivered.push(message);
-        },
+      delivery: ({ message, text }) => {
+        delivered.push({ text });
+        deliveredMessage = message;
       },
     });
 
     expect(outcome.status).toBe("completed");
     expect(delivered).toEqual([{ text: "Handoff model completed it." }]);
+    expect(deliveredMessage).toMatchObject({
+      role: "assistant",
+      stopReason: "stop",
+    });
   });
 
   it("executes tools before a terminal assistant delivery failure", async () => {
@@ -685,10 +690,8 @@ describe("model handoff composition", () => {
           destination: { platform: "local", conversationId },
           source: createLocalSource(conversationId),
         },
-        delivery: {
-          onAssistantMessage: () => {
-            throw deliveryError;
-          },
+        delivery: () => {
+          throw deliveryError;
         },
         observers: {
           onStatus: ({ text }) => {
@@ -715,14 +718,12 @@ describe("model handoff composition", () => {
         destination: { platform: "local" as const, conversationId },
         source: createLocalSource(conversationId),
       },
-      delivery: {
-        onAssistantMessage: (message: { text: string }) => {
-          deliveryAttempts += 1;
-          if (deliveryAttempts === 1) {
-            throw new RetryableDeliveryError(new Error("Slack unavailable"));
-          }
-          delivered.push(message);
-        },
+      delivery: ({ text }: Reply) => {
+        deliveryAttempts += 1;
+        if (deliveryAttempts === 1) {
+          throw new RetryableDeliveryError(new Error("Slack unavailable"));
+        }
+        delivered.push({ text });
       },
     };
 

--- a/packages/junior/tests/component/runtime/agent-run-provider-retry.test.ts
+++ b/packages/junior/tests/component/runtime/agent-run-provider-retry.test.ts
@@ -901,10 +901,8 @@ describe("provider retry composition", () => {
         source: TEST_SOURCE,
         actor: { platform: "slack", teamId: "T123", userId: "U123" },
       },
-      delivery: {
-        onAssistantMessage: (message) => {
-          delivered.push(message);
-        },
+      delivery: ({ text }) => {
+        delivered.push({ text });
       },
       durability: {
         drainSteeringMessages: async (inject) => {
@@ -941,10 +939,8 @@ describe("provider retry composition", () => {
         source: TEST_SOURCE,
         actor: { platform: "slack", teamId: "T123", userId: "U123" },
       },
-      delivery: {
-        onAssistantMessage: (message) => {
-          delivered.push(message);
-        },
+      delivery: ({ text }) => {
+        delivered.push({ text });
       },
       durability: { shouldYield: () => true },
     });
@@ -966,10 +962,8 @@ describe("provider retry composition", () => {
         source: TEST_SOURCE,
         actor: { platform: "slack", teamId: "T123", userId: "U123" },
       },
-      delivery: {
-        onAssistantMessage: (message) => {
-          delivered.push(message);
-        },
+      delivery: ({ text }) => {
+        delivered.push({ text });
       },
       durability: {
         drainSteeringMessages: async (inject) => {

--- a/packages/junior/tests/component/runtime/agent-run-provider-retry.test.ts
+++ b/packages/junior/tests/component/runtime/agent-run-provider-retry.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createSlackSource, type Destination } from "@sentry/junior-plugin-api";
 import { renderCurrentInstruction } from "@/chat/current-instruction";
 import type { PiMessage } from "@/chat/pi/messages";
+import { extractAssistantText } from "@/chat/pi/transcript";
 import { readConversationDetail } from "@/api/conversations/detail";
 
 const { agentMode, compactionState, counters, sessionLogState } = vi.hoisted(
@@ -901,8 +902,8 @@ describe("provider retry composition", () => {
         source: TEST_SOURCE,
         actor: { platform: "slack", teamId: "T123", userId: "U123" },
       },
-      delivery: ({ text }) => {
-        delivered.push({ text });
+      delivery: (message) => {
+        delivered.push({ text: extractAssistantText(message) });
       },
       durability: {
         drainSteeringMessages: async (inject) => {
@@ -939,8 +940,8 @@ describe("provider retry composition", () => {
         source: TEST_SOURCE,
         actor: { platform: "slack", teamId: "T123", userId: "U123" },
       },
-      delivery: ({ text }) => {
-        delivered.push({ text });
+      delivery: (message) => {
+        delivered.push({ text: extractAssistantText(message) });
       },
       durability: { shouldYield: () => true },
     });
@@ -962,8 +963,8 @@ describe("provider retry composition", () => {
         source: TEST_SOURCE,
         actor: { platform: "slack", teamId: "T123", userId: "U123" },
       },
-      delivery: ({ text }) => {
-        delivered.push({ text });
+      delivery: (message) => {
+        delivered.push({ text: extractAssistantText(message) });
       },
       durability: {
         drainSteeringMessages: async (inject) => {

--- a/packages/junior/tests/fixtures/agent-runner.ts
+++ b/packages/junior/tests/fixtures/agent-runner.ts
@@ -1,7 +1,35 @@
 import type { AgentRunner } from "@/chat/runtime/agent-runner";
-import type { AgentAssistantMessage } from "@/chat/agent/request";
+import type { Reply } from "@/chat/agent/request";
 import type { AgentRunResult } from "@/chat/services/turn-result";
 import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
+import type { PiMessage } from "@/chat/pi/messages";
+import { isAssistantMessage } from "@/chat/pi/transcript";
+
+function assistantMessage(text: string): Reply["message"] {
+  return {
+    role: "assistant",
+    content: [{ type: "text", text }],
+    api: "responses",
+    provider: "openai",
+    model: "fake-agent",
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        total: 0,
+      },
+    },
+    stopReason: "stop",
+    timestamp: Date.now(),
+  };
+}
 
 /**
  * Default harness runner: resolve @/chat/agent-run at call time so a test's
@@ -30,7 +58,7 @@ export function flattenAgentRunRequestForTest(
     ...(request.policy ?? {}),
     ...(request.state ?? {}),
     ...(request.observers ?? {}),
-    ...(request.delivery ?? {}),
+    ...(request.delivery ? { delivery: request.delivery } : {}),
     ...(request.durability ?? {}),
   };
 }
@@ -50,24 +78,40 @@ export function neverRunAgentRunner(): AgentRunner {
 /** Deliver explicitly scripted assistant messages from an inline fake runner. */
 export async function deliverAssistantMessagesForTest(
   request: Parameters<AgentRunner["run"]>[0],
-  messages: AgentAssistantMessage[],
-): Promise<void> {
+  replies: Array<Pick<Reply, "text">>,
+  finalHistory?: PiMessage[],
+): Promise<PiMessage[]> {
   if (!request.delivery) {
     throw new Error("scripted runner requires assistant delivery");
   }
-  for (const message of messages) {
-    await request.delivery.onAssistantMessage(message);
+  const history = finalHistory
+    ? finalHistory.slice(0, -replies.length)
+    : [...(request.input.piMessages ?? [])];
+  const firstReplyIndex = (finalHistory?.length ?? 0) - replies.length;
+  for (const [index, reply] of replies.entries()) {
+    const message =
+      finalHistory?.[firstReplyIndex + index] ?? assistantMessage(reply.text);
+    if (!isAssistantMessage(message)) {
+      throw new Error("scripted reply requires an assistant message");
+    }
+    history.push(message);
+    await request.delivery({ message, text: reply.text });
   }
+  return history;
 }
 
 /** Script completed assistant messages through the production delivery port. */
 export function scriptedAssistantMessageRunner(args: {
-  messages: AgentAssistantMessage[];
+  messages: Array<Pick<Reply, "text">>;
   result: AgentRunResult;
 }): AgentRunner {
   return {
     run: async (request) => {
-      await deliverAssistantMessagesForTest(request, args.messages);
+      await deliverAssistantMessagesForTest(
+        request,
+        args.messages,
+        args.result.piMessages,
+      );
       return completedAgentRun(args.result);
     },
   };

--- a/packages/junior/tests/fixtures/agent-runner.ts
+++ b/packages/junior/tests/fixtures/agent-runner.ts
@@ -1,34 +1,16 @@
 import type { AgentRunner } from "@/chat/runtime/agent-runner";
-import type { Reply } from "@/chat/agent/request";
-import type { AgentRunResult } from "@/chat/services/turn-result";
+import type { AssistantMessage } from "@earendil-works/pi-ai";
+import { fauxAssistantMessage } from "@earendil-works/pi-ai/providers/faux";
+import {
+  getAssistantMessageText,
+  type AgentRunResult,
+} from "@/chat/services/turn-result";
 import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 import type { PiMessage } from "@/chat/pi/messages";
 import { isAssistantMessage } from "@/chat/pi/transcript";
 
-function assistantMessage(text: string): Reply["message"] {
-  return {
-    role: "assistant",
-    content: [{ type: "text", text }],
-    api: "responses",
-    provider: "openai",
-    model: "fake-agent",
-    usage: {
-      input: 0,
-      output: 0,
-      cacheRead: 0,
-      cacheWrite: 0,
-      totalTokens: 0,
-      cost: {
-        input: 0,
-        output: 0,
-        cacheRead: 0,
-        cacheWrite: 0,
-        total: 0,
-      },
-    },
-    stopReason: "stop",
-    timestamp: Date.now(),
-  };
+function assistantMessage(text: string): AssistantMessage {
+  return fauxAssistantMessage(text);
 }
 
 /**
@@ -78,7 +60,7 @@ export function neverRunAgentRunner(): AgentRunner {
 /** Deliver explicitly scripted assistant messages from an inline fake runner. */
 export async function deliverAssistantMessagesForTest(
   request: Parameters<AgentRunner["run"]>[0],
-  replies: Array<Pick<Reply, "text">>,
+  replies: Array<{ text: string }>,
   finalHistory?: PiMessage[],
 ): Promise<PiMessage[]> {
   if (!request.delivery) {
@@ -94,15 +76,22 @@ export async function deliverAssistantMessagesForTest(
     if (!isAssistantMessage(message)) {
       throw new Error("scripted reply requires an assistant message");
     }
+    const visibleText = getAssistantMessageText(message);
+    if (visibleText !== reply.text.trim()) {
+      throw new Error(
+        `scripted reply text ${JSON.stringify(reply.text)} does not match ` +
+          `its assistant message text ${JSON.stringify(visibleText)}`,
+      );
+    }
     history.push(message);
-    await request.delivery({ message, text: reply.text });
+    await request.delivery(message);
   }
   return history;
 }
 
 /** Script completed assistant messages through the production delivery port. */
 export function scriptedAssistantMessageRunner(args: {
-  messages: Array<Pick<Reply, "text">>;
+  messages: Array<{ text: string }>;
   result: AgentRunResult;
 }): AgentRunner {
   return {

--- a/packages/junior/tests/integration/agent-continue-slack.test.ts
+++ b/packages/junior/tests/integration/agent-continue-slack.test.ts
@@ -1219,21 +1219,24 @@ describe("agent continuation Slack integration", () => {
     const conversationId = "slack:C123:1712345.0008";
     const sessionId = "turn_msg_8";
     executeAgentRunMock.mockImplementationOnce(async (request) => {
-      await deliverAssistantMessagesForTest(request, [
-        { text: "Final resumed answer" },
-      ]);
+      const history = [
+        {
+          role: "user",
+          content: [{ type: "text", text: "hello" }],
+          timestamp: 1,
+        },
+        {
+          ...assistantPiMessage("Final resumed answer", 2),
+        },
+      ] as any;
+      await deliverAssistantMessagesForTest(
+        request,
+        [{ text: "Final resumed answer" }],
+        history,
+      );
       return completedAgentRun({
         text: "Final resumed answer",
-        piMessages: [
-          {
-            role: "user",
-            content: [{ type: "text", text: "hello" }],
-            timestamp: 1,
-          },
-          {
-            ...assistantPiMessage("Final resumed answer", 2),
-          },
-        ] as any,
+        piMessages: history,
         diagnostics: makeDiagnostics(),
       });
     });
@@ -1449,15 +1452,18 @@ describe("agent continuation Slack integration", () => {
         conversationId,
         sessionId,
       );
-      await deliverAssistantMessagesForTest(request, [
-        { text: "Handoff recovery completed." },
-      ]);
+      const history = [
+        summaryMessage,
+        assistantPiMessage("Handoff recovery completed.", 6),
+      ] as any;
+      await deliverAssistantMessagesForTest(
+        request,
+        [{ text: "Handoff recovery completed." }],
+        history,
+      );
       return completedAgentRun({
         text: "Handoff recovery completed.",
-        piMessages: [
-          summaryMessage,
-          assistantPiMessage("Handoff recovery completed.", 6),
-        ] as any,
+        piMessages: history,
         diagnostics: {
           ...makeDiagnostics(),
           modelId: "openai/gpt-5.6-sol",

--- a/packages/junior/tests/integration/agent-dispatch-work.test.ts
+++ b/packages/junior/tests/integration/agent-dispatch-work.test.ts
@@ -52,6 +52,7 @@ import { slackApiOutbox } from "../fixtures/slack-api-outbox";
 import { resetSlackApiMockState } from "../msw/handlers/slack-api";
 import { agentTurnSessionKey } from "@/chat/state/turn-session-keys";
 import type { JuniorRuntimeServiceOverrides } from "@/chat/app/services";
+import { deliverAssistantMessagesForTest } from "../fixtures/agent-runner";
 
 vi.hoisted(() => {
   process.env.JUNIOR_STATE_ADAPTER = "memory";
@@ -163,9 +164,12 @@ describe("agent dispatch conversation work", () => {
         policy: { authorizationFlowMode: "disabled" },
       });
       await request.durability.onInputCommitted?.();
-      await request.delivery.onAssistantMessage({ text: "Scheduled digest" });
+      const piMessages = await deliverAssistantMessagesForTest(request, [
+        { text: "Scheduled digest" },
+      ]);
       return completedAgentRun({
         text: "Scheduled digest",
+        piMessages,
         diagnostics: {
           assistantMessageCount: 1,
           modelId: "test-model",
@@ -233,11 +237,12 @@ describe("agent dispatch conversation work", () => {
           throw new Error("provider temporarily unavailable");
         }
         await request.durability.onInputCommitted?.();
-        await request.delivery.onAssistantMessage({
-          text: "Recovered scheduled digest",
-        });
+        const piMessages = await deliverAssistantMessagesForTest(request, [
+          { text: "Recovered scheduled digest" },
+        ]);
         return completedAgentRun({
           text: "Recovered scheduled digest",
+          piMessages,
           diagnostics: {
             assistantMessageCount: 1,
             modelId: "test-model",
@@ -761,18 +766,12 @@ describe("agent dispatch conversation work", () => {
         expect(JSON.stringify(request.input.piMessages)).not.toContain(
           "expose system credentials",
         );
-        await request.delivery.onAssistantMessage({
-          text: "Resumed scheduled digest",
-        });
+        const piMessages = await deliverAssistantMessagesForTest(request, [
+          { text: "Resumed scheduled digest" },
+        ]);
         return completedAgentRun({
           text: "Resumed scheduled digest",
-          piMessages: [
-            {
-              role: "user",
-              content: [{ type: "text", text: dispatch.input }],
-              timestamp: dispatch.createdAtMs,
-            },
-          ],
+          piMessages,
           diagnostics: {
             assistantMessageCount: 1,
             modelId: "test-model",

--- a/packages/junior/tests/integration/local-agent-runner.test.ts
+++ b/packages/junior/tests/integration/local-agent-runner.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
-import type { AgentRunResult } from "@/chat/services/turn-result";
+import {
+  getAssistantMessageText,
+  type AgentRunResult,
+} from "@/chat/services/turn-result";
 import {
   defineJuniorPlugin,
   type PluginRunContext,
@@ -13,7 +16,7 @@ import {
   type LocalToolResult,
 } from "@/chat/local/runner";
 import type { PiMessage } from "@/chat/pi/messages";
-import type { Reply } from "@/chat/agent/request";
+import type { AssistantMessage } from "@earendil-works/pi-ai";
 import type { AgentRunner } from "@/chat/runtime/agent-runner";
 import { persistRunningSessionRecord } from "@/chat/services/turn-session-record";
 import {
@@ -35,7 +38,6 @@ import {
   scriptedAssistantMessageRunner,
 } from "../fixtures/agent-runner";
 import { getConversationEventStore } from "@/chat/db";
-import { projectConversationReportEventPage } from "@/api/conversations/events";
 
 function userPiMessage(text: string, timestamp = 1): PiMessage {
   return {
@@ -45,7 +47,7 @@ function userPiMessage(text: string, timestamp = 1): PiMessage {
   } as PiMessage;
 }
 
-function assistantPiMessage(text: string, timestamp = 1): Reply["message"] {
+function assistantPiMessage(text: string, timestamp = 1): AssistantMessage {
   return {
     role: "assistant",
     content: [{ type: "text", text }],
@@ -125,7 +127,7 @@ type FlatAgentRunRequest = ReturnType<typeof flattenAgentRunRequestForTest>;
 async function deliverAssistantText(
   request: Parameters<AgentRunner["run"]>[0],
   text: string,
-  message: Reply["message"] = assistantPiMessage(text),
+  message: AssistantMessage = assistantPiMessage(text),
   historyBeforeMessage?: PiMessage[],
 ): Promise<void> {
   if (!request.delivery) {
@@ -137,10 +139,10 @@ async function deliverAssistantText(
       messages: historyBeforeMessage,
     });
   }
-  await request.delivery({
-    message,
-    text,
-  });
+  if (getAssistantMessageText(message) !== text) {
+    throw new Error("fake delivery text must match its assistant message");
+  }
+  await request.delivery(message);
 }
 
 async function persistRunningSessionForFakeReply(
@@ -202,58 +204,6 @@ describe("local agent runner", () => {
         .filter((message) => message.role === "assistant")
         .map((message) => message.text),
     ).toEqual(["Checking now.", "Done."]);
-  });
-
-  it("records agent history before its accepted visible reply", async () => {
-    const conversationId = normalizeLocalConversationId({
-      alias: "assistant-message-event-order",
-      cwd: "/tmp/local-agent-runner-assistant-message-event-order",
-    });
-    expect(conversationId).toBeDefined();
-    const message: Reply["message"] = {
-      ...assistantPiMessage("ordered reply", 2_000),
-      content: [
-        { type: "thinking", thinking: "Check the final answer." },
-        { type: "text", text: "ordered reply" },
-      ],
-    };
-    const history = [userPiMessage("check ordering", 1_000), message];
-
-    await runLocalAgentTurn(
-      {
-        conversationId: conversationId!,
-        message: "check ordering",
-      },
-      {
-        agentRunner: {
-          run: async (request) => {
-            await commitMessages({
-              conversationId: request.conversationId,
-              messages: history.slice(0, -1),
-            });
-            await request.delivery?.({ message, text: "ordered reply" });
-            return completedAgentRun(
-              successReply("ordered reply", { piMessages: history }),
-            );
-          },
-        },
-        deliverReply: async () => undefined,
-      },
-    );
-
-    const report = projectConversationReportEventPage({
-      canExposePayload: true,
-      events: await getConversationEventStore().loadHistory(conversationId!),
-    });
-    expect(
-      report
-        .filter(
-          (event) =>
-            event.data.type === "assistant_message" ||
-            (event.data.type === "message" && event.data.role === "assistant"),
-        )
-        .map((event) => event.data.type),
-    ).toEqual(["assistant_message", "message"]);
   });
 
   it("runs a local message without Slack actor or destination state", async () => {
@@ -1122,7 +1072,7 @@ describe("local agent runner", () => {
     });
     expect(conversationId).toBeDefined();
 
-    const generatedMessage = assistantPiMessage("persisted pi output", 2);
+    const generatedMessage = assistantPiMessage("persisted visible output", 2);
     const generatedMessages: PiMessage[] = [
       userPiMessage("hello"),
       generatedMessage,

--- a/packages/junior/tests/integration/local-agent-runner.test.ts
+++ b/packages/junior/tests/integration/local-agent-runner.test.ts
@@ -13,8 +13,9 @@ import {
   type LocalToolResult,
 } from "@/chat/local/runner";
 import type { PiMessage } from "@/chat/pi/messages";
+import type { Reply } from "@/chat/agent/request";
 import type { AgentRunner } from "@/chat/runtime/agent-runner";
-import { persistCompletedSessionRecord } from "@/chat/services/turn-session-record";
+import { persistRunningSessionRecord } from "@/chat/services/turn-session-record";
 import {
   getPersistedSandboxState,
   getPersistedThreadState,
@@ -34,6 +35,7 @@ import {
   scriptedAssistantMessageRunner,
 } from "../fixtures/agent-runner";
 import { getConversationEventStore } from "@/chat/db";
+import { projectConversationReportEventPage } from "@/api/conversations/events";
 
 function userPiMessage(text: string, timestamp = 1): PiMessage {
   return {
@@ -43,7 +45,7 @@ function userPiMessage(text: string, timestamp = 1): PiMessage {
   } as PiMessage;
 }
 
-function assistantPiMessage(text: string, timestamp = 1): PiMessage {
+function assistantPiMessage(text: string, timestamp = 1): Reply["message"] {
   return {
     role: "assistant",
     content: [{ type: "text", text }],
@@ -66,7 +68,7 @@ function assistantPiMessage(text: string, timestamp = 1): PiMessage {
     },
     stopReason: "stop",
     timestamp,
-  } as PiMessage;
+  };
 }
 
 function successReply(
@@ -123,20 +125,31 @@ type FlatAgentRunRequest = ReturnType<typeof flattenAgentRunRequestForTest>;
 async function deliverAssistantText(
   request: Parameters<AgentRunner["run"]>[0],
   text: string,
+  message: Reply["message"] = assistantPiMessage(text),
+  historyBeforeMessage?: PiMessage[],
 ): Promise<void> {
   if (!request.delivery) {
     throw new Error("local test runner requires assistant delivery");
   }
-  await request.delivery.onAssistantMessage({ text });
+  if (historyBeforeMessage) {
+    await commitMessages({
+      conversationId: request.conversationId,
+      messages: historyBeforeMessage,
+    });
+  }
+  await request.delivery({
+    message,
+    text,
+  });
 }
 
-async function persistCompletedSessionForFakeReply(
+async function persistRunningSessionForFakeReply(
   context: FlatAgentRunRequest,
   piMessages: PiMessage[],
 ): Promise<void> {
   const conversationId = context.conversationId;
   const sessionId = context.turnId;
-  await persistCompletedSessionRecord({
+  await persistRunningSessionRecord({
     modelId: "fake-local-agent",
     conversationId,
     destination: context.destination,
@@ -145,7 +158,8 @@ async function persistCompletedSessionForFakeReply(
     source: context.source,
     sessionId,
     sliceId: 1,
-    allMessages: piMessages,
+    messages: piMessages.slice(0, -1),
+    logContext: {},
     surface: context.surface,
     turnStartMessageIndex: context.piMessages?.length ?? 0,
   });
@@ -188,6 +202,58 @@ describe("local agent runner", () => {
         .filter((message) => message.role === "assistant")
         .map((message) => message.text),
     ).toEqual(["Checking now.", "Done."]);
+  });
+
+  it("records agent history before its accepted visible reply", async () => {
+    const conversationId = normalizeLocalConversationId({
+      alias: "assistant-message-event-order",
+      cwd: "/tmp/local-agent-runner-assistant-message-event-order",
+    });
+    expect(conversationId).toBeDefined();
+    const message: Reply["message"] = {
+      ...assistantPiMessage("ordered reply", 2_000),
+      content: [
+        { type: "thinking", thinking: "Check the final answer." },
+        { type: "text", text: "ordered reply" },
+      ],
+    };
+    const history = [userPiMessage("check ordering", 1_000), message];
+
+    await runLocalAgentTurn(
+      {
+        conversationId: conversationId!,
+        message: "check ordering",
+      },
+      {
+        agentRunner: {
+          run: async (request) => {
+            await commitMessages({
+              conversationId: request.conversationId,
+              messages: history.slice(0, -1),
+            });
+            await request.delivery?.({ message, text: "ordered reply" });
+            return completedAgentRun(
+              successReply("ordered reply", { piMessages: history }),
+            );
+          },
+        },
+        deliverReply: async () => undefined,
+      },
+    );
+
+    const report = projectConversationReportEventPage({
+      canExposePayload: true,
+      events: await getConversationEventStore().loadHistory(conversationId!),
+    });
+    expect(
+      report
+        .filter(
+          (event) =>
+            event.data.type === "assistant_message" ||
+            (event.data.type === "message" && event.data.role === "assistant"),
+        )
+        .map((event) => event.data.type),
+    ).toEqual(["assistant_message", "message"]);
   });
 
   it("runs a local message without Slack actor or destination state", async () => {
@@ -798,12 +864,18 @@ describe("local agent runner", () => {
             run: async (request) => {
               const context = flattenAgentRunRequestForTest(request);
 
-              const piMessages = [
+              const replyMessage = assistantPiMessage("captured", 2);
+              const piMessages: PiMessage[] = [
                 userPiMessage("capture this local turn"),
-                assistantPiMessage("captured", 2),
+                replyMessage,
               ];
-              await persistCompletedSessionForFakeReply(context, piMessages);
-              await deliverAssistantText(request, "captured");
+              await persistRunningSessionForFakeReply(context, piMessages);
+              await deliverAssistantText(
+                request,
+                "captured",
+                replyMessage,
+                piMessages.slice(0, -1),
+              );
               return completedAgentRun(
                 successReply("captured", {
                   piMessages,
@@ -1050,12 +1122,18 @@ describe("local agent runner", () => {
     });
     expect(conversationId).toBeDefined();
 
-    const generatedMessages = [
+    const generatedMessage = assistantPiMessage("persisted pi output", 2);
+    const generatedMessages: PiMessage[] = [
       userPiMessage("hello"),
-      assistantPiMessage("persisted pi output", 2),
+      generatedMessage,
     ];
     const generateReply = vi.fn<AgentRunner["run"]>(async (request) => {
-      await deliverAssistantText(request, "persisted visible output");
+      await deliverAssistantText(
+        request,
+        "persisted visible output",
+        generatedMessage,
+        generatedMessages.slice(0, -1),
+      );
       return completedAgentRun(
         successReply("persisted visible output", {
           piMessages: generatedMessages,
@@ -1107,9 +1185,10 @@ describe("local agent runner", () => {
     });
     expect(conversationId).toBeDefined();
 
-    const generatedMessages = [
+    const generatedMessage = assistantPiMessage("visible reply", 2);
+    const generatedMessages: PiMessage[] = [
       userPiMessage("hello"),
-      assistantPiMessage("visible reply", 2),
+      generatedMessage,
     ];
     const delivered: LocalAgentReply[] = [];
     let taskRuns = 0;
@@ -1146,11 +1225,16 @@ describe("local agent runner", () => {
               run: async (request) => {
                 const context = flattenAgentRunRequestForTest(request);
 
-                await persistCompletedSessionForFakeReply(
+                await persistRunningSessionForFakeReply(
                   context,
                   generatedMessages,
                 );
-                await deliverAssistantText(request, "visible reply");
+                await deliverAssistantText(
+                  request,
+                  "visible reply",
+                  generatedMessage,
+                  generatedMessages.slice(0, -1),
+                );
                 return completedAgentRun(
                   successReply("visible reply", {
                     piMessages: generatedMessages,

--- a/packages/junior/tests/integration/oauth-callback.test.ts
+++ b/packages/junior/tests/integration/oauth-callback.test.ts
@@ -216,22 +216,27 @@ describe("oauth callback integration", () => {
             providerDisplayName: "Eval OAuth",
           };
         }
-        await deliverAssistantMessagesForTest(request, [{ text: "uploaded" }]);
+        const history = [
+          ...(request.input.piMessages ?? []),
+          {
+            role: "assistant",
+            content: [{ type: "text", text: "uploaded" }],
+            api: "openai-responses",
+            provider: "openai",
+            model: "test-model",
+            usage: {},
+            stopReason: "stop",
+            timestamp: Date.now(),
+          },
+        ] as NonNullable<AgentRunResult["piMessages"]>;
+        await deliverAssistantMessagesForTest(
+          request,
+          [{ text: "uploaded" }],
+          history,
+        );
         return completedAgentRun({
           text: "uploaded",
-          piMessages: [
-            ...(request.input.piMessages ?? []),
-            {
-              role: "assistant",
-              content: [{ type: "text", text: "uploaded" }],
-              api: "openai-responses",
-              provider: "openai",
-              model: "test-model",
-              usage: {},
-              stopReason: "stop",
-              timestamp: Date.now(),
-            },
-          ] as NonNullable<AgentRunResult["piMessages"]>,
+          piMessages: history,
           diagnostics: makeDiagnostics(),
         });
       }),

--- a/packages/junior/tests/integration/slack/bot-handlers.test.ts
+++ b/packages/junior/tests/integration/slack/bot-handlers.test.ts
@@ -8,9 +8,12 @@ import { disconnectStateAdapter, getStateAdapter } from "@/chat/state/adapter";
 import { acquireActiveLock } from "@/chat/state/locks";
 import { instructionActors } from "@/chat/conversations/provenance";
 import {
+  commitMessages,
   loadProjection,
   loadConversationProjection,
 } from "@/chat/conversations/projection";
+import { projectConversationReportEventPage } from "@/api/conversations/events";
+import { getConversationEventStore } from "@/chat/db";
 import {
   hydrateConversationMessages,
   persistConversationMessages,
@@ -702,7 +705,13 @@ describe("bot handlers (integration)", () => {
             run: async (request) => {
               const replyMessage = {
                 role: "assistant" as const,
-                content: [{ type: "text" as const, text: finalText }],
+                content: [
+                  {
+                    type: "thinking" as const,
+                    thinking: "Check the final answer.",
+                  },
+                  { type: "text" as const, text: finalText },
+                ],
                 api: "responses" as const,
                 provider: "openai",
                 model: "gpt-5.3",
@@ -731,6 +740,10 @@ describe("bot handlers (integration)", () => {
                 sliceId: 1,
                 state: "running",
                 piMessages: promptMessages,
+              });
+              await commitMessages({
+                conversationId,
+                messages: promptMessages,
               });
               await deliverAssistantMessagesForTest(
                 request,
@@ -824,6 +837,19 @@ describe("bot handlers (integration)", () => {
     await expect(loadProjection({ conversationId })).resolves.toEqual(
       expect.arrayContaining([expect.objectContaining({ role: "assistant" })]),
     );
+    const report = projectConversationReportEventPage({
+      canExposePayload: true,
+      events: await getConversationEventStore().loadHistory(conversationId),
+    });
+    expect(
+      report
+        .filter(
+          (event) =>
+            event.data.type === "assistant_message" ||
+            (event.data.type === "message" && event.data.role === "assistant"),
+        )
+        .map((event) => event.data.type),
+    ).toEqual(["assistant_message", "message"]);
     expect(turnLifecycle.fail).toHaveBeenCalledWith(
       expect.objectContaining({
         eventId: expect.stringMatching(/^[a-f0-9]{32}$/i),

--- a/packages/junior/tests/integration/slack/bot-handlers.test.ts
+++ b/packages/junior/tests/integration/slack/bot-handlers.test.ts
@@ -1,5 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createFauxCore,
+  fauxAssistantMessage,
+  fauxText,
+  fauxThinking,
+} from "@earendil-works/pi-ai/providers/faux";
 import { createSlackSource, type Destination } from "@sentry/junior-plugin-api";
+import { executeAgentRun } from "@/chat/agent";
 import type { JuniorRuntimeServiceOverrides } from "@/chat/app/services";
 import { makeAssistantStatus } from "@/chat/slack/assistant-thread/status";
 import { getSlackInterruptionMarker } from "@/chat/slack/output";
@@ -8,9 +15,9 @@ import { disconnectStateAdapter, getStateAdapter } from "@/chat/state/adapter";
 import { acquireActiveLock } from "@/chat/state/locks";
 import { instructionActors } from "@/chat/conversations/provenance";
 import {
-  commitMessages,
   loadProjection,
   loadConversationProjection,
+  recordTurnRoute,
 } from "@/chat/conversations/projection";
 import { projectConversationReportEventPage } from "@/api/conversations/events";
 import { getConversationEventStore } from "@/chat/db";
@@ -691,11 +698,10 @@ describe("bot handlers (integration)", () => {
     );
   });
 
-  it("keeps the turn successful when persistence fails after Slack accepted the reply", async () => {
+  it("commits real agent history before the Slack reply when later state persistence fails", async () => {
     const conversationId = "slack:C0POSTDELIVERY:1700000000.000";
     const sessionId = "turn_msg-post-delivery";
     const finalText = "Delivered before the state store failed.";
-    const promptMessages = turnPiMessages("please answer");
     const turnLifecycle = createTurnLifecycleMock();
     const { slackRuntime } = createTestChatRuntime({
       services: {
@@ -703,66 +709,25 @@ describe("bot handlers (integration)", () => {
           turnLifecycle,
           agentRunner: {
             run: async (request) => {
-              const replyMessage = {
-                role: "assistant" as const,
-                content: [
-                  {
-                    type: "thinking" as const,
-                    thinking: "Check the final answer.",
-                  },
-                  { type: "text" as const, text: finalText },
-                ],
-                api: "responses" as const,
-                provider: "openai",
-                model: "gpt-5.3",
-                usage: {
-                  input: 1,
-                  output: 1,
-                  cacheRead: 0,
-                  cacheWrite: 0,
-                  totalTokens: 2,
-                  cost: {
-                    input: 0,
-                    output: 0,
-                    cacheRead: 0,
-                    cacheWrite: 0,
-                    total: 0,
-                  },
-                },
-                stopReason: "stop" as const,
-                timestamp: 2,
-              };
-              const piMessages = [...promptMessages, replyMessage];
-              await upsertAgentTurnSessionRecord({
+              await recordTurnRoute({
+                conversationId,
+                turnId: request.turnId,
+                modelProfile: "standard",
                 modelId: "test/model",
-                conversationId,
-                sessionId,
-                sliceId: 1,
-                state: "running",
-                piMessages: promptMessages,
+                reasoningLevel: "medium",
+                source: "configured",
               });
-              await commitMessages({
-                conversationId,
-                messages: promptMessages,
+              const faux = createFauxCore({
+                api: "test",
+                provider: "test",
               });
-              await deliverAssistantMessagesForTest(
-                request,
-                [{ text: finalText }],
-                piMessages,
-              );
-              return completedAgentRun({
-                text: finalText,
-                piMessages,
-                diagnostics: {
-                  assistantMessageCount: 1,
-                  modelId: "fake-agent-model",
-                  outcome: "success" as const,
-                  toolCalls: [],
-                  toolErrorCount: 0,
-                  toolResultCount: 0,
-                  usedPrimaryText: true,
-                },
-              });
+              faux.setResponses([
+                fauxAssistantMessage([
+                  fauxThinking("Check the final answer."),
+                  fauxText(finalText),
+                ]),
+              ]);
+              return executeAgentRun(request, faux.stream);
             },
           },
         },
@@ -848,8 +813,18 @@ describe("bot handlers (integration)", () => {
             event.data.type === "assistant_message" ||
             (event.data.type === "message" && event.data.role === "assistant"),
         )
-        .map((event) => event.data.type),
-    ).toEqual(["assistant_message", "message"]);
+        .map((event) => event.data),
+    ).toMatchObject([
+      {
+        type: "assistant_message",
+        parts: [{ type: "reasoning", text: "Check the final answer." }],
+      },
+      {
+        type: "message",
+        role: "assistant",
+        text: finalText,
+      },
+    ]);
     expect(turnLifecycle.fail).toHaveBeenCalledWith(
       expect.objectContaining({
         eventId: expect.stringMatching(/^[a-f0-9]{32}$/i),

--- a/packages/junior/tests/integration/slack/bot-handlers.test.ts
+++ b/packages/junior/tests/integration/slack/bot-handlers.test.ts
@@ -700,6 +700,30 @@ describe("bot handlers (integration)", () => {
           turnLifecycle,
           agentRunner: {
             run: async (request) => {
+              const replyMessage = {
+                role: "assistant" as const,
+                content: [{ type: "text" as const, text: finalText }],
+                api: "responses" as const,
+                provider: "openai",
+                model: "gpt-5.3",
+                usage: {
+                  input: 1,
+                  output: 1,
+                  cacheRead: 0,
+                  cacheWrite: 0,
+                  totalTokens: 2,
+                  cost: {
+                    input: 0,
+                    output: 0,
+                    cacheRead: 0,
+                    cacheWrite: 0,
+                    total: 0,
+                  },
+                },
+                stopReason: "stop" as const,
+                timestamp: 2,
+              };
+              const piMessages = [...promptMessages, replyMessage];
               await upsertAgentTurnSessionRecord({
                 modelId: "test/model",
                 conversationId,
@@ -708,37 +732,14 @@ describe("bot handlers (integration)", () => {
                 state: "running",
                 piMessages: promptMessages,
               });
-              await deliverAssistantMessagesForTest(request, [
-                { text: finalText },
-              ]);
+              await deliverAssistantMessagesForTest(
+                request,
+                [{ text: finalText }],
+                piMessages,
+              );
               return completedAgentRun({
                 text: finalText,
-                piMessages: [
-                  ...promptMessages,
-                  {
-                    role: "assistant" as const,
-                    content: [{ type: "text" as const, text: finalText }],
-                    api: "responses" as const,
-                    provider: "openai",
-                    model: "gpt-5.3",
-                    usage: {
-                      input: 1,
-                      output: 1,
-                      cacheRead: 0,
-                      cacheWrite: 0,
-                      totalTokens: 2,
-                      cost: {
-                        input: 0,
-                        output: 0,
-                        cacheRead: 0,
-                        cacheWrite: 0,
-                        total: 0,
-                      },
-                    },
-                    stopReason: "stop" as const,
-                    timestamp: 2,
-                  },
-                ],
+                piMessages,
                 diagnostics: {
                   assistantMessageCount: 1,
                   modelId: "fake-agent-model",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -365,6 +365,9 @@ importers:
       '@chat-adapter/slack':
         specifier: 4.29.0
         version: 4.29.0(ai@6.0.190(zod@4.4.3))(zod@4.4.3)
+      '@earendil-works/pi-ai':
+        specifier: 0.80.6
+        version: 0.80.6(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)
       '@sentry/junior':
         specifier: workspace:*
         version: file:packages/junior


### PR DESCRIPTION
Agent runs now deliver the completed Pi `AssistantMessage` itself. Slack, resumed Slack, and local destinations derive visible text from that message; after the destination accepts it, Junior atomically appends the `assistant_message` before the visible assistant `message`. Conversation reports therefore show bundled reasoning before the answer it produced.

The delivery port carries neither history nor a duplicate text value. Prompt and tool-result history remains owned by the runner’s existing durable checkpoints, while the visible message ID makes accepted assistant output idempotent across persistence retries. Non-agent fallback replies, lifecycle behavior, recovery, and historical data are unchanged.

The production ordering contract is covered end to end in the existing Slack post-delivery integration scenario: a scripted Pi response runs through the real agent executor, destination delivery, accepted-reply transaction, and conversation-report projection. Eval `reply_texts` uses the same approach, replacing only Pi’s model stream while leaving routing, prompt assembly, checkpoints, delivery, and transcript completion on the normal runtime path.
