### PR TITLE
fix(tools): bound conversation event query responses

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -72,8 +72,16 @@ Tool failures or slow tool calls.
 
 ```text
 dataset=spans query='span.op:gen_ai.execute_tool gen_ai.tool.name:"<tool_name>"'
-fields=timestamp,trace,span.description,span.duration,gen_ai.conversation.id,error.type
+fields=timestamp,trace,span.description,span.duration,gen_ai.conversation.id,gen_ai.tool.call.result.size,error.type
 sort=-timestamp
+```
+
+Large tool results.
+
+```text
+dataset=spans query='span.op:gen_ai.execute_tool gen_ai.tool.call.result.size:>20000'
+fields=timestamp,trace,gen_ai.conversation.id,gen_ai.tool.name,gen_ai.tool.call.result.size,span.duration
+sort=-gen_ai.tool.call.result.size
 ```
 
 Search tool volume, truncation, and raw output size.
@@ -160,7 +168,8 @@ Events: `agent_tool_call_failed`, `mcp_tool_call_failed`,
 Spans: `execute_tool <toolName>`, `sandbox.acquire`, `sandbox.create`,
 `sandbox.snapshot.resolve`, `sandbox.sync_skills`, `bash`
 
-Attributes: `gen_ai.tool.name`, `gen_ai.tool.call.id`, `gen_ai.tool.call.result`, `mcp.method.name`,
+Attributes: `gen_ai.tool.name`, `gen_ai.tool.call.id`,
+`gen_ai.tool.call.result`, `gen_ai.tool.call.result.size`, `mcp.method.name`,
 `process.executable.name`, `process.exit.code`, `app.sandbox.source`,
 `app.sandbox.snapshot.resolve_outcome`, `app.sandbox.search.raw_output_bytes`,
 `app.sandbox.search.parsed_records`,

