### PR TITLE
feat(memory): add system diagnostics

### DIFF
--- a/packages/junior-memory/src/operational-report.ts
+++ b/packages/junior-memory/src/operational-report.ts
@@ -41,8 +41,8 @@ async function aggregateMemoryDays(args: { db: MemoryDb; nowMs: number }) {
   const result = await args.db.execute(sql`
     WITH days AS (
       SELECT generate_series(
-        ${start}::date,
-        ${end}::date,
+        date_trunc('day', ${start}::timestamptz AT TIME ZONE 'UTC'),
+        date_trunc('day', ${end}::timestamptz AT TIME ZONE 'UTC'),
         interval '1 day'
       ) AS day
     ), daily AS (

--- a/packages/junior-memory/src/operational-report.ts
+++ b/packages/junior-memory/src/operational-report.ts
@@ -1,0 +1,191 @@
+import type { PluginOperationalReportContent } from "@sentry/junior-plugin-api";
+import { and, eq, gt, isNull, or, sql } from "drizzle-orm";
+import { z } from "zod";
+import { juniorMemoryEmbeddings, juniorMemoryMemories } from "./db/schema";
+import type { MemoryDb } from "./store";
+
+const DAY_MS = 24 * 60 * 60 * 1_000;
+const WINDOWS = [7, 30, 90] as const;
+
+const memoryDaySchema = z
+  .object({
+    conversation: z.number().int().nonnegative(),
+    date: z.string().date(),
+    personal: z.number().int().nonnegative(),
+  })
+  .strict();
+
+function queryRows(result: unknown): unknown[] {
+  if (
+    typeof result !== "object" ||
+    result === null ||
+    !("rows" in result) ||
+    !Array.isArray(result.rows)
+  ) {
+    throw new TypeError("Memory activity query did not return rows");
+  }
+  return result.rows;
+}
+
+function startOfUtcDay(value: number): Date {
+  const date = new Date(value);
+  date.setUTCHours(0, 0, 0, 0);
+  return date;
+}
+
+async function aggregateMemoryDays(args: { db: MemoryDb; nowMs: number }) {
+  const end = startOfUtcDay(args.nowMs);
+  const start = startOfUtcDay(args.nowMs - (WINDOWS.at(-1)! - 1) * DAY_MS);
+  const endExclusiveMs = end.getTime() + DAY_MS;
+  const table = juniorMemoryMemories;
+  const result = await args.db.execute(sql`
+    WITH days AS (
+      SELECT generate_series(
+        ${start}::date,
+        ${end}::date,
+        interval '1 day'
+      ) AS day
+    ), daily AS (
+      SELECT
+        date_trunc(
+          'day',
+          to_timestamp(${table.createdAtMs} / 1000.0) AT TIME ZONE 'UTC'
+        ) AS day,
+        count(*) FILTER (
+          WHERE ${table.scope} = 'personal'
+        )::integer AS personal,
+        count(*) FILTER (
+          WHERE ${table.scope} = 'conversation'
+        )::integer AS conversation
+      FROM ${table}
+      WHERE ${table.createdAtMs} >= ${start.getTime()}
+        AND ${table.createdAtMs} < ${endExclusiveMs}
+      GROUP BY date_trunc(
+        'day',
+        to_timestamp(${table.createdAtMs} / 1000.0) AT TIME ZONE 'UTC'
+      )
+    )
+    SELECT
+      to_char(days.day, 'YYYY-MM-DD') AS date,
+      coalesce(daily.personal, 0)::integer AS personal,
+      coalesce(daily.conversation, 0)::integer AS conversation
+    FROM days
+    LEFT JOIN daily ON daily.day = days.day
+    ORDER BY days.day
+  `);
+  return z.array(memoryDaySchema).parse(queryRows(result));
+}
+
+function formatCount(value: number): string {
+  return new Intl.NumberFormat("en-US").format(value);
+}
+
+function formatPercent(value: number): string {
+  return new Intl.NumberFormat("en-US", {
+    maximumFractionDigits: 0,
+    style: "percent",
+  }).format(value);
+}
+
+/** Build aggregate memory storage and indexing diagnostics for the System page. */
+export async function buildMemoryOperationalReport(args: {
+  db: MemoryDb;
+  nowMs: number;
+}): Promise<PluginOperationalReportContent> {
+  const active = and(
+    isNull(juniorMemoryMemories.archivedAtMs),
+    isNull(juniorMemoryMemories.supersededAtMs),
+    isNull(juniorMemoryMemories.supersededById),
+    or(
+      isNull(juniorMemoryMemories.expiresAtMs),
+      gt(juniorMemoryMemories.expiresAtMs, args.nowMs),
+    ),
+  );
+  const [[counts], memoryDays] = await Promise.all([
+    args.db
+      .select({
+        active: sql<number>`count(*) filter (where ${active})`.mapWith(Number),
+        conversation:
+          sql<number>`count(*) filter (where ${active} and ${juniorMemoryMemories.scope} = 'conversation')`.mapWith(
+            Number,
+          ),
+        createdThirtyDays:
+          sql<number>`count(*) filter (where ${juniorMemoryMemories.createdAtMs} >= ${args.nowMs - 30 * DAY_MS})`.mapWith(
+            Number,
+          ),
+        embedded:
+          sql<number>`count(${juniorMemoryEmbeddings.memoryId}) filter (where ${active})`.mapWith(
+            Number,
+          ),
+        personal:
+          sql<number>`count(*) filter (where ${active} and ${juniorMemoryMemories.scope} = 'personal')`.mapWith(
+            Number,
+          ),
+      })
+      .from(juniorMemoryMemories)
+      .leftJoin(
+        juniorMemoryEmbeddings,
+        eq(juniorMemoryEmbeddings.memoryId, juniorMemoryMemories.id),
+      ),
+    aggregateMemoryDays(args),
+  ]);
+
+  const activeCount = counts?.active ?? 0;
+  const embeddedCount = counts?.embedded ?? 0;
+  const embeddingCoverage = activeCount === 0 ? 0 : embeddedCount / activeCount;
+
+  return {
+    generatedAt: new Date(args.nowMs).toISOString(),
+    title: "Memory",
+    metrics: [
+      {
+        label: "active memories",
+        tone: activeCount > 0 ? "good" : "neutral",
+        value: formatCount(activeCount),
+      },
+      {
+        label: "created · 30d",
+        value: formatCount(counts?.createdThirtyDays ?? 0),
+      },
+      {
+        label: "personal",
+        value: formatCount(counts?.personal ?? 0),
+      },
+      {
+        label: "conversation",
+        value: formatCount(counts?.conversation ?? 0),
+      },
+      {
+        label: "embedding coverage",
+        tone:
+          activeCount === 0
+            ? "neutral"
+            : embeddedCount === activeCount
+              ? "good"
+              : "warning",
+        value: formatPercent(embeddingCoverage),
+      },
+    ],
+    widgets: [
+      {
+        categories: memoryDays.map((day) => ({
+          id: day.date,
+          label: day.date,
+          values: {
+            conversation: day.conversation,
+            personal: day.personal,
+          },
+        })),
+        description: "Memories stored per day by scope",
+        id: "memories-created",
+        series: [
+          { key: "personal", label: "Personal" },
+          { key: "conversation", label: "Conversation" },
+        ],
+        timeRangeDays: [...WINDOWS],
+        title: "Memories created",
+        type: "bar_chart",
+      },
+    ],
+  };
+}

--- a/packages/junior-memory/src/plugin.ts
+++ b/packages/junior-memory/src/plugin.ts
@@ -13,6 +13,7 @@ import {
 } from "./tools";
 import { processMemorySession } from "./process-session";
 import { createMemoryPromptContributions } from "./recall";
+import { buildMemoryOperationalReport } from "./operational-report";
 import type { MemoryDb } from "./store";
 import { createMemoryUserPage } from "./user-pages";
 
@@ -111,6 +112,12 @@ export function memoryPlugin(options: MemoryPluginOptions = {}) {
     },
     userPages: [createMemoryUserPage()],
     hooks: {
+      async operationalReport(ctx) {
+        return await buildMemoryOperationalReport({
+          db: ctx.db as MemoryDb,
+          nowMs: ctx.nowMs,
+        });
+      },
       apiRoutes(ctx) {
         return createMemoryApi({
           actors: ctx.viewer.actors,

--- a/packages/junior-memory/tests/operational-report.test.ts
+++ b/packages/junior-memory/tests/operational-report.test.ts
@@ -1,0 +1,169 @@
+import { readdir, readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  createLocalPgliteFixture,
+  pgliteVectorExtension,
+  type LocalPgliteFixture,
+} from "@sentry/junior-testing/pglite";
+import { createLocalSource } from "@sentry/junior-plugin-api";
+import { describe, expect, it } from "vitest";
+import * as memorySqlSchema from "../src/db/schema";
+import { juniorMemoryMemories } from "../src/db/schema";
+import { buildMemoryOperationalReport } from "../src/operational-report";
+import { createMemoryStore, type MemoryDb } from "../src/store";
+
+const TEST_NOW_MS = Date.parse("2026-07-28T12:00:00.000Z");
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+type MemoryFixture = LocalPgliteFixture<MemoryDb>;
+
+async function createMemoryFixture(): Promise<MemoryFixture> {
+  const fixture = await createLocalPgliteFixture<MemoryDb>(memorySqlSchema, {
+    extensions: { vector: pgliteVectorExtension },
+  });
+  const migrations = (await readdir(resolve(__dirname, "../migrations")))
+    .filter((filename) => filename.endsWith(".sql"))
+    .sort();
+  for (const migration of migrations) {
+    await fixture.execute(
+      await readFile(resolve(__dirname, "../migrations", migration), "utf8"),
+    );
+  }
+  return fixture;
+}
+
+function localContext() {
+  return {
+    conversationId: "local:junior:memory-report",
+    actor: { platform: "local" as const, userId: "report-user" },
+    source: createLocalSource("local:junior:memory-report"),
+  };
+}
+
+function testEmbedder() {
+  return {
+    async embedTexts(input: { texts: string[] }) {
+      return {
+        dimensions: 1536,
+        model: "test-model",
+        provider: "test-provider",
+        vectors: input.texts.map(() => [
+          1,
+          ...Array.from({ length: 1535 }, () => 0),
+        ]),
+      };
+    },
+  };
+}
+
+describe("memory operational report", () => {
+  it("reports an empty memory system", async () => {
+    const fixture = await createMemoryFixture();
+    try {
+      const report = await buildMemoryOperationalReport({
+        db: fixture.db(),
+        nowMs: TEST_NOW_MS,
+      });
+      expect(report).toMatchObject({
+        generatedAt: "2026-07-28T12:00:00.000Z",
+        title: "Memory",
+        metrics: [
+          {
+            label: "active memories",
+            tone: "neutral",
+            value: "0",
+          },
+          { label: "created · 30d", value: "0" },
+          { label: "personal", value: "0" },
+          { label: "conversation", value: "0" },
+          {
+            label: "embedding coverage",
+            tone: "neutral",
+            value: "0%",
+          },
+        ],
+      });
+      expect(report.widgets).toEqual([
+        expect.objectContaining({
+          id: "memories-created",
+          series: [
+            { key: "personal", label: "Personal" },
+            { key: "conversation", label: "Conversation" },
+          ],
+          timeRangeDays: [7, 30, 90],
+          title: "Memories created",
+          type: "bar_chart",
+        }),
+      ]);
+      expect(report.widgets?.[0]?.categories).toHaveLength(90);
+      expect(
+        report.widgets?.[0]?.categories.every((day) => {
+          return day.values.personal === 0 && day.values.conversation === 0;
+        }),
+      ).toBe(true);
+    } finally {
+      await fixture.close();
+    }
+  });
+
+  it("counts active scopes and embedding coverage without exposing contents", async () => {
+    const fixture = await createMemoryFixture();
+    try {
+      const db = fixture.db();
+      const store = createMemoryStore(db, localContext(), {
+        embedder: testEmbedder(),
+        now: () => TEST_NOW_MS,
+      });
+      await store.createMemory({
+        content: "Use compact pull request summaries.",
+        idempotencyKey: "report-personal",
+        kind: "preference",
+      });
+      await store.createConversationMemory({
+        content: "The checkout runbook lives in the service repository.",
+        idempotencyKey: "report-conversation",
+        kind: "procedure",
+      });
+      await db.insert(juniorMemoryMemories).values({
+        archivedAtMs: TEST_NOW_MS,
+        content: "Archived memory content.",
+        createdAtMs: TEST_NOW_MS,
+        id: "archived-memory",
+        kind: "knowledge",
+        observedAtMs: TEST_NOW_MS,
+        scope: "personal",
+        scopeKey: "local:report-user",
+        sourceKey: "local:junior:memory-report",
+        sourcePlatform: "local",
+        subjectKey: "report-user",
+        subjectType: "user",
+      });
+
+      const report = await buildMemoryOperationalReport({
+        db,
+        nowMs: TEST_NOW_MS,
+      });
+
+      expect(report.metrics).toEqual([
+        { label: "active memories", tone: "good", value: "2" },
+        { label: "created · 30d", value: "3" },
+        { label: "personal", value: "1" },
+        { label: "conversation", value: "1" },
+        { label: "embedding coverage", tone: "good", value: "100%" },
+      ]);
+      expect(report.widgets?.[0]?.categories.at(-1)).toEqual({
+        id: "2026-07-28",
+        label: "2026-07-28",
+        values: {
+          conversation: 1,
+          personal: 2,
+        },
+      });
+      expect(JSON.stringify(report)).not.toContain("checkout");
+      expect(JSON.stringify(report)).not.toContain("report-user");
+    } finally {
+      await fixture.close();
+    }
+  });
+});

--- a/packages/junior-memory/tests/operational-report.test.ts
+++ b/packages/junior-memory/tests/operational-report.test.ts
@@ -58,6 +58,46 @@ function testEmbedder() {
 }
 
 describe("memory operational report", () => {
+  it("keeps chart days in UTC when the database session uses another timezone", async () => {
+    const fixture = await createMemoryFixture();
+    try {
+      await fixture.execute("SET TIME ZONE 'America/Los_Angeles'");
+      await fixture
+        .db()
+        .insert(juniorMemoryMemories)
+        .values({
+          content: "A memory created shortly after UTC midnight.",
+          createdAtMs: Date.parse("2026-07-28T00:30:00.000Z"),
+          id: "utc-boundary-memory",
+          kind: "knowledge",
+          observedAtMs: Date.parse("2026-07-28T00:30:00.000Z"),
+          scope: "personal",
+          scopeKey: "local:report-user",
+          sourceKey: "local:junior:memory-report",
+          sourcePlatform: "local",
+          subjectKey: "report-user",
+          subjectType: "user",
+        });
+
+      const report = await buildMemoryOperationalReport({
+        db: fixture.db(),
+        nowMs: TEST_NOW_MS,
+      });
+
+      expect(report.widgets?.[0]?.categories).toHaveLength(90);
+      expect(report.widgets?.[0]?.categories.at(-1)).toEqual({
+        id: "2026-07-28",
+        label: "2026-07-28",
+        values: {
+          conversation: 0,
+          personal: 1,
+        },
+      });
+    } finally {
+      await fixture.close();
+    }
+  });
+
   it("reports an empty memory system", async () => {
     const fixture = await createMemoryFixture();
     try {


### PR DESCRIPTION
The Memory System page now exposes aggregate operational diagnostics: active and recently created memory counts, scope totals, embedding coverage, and a 7/30/90-day creation chart split between personal and conversation memories.

Snapshot metrics continue to exclude archived, superseded, and expired memories. Creation activity intentionally includes memories that were later archived or superseded so historical bars remain an honest record of writes. The report contains no memory content or actor identifiers, and PGlite integration coverage exercises empty, active, embedded, and archived states.
