### PR TITLE
feat(github): watch deployments by commit

### DIFF
--- a/packages/docs/src/content/docs/extend/github-plugin.md
+++ b/packages/docs/src/content/docs/extend/github-plugin.md
@@ -155,12 +155,13 @@ Webhook events are delivered as normal queued conversation messages. They do not
 
 ## Watch deployment events
 
-Use `github_getDeployment` when Junior should inspect or watch the deployment
-for an exact repository, environment, and full commit SHA. The result includes
-the latest matching deployment and its latest status when GitHub has created
-one. It also remains subscribable before the deployment exists, which lets
-Junior wait for a deployment that will be created after a branch merge or
-release action.
+Use `github_getDeployment` when Junior should inspect or watch deployments for
+an exact repository and full commit SHA. Supply an environment to limit the
+lookup and watch to that environment, or omit it to watch deployments for the
+commit across environments. The result includes the latest matching deployment
+and its latest status when GitHub has created one. It also remains subscribable
+before the deployment exists, which lets Junior wait for a deployment that
+will be created after a branch merge or release action.
 
 The GitHub App needs `Deployments: read`, and its webhook must subscribe to
 both Deployment and Deployment status. Junior maps those deliveries to these

--- a/packages/docs/src/content/docs/extend/github-plugin.md
+++ b/packages/docs/src/content/docs/extend/github-plugin.md
@@ -172,10 +172,12 @@ resource events:
 | `deployment` created        | `deployment.created`                                                                                                                 |
 | `deployment_status` created | `deployment.queued`, `deployment.pending`, `deployment.in_progress`, `deployment.succeeded`, `deployment.failed`, `deployment.error` |
 
-Success, failure, and error complete the subscription after Junior accepts the
-event. Creation and progress events keep the watch active. GitHub does not send
-a `deployment_status` webhook for the `inactive` state, so Junior does not
-offer an inactive event.
+For an environment-specific watch, success, failure, and error complete the
+subscription after Junior accepts the event. A commit-wide watch remains active
+across terminal outcomes so it can observe deployments in later environments;
+it ends through cancellation or its configured TTL. Creation and progress
+events keep either watch active. GitHub does not send a `deployment_status`
+webhook for the `inactive` state, so Junior does not offer an inactive event.
 
 The GitHub plugin classifies a pull request or issue as Junior-owned on its
 signed `opened` event when the author matches the bot login derived from

--- a/packages/junior-github/SETUP.md
+++ b/packages/junior-github/SETUP.md
@@ -88,6 +88,8 @@ webhooks are configured, its result can subscribe the current conversation to
 deployment creation, progress, success, failure, and error events. Omitting the
 environment watches deployments for that commit across environments. The
 subscription remains available when GitHub has not created the deployment yet.
+Commit-wide watches remain active across terminal outcomes so later
+environments for the same commit can also notify the conversation.
 
 ```bash
 vercel env add GITHUB_WEBHOOK_SECRET production

--- a/packages/junior-github/SETUP.md
+++ b/packages/junior-github/SETUP.md
@@ -83,10 +83,11 @@ status, Issue comment, Pull request review, and Pull request review comment
 events.
 
 `github_getDeployment` reads the latest deployment and status for an exact
-repository, environment, and commit SHA. When webhooks are configured, its
-result can subscribe the current conversation to deployment creation, progress,
-success, failure, and error events. The subscription remains available when
-GitHub has not created the deployment yet.
+repository and commit SHA, optionally limited to one environment. When
+webhooks are configured, its result can subscribe the current conversation to
+deployment creation, progress, success, failure, and error events. Omitting the
+environment watches deployments for that commit across environments. The
+subscription remains available when GitHub has not created the deployment yet.
 
 ```bash
 vercel env add GITHUB_WEBHOOK_SECRET production

