### PR TITLE
feat(scheduler): add personal scheduled tasks page

### DIFF
--- a/packages/junior-scheduler/README.md
+++ b/packages/junior-scheduler/README.md
@@ -48,12 +48,18 @@ Junior's durable agent runtime.
   remains disabled.
 - Stored creator attribution grants no broader task-management or execution
   authority.
-- User-visible schedule management remains scoped to the active Slack context.
+- Slack tool management remains scoped to the active Slack context. The
+  dashboard may list and delete a viewer's own tasks across linked Slack
+  workspaces.
 
 ## Operations
 
 The plugin exposes create, update, delete, list, and run-now tools plus bounded
-operational reporting. Generate schema changes with
+operational reporting. The dashboard exposes a searchable **Scheduled tasks**
+user page containing non-deleted tasks created by the signed-in viewer's linked
+Slack actors. A viewer may delete those tasks from the page.
+
+Generate schema changes with
 `pnpm --filter @sentry/junior-scheduler db:generate`.
 
 Follow `../../policies/serverless-background-work.md`,

--- a/packages/junior-scheduler/migrations/0002_lying_risque.sql
+++ b/packages/junior-scheduler/migrations/0002_lying_risque.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "junior_scheduler_tasks" ADD COLUMN "creator_slack_user_id" text;--> statement-breakpoint
+UPDATE "junior_scheduler_tasks"
+SET "creator_slack_user_id" = "record"->'createdBy'->>'slackUserId';--> statement-breakpoint
+CREATE INDEX "junior_scheduler_tasks_creator_idx" ON "junior_scheduler_tasks" USING btree ("team_id","creator_slack_user_id","created_at_ms","id") WHERE "junior_scheduler_tasks"."status" <> 'deleted';

