### PR TITLE
fix(memory): persist personal recall context

### DIFF
--- a/packages/junior-dashboard/tests/markdownExport.test.ts
+++ b/packages/junior-dashboard/tests/markdownExport.test.ts
@@ -100,6 +100,13 @@ describe("dashboard canonical-event Markdown export", () => {
           content: {
             memories: [
               {
+                id: "memory-personal",
+                content: "Prefers release summaries with risks first.",
+                observedAtMs: Date.parse("2026-01-02T00:00:00.000Z"),
+                scope: "personal",
+                kind: "preference",
+              },
+              {
                 id: "memory-1",
                 content: "Release notes live in Notion.",
                 observedAtMs: Date.parse("2026-01-01T00:00:00.000Z"),
@@ -113,6 +120,9 @@ describe("dashboard canonical-event Markdown export", () => {
     );
 
     expect(markdown).toContain("#### Recalled memories");
+    expect(markdown).toContain("Prefers release summaries with risks first.");
+    expect(markdown).toContain("`memory-personal`");
+    expect(markdown).toContain("Scope: personal");
     expect(markdown).toContain("Release notes live in Notion.");
     expect(markdown).toContain("`memory-1`");
     expect(markdown).toContain("Scope: conversation");

--- a/packages/junior-memory/src/recall.ts
+++ b/packages/junior-memory/src/recall.ts
@@ -108,12 +108,7 @@ const memoryRecallContext = definePromptContext({
   renderPrompt: (content) => renderMemoryPrompt(content.memories),
 });
 
-/**
- * Build active memory recall contributions.
- *
- * Personal recall remains prompt-only so conversation reporting cannot widen
- * actor-scoped memory visibility.
- */
+/** Build active memory recall contributions. */
 export async function createMemoryPromptContributions(
   context: MemoryRecallContext,
 ): Promise<UserPromptContribution[] | undefined> {
@@ -161,9 +156,6 @@ export async function createMemoryPromptContributions(
   const selected = selectPromptMemories(relevant);
   if (selected.length === 0) {
     return undefined;
-  }
-  if (selected.some((memory) => memory.scope === "personal")) {
-    return [{ text: renderMemoryPrompt(selected) }];
   }
   return [memoryRecallContext({ memories: selected })];
 }

--- a/packages/junior-memory/tests/storage.test.ts
+++ b/packages/junior-memory/tests/storage.test.ts
@@ -3330,7 +3330,7 @@ WHERE id = '${superseded.memory.id}'
     }
   }, 15_000);
 
-  it("keeps personal memory recall out of durable prompt context", async () => {
+  it("retains personal and conversation memory recall as structured prompt context", async () => {
     const fixture = await createMemoryFixture();
 
     try {
@@ -3382,11 +3382,33 @@ WHERE id = '${superseded.memory.id}'
       });
 
       const contribution = result?.[0];
-      expect(contribution && "text" in contribution).toBe(true);
-      if (!contribution || !("text" in contribution)) {
-        throw new Error("Memory recall did not return prompt text");
+      expect(contribution && "context" in contribution).toBe(true);
+      if (!contribution || !("context" in contribution)) {
+        throw new Error("Memory recall did not return structured context");
       }
-      const text = contribution.text;
+      expect(contribution.context).toEqual({
+        kind: "recall",
+        version: 1,
+        content: {
+          memories: [
+            {
+              id: conversation.memory.id,
+              content: conversation.memory.content,
+              kind: conversation.memory.kind,
+              observedAtMs: conversation.memory.observedAtMs,
+              scope: "conversation",
+            },
+            {
+              id: personal.memory.id,
+              content: personal.memory.content,
+              kind: personal.memory.kind,
+              observedAtMs: personal.memory.observedAtMs,
+              scope: "personal",
+            },
+          ],
+        },
+      });
+      const text = contribution.renderPrompt();
       expect(text).toContain(`Observed 2026-06-19: ${personal.memory.content}`);
       expect(text).toContain(conversation.memory.content);
       expect(text).not.toContain(personal.memory.id);
@@ -3652,11 +3674,11 @@ WHERE id = '${superseded.memory.id}'
         text: query,
       });
       const contribution = result?.[0];
-      expect(contribution && "text" in contribution).toBe(true);
-      if (!contribution || !("text" in contribution)) {
-        throw new Error("Memory recall did not return prompt text");
+      expect(contribution && "context" in contribution).toBe(true);
+      if (!contribution || !("context" in contribution)) {
+        throw new Error("Memory recall did not return structured context");
       }
-      expect(contribution.text).toContain(memory);
+      expect(contribution.renderPrompt()).toContain(memory);
     } finally {
       await fixture.close();
     }


### PR DESCRIPTION
Personal memory recalls now use the same structured turn context as conversation recalls, so the dashboard reports the preferences that informed a turn instead of silently dropping them. Personal is an actor-ownership scope, not a privacy classification; stored memory content already must satisfy the plugin's public/shareable policy.

Regression coverage exercises mixed personal and conversation recall, semantic personal recall, and dashboard Markdown export. The existing context schema and dashboard renderer already support personal memories, so this requires no migration or dashboard runtime change.