--- a/packages/junior-github/src/resource-events/deployment.ts
+++ b/packages/junior-github/src/resource-events/deployment.ts
@@ -19,23 +19,25 @@ const SUGGESTED_EVENTS = [
 /** Build the stable deployment-source identity shared by tools and webhooks. */
 export function gitHubDeploymentSourceResource(input: {
   commitSha: string;
-  environment: string;
+  environment?: string;
   repo: string;
 }): Pick<SubscribableResource, "label" | "provider" | "resourceRef"> {
   const commitSha = input.commitSha.toLowerCase();
-  const environment = input.environment.trim();
+  const environment = input.environment?.trim();
   const repo = input.repo.toLowerCase();
   return {
     label: `GitHub deployment for ${repo} at ${commitSha.slice(0, 12)}`,
     provider: "github",
-    resourceRef: `github:deployment-source:${repo}:${encodeURIComponent(environment.toLowerCase())}:${commitSha}`,
+    resourceRef: environment
+      ? `github:deployment-source:${repo}:${encodeURIComponent(environment.toLowerCase())}:${commitSha}`
+      : `github:deployment-source:${repo}:${commitSha}`,
   };
 }
 
 /** Describe a deployment source when GitHub webhooks are enabled. */
 export function gitHubDeploymentSourceSubscribable(input: {
   commitSha: string;
-  environment: string;
+  environment?: string;
   repo: string;
 }): SubscribableResource | undefined {
   if (!process.env.GITHUB_WEBHOOK_SECRET?.trim()) return undefined;

--- a/packages/junior-github/src/tools/get-deployment.ts
+++ b/packages/junior-github/src/tools/get-deployment.ts
@@ -21,7 +21,10 @@ const inputSchema = z
       .string()
       .trim()
       .min(1)
-      .describe('GitHub deployment environment, such as "Production".'),
+      .describe(
+        'Optional GitHub deployment environment, such as "Production". Omit to inspect and watch deployments for the commit across environments.',
+      )
+      .optional(),
   })
   .strict();
 const statusSchema = z
@@ -53,7 +56,7 @@ const deploymentSourceSchema = z
   .object({
     commitSha: commitShaSchema,
     deployment: deploymentSchema.nullable(),
-    environment: z.string(),
+    environment: z.string().nullable(),
     repo: z.string(),
     subscribable: subscribableResourceSchema.optional(),
   })