--- a/packages/junior-scheduler/migrations/meta/0002_snapshot.json
+++ b/packages/junior-scheduler/migrations/meta/0002_snapshot.json
@@ -1,0 +1,291 @@
+{
+  "id": "98d166a4-5084-4d72-838f-264405127046",
+  "prevId": "ccd0c14d-8a21-41aa-82b9-69a3d80cdc88",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.junior_scheduler_runs": {
+      "name": "junior_scheduler_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduled_for_ms": {
+          "name": "scheduled_for_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record": {
+          "name": "record",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "junior_scheduler_runs_task_status_idx": {
+          "name": "junior_scheduler_runs_task_status_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduled_for_ms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_scheduler_runs_status_idx": {
+          "name": "junior_scheduler_runs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduled_for_ms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_scheduler_tasks": {
+      "name": "junior_scheduler_tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_slack_user_id": {
+          "name": "creator_slack_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_run_at_ms": {
+          "name": "next_run_at_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_now_at_ms": {
+          "name": "run_now_at_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at_ms": {
+          "name": "created_at_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record": {
+          "name": "record",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "junior_scheduler_tasks_creator_idx": {
+          "name": "junior_scheduler_tasks_creator_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "creator_slack_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at_ms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"junior_scheduler_tasks\".\"status\" <> 'deleted'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_scheduler_tasks_team_status_idx": {
+          "name": "junior_scheduler_tasks_team_status_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at_ms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"junior_scheduler_tasks\".\"status\" <> 'deleted'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_scheduler_tasks_run_now_due_idx": {
+          "name": "junior_scheduler_tasks_run_now_due_idx",
+          "columns": [
+            {
+              "expression": "run_now_at_ms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at_ms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"junior_scheduler_tasks\".\"status\" = 'active' AND \"junior_scheduler_tasks\".\"run_now_at_ms\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_scheduler_tasks_next_run_due_idx": {
+          "name": "junior_scheduler_tasks_next_run_due_idx",
+          "columns": [
+            {
+              "expression": "next_run_at_ms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at_ms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"junior_scheduler_tasks\".\"status\" = 'active' AND \"junior_scheduler_tasks\".\"next_run_at_ms\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/junior-scheduler/migrations/meta/_journal.json
+++ b/packages/junior-scheduler/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1783964295816,
       "tag": "0001_explicit_credential_mode",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1785341122333,
+      "tag": "0002_lying_risque",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/junior-scheduler/src/api.ts
+++ b/packages/junior-scheduler/src/api.ts
@@ -1,0 +1,72 @@
+import {
+  pluginApiRouteRequestContextSchema,
+  type PluginApiRouteRequestContext,
+  type PluginRouteApp,
+  type PluginUserPageActor,
+} from "@sentry/junior-plugin-api";
+import {
+  createViewerScheduledTasks,
+  PersonalScheduledTaskNotFoundError,
+} from "./personal";
+import { createSchedulerSqlStore, type SchedulerDb } from "./store";
+
+interface SchedulerApiOptions {
+  actors(email: string): Promise<PluginUserPageActor[]>;
+  db: SchedulerDb;
+}
+
+function json(body: unknown, status: number): Response {
+  return Response.json(body, {
+    headers: { "cache-control": "no-store" },
+    status,
+  });
+}
+
+function viewerEmail(
+  context: PluginApiRouteRequestContext | undefined,
+): string | undefined {
+  const parsed = pluginApiRouteRequestContextSchema.safeParse(context);
+  if (!parsed.success || parsed.data.auth.user.emailVerified !== true) {
+    return undefined;
+  }
+  return parsed.data.auth.user.email?.trim().toLowerCase() || undefined;
+}
+
+/** Create authenticated API routes for personal scheduled-task actions. */
+export function createSchedulerApi(
+  options: SchedulerApiOptions,
+): PluginRouteApp {
+  return {
+    async fetch(request, context) {
+      const email = viewerEmail(context);
+      if (!email) {
+        return json({ error: "Authentication required." }, 401);
+      }
+
+      const taskPath = /^\/tasks\/([^/]+)$/.exec(new URL(request.url).pathname);
+      if (!taskPath) {
+        return json({ error: "Not found." }, 404);
+      }
+      if (request.method !== "DELETE") {
+        return json({ error: "Method not allowed." }, 405);
+      }
+
+      const actors = await options.actors(email);
+      try {
+        await createViewerScheduledTasks(
+          createSchedulerSqlStore(options.db),
+          actors,
+        ).delete(decodeURIComponent(taskPath[1]!));
+        return new Response(null, {
+          headers: { "cache-control": "no-store" },
+          status: 204,
+        });
+      } catch (error) {
+        if (error instanceof PersonalScheduledTaskNotFoundError) {
+          return json({ error: error.message }, 404);
+        }
+        throw error;
+      }
+    },
+  };
+}

--- a/packages/junior-scheduler/src/db/schema.ts
+++ b/packages/junior-scheduler/src/db/schema.ts
@@ -7,6 +7,7 @@ export const juniorSchedulerTasks = pgTable(
   {
     id: text("id").primaryKey(),
     teamId: text("team_id").notNull(),
+    creatorSlackUserId: text("creator_slack_user_id"),
     status: text("status").notNull(),
     nextRunAtMs: bigint("next_run_at_ms", { mode: "number" }),
     runNowAtMs: bigint("run_now_at_ms", { mode: "number" }),
@@ -14,6 +15,9 @@ export const juniorSchedulerTasks = pgTable(
     record: jsonb("record").$type<ScheduledTask>().notNull(),
   },
   (table) => [
+    index("junior_scheduler_tasks_creator_idx")
+      .on(table.teamId, table.creatorSlackUserId, table.createdAtMs, table.id)
+      .where(sql`${table.status} <> 'deleted'`),
     index("junior_scheduler_tasks_team_status_idx")
       .on(table.teamId, table.createdAtMs, table.id)
       .where(sql`${table.status} <> 'deleted'`),

--- a/packages/junior-scheduler/src/personal.ts
+++ b/packages/junior-scheduler/src/personal.ts
@@ -1,0 +1,135 @@
+import type { PluginUserPageActor } from "@sentry/junior-plugin-api";
+import { z } from "zod";
+import type { SchedulerStore } from "./store";
+import type { ScheduledTask } from "./types";
+
+const cursorSchema = z
+  .object({
+    createdAtMs: z.number().finite(),
+    id: z.string().min(1),
+    query: z.string().max(200).optional(),
+    version: z.literal(1),
+  })
+  .strict();
+
+type PersonalScheduledTaskStore = Pick<
+  SchedulerStore,
+  "getTask" | "listTasksCreatedBy" | "saveTask"
+>;
+
+export interface ViewerScheduledTaskPage {
+  nextCursor?: string;
+  tasks: ScheduledTask[];
+}
+
+export interface ViewerScheduledTaskPageInput {
+  cursor?: string;
+  limit: number;
+  query?: string;
+}
+
+export class InvalidScheduledTaskCursorError extends Error {
+  constructor() {
+    super("Scheduled task cursor is invalid.");
+    this.name = "InvalidScheduledTaskCursorError";
+  }
+}
+
+export class PersonalScheduledTaskNotFoundError extends Error {
+  constructor() {
+    super("Scheduled task was not found.");
+    this.name = "PersonalScheduledTaskNotFoundError";
+  }
+}
+
+function normalizeQuery(query: string | undefined): string | undefined {
+  return query?.trim().toLowerCase() || undefined;
+}
+
+function decodeCursor(value: string | undefined, query: string | undefined) {
+  if (!value) return undefined;
+  try {
+    const parsed = cursorSchema.parse(
+      JSON.parse(Buffer.from(value, "base64url").toString("utf8")),
+    );
+    if (parsed.query !== query) {
+      throw new InvalidScheduledTaskCursorError();
+    }
+    return { createdAtMs: parsed.createdAtMs, id: parsed.id };
+  } catch {
+    throw new InvalidScheduledTaskCursorError();
+  }
+}
+
+function encodeCursor(
+  task: Pick<ScheduledTask, "createdAtMs" | "id">,
+  query: string | undefined,
+): string {
+  return Buffer.from(
+    JSON.stringify({
+      createdAtMs: task.createdAtMs,
+      id: task.id,
+      ...(query ? { query } : {}),
+      version: 1,
+    }),
+    "utf8",
+  ).toString("base64url");
+}
+
+/** Build scheduled-task operations limited to tasks created by linked actors. */
+export function createViewerScheduledTasks(
+  store: PersonalScheduledTaskStore,
+  actors: PluginUserPageActor[],
+) {
+  const creators = actors
+    .filter((actor) => actor.platform === "slack")
+    .map((actor) => ({
+      slackUserId: actor.userId,
+      teamId: actor.teamId,
+    }));
+  const creatorKeys = new Set(
+    creators.map((creator) => `${creator.teamId}:${creator.slackUserId}`),
+  );
+
+  return {
+    async delete(id: string, nowMs = Date.now()): Promise<void> {
+      const task = await store.getTask(id);
+      if (
+        !task ||
+        task.status === "deleted" ||
+        !creatorKeys.has(
+          `${task.destination.teamId}:${task.createdBy.slackUserId}`,
+        )
+      ) {
+        throw new PersonalScheduledTaskNotFoundError();
+      }
+      await store.saveTask({
+        ...task,
+        nextRunAtMs: undefined,
+        runNowAtMs: undefined,
+        status: "deleted",
+        updatedAtMs: nowMs,
+      });
+    },
+
+    async list(
+      input: ViewerScheduledTaskPageInput,
+    ): Promise<ViewerScheduledTaskPage> {
+      const query = normalizeQuery(input.query);
+      const cursor = decodeCursor(input.cursor, query);
+      const matching = await store.listTasksCreatedBy({
+        ...(cursor ? { before: cursor } : {}),
+        creators,
+        limit: input.limit + 1,
+        ...(query ? { query } : {}),
+      });
+      const tasks = matching.slice(0, input.limit);
+      return {
+        tasks,
+        ...(matching.length > input.limit && tasks.length > 0
+          ? { nextCursor: encodeCursor(tasks.at(-1)!, query) }
+          : {}),
+      };
+    },
+  };
+}

--- a/packages/junior-scheduler/src/plugin.ts
+++ b/packages/junior-scheduler/src/plugin.ts
@@ -34,6 +34,8 @@ import {
   createSlackScheduleUpdateTaskTool,
   type SchedulerToolContext,
 } from "./schedule-tools";
+import { createSchedulerApi } from "./api";
+import { createSchedulerUserPage } from "./user-pages";
 
 const SCHEDULER_HEARTBEAT_LIMIT = 10;
 const DASHBOARD_TABLE_LIMIT = 5;
@@ -423,7 +425,14 @@ export function schedulerPlugin() {
       description: "Scheduled Junior task management and heartbeat dispatch",
     },
     packageName: "@sentry/junior-scheduler",
+    userPages: [createSchedulerUserPage()],
     hooks: {
+      apiRoutes(ctx) {
+        return createSchedulerApi({
+          actors: ctx.viewer.actors,
+          db: ctx.db as SchedulerDb,
+        });
+      },
       systemPrompt(ctx) {
         if (ctx.platform !== "slack") {
           return [];

--- a/packages/junior-scheduler/src/store.ts
+++ b/packages/junior-scheduler/src/store.ts
@@ -1262,45 +1262,67 @@ async function listTasksCreatedByFromSql(
     return [];
   }
   const query = normalizedTaskQuery(input.query);
-  const rows = await db
-    .select({ record: juniorSchedulerTasks.record })
-    .from(juniorSchedulerTasks)
-    .where(
-      and(
-        ne(juniorSchedulerTasks.status, "deleted"),
-        or(
-          ...input.creators.map((creator) =>
-            and(
-              eq(juniorSchedulerTasks.teamId, creator.teamId),
-              eq(juniorSchedulerTasks.creatorSlackUserId, creator.slackUserId),
+  const tasks: ScheduledTask[] = [];
+  let before = input.before;
+
+  while (tasks.length < input.limit) {
+    const rows = await db
+      .select({
+        createdAtMs: juniorSchedulerTasks.createdAtMs,
+        id: juniorSchedulerTasks.id,
+        record: juniorSchedulerTasks.record,
+      })
+      .from(juniorSchedulerTasks)
+      .where(
+        and(
+          ne(juniorSchedulerTasks.status, "deleted"),
+          or(
+            ...input.creators.map((creator) =>
+              and(
+                eq(juniorSchedulerTasks.teamId, creator.teamId),
+                eq(
+                  juniorSchedulerTasks.creatorSlackUserId,
+                  creator.slackUserId,
+                ),
+              ),
             ),
           ),
+          before
+            ? or(
+                lt(juniorSchedulerTasks.createdAtMs, before.createdAtMs),
+                and(
+                  eq(juniorSchedulerTasks.createdAtMs, before.createdAtMs),
+                  lt(juniorSchedulerTasks.id, before.id),
+                ),
+              )
+            : undefined,
+          query
+            ? or(
+                sql<boolean>`strpos(lower(${juniorSchedulerTasks.record}->'task'->>'text'), ${query}) > 0`,
+                sql<boolean>`strpos(lower(${juniorSchedulerTasks.record}->'schedule'->>'description'), ${query}) > 0`,
+                sql<boolean>`strpos(lower(${juniorSchedulerTasks.record}->'schedule'->>'timezone'), ${query}) > 0`,
+                sql<boolean>`strpos(lower(${juniorSchedulerTasks.status}), ${query}) > 0`,
+              )
+            : undefined,
         ),
-        input.before
-          ? or(
-              lt(juniorSchedulerTasks.createdAtMs, input.before.createdAtMs),
-              and(
-                eq(juniorSchedulerTasks.createdAtMs, input.before.createdAtMs),
-                lt(juniorSchedulerTasks.id, input.before.id),
-              ),
-            )
-          : undefined,
-        query
-          ? or(
-              sql<boolean>`strpos(lower(${juniorSchedulerTasks.record}->'task'->>'text'), ${query}) > 0`,
-              sql<boolean>`strpos(lower(${juniorSchedulerTasks.record}->'schedule'->>'description'), ${query}) > 0`,
-              sql<boolean>`strpos(lower(${juniorSchedulerTasks.record}->'schedule'->>'timezone'), ${query}) > 0`,
-              sql<boolean>`strpos(lower(${juniorSchedulerTasks.status}), ${query}) > 0`,
-            )
-          : undefined,
-      ),
-    )
-    .orderBy(
-      desc(juniorSchedulerTasks.createdAtMs),
-      desc(juniorSchedulerTasks.id),
-    )
-    .limit(input.limit);
-  return rows.map(parseSqlTaskRow).filter(present);
+      )
+      .orderBy(
+        desc(juniorSchedulerTasks.createdAtMs),
+        desc(juniorSchedulerTasks.id),
+      )
+      .limit(input.limit);
+    tasks.push(...rows.map(parseSqlTaskRow).filter(present));
+    if (rows.length < input.limit) {
+      break;
+    }
+    const last = rows.at(-1)!;
+    before = {
+      createdAtMs: last.createdAtMs,
+      id: last.id,
+    };
+  }
+
+  return tasks.slice(0, input.limit);
 }
 
 async function listTasksForTeamFromSql(

--- a/packages/junior-scheduler/src/store.ts
+++ b/packages/junior-scheduler/src/store.ts
@@ -8,9 +8,11 @@ import {
 import {
   and,
   asc,
+  desc,
   eq,
   inArray,
   isNotNull,
+  lt,
   lte,
   ne,
   or,
@@ -145,6 +147,7 @@ export interface SchedulerStore {
   getTask(taskId: string): Promise<ScheduledTask | undefined>;
   listIncompleteRuns(): Promise<ScheduledRun[]>;
   listTasks(): Promise<ScheduledTask[]>;
+  listTasksCreatedBy(input: ListTasksCreatedByInput): Promise<ScheduledTask[]>;
   listTasksForTeam(teamId: string): Promise<ScheduledTask[]>;
   markRunBlocked(args: {
     completedAtMs: number;
@@ -184,9 +187,62 @@ export interface SchedulerStore {
   }): Promise<void>;
 }
 
+export interface ListTasksCreatedByInput {
+  before?: { createdAtMs: number; id: string };
+  creators: Array<{ slackUserId: string; teamId: string }>;
+  limit: number;
+  query?: string;
+}
+
 export interface SchedulerOperationalStore {
   listIncompleteRunsForTasks(tasks: ScheduledTask[]): Promise<ScheduledRun[]>;
   listTasks(): Promise<ScheduledTask[]>;
+}
+
+function normalizedTaskQuery(query: string | undefined): string | undefined {
+  return query?.trim().toLowerCase() || undefined;
+}
+
+function taskCreatorKey(task: ScheduledTask): string {
+  return `${task.destination.teamId}:${task.createdBy.slackUserId}`;
+}
+
+function listedAfter(
+  task: ScheduledTask,
+  before: { createdAtMs: number; id: string },
+): boolean {
+  return (
+    task.createdAtMs < before.createdAtMs ||
+    (task.createdAtMs === before.createdAtMs && task.id < before.id)
+  );
+}
+
+function taskMatchesQuery(task: ScheduledTask, query: string): boolean {
+  return [
+    task.task.text,
+    task.schedule.description,
+    task.schedule.timezone,
+    task.status,
+  ].some((value) => value.toLowerCase().includes(query));
+}
+
+function listCreatedTasks(
+  tasks: ScheduledTask[],
+  input: ListTasksCreatedByInput,
+): ScheduledTask[] {
+  const creators = new Set(
+    input.creators.map((creator) => `${creator.teamId}:${creator.slackUserId}`),
+  );
+  const query = normalizedTaskQuery(input.query);
+  return tasks
+    .filter((task) => creators.has(taskCreatorKey(task)))
+    .filter((task) => !query || taskMatchesQuery(task, query))
+    .sort(
+      (left, right) =>
+        right.createdAtMs - left.createdAtMs || right.id.localeCompare(left.id),
+    )
+    .filter((task) => !input.before || listedAfter(task, input.before))
+    .slice(0, input.limit);
 }
 
 function taskKey(taskId: string): string {
@@ -680,6 +736,12 @@ class PluginStateSchedulerStore implements SchedulerStore {
     return await listTasksFromState(this.state, globalTaskIndexKey());
   }
 
+  async listTasksCreatedBy(
+    input: ListTasksCreatedByInput,
+  ): Promise<ScheduledTask[]> {
+    return listCreatedTasks(await this.listTasks(), input);
+  }
+
   async listTasksForTeam(teamId: string): Promise<ScheduledTask[]> {
     return await listTasksFromState(this.state, teamTaskIndexKey(teamId));
   }
@@ -1113,6 +1175,7 @@ async function upsertSqlTask(
     .insert(juniorSchedulerTasks)
     .values({
       createdAtMs: task.createdAtMs,
+      creatorSlackUserId: task.createdBy.slackUserId,
       id: task.id,
       nextRunAtMs: task.nextRunAtMs,
       record: task,
@@ -1124,6 +1187,7 @@ async function upsertSqlTask(
       target: juniorSchedulerTasks.id,
       set: {
         createdAtMs: sql`excluded.created_at_ms`,
+        creatorSlackUserId: sql`excluded.creator_slack_user_id`,
         nextRunAtMs: sql`excluded.next_run_at_ms`,
         record: sql`excluded.record`,
         runNowAtMs: sql`excluded.run_now_at_ms`,
@@ -1187,6 +1251,55 @@ async function listTasksFromSql(db: SchedulerDb): Promise<ScheduledTask[]> {
       asc(juniorSchedulerTasks.createdAtMs),
       asc(juniorSchedulerTasks.id),
     );
+  return rows.map(parseSqlTaskRow).filter(present);
+}
+
+async function listTasksCreatedByFromSql(
+  db: SchedulerDb,
+  input: ListTasksCreatedByInput,
+): Promise<ScheduledTask[]> {
+  if (input.creators.length === 0) {
+    return [];
+  }
+  const query = normalizedTaskQuery(input.query);
+  const rows = await db
+    .select({ record: juniorSchedulerTasks.record })
+    .from(juniorSchedulerTasks)
+    .where(
+      and(
+        ne(juniorSchedulerTasks.status, "deleted"),
+        or(
+          ...input.creators.map((creator) =>
+            and(
+              eq(juniorSchedulerTasks.teamId, creator.teamId),
+              eq(juniorSchedulerTasks.creatorSlackUserId, creator.slackUserId),
+            ),
+          ),
+        ),
+        input.before
+          ? or(
+              lt(juniorSchedulerTasks.createdAtMs, input.before.createdAtMs),
+              and(
+                eq(juniorSchedulerTasks.createdAtMs, input.before.createdAtMs),
+                lt(juniorSchedulerTasks.id, input.before.id),
+              ),
+            )
+          : undefined,
+        query
+          ? or(
+              sql<boolean>`strpos(lower(${juniorSchedulerTasks.record}->'task'->>'text'), ${query}) > 0`,
+              sql<boolean>`strpos(lower(${juniorSchedulerTasks.record}->'schedule'->>'description'), ${query}) > 0`,
+              sql<boolean>`strpos(lower(${juniorSchedulerTasks.record}->'schedule'->>'timezone'), ${query}) > 0`,
+              sql<boolean>`strpos(lower(${juniorSchedulerTasks.status}), ${query}) > 0`,
+            )
+          : undefined,
+      ),
+    )
+    .orderBy(
+      desc(juniorSchedulerTasks.createdAtMs),
+      desc(juniorSchedulerTasks.id),
+    )
+    .limit(input.limit);
   return rows.map(parseSqlTaskRow).filter(present);
 }
 
@@ -1290,6 +1403,12 @@ class SqlSchedulerStore implements SchedulerStore, SchedulerOperationalStore {
 
   async listTasks(): Promise<ScheduledTask[]> {
     return await listTasksFromSql(this.db);
+  }
+
+  async listTasksCreatedBy(
+    input: ListTasksCreatedByInput,
+  ): Promise<ScheduledTask[]> {
+    return await listTasksCreatedByFromSql(this.db, input);
   }
 
   async listTasksForTeam(teamId: string): Promise<ScheduledTask[]> {

--- a/packages/junior-scheduler/src/user-pages.ts
+++ b/packages/junior-scheduler/src/user-pages.ts
@@ -1,0 +1,80 @@
+import type { PluginUserPageDefinition } from "@sentry/junior-plugin-api";
+import { createViewerScheduledTasks } from "./personal";
+import { createSchedulerSqlStore, type SchedulerDb } from "./store";
+import type { ScheduledTask } from "./types";
+
+function sentenceCase(value: string): string {
+  return value.charAt(0).toUpperCase() + value.slice(1).replaceAll("_", " ");
+}
+
+function bounded(value: string, limit: number): string {
+  const trimmed = value.trim();
+  if (trimmed.length <= limit) return trimmed;
+  return `${trimmed.slice(0, limit - 1).trimEnd()}…`;
+}
+
+function formattedRun(task: ScheduledTask): string {
+  const nextRunAtMs = task.runNowAtMs ?? task.nextRunAtMs;
+  if (nextRunAtMs === undefined) return "Not scheduled";
+  try {
+    return new Intl.DateTimeFormat("en-US", {
+      day: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+      month: "short",
+      timeZone: task.schedule.timezone,
+      timeZoneName: "short",
+      year: "numeric",
+    }).format(new Date(nextRunAtMs));
+  } catch {
+    return new Date(nextRunAtMs).toISOString();
+  }
+}
+
+/** Create the personal Scheduled tasks dashboard page. */
+export function createSchedulerUserPage(): PluginUserPageDefinition {
+  return {
+    id: "scheduled-tasks",
+    label: "Scheduled tasks",
+    description: "Junior tasks you created across your linked workspaces.",
+    async read(ctx, input) {
+      const page = await createViewerScheduledTasks(
+        createSchedulerSqlStore(ctx.db as SchedulerDb),
+        ctx.viewer.actors,
+      ).list({
+        cursor: input.cursor,
+        limit: input.limit,
+        ...(input.query ? { query: input.query } : {}),
+      });
+      return {
+        type: "list",
+        emptyText: input.query
+          ? "No scheduled tasks matched your search."
+          : "You have not created any scheduled tasks.",
+        ...(page.nextCursor ? { nextCursor: page.nextCursor } : {}),
+        searchPlaceholder: "Search scheduled tasks",
+        records: page.tasks.map((task) => {
+          const description = bounded(task.schedule.description, 1_000);
+          return {
+            actions: [
+              {
+                confirmation: "Delete this scheduled task?",
+                href: `/api/plugins/scheduler/tasks/${encodeURIComponent(task.id)}`,
+                label: "Delete",
+                method: "DELETE" as const,
+                tone: "danger" as const,
+              },
+            ],
+            ...(description ? { description } : {}),
+            id: task.id,
+            metadata: [
+              { label: "Status", value: sentenceCase(task.status) },
+              { label: "Next run", value: formattedRun(task) },
+            ],
+            title: bounded(task.task.text, 4_000) || "Untitled scheduled task",
+          };
+        }),
+      };
+    },
+  };
+}

--- a/packages/junior/tests/component/scheduler-sql-plugin.test.ts
+++ b/packages/junior/tests/component/scheduler-sql-plugin.test.ts
@@ -4,6 +4,11 @@ import { tmpdir } from "node:os";
 import { readMigrationFiles } from "drizzle-orm/migrator";
 import { describe, expect, it, vi } from "vitest";
 import {
+  pluginApiRouteRequestContextSchema,
+  pluginUserPageContentSchema,
+  type PluginLogger,
+} from "@sentry/junior-plugin-api";
+import {
   createSchedulerSqlStore,
   schedulerPlugin,
   type SchedulerDb,
@@ -18,6 +23,11 @@ const TEST_RUN_AT_MS = Date.parse("2026-05-26T12:00:00.000Z");
 const TEST_NOW_MS = Date.parse("2026-05-26T12:05:00.000Z");
 const LEGACY_SCHEDULER_MIGRATION_CHECKSUM =
   "d1d2f712181dd3a0557808f0fc67fd0722691d25f4c8cfb816b77c71d19e1e42";
+const noopLogger: PluginLogger = {
+  error() {},
+  info() {},
+  warn() {},
+};
 
 function schedulerMigrationsDir(): string {
   return path.resolve(process.cwd(), "../junior-scheduler/migrations");
@@ -78,6 +88,12 @@ WHERE schemaname = 'drizzle'
 `);
       expect(migrationTable).toBeDefined();
       await fixture.sql.execute(
+        `DROP INDEX junior_scheduler_tasks_creator_idx`,
+      );
+      await fixture.sql.execute(
+        `ALTER TABLE junior_scheduler_tasks DROP COLUMN creator_slack_user_id`,
+      );
+      await fixture.sql.execute(
         `DROP TABLE drizzle.${migrationTable!.tablename}`,
       );
       await fixture.sql.execute(`
@@ -131,7 +147,7 @@ INSERT INTO junior_scheduler_tasks (
             pluginName: "scheduler",
           },
         ]),
-      ).resolves.toEqual({ existing: 1, migrated: 1, scanned: 2 });
+      ).resolves.toEqual({ existing: 1, migrated: 2, scanned: 3 });
       const migrations = readMigrationFiles({
         migrationsFolder: schedulerMigrationsDir(),
       });
@@ -149,10 +165,20 @@ ORDER BY created_at
           hash: migration.hash,
         })),
       );
-      const [migratedTask] = await fixture.sql.query<{ record: unknown }>(
-        `SELECT record FROM junior_scheduler_tasks WHERE id = $1`,
+      const [migratedTask] = await fixture.sql.query<{
+        creatorSlackUserId: string;
+        record: unknown;
+      }>(
+        `
+SELECT
+  creator_slack_user_id AS "creatorSlackUserId",
+  record
+FROM junior_scheduler_tasks
+WHERE id = $1
+`,
         [legacyTask.id],
       );
+      expect(migratedTask?.creatorSlackUserId).toBe("U123");
       expect(migratedTask?.record).toMatchObject({
         credentialMode: "system",
       });
@@ -164,7 +190,7 @@ ORDER BY created_at
             pluginName: "scheduler",
           },
         ]),
-      ).resolves.toEqual({ existing: 2, migrated: 0, scanned: 2 });
+      ).resolves.toEqual({ existing: 3, migrated: 0, scanned: 3 });
       await expect(
         fixture.sql.query<{
           createdAt: string;
@@ -301,6 +327,145 @@ ORDER BY tablename
         lastRunAtMs: TEST_RUN_AT_MS,
         status: "paused",
       });
+    } finally {
+      await fixture.close();
+    }
+  }, 15_000);
+
+  it("lists viewer-created tasks with search and cursor pagination", async () => {
+    const fixture = await createLocalJuniorSqlFixture();
+
+    try {
+      await migrateSchedulerSchema(fixture);
+      const db = fixture.sql.db() as unknown as SchedulerDb;
+      const store = createSchedulerSqlStore(db);
+      const visibleOld = createTask({
+        createdAtMs: TEST_RUN_AT_MS + 100,
+        id: "sched_visible_old",
+        schedule: {
+          description: "Every Friday",
+          kind: "recurring",
+          timezone: "UTC",
+        },
+        task: { text: "Prepare the weekly summary." },
+      });
+      const visibleNew = createTask({
+        createdAtMs: TEST_RUN_AT_MS + 200,
+        id: "sched_visible_new",
+        nextRunAtMs: TEST_NOW_MS + 60_000,
+        runNowAtMs: TEST_NOW_MS,
+        task: { text: "Post the daily summary." },
+      });
+      await store.saveTask(visibleOld);
+      await store.saveTask(visibleNew);
+      await store.saveTask(
+        createTask({
+          createdAtMs: TEST_RUN_AT_MS + 300,
+          createdBy: { slackUserId: "U999" },
+          id: "sched_other_creator",
+        }),
+      );
+      await store.saveTask(
+        createTask({
+          createdAtMs: TEST_RUN_AT_MS + 400,
+          destination: {
+            platform: "slack",
+            teamId: "T999",
+            channelId: "C999",
+          },
+          id: "sched_other_workspace",
+        }),
+      );
+
+      const page = schedulerPlugin().userPages?.[0];
+      expect(page).toBeDefined();
+      const context = {
+        db,
+        log: noopLogger,
+        plugin: { name: "scheduler" },
+        viewer: {
+          actors: [
+            {
+              platform: "slack" as const,
+              teamId: "T123",
+              userId: "U123",
+            },
+          ],
+          email: "person@example.com",
+        },
+      };
+      const first = pluginUserPageContentSchema.parse(
+        await page!.read(context, { limit: 1 }),
+      );
+      expect(first.records).toEqual([
+        expect.objectContaining({
+          id: visibleNew.id,
+          metadata: expect.arrayContaining([
+            {
+              label: "Next run",
+              value: expect.stringContaining("12:05 PM UTC"),
+            },
+          ]),
+        }),
+      ]);
+      expect(first.nextCursor).toEqual(expect.any(String));
+
+      const second = pluginUserPageContentSchema.parse(
+        await page!.read(context, {
+          cursor: first.nextCursor,
+          limit: 1,
+        }),
+      );
+      expect(second.records).toEqual([
+        expect.objectContaining({ id: visibleOld.id }),
+      ]);
+
+      const search = pluginUserPageContentSchema.parse(
+        await page!.read(context, { limit: 20, query: "friday" }),
+      );
+      expect(search.records).toEqual([
+        expect.objectContaining({ id: visibleOld.id }),
+      ]);
+
+      const api = schedulerPlugin().hooks?.apiRoutes?.({
+        db,
+        log: noopLogger,
+        plugin: { name: "scheduler" },
+        viewer: { actors: async () => context.viewer.actors },
+      });
+      expect(api).toBeDefined();
+      const requestContext = pluginApiRouteRequestContextSchema.parse({
+        auth: {
+          user: {
+            email: context.viewer.email,
+            emailVerified: true,
+          },
+        },
+        pluginName: "scheduler",
+      });
+      const deleteResponse = await api!.fetch(
+        new Request(`http://localhost/tasks/${visibleOld.id}`, {
+          method: "DELETE",
+        }),
+        requestContext,
+      );
+      expect(deleteResponse.status).toBe(204);
+      await expect(store.getTask(visibleOld.id)).resolves.toMatchObject({
+        status: "deleted",
+      });
+
+      const forbiddenResponse = await api!.fetch(
+        new Request("http://localhost/tasks/sched_other_creator", {
+          method: "DELETE",
+        }),
+        requestContext,
+      );
+      expect(forbiddenResponse.status).toBe(404);
+      await expect(store.getTask("sched_other_creator")).resolves.toMatchObject(
+        {
+          status: "active",
+        },
+      );
     } finally {
       await fixture.close();
     }
@@ -486,8 +651,8 @@ ORDER BY tablename
         }),
       ).resolves.toEqual({
         existing: 0,
-        migrated: 2,
-        scanned: 2,
+        migrated: 3,
+        scanned: 3,
       });
 
       const db = fixture.sql.db() as unknown as SchedulerDb;
@@ -516,8 +681,8 @@ ORDER BY tablename
         }),
       ).resolves.toEqual({
         existing: 0,
-        migrated: 2,
-        scanned: 2,
+        migrated: 3,
+        scanned: 3,
       });
     } finally {
       await fixture.close();
@@ -538,15 +703,17 @@ ORDER BY tablename
 INSERT INTO junior_scheduler_tasks (
   id,
   team_id,
+  creator_slack_user_id,
   status,
   next_run_at_ms,
   created_at_ms,
   record
-) VALUES ($1, $2, $3, $4, $5, $6)
+) VALUES ($1, $2, $3, $4, $5, $6, $7)
 `,
         [
           "sched_bad_record",
           task.destination.teamId,
+          task.createdBy.slackUserId,
           "active",
           TEST_RUN_AT_MS,
           TEST_RUN_AT_MS - 1,
@@ -560,15 +727,17 @@ INSERT INTO junior_scheduler_tasks (
 INSERT INTO junior_scheduler_tasks (
   id,
   team_id,
+  creator_slack_user_id,
   status,
   next_run_at_ms,
   created_at_ms,
   record
-) VALUES ($1, $2, $3, $4, $5, $6)
+) VALUES ($1, $2, $3, $4, $5, $6, $7)
 `,
         [
           "sched_bad_string_record",
           task.destination.teamId,
+          task.createdBy.slackUserId,
           "active",
           TEST_RUN_AT_MS,
           TEST_RUN_AT_MS - 1,

--- a/packages/junior/tests/component/scheduler-sql-plugin.test.ts
+++ b/packages/junior/tests/component/scheduler-sql-plugin.test.ts
@@ -358,6 +358,26 @@ ORDER BY tablename
       });
       await store.saveTask(visibleOld);
       await store.saveTask(visibleNew);
+      await fixture.sql.execute(
+        `
+INSERT INTO junior_scheduler_tasks (
+  id,
+  team_id,
+  creator_slack_user_id,
+  status,
+  created_at_ms,
+  record
+) VALUES ($1, $2, $3, $4, $5, $6)
+`,
+        [
+          "sched_malformed_between_pages",
+          visibleNew.destination.teamId,
+          visibleNew.createdBy.slackUserId,
+          "active",
+          TEST_RUN_AT_MS + 150,
+          JSON.stringify({ id: "sched_malformed_between_pages" }),
+        ],
+      );
       await store.saveTask(
         createTask({
           createdAtMs: TEST_RUN_AT_MS + 300,


### PR DESCRIPTION
Adds a **Scheduled tasks** page to the signed-in user menu. It lists, searches, and paginates non-deleted tasks created by the viewer’s linked Slack identities, shows the actual next execution including queued run-now work, and lets the creator delete a task from the dashboard.

Creator selection is enforced in a bounded SQL query rather than by scanning all scheduler data. A nullable `creator_slack_user_id` projection and partial index support that query; the migration backfills existing valid records without making malformed legacy rows block deployment. Component coverage exercises migration adoption, cross-creator and cross-workspace isolation, search, cursor pagination, queued run-now display, authorized deletion, and denied deletion.