--- a/packages/junior/src/chat/conversation-privacy.ts
+++ b/packages/junior/src/chat/conversation-privacy.ts
@@ -134,9 +134,11 @@ export function toGenAiPayloadTraceAttributes(
   prefix: "gen_ai.tool.call.arguments" | "gen_ai.tool.call.result",
   payload: unknown,
 ): Record<string, TraceAttributeValue> {
+  const size = serializedLength(payload);
   const attributes: Record<string, TraceAttributeValue> = {
     [`${prefix}.type`]: payloadType(payload),
-    [`${prefix}.size_chars`]: serializedLength(payload),
+    [`${prefix}.size_chars`]: size,
+    [`${prefix}.size`]: size,
   };
   const keys = payloadKeys(payload);
   if (keys) {

--- a/packages/junior/src/chat/conversations/README.md
+++ b/packages/junior/src/chat/conversations/README.md
@@ -71,9 +71,11 @@ assistant reasoning. Mixed reasoning and tool history extends the existing
 `tool_calls` event with ordering metadata; reasoning-only history uses
 `assistant_message`. Tool payloads and lifecycle remain owned by `tool_calls`.
 The deferred `queryConversationEvents` tool is the agent-facing
-observational reader for that same log: it returns bounded raw events for the
+observational reader for that same log: it returns bounded events for the
 current conversation tree, or for another retained public conversation in the
-same Slack workspace.
+same Slack workspace. Oversized event data is represented by identifying
+fields and its original JSON byte size. The complete event array also has a
+fixed byte budget and reports omitted events through its pagination contract.
 
 ## Stored Event Compatibility
 

--- a/packages/junior/src/chat/tools/query-conversation-events.ts
+++ b/packages/junior/src/chat/tools/query-conversation-events.ts
@@ -18,6 +18,10 @@ import type { ToolRuntimeContext } from "@/chat/tools/types";
 
 const DEFAULT_LIMIT = 25;
 const MAX_LIMIT = 100;
+const MAX_EVENT_DATA_BYTES = 4_000;
+const MAX_EVENTS_JSON_BYTES = 20_000;
+const MAX_IDENTITY_CHARS = 256;
+const textEncoder = new TextEncoder();
 const CONVERSATION_EVENTS_TOOL_SOURCE = {
   id: "conversation-events",
   description:
@@ -49,7 +53,7 @@ const projectedEventSchema = z
     data: z
       .record(z.string(), z.unknown())
       .describe(
-        "Event payload. The type field identifies the event; replacement-history events report replacement_history_count instead of replaying the full model context.",
+        "Event data. Oversized payloads are replaced by identifying fields, payload_omitted, and payload_json_bytes.",
       ),
   })
   .strict();
@@ -67,6 +71,14 @@ const queryConversationEventsOutputSchema = juniorToolResultSchema.extend({
     .describe(
       "Whether matching events exist after this page; request them with after_seq set to the last returned seq.",
     ),
+  omitted_event_count: z
+    .number()
+    .int()
+    .nonnegative()
+    .optional()
+    .describe(
+      "Fetched events omitted to keep this response bounded. Continue with the pagination cursor for the omitted direction.",
+    ),
 });
 
 interface QueryAccessScope {
@@ -76,7 +88,7 @@ interface QueryAccessScope {
   providerTenantId?: string;
 }
 
-/** Create a deferred tool that returns a bounded raw conversation event page. */
+/** Create a deferred tool that returns a bounded conversation event page. */
 export function createQueryConversationEventsTool(context: ToolRuntimeContext) {
   return zodTool({
     description:
@@ -197,15 +209,22 @@ export function createQueryConversationEventsTool(context: ToolRuntimeContext) {
         ...(beforeSeq === undefined ? {} : { beforeSeq }),
         ...(types === undefined ? {} : { types }),
       });
-      const events = projectEventsForTool(page);
+      const newestFirst = afterSeq === undefined;
+      const projected = projectEventsForTool(page, { newestFirst });
 
       return {
         ok: true,
         status: "success" as const,
         conversation_id: conversationId,
-        events,
-        has_older: page.hasOlder,
-        has_newer: page.hasNewer,
+        events: projected.events,
+        has_older:
+          page.hasOlder || (newestFirst && projected.omittedEventCount > 0),
+        has_newer:
+          page.hasNewer || (!newestFirst && projected.omittedEventCount > 0),
+        truncated: projected.omittedEventCount > 0,
+        ...(projected.omittedEventCount > 0
+          ? { omitted_event_count: projected.omittedEventCount }
+          : {}),
       };
     },
   });
@@ -338,12 +357,36 @@ function assertCanQueryConversationEvents(args: {
   );
 }
 
-function projectEventsForTool(page: ConversationEventPage) {
-  return page.events.map(projectEvent);
+function projectEventsForTool(
+  page: ConversationEventPage,
+  options: { newestFirst: boolean },
+) {
+  const projected = page.events.map(projectEvent);
+  const events = [];
+  let jsonBytes = 2;
+  const candidates = options.newestFirst ? [...projected].reverse() : projected;
+
+  for (const event of candidates) {
+    const eventBytes = jsonByteLength(event);
+    const separatorBytes = events.length === 0 ? 0 : 1;
+    if (jsonBytes + separatorBytes + eventBytes > MAX_EVENTS_JSON_BYTES) {
+      break;
+    }
+    events.push(event);
+    jsonBytes += separatorBytes + eventBytes;
+  }
+
+  if (options.newestFirst) {
+    events.reverse();
+  }
+  return {
+    events,
+    omittedEventCount: projected.length - events.length,
+  };
 }
 
 function projectEvent(event: ConversationEvent) {
-  const data = stripReplacementHistory(event.data);
+  const data = boundEventData(stripReplacementHistory(event.data));
   return {
     seq: event.seq,
     history_version: event.historyVersion,
@@ -351,6 +394,55 @@ function projectEvent(event: ConversationEvent) {
     ...(event.idempotencyKey ? { idempotency_key: event.idempotencyKey } : {}),
     data,
   };
+}
+
+function boundEventData(
+  data: ConversationEvent["data"] | Record<string, unknown>,
+) {
+  const payloadJsonBytes = jsonByteLength(data);
+  if (payloadJsonBytes <= MAX_EVENT_DATA_BYTES) {
+    return data;
+  }
+
+  return {
+    ...eventIdentity(data),
+    payload_omitted: true,
+    payload_json_bytes: payloadJsonBytes,
+  };
+}
+
+function jsonByteLength(value: unknown): number {
+  return textEncoder.encode(JSON.stringify(value)).byteLength;
+}
+
+function eventIdentity(data: Record<string, unknown>) {
+  const identityKeys = [
+    "type",
+    "originalType",
+    "messageId",
+    "role",
+    "turnId",
+    "toolCallId",
+    "toolName",
+    "subagentInvocationId",
+    "subagentKind",
+    "childConversationId",
+    "outcome",
+    "failureCode",
+    "provider",
+    "kind",
+    "modelProfile",
+    "modelId",
+  ] as const;
+
+  return Object.fromEntries(
+    identityKeys.flatMap((key) => {
+      const value = data[key];
+      return typeof value === "string"
+        ? [[key, value.slice(0, MAX_IDENTITY_CHARS)]]
+        : [];
+    }),
+  );
 }
 
 function stripReplacementHistory(

--- a/packages/junior/tests/integration/query-conversation-events.test.ts
+++ b/packages/junior/tests/integration/query-conversation-events.test.ts
@@ -128,6 +128,7 @@ describe("queryConversationEvents", () => {
       conversation_id: CURRENT_CONVERSATION_ID,
       has_older: true,
       has_newer: false,
+      truncated: false,
       events: [
         { seq: 1, data: { type: "message", text: "second" } },
         {
@@ -164,6 +165,74 @@ describe("queryConversationEvents", () => {
       events: [{ seq: 1 }],
       has_older: true,
       has_newer: true,
+    });
+
+    await events.append(CURRENT_CONVERSATION_ID, [
+      {
+        createdAtMs: 4,
+        data: {
+          type: "tool_result",
+          toolCallId: "tool-1",
+          toolName: "oversized",
+          isError: false,
+          content: [{ type: "text", text: "x".repeat(20_000) }],
+          timestamp: 4,
+        },
+      },
+    ]);
+    const oversized = await executeTool({
+      conversation_id: CURRENT_CONVERSATION_ID,
+      types: ["tool_result"],
+    });
+
+    expect(oversized.events).toEqual([
+      expect.objectContaining({
+        data: expect.objectContaining({
+          type: "tool_result",
+          toolCallId: "tool-1",
+          toolName: "oversized",
+          payload_omitted: true,
+          payload_json_bytes: expect.any(Number),
+        }),
+      }),
+    ]);
+    expect(oversized.events[0]!.data).not.toHaveProperty("json_preview");
+
+    await events.append(
+      CURRENT_CONVERSATION_ID,
+      Array.from({ length: 10 }, (_, index) => ({
+        createdAtMs: 5 + index,
+        data: {
+          type: "message" as const,
+          messageId: `large-${index}`,
+          role: "assistant" as const,
+          text: "y".repeat(3_500),
+        },
+      })),
+    );
+    const bounded = await executeTool({
+      conversation_id: CURRENT_CONVERSATION_ID,
+      types: ["message"],
+    });
+
+    expect(bounded.omitted_event_count).toBeGreaterThan(0);
+    expect(bounded.has_older).toBe(true);
+    expect(bounded.events.at(-1)?.data).toMatchObject({
+      messageId: "large-9",
+    });
+    expect(
+      new TextEncoder().encode(JSON.stringify(bounded.events)).byteLength,
+    ).toBeLessThanOrEqual(20_000);
+
+    const boundedNewer = await executeTool({
+      conversation_id: CURRENT_CONVERSATION_ID,
+      after_seq: 3,
+      types: ["message"],
+    });
+    expect(boundedNewer.omitted_event_count).toBeGreaterThan(0);
+    expect(boundedNewer.has_newer).toBe(true);
+    expect(boundedNewer.events[0]?.data).toMatchObject({
+      messageId: "large-0",
     });
   });
 

--- a/packages/junior/tests/unit/privacy/conversation-privacy.test.ts
+++ b/packages/junior/tests/unit/privacy/conversation-privacy.test.ts
@@ -75,6 +75,9 @@ describe("conversation privacy metadata", () => {
     expect(attributes["gen_ai.tool.call.arguments.keys"]).not.toContain(
       "privateKey20",
     );
+    expect(attributes["gen_ai.tool.call.arguments.size"]).toBe(
+      JSON.stringify(payload).length,
+    );
     expect(JSON.stringify(metadata)).not.toContain("private value");
   });
 });

--- a/packages/junior/tests/unit/tool-support/pi-tool-adapter-telemetry.test.ts
+++ b/packages/junior/tests/unit/tool-support/pi-tool-adapter-telemetry.test.ts
@@ -75,6 +75,13 @@ describe("createPiAgentTools telemetry", () => {
     expect(endAttributes.value["gen_ai.tool.call.result.keys"]).toContain(
       "secret",
     );
+    expect(endAttributes.value["gen_ai.tool.call.result.size"]).toBe(
+      JSON.stringify({
+        ok: true,
+        status: "success",
+        secret: "private result",
+      }).length,
+    );
   });
 
   it("lets sandbox tools add safe attributes to the tool call span", async () => {


### PR DESCRIPTION
`queryConversationEvents` now bounds model-visible event data by serialized UTF-8 size. Oversized payloads retain their identifying fields and original byte size, while event pages stop at a 20 KB budget and expose `truncated`, `omitted_event_count`, and the existing directional pagination hints. Native tool spans also expose `gen_ai.tool.call.result.size`, making large results queryable in Sentry without retaining their content.

Count-based pagination and replacement-history stripping previously allowed a single native tool result—or several moderately large events—to produce an unbounded tool response, while the existing `size_chars` metadata was not available through the same `.size` field used for model messages. Small event payloads and the existing 25/100 count limits remain unchanged. Coverage verifies oversized payload projection, the total byte ceiling, cursor behavior in both pagination directions, and private-safe tool size telemetry.