@@ -155,7 +158,7 @@ export function createGitHubGetDeploymentTool(
 ) {
   return definePluginTool({
     description:
-      "Get the latest GitHub deployment and status for an exact repository, environment, and full commit SHA. The result remains subscribable when no deployment exists yet, so use it before waiting for a deployment outcome.",
+      "Get the latest GitHub deployment and status for an exact repository and full commit SHA, optionally limited to one environment. The result remains subscribable when no deployment exists yet, so use it before waiting for a deployment outcome.",
     inputSchema,
     outputSchema,
     async execute(input): Promise<Result> {
@@ -163,7 +166,9 @@ export function createGitHubGetDeploymentTool(
       const commitSha = input.commitSha.toLowerCase();
       const deploymentsUrl = new URL(repositoryUrl(repo, "deployments"));
       deploymentsUrl.searchParams.set("sha", commitSha);
-      deploymentsUrl.searchParams.set("environment", input.environment);
+      if (input.environment) {
+        deploymentsUrl.searchParams.set("environment", input.environment);
+      }
       deploymentsUrl.searchParams.set("per_page", "1");
       const deploymentsResponse = await ctx.egress.fetch({
         provider: "github",
@@ -245,7 +250,7 @@ export function createGitHubGetDeploymentTool(
       const data: DeploymentSource = {
         commitSha,
         deployment,
-        environment: input.environment,
+        environment: input.environment ?? null,
         repo: repo.ref,
         ...(subscribable ? { subscribable } : {}),
       };

--- a/packages/junior-github/src/tools/get-pull-request.ts
+++ b/packages/junior-github/src/tools/get-pull-request.ts
@@ -10,6 +10,7 @@ import { z } from "zod";
 import { subscribableResourceSchema } from "@sentry/junior-plugin-api";
 import { gitHubPullRequestSubscribable } from "../resource-events/pull-request.js";
 
+const commitShaSchema = z.string().regex(/^[0-9a-f]{40}$/i);
 const inputSchema = z
   .object({
     repo: z.string().describe('Repository in "owner/name" format.'),
@@ -20,6 +21,7 @@ const pullRequestSchema = z.object({
   base: z.string(),
   draft: z.boolean(),
   head: z.string(),
+  headSha: commitShaSchema,
   merged: z.boolean(),
   number: z.number(),
   state: z.string(),
@@ -92,7 +94,7 @@ export function createGitHubGetPullRequestTool(
         .object({
           base: z.object({ ref: z.string() }),
           draft: z.boolean(),
-          head: z.object({ ref: z.string() }),
+          head: z.object({ ref: z.string(), sha: commitShaSchema }),
           html_url: z.string(),
           merged: z.boolean().optional().default(false),
           number: z.number(),
@@ -108,6 +110,7 @@ export function createGitHubGetPullRequestTool(
         base: providerResult.base.ref,
         draft: providerResult.draft,
         head: providerResult.head.ref,
+        headSha: providerResult.head.sha.toLowerCase(),
         merged: providerResult.merged,
         number: providerResult.number,
         state: providerResult.state,

--- a/packages/junior-github/src/webhooks/resource-events.ts
+++ b/packages/junior-github/src/webhooks/resource-events.ts
@@ -59,23 +59,18 @@ function parseDeploymentEvent(body: unknown) {
 function normalizeDeploymentEvent(
   deliveryId: string,
   body: unknown,
-): ResourceEvent | undefined {
+): ResourceEvent[] {
   const parsed = parseDeploymentEvent(body);
-  if (!parsed || parsed.action !== "created") return undefined;
-  const resource = gitHubDeploymentSourceResource({
-    commitSha: parsed.commitSha,
-    environment: parsed.environment,
-    repo: parsed.repo,
-  });
+  if (!parsed || parsed.action !== "created") return [];
   const eventType = "deployment.created";
-  return {
+  return deploymentSourceResources(parsed).map((resource) => ({
     eventKey: gitHubEventKey(deliveryId, eventType),
     eventType,
     occurredAtMs: providerTime(parsed.createdAt) ?? Date.now(),
     provider: "github",
     resourceRef: resource.resourceRef,
     trustedSummary: `${resource.label} was created (deployment ${parsed.deploymentId}).`,
-  };
+  }));
 }
 
 const deploymentStatusWebhookSchema = z
@@ -139,16 +134,11 @@ function deploymentStatusEventType(state: string): string | undefined {
 function normalizeDeploymentStatusEvent(
   deliveryId: string,
   body: unknown,
-): ResourceEvent | undefined {
+): ResourceEvent[] {
   const parsed = parseDeploymentStatusEvent(body);
-  if (!parsed || parsed.action !== "created") return undefined;
+  if (!parsed || parsed.action !== "created") return [];
   const eventType = deploymentStatusEventType(parsed.state);
-  if (!eventType) return undefined;
-  const resource = gitHubDeploymentSourceResource({
-    commitSha: parsed.commitSha,
-    environment: parsed.environment,
-    repo: parsed.repo,
-  });
+  if (!eventType) return [];
   const outcome =
     eventType === "deployment.succeeded"
       ? "succeeded"
@@ -163,7 +153,7 @@ function normalizeDeploymentStatusEvent(
     eventType === "deployment.succeeded" ||
     eventType === "deployment.failed" ||
     eventType === "deployment.error";
-  return {
+  return deploymentSourceResources(parsed).map((resource) => ({
     eventKey: gitHubEventKey(deliveryId, eventType),
     eventType,
     occurredAtMs: providerTime(parsed.statusCreatedAt) ?? Date.now(),
@@ -172,7 +162,22 @@ function normalizeDeploymentStatusEvent(
     ...(terminal ? { terminal: true } : {}),
     trustedSummary: `${resource.label} ${outcome} (deployment ${parsed.deploymentId}).`,
     untrustedText: parsed.description ?? undefined,
-  };
+  }));
+}
+
+/** Address one deployment through both its exact environment and its commit. */
+function deploymentSourceResources(input: {
+  commitSha: string;
+  environment: string;
+  repo: string;
+}) {
+  return [
+    gitHubDeploymentSourceResource(input),
+    gitHubDeploymentSourceResource({
+      commitSha: input.commitSha,
+      repo: input.repo,
+    }),
+  ];
 }
 
 const checkSuiteWebhookSchema = z.object({
@@ -408,12 +413,10 @@ export function normalizeGitHubResourceEvents(args: {
 }): ResourceEvent[] {
   switch (args.eventName) {
     case "deployment": {
-      const event = normalizeDeploymentEvent(args.deliveryId, args.body);
-      return event ? [event] : [];
+      return normalizeDeploymentEvent(args.deliveryId, args.body);
     }
     case "deployment_status": {
-      const event = normalizeDeploymentStatusEvent(args.deliveryId, args.body);
-      return event ? [event] : [];
+      return normalizeDeploymentStatusEvent(args.deliveryId, args.body);
     }
     case "pull_request": {
       const event = normalizePullRequestEvent(args.deliveryId, args.body);

--- a/packages/junior-github/src/webhooks/resource-events.ts
+++ b/packages/junior-github/src/webhooks/resource-events.ts
@@ -63,7 +63,7 @@ function normalizeDeploymentEvent(
   const parsed = parseDeploymentEvent(body);
   if (!parsed || parsed.action !== "created") return [];
   const eventType = "deployment.created";
-  return deploymentSourceResources(parsed).map((resource) => ({
+  return deploymentSourceTargets(parsed).map(({ resource }) => ({
     eventKey: gitHubEventKey(deliveryId, eventType),
     eventType,
     occurredAtMs: providerTime(parsed.createdAt) ?? Date.now(),
@@ -153,30 +153,38 @@ function normalizeDeploymentStatusEvent(
     eventType === "deployment.succeeded" ||
     eventType === "deployment.failed" ||
     eventType === "deployment.error";
-  return deploymentSourceResources(parsed).map((resource) => ({
-    eventKey: gitHubEventKey(deliveryId, eventType),
-    eventType,
-    occurredAtMs: providerTime(parsed.statusCreatedAt) ?? Date.now(),
-    provider: "github",
-    resourceRef: resource.resourceRef,
-    ...(terminal ? { terminal: true } : {}),
-    trustedSummary: `${resource.label} ${outcome} (deployment ${parsed.deploymentId}).`,
-    untrustedText: parsed.description ?? undefined,
-  }));
+  return deploymentSourceTargets(parsed).map(
+    ({ completeOnTerminalEvent, resource }) => ({
+      eventKey: gitHubEventKey(deliveryId, eventType),
+      eventType,
+      occurredAtMs: providerTime(parsed.statusCreatedAt) ?? Date.now(),
+      provider: "github",
+      resourceRef: resource.resourceRef,
+      ...(terminal && completeOnTerminalEvent ? { terminal: true } : {}),
+      trustedSummary: `${resource.label} ${outcome} (deployment ${parsed.deploymentId}).`,
+      untrustedText: parsed.description ?? undefined,
+    }),
+  );
 }
 
 /** Address one deployment through both its exact environment and its commit. */
-function deploymentSourceResources(input: {
+function deploymentSourceTargets(input: {
   commitSha: string;
   environment: string;
   repo: string;
 }) {
   return [
-    gitHubDeploymentSourceResource(input),
-    gitHubDeploymentSourceResource({
-      commitSha: input.commitSha,
-      repo: input.repo,
-    }),
+    {
+      completeOnTerminalEvent: true,
+      resource: gitHubDeploymentSourceResource(input),
+    },
+    {
+      completeOnTerminalEvent: false,
+      resource: gitHubDeploymentSourceResource({
+        commitSha: input.commitSha,
+        repo: input.repo,
+      }),
+    },
   ];
 }
 

--- a/packages/junior-github/tests/deployment-resource-events.test.ts
+++ b/packages/junior-github/tests/deployment-resource-events.test.ts
@@ -28,6 +28,16 @@ describe("GitHub deployment resource events", () => {
         trustedSummary:
           "GitHub deployment for getsentry/junior-prod at c610b5d6a88c was created (deployment 5634510476).",
       },
+      {
+        eventKey: "github:delivery-deployment:deployment.created",
+        eventType: "deployment.created",
+        occurredAtMs: Date.parse("2026-07-28T05:15:00.000Z"),
+        provider: "github",
+        resourceRef:
+          "github:deployment-source:getsentry/junior-prod:c610b5d6a88c9da5d65627a1cdb3829b05c14f75",
+        trustedSummary:
+          "GitHub deployment for getsentry/junior-prod at c610b5d6a88c was created (deployment 5634510476).",
+      },
     ]);
 
     expect(
@@ -58,6 +68,18 @@ describe("GitHub deployment resource events", () => {
           "GitHub deployment for getsentry/junior-prod at c610b5d6a88c failed (deployment 5634510476).",
         untrustedText: "Deployment has failed",
       },
+      {
+        eventKey: "github:delivery-status:deployment.failed",
+        eventType: "deployment.failed",
+        occurredAtMs: Date.parse("2026-07-28T05:17:14.000Z"),
+        provider: "github",
+        resourceRef:
+          "github:deployment-source:getsentry/junior-prod:c610b5d6a88c9da5d65627a1cdb3829b05c14f75",
+        terminal: true,
+        trustedSummary:
+          "GitHub deployment for getsentry/junior-prod at c610b5d6a88c failed (deployment 5634510476).",
+        untrustedText: "Deployment has failed",
+      },
     ]);
 
     expect(
@@ -74,6 +96,16 @@ describe("GitHub deployment resource events", () => {
     ).toEqual([
       expect.objectContaining({
         eventType: "deployment.succeeded",
+        resourceRef:
+          "github:deployment-source:getsentry/junior-prod:production:c610b5d6a88c9da5d65627a1cdb3829b05c14f75",
+        terminal: true,
+        trustedSummary:
+          "GitHub deployment for getsentry/junior-prod at c610b5d6a88c succeeded (deployment 5634510476).",
+      }),
+      expect.objectContaining({
+        eventType: "deployment.succeeded",
+        resourceRef:
+          "github:deployment-source:getsentry/junior-prod:c610b5d6a88c9da5d65627a1cdb3829b05c14f75",
         terminal: true,
         trustedSummary:
           "GitHub deployment for getsentry/junior-prod at c610b5d6a88c succeeded (deployment 5634510476).",

--- a/packages/junior-github/tests/deployment-resource-events.test.ts
+++ b/packages/junior-github/tests/deployment-resource-events.test.ts
@@ -75,25 +75,23 @@ describe("GitHub deployment resource events", () => {
         provider: "github",
         resourceRef:
           "github:deployment-source:getsentry/junior-prod:c610b5d6a88c9da5d65627a1cdb3829b05c14f75",
-        terminal: true,
         trustedSummary:
           "GitHub deployment for getsentry/junior-prod at c610b5d6a88c failed (deployment 5634510476).",
         untrustedText: "Deployment has failed",
       },
     ]);
 
-    expect(
-      normalizeGitHubResourceEvents({
-        body: {
-          action: "created",
-          deployment,
-          deployment_status: { state: "success" },
-          repository,
-        },
-        deliveryId: "delivery-success",
-        eventName: "deployment_status",
-      }),
-    ).toEqual([
+    const successEvents = normalizeGitHubResourceEvents({
+      body: {
+        action: "created",
+        deployment,
+        deployment_status: { state: "success" },
+        repository,
+      },
+      deliveryId: "delivery-success",
+      eventName: "deployment_status",
+    });
+    expect(successEvents).toEqual([
       expect.objectContaining({
         eventType: "deployment.succeeded",
         resourceRef:
@@ -106,11 +104,11 @@ describe("GitHub deployment resource events", () => {
         eventType: "deployment.succeeded",
         resourceRef:
           "github:deployment-source:getsentry/junior-prod:c610b5d6a88c9da5d65627a1cdb3829b05c14f75",
-        terminal: true,
         trustedSummary:
           "GitHub deployment for getsentry/junior-prod at c610b5d6a88c succeeded (deployment 5634510476).",
       }),
     ]);
+    expect(successEvents[1]).not.toHaveProperty("terminal");
   });
 
   it("keeps provider-controlled environment names out of trusted summaries", () => {

--- a/packages/junior-github/tests/get-deployment.test.ts
+++ b/packages/junior-github/tests/get-deployment.test.ts
@@ -117,6 +117,30 @@ describe("getDeployment", () => {
     expect(adapter.requests()).toHaveLength(1);
   });
 
+  it("watches every environment for a commit when environment is omitted", async () => {
+    vi.stubEnv("GITHUB_WEBHOOK_SECRET", "test-secret");
+    const { adapter, tool } = toolContext([{ body: [] }]);
+
+    await expect(
+      tool.execute?.(
+        {
+          commitSha: COMMIT_SHA,
+          repo: "GetSentry/Junior-Prod",
+        },
+        { toolCallId: "watch-commit-deployments" },
+      ),
+    ).resolves.toMatchObject({
+      deployment: null,
+      environment: null,
+      subscribable: {
+        resourceRef: `github:deployment-source:getsentry/junior-prod:${COMMIT_SHA}`,
+      },
+    });
+    const [request] = adapter.requests();
+    expect(request?.request.url).toContain(`sha=${COMMIT_SHA}`);
+    expect(request?.request.url).not.toContain("environment=");
+  });
+
   it("reports a missing repository as a repairable tool error", async () => {
     const { tool } = toolContext([
       { body: { message: "Not Found" }, status: 404 },

--- a/packages/junior-github/tests/get-pull-request.test.ts
+++ b/packages/junior-github/tests/get-pull-request.test.ts
@@ -3,13 +3,15 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { createGitHubGetPullRequestTool } from "../src/tools/get-pull-request";
 import { createGitHubApiTestAdapter } from "./github-api-adapter";
 
+const HEAD_SHA = "c610b5d6a88c9da5d65627a1cdb3829b05c14f75";
+
 function toolContext() {
   const adapter = createGitHubApiTestAdapter([
     {
       body: {
         base: { ref: "main" },
         draft: false,
-        head: { ref: "feat/resource-events" },
+        head: { ref: "feat/resource-events", sha: HEAD_SHA },
         html_url: "https://github.com/getsentry/junior/pull/691",
         merged: false,
         number: 691,
@@ -39,6 +41,7 @@ describe("getPullRequest", () => {
         { toolCallId: "get-pr" },
       ),
     ).resolves.toMatchObject({
+      headSha: HEAD_SHA,
       number: 691,
       subscribable: {
         label: "GitHub PR getsentry/junior#691",


### PR DESCRIPTION
GitHub deployment watches can now target a repository and commit across every environment by omitting the environment filter. Deployment webhooks publish both the existing environment-specific identity and the new commit-wide identity, so callers can subscribe before GitHub creates any matching deployment.

`github_getPullRequest` now returns the normalized head commit SHA, allowing workflows to connect a PR to its deployment watch without reconstructing that relationship from local Git state. Existing environment-specific deployment watches remain unchanged.
