### PR TITLE
ref(logging): simplify structured event emission

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -63,7 +63,7 @@ sort=timestamp
 Recent failed or timed-out agent runs.
 
 ```text
-dataset=logs query='event.name:agent_turn_timeout OR event.name:agent_turn_failed OR event.name:agent_turn_provider_error'
+dataset=logs query='event.name:agent.turn.timed_out OR event.name:agent.turn.failed OR event.name:agent.turn.provider_error'
 fields=timestamp,event.name,trace_id,span_id,gen_ai.conversation.id,gen_ai.request.model,error.type
 sort=-timestamp
 ```
@@ -95,7 +95,7 @@ sort=-timestamp
 Slack delivery failures after the agent turn ran.
 
 ```text
-dataset=logs query='event.name:slack_thread_post_failed app.slack.error_code:*'
+dataset=logs query='event.name:slack.thread.post.failed app.slack.error_code:*'
 fields=timestamp,event.name,gen_ai.conversation.id,messaging.destination.name,app.slack.reply_stage,app.slack.error_code,app.slack.api_error,exception.message
 sort=-timestamp
 ```
@@ -114,8 +114,9 @@ sort=-timestamp
 
 Slack or Vercel webhook delivery/routing failures.
 
-Events: `webhook_platform_unknown`, `webhook_non_success_response`,
-`webhook_handler_failed`, `slack_message_changed_side_channel_failed`
+Events: `webhook.response.unsuccessful`, `webhook.handler.failed`,
+`slack.event.persist.failed`, `slack.event.routing.failed`,
+`slack.event.enqueue.failed`
 
 Spans: `http.server.request`
 
@@ -126,9 +127,9 @@ Attributes: `http.request.method`, `http.response.status_code`, `url.path`,
 
 Slack accepted the request but no final reply appeared.
 
-Events: `agent_turn_started`, `agent_turn_completed`, `agent_turn_failed`,
-`slack_thread_post_failed`, `assistant_status_update_failed`,
-`slack_action_failed`, `slack_action_retrying`
+Events: `agent.turn.started`, `agent.turn.completed`, `agent.turn.failed`,
+`slack.thread.post.failed`, `assistant.status.update.failed`,
+`slack.action.failed`, `slack.action.retrying`
 
 Spans: `chat.turn`, `chat.reply`, `chat.slash_command`,
 `chat.app_home_opened`, `chat.app_home_disconnect`
@@ -141,9 +142,10 @@ Attributes: `trace_id`, `span_id`, `gen_ai.conversation.id`,
 
 The turn timed out, returned no useful answer, or used unexpected reasoning.
 
-Events: `agent_message_in`, `agent_message_out`, `agent_turn_timeout`,
-`agent_turn_provider_error`, `agent_turn_execution_failure`,
-`assistant_reply_generation_failed`
+Events: `agent.message.received`, `agent.message.generated`,
+`agent.turn.timed_out`,
+`agent.turn.provider_error`, `agent.turn.execution.failed`,
+`assistant.reply.generation.failed`
 
 Spans: `ai.generate_assistant_reply`, `ai.chat_completion`,
 `chat.route_thinking`, `gen_ai.invoke_agent`, `gen_ai.chat`
@@ -161,9 +163,9 @@ Attributes: `gen_ai.operation.name`, `gen_ai.request.model`,
 
 A tool failed, an MCP call failed, a command exited non-zero, or sandbox startup was slow.
 
-Events: `agent_tool_call_failed`, `mcp_tool_call_failed`,
-`mcp_tool_manager_close_failed`, `sandbox_boot_requested`,
-`sandbox_network_policy_restore_failed`
+Events: `agent.tool_call.failed`, `mcp.tool_call.failed`,
+`mcp.tool_manager.close.failed`, `sandbox.boot.requested`,
+`sandbox.network_policy_restore.failed`
 
 Spans: `execute_tool <toolName>`, `sandbox.acquire`, `sandbox.create`,
 `sandbox.snapshot.resolve`, `sandbox.sync_skills`, `bash`
@@ -181,11 +183,12 @@ Attributes: `gen_ai.tool.name`, `gen_ai.tool.call.id`,
 
 A turn parked for auth, resumed late, or failed after callback.
 
-Events: `credential_issue_failed`, `credential_issue_request`,
-`credential_issue_success`, `mention_handler_auth_pause`,
-`subscribed_message_handler_auth_pause`, `agent_continue_schedule_failed`,
-`agent_continue_lock_busy`, `oauth_callback_resume_complete`,
-`mcp_oauth_callback_failed`
+Events: `sandbox.egress.credential.needed`,
+`sandbox.egress.credential.unavailable`, `plugin.credential.rejected`,
+`subscribed_message.authorization.required`, `agent.continue.schedule.failed`,
+`agent.continue.lock.busy`, `agent.continue.lock.retrying`,
+`oauth.callback.resume.completed`, `oauth.callback.resume.busy`,
+`mcp.oauth_callback.failed`
 
 Spans: resumed `chat.turn`, `chat.reply`
 
@@ -197,9 +200,9 @@ Attributes: `app.credential.provider`, `app.credential.delivery`,
 
 A skill/tool is missing, plugin discovery failed, or capability activation looks wrong.
 
-Events: `startup_discovery_summary`, `plugin_loaded`,
-`capability_catalog_loaded`, `skill_directory_read_failed`,
-`skill_frontmatter_invalid`, `skill_load_stat_failed`, `plugin_root_read_failed`
+Events: `startup.discovery.completed`, `plugin.loaded`,
+`skill.directory.read.failed`, `skill.frontmatter.invalid`,
+`skill.load.stat.failed`, `plugin.root.read.failed`
 
 Spans: active turn spans carry plugin/skill attributes
 
@@ -211,9 +214,9 @@ Attributes: `app.skill.name`, `app.skill.count`, `app.plugin.name`,
 
 Screenshots, file attachments, image context, or web search failed.
 
-Events: `attachment_resolution_failed`, `attachment_skipped_size_limit`,
-`image_attachment_processing_failed`, `conversation_image_context_hydrated`,
-`conversation_image_vision_failed`, `web_search_failed`
+Events: `attachment.resolution.failed`, `attachment.size_limit.skipped`,
+`image.attachment.processing.failed`, `conversation.image.context.hydrated`,
+`conversation.image.vision.failed`, `web.search.failed`
 
 Spans: model/tool spans around vision or search calls
 

--- a/ast-grep/rules/no-imperative-log-event-outcomes.yml
+++ b/ast-grep/rules/no-imperative-log-event-outcomes.yml
@@ -1,0 +1,28 @@
+id: no-imperative-log-event-outcomes
+language: TypeScript
+severity: error
+message: Log event names describe observations. Use a past-participle outcome, an in-progress participle such as retrying, or an observed state.
+files:
+  - packages/junior/src/**/*.ts
+  - packages/junior/src/**/*.tsx
+rule:
+  any:
+    - pattern: logInfo($EVENT)
+    - pattern: logInfo($EVENT, $$$ARGS)
+    - pattern: logWarn($EVENT)
+    - pattern: logWarn($EVENT, $$$ARGS)
+    - pattern: logError($EVENT)
+    - pattern: logError($EVENT, $$$ARGS)
+    - pattern: logException($ERROR, $EVENT)
+    - pattern: logException($ERROR, $EVENT, $$$ARGS)
+    - pattern: $LOGGER.logInfo($EVENT)
+    - pattern: $LOGGER.logInfo($EVENT, $$$ARGS)
+    - pattern: $LOGGER.logWarn($EVENT)
+    - pattern: $LOGGER.logWarn($EVENT, $$$ARGS)
+    - pattern: $LOGGER.logError($EVENT)
+    - pattern: $LOGGER.logError($EVENT, $$$ARGS)
+    - pattern: $LOGGER.logException($ERROR, $EVENT)
+    - pattern: $LOGGER.logException($ERROR, $EVENT, $$$ARGS)
+constraints:
+  EVENT:
+    regex: '^["''].*\.(retry|start|complete|fail|reject|skip|yield|unlink|in|out|fallback)["'']$'

--- a/packages/docs/src/content/docs/extend/maintenance-plugin.md
+++ b/packages/docs/src/content/docs/extend/maintenance-plugin.md
@@ -33,9 +33,7 @@ Add the package name to the plugin set exported from `plugins.ts`:
 ```ts title="plugins.ts"
 import { defineJuniorPlugins } from "@sentry/junior";
 
-export const plugins = defineJuniorPlugins([
-  "@sentry/junior-maintenance",
-]);
+export const plugins = defineJuniorPlugins(["@sentry/junior-maintenance"]);
 ```
 
 Point `juniorNitro()` at that module in `nitro.config.ts`:
@@ -65,8 +63,8 @@ The `self-update` skill uses the app's existing package manager and repository t
 
 ## Skills
 
-| Skill | Purpose |
-| ----- | ------- |
+| Skill         | Purpose                                                                                                                                                                       |
+| ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `self-update` | Updates `@sentry/junior` and enabled `@sentry/junior-*` packages to the latest published release, syncs the lockfile, runs checks and builds, and opens a draft pull request. |
 
 The `self-update` skill also builds a best-effort release summary from npm publish timestamps and merged PRs, and compares app config against Junior's example app to catch config-shape drift before checks run.

--- a/packages/docs/src/content/docs/operate/observability.md
+++ b/packages/docs/src/content/docs/operate/observability.md
@@ -11,13 +11,13 @@ related:
 
 ## Key event signals
 
-- `webhook_handler_failed`
-- `conversation_work_failed`
-- `conversation_work_recovery_failed`
-- `agent_continue_schedule_failed`
-- `agent_turn_failed`
-- `agent_turn_timeout`
-- `agent_tool_call_failed`
+- `webhook.handler.failed`
+- `conversation.work.failed`
+- `conversation.work.recovery.failed`
+- `agent.continue.schedule.failed`
+- `agent.turn.failed`
+- `agent.turn.timed_out`
+- `agent.tool_call.failed`
 
 ## Key spans
 
@@ -40,27 +40,27 @@ related:
 ## Starter queries
 
 ```text
-event.name:webhook_handler_failed
+event.name:webhook.handler.failed
 ```
 
 ```text
-event.name:conversation_work_failed OR event.name:conversation_work_recovery_failed
+event.name:conversation.work.failed OR event.name:conversation.work.recovery.failed
 ```
 
 ```text
-event.name:conversation_work_pending_requeued OR event.name:conversation_work_lease_expired_requeued
+event.name:conversation.work.pending.requeued OR event.name:conversation.work.lease_expired.requeued
 ```
 
 ```text
-event.name:agent_continue_schedule_failed OR event.name:agent_continue_lock_busy
+event.name:agent.continue.schedule.failed OR event.name:agent.continue.lock.busy
 ```
 
 ```text
-event.name:agent_turn_timeout OR event.name:agent_turn_failed
+event.name:agent.turn.timed_out OR event.name:agent.turn.failed
 ```
 
 ```text
-event.name:agent_tool_call_failed
+event.name:agent.tool_call.failed
 ```
 
 ## Next step

--- a/packages/docs/src/content/docs/operate/reliability-runbooks.md
+++ b/packages/docs/src/content/docs/operate/reliability-runbooks.md
@@ -15,8 +15,8 @@ Question: are webhook requests accepted and routed correctly?
 
 Check:
 
-- `event.name:webhook_handler_failed`
-- `event.name:webhook_non_success_response`
+- `event.name:webhook.handler.failed`
+- `event.name:webhook.response.unsuccessful`
 - `span.op:http.server url.path:"/api/webhooks"`
 
 ## Queue callback failures
@@ -25,9 +25,9 @@ Question: are messages enqueued and processed successfully?
 
 Check:
 
-- `event.name:conversation_work_failed OR event.name:conversation_work_recovery_failed`
-- `event.name:conversation_work_pending_requeued OR event.name:conversation_work_lease_expired_requeued`
-- `event.name:agent_continue_schedule_failed OR event.name:agent_continue_lock_busy`
+- `event.name:conversation.work.failed OR event.name:conversation.work.recovery.failed`
+- `event.name:conversation.work.pending.requeued OR event.name:conversation.work.lease_expired.requeued`
+- `event.name:agent.continue.schedule.failed OR event.name:agent.continue.lock.busy`
 - `span.op:queue.process_message`
 
 ## Turn execution failures
@@ -36,8 +36,8 @@ Question: are assistant turns timing out or failing due to provider/tool issues?
 
 Check:
 
-- `event.name:agent_turn_timeout`
-- `event.name:agent_turn_failed OR event.name:agent_turn_provider_error`
+- `event.name:agent.turn.timed_out`
+- `event.name:agent.turn.failed OR event.name:agent.turn.provider_error`
 - `span.op:gen_ai.invoke_agent`
 
 ## Tool failure hotspots
@@ -46,8 +46,8 @@ Question: which tools fail most and why?
 
 Check:
 
-- `event.name:agent_tool_call_failed`
-- `event.name:agent_tool_call_invalid_input`
+- `event.name:agent.tool_call.failed`
+- `event.name:agent.tool_call.input_invalid`
 - `span.op:gen_ai.execute_tool`
 
 ## Recovery order

--- a/packages/docs/src/content/docs/start-here/verify-and-troubleshoot.md
+++ b/packages/docs/src/content/docs/start-here/verify-and-troubleshoot.md
@@ -31,11 +31,11 @@ related:
 
 ## Useful signals
 
-- `webhook_handler_failed`
-- `conversation_work_failed`
-- `conversation_work_pending_requeued`
-- `agent_turn_failed`
-- `sandbox_egress_credential_unavailable`
+- `webhook.handler.failed`
+- `conversation.work.failed`
+- `conversation.work.pending.requeued`
+- `agent.turn.failed`
+- `sandbox.egress.credential.unavailable`
 
 ## Recovery order
 

--- a/packages/junior/src/app.ts
+++ b/packages/junior/src/app.ts
@@ -646,7 +646,7 @@ export async function createApp(options?: JuniorAppOptions): Promise<Hono> {
   const app = new Hono();
 
   app.onError((err, c) => {
-    logException(err, "unhandled_route_error");
+    logException(err, "route.unhandled.exception");
     return c.text("Internal Server Error", 500);
   });
 

--- a/packages/junior/src/chat/agent-dispatch/heartbeat.ts
+++ b/packages/junior/src/chat/agent-dispatch/heartbeat.ts
@@ -71,24 +71,15 @@ export async function runPluginHeartbeats(args: {
         typeof result?.dispatchCount === "number" &&
         result.dispatchCount > 0
       ) {
-        logInfo(
-          "plugin_heartbeat_dispatched",
-          {},
-          {
-            "app.dispatch.count": result.dispatchCount,
-            "app.plugin.name": pluginName,
-          },
-          "Plugin heartbeat dispatched agent work",
-        );
+        logInfo("plugin.heartbeat.dispatched", {
+          "app.dispatch.count": result.dispatchCount,
+          "app.plugin.name": pluginName,
+        });
       }
     } catch (error) {
-      logException(
-        error,
-        "plugin_heartbeat_failed",
-        {},
-        { "app.plugin.name": pluginName },
-        "Plugin heartbeat failed",
-      );
+      logException(error, "plugin.heartbeat.failed", {
+        "app.plugin.name": pluginName,
+      });
     }
   }
 }
@@ -127,13 +118,9 @@ export async function recoverPendingDispatchMailboxAppends(args: {
         queue: args.conversationWorkQueue,
       });
     } catch (error) {
-      logException(
-        error,
-        "dispatch_mailbox_append_recovery_failed",
-        {},
-        { "app.dispatch.id": id },
-        "Pending dispatch mailbox append recovery failed",
-      );
+      logException(error, "dispatch.mailbox.append_recovery.failed", {
+        "app.dispatch.id": id,
+      });
     }
   }
 }

--- a/packages/junior/src/chat/agent/index.ts
+++ b/packages/junior/src/chat/agent/index.ts
@@ -306,24 +306,6 @@ async function executeAgentRunInPrivacyContext(
     routing.destination.platform === "slack" ? routing.destination : undefined;
   const slackActor = actor?.platform === "slack" ? actor : undefined;
   const userInput = input.messageText;
-  const credentialActor = routing.credentialContext?.actor;
-  const credentialActorLogContext = credentialActor
-    ? {
-        actorType: "type" in credentialActor ? credentialActor.type : "system",
-        actorId:
-          "type" in credentialActor
-            ? credentialActor.userId
-            : credentialActor.name,
-      }
-    : {};
-  const sessionRecordLogContext = {
-    threadId: slackSource ? conversationId : undefined,
-    actorId: slackActor?.userId,
-    channelId: slackDestination?.channelId,
-    runId,
-    ...credentialActorLogContext,
-    assistantUserName: botConfig.userName,
-  };
   const recordConnectedMcpProvider = async (provider: string) => {
     if (connectedMcpProviders.has(provider)) {
       return;
@@ -353,26 +335,20 @@ async function executeAgentRunInPrivacyContext(
     // ── Skill discovery ──────────────────────────────────────────────
     const availableSkills = await discoverRunSkills({
       skillDirs: policy.skillDirs,
-      spanContext,
     });
     if (shouldTrace) {
       const inboundAttachmentCount = input.inboundAttachmentCount ?? 0;
       const promptAttachmentCount = input.userAttachments?.length ?? 0;
-      logInfo(
-        "agent_message_in",
-        spanContext,
-        {
-          "app.message.kind": "user_inbound",
-          "app.message.length": userInput.length,
-          "app.message.input": summarizeMessageText(userInput),
-          // Log both counts so image uploads filtered by vision/config do not
-          // look indistinguishable from Slack ingress dropping attachments.
-          "app.message.attachment_count": inboundAttachmentCount,
-          "app.message.prompt_attachment_count": promptAttachmentCount,
-          "messaging.message.id": slackSource?.messageTs ?? "",
-        },
-        "Agent message received",
-      );
+      logInfo("agent.message.received", {
+        "app.message.kind": "user_inbound",
+        "app.message.length": userInput.length,
+        "app.message.input": summarizeMessageText(userInput),
+        // Log both counts so image uploads filtered by vision/config do not
+        // look indistinguishable from Slack ingress dropping attachments.
+        "app.message.attachment_count": inboundAttachmentCount,
+        "app.message.prompt_attachment_count": promptAttachmentCount,
+        "messaging.message.id": slackSource?.messageTs ?? "",
+      });
     }
     const skillInvocation = parseSkillInvocation(userInput, availableSkills);
     const invokedSkill = skillInvocation
@@ -414,7 +390,6 @@ async function executeAgentRunInPrivacyContext(
       durability,
       getLoadedSkillNames: () => loadedSkillNamesForResume,
       getReasoningLevel: () => turnRoute?.reasoningLevel,
-      logContext: sessionRecordLogContext,
       getModelId: () => activeModelId,
       recordActiveMcpProviders,
       actor,
@@ -440,15 +415,9 @@ async function executeAgentRunInPrivacyContext(
       } catch (error) {
         // Host-only activity events are best-effort reporting writes; a
         // failed append must not abort the in-flight model turn.
-        logException(
-          error,
-          "agent_turn_session_log_append_failed",
-          spanContext,
-          {
-            "gen_ai.tool.name": event.toolName,
-          },
-          "Failed to record host-only tool execution start",
-        );
+        logException(error, "agent.turn.session_log_append.failed", {
+          "gen_ai.tool.name": event.toolName,
+        });
       }
     };
     const persistedConfigurationValues = policy.channelConfiguration
@@ -645,15 +614,10 @@ async function executeAgentRunInPrivacyContext(
       void (async () => {
         await observers.onStatus?.({ text: "Switching models" });
       })().catch((error) => {
-        logWarn(
-          "assistant_status_observer_failed",
-          {},
-          {
-            "exception.message":
-              error instanceof Error ? error.message : String(error),
-          },
-          "Failed to report assistant status",
-        );
+        logWarn("assistant.status.observer.failed", {
+          "exception.message":
+            error instanceof Error ? error.message : String(error),
+        });
       });
       const handoffMessages = await compactContextForHandoff(
         {
@@ -965,28 +929,18 @@ async function executeAgentRunInPrivacyContext(
           steeredMessageCount += piMessages.length;
         });
         if (steeredMessageCount > 0) {
-          logInfo(
-            "agent_turn_steering_messages_accepted",
-            spanContext,
-            {
-              "app.ai.steering_message_count": steeredMessageCount,
-            },
-            "Agent turn steering messages accepted",
-          );
+          logInfo("agent.turn.steering_messages.accepted", {
+            "app.ai.steering_message_count": steeredMessageCount,
+          });
         }
       } catch (error) {
         if (isTurnInputCommitLostError(error)) {
           throw error;
         }
-        logWarn(
-          "agent_turn_steering_messages_drain_failed",
-          spanContext,
-          {
-            "exception.message":
-              error instanceof Error ? error.message : String(error),
-          },
-          "Agent turn steering message drain failed",
-        );
+        logWarn("agent.turn.steering_messages_drain.failed", {
+          "exception.message":
+            error instanceof Error ? error.message : String(error),
+        });
       }
       return acceptedMessages;
     };
@@ -1176,41 +1130,30 @@ async function executeAgentRunInPrivacyContext(
               );
             } catch (error) {
               if (runResume.timedOut) {
-                logWarn(
-                  "agent_turn_timeout",
-                  {},
-                  {
-                    "gen_ai.provider.name": GEN_AI_PROVIDER_NAME,
-                    "gen_ai.operation.name": "invoke_agent",
-                    "gen_ai.request.model": activeModelId,
-                    ...(turnRoute
-                      ? {
-                          "gen_ai.request.reasoning.level":
-                            turnRoute.reasoningLevel,
-                        }
-                      : {}),
-                    "app.ai.turn_timeout_ms": turnTimeoutBudgetMs,
-                    "app.ai.turn_deadline_remaining_ms": Math.max(
-                      0,
-                      turnDeadlineAtMs - Date.now(),
-                    ),
-                  },
-                  "Agent turn timed out and was aborted",
-                );
+                logWarn("agent.turn.timed_out", {
+                  "gen_ai.provider.name": GEN_AI_PROVIDER_NAME,
+                  "gen_ai.operation.name": "invoke_agent",
+                  "gen_ai.request.model": activeModelId,
+                  ...(turnRoute
+                    ? {
+                        "gen_ai.request.reasoning.level":
+                          turnRoute.reasoningLevel,
+                      }
+                    : {}),
+                  "app.ai.turn_timeout_ms": turnTimeoutBudgetMs,
+                  "app.ai.turn_deadline_remaining_ms": Math.max(
+                    0,
+                    turnDeadlineAtMs - Date.now(),
+                  ),
+                });
                 const settled = await waitForAbortSettlement(
                   run,
                   AGENT_ABORT_SETTLE_GRACE_MS,
                 );
                 if (!settled) {
-                  logWarn(
-                    "agent_turn_abort_settle_timeout",
-                    {},
-                    {
-                      "app.ai.abort_settle_grace_ms":
-                        AGENT_ABORT_SETTLE_GRACE_MS,
-                    },
-                    "Timed-out agent run did not settle after abort before resume snapshot",
-                  );
+                  logWarn("agent.turn.abort_settle.timed_out", {
+                    "app.ai.abort_settle_grace_ms": AGENT_ABORT_SETTLE_GRACE_MS,
+                  });
                 }
                 runResume.captureResumeSnapshot(
                   runResume.getResumeSnapshot(currentAgentMessages()),
@@ -1350,12 +1293,7 @@ async function executeAgentRunInPrivacyContext(
               retryUsage = currentPhaseUsage;
               agent!.state.messages = providerRetry.messages;
               await runResume.persistSafeBoundary(providerRetry.messages);
-              logWarn(
-                "agent_turn_provider_retry",
-                spanContext,
-                {},
-                "Retrying transient provider failure",
-              );
+              logWarn("agent.turn.provider.retrying");
               await sleep(providerRetry.delayMs, signal);
               signal?.throwIfAborted();
               run = agent!.continue();
@@ -1417,7 +1355,6 @@ async function executeAgentRunInPrivacyContext(
       durationMs: Date.now() - replyStartedAtMs,
       generatedFileCount: generatedFiles.length,
       shouldTrace,
-      spanContext,
       usage: turnUsage,
       executionProfile: turnRoute,
       assistantUserName: botConfig.userName,
@@ -1476,13 +1413,7 @@ async function executeAgentRunInPrivacyContext(
       throw error;
     }
 
-    logException(
-      error,
-      "assistant_reply_generation_failed",
-      { modelId: activeModelId },
-      {},
-      "executeAgentRun failed",
-    );
+    logException(error, "assistant.reply.generation.failed");
 
     // Raw exception text is diagnostics-only; the failure-response service
     // owns the sanitized user-visible fallback for empty provider errors.

--- a/packages/junior/src/chat/agent/resume.ts
+++ b/packages/junior/src/chat/agent/resume.ts
@@ -45,10 +45,6 @@ import type { PluginTurnContext } from "@/chat/plugins/prompt";
 type LoadedSessionRecordState = Awaited<
   ReturnType<typeof loadTurnSessionRecord>
 >;
-type SessionRecordLogContext = NonNullable<
-  Parameters<typeof persistRunningSessionRecord>[0]["logContext"]
->;
-
 interface ResumeStateArgs {
   channelName?: string;
   destination: Destination;
@@ -56,7 +52,6 @@ interface ResumeStateArgs {
   durability: AgentRunDurability;
   getLoadedSkillNames: () => string[];
   getModelId: () => string;
-  logContext: SessionRecordLogContext;
   getReasoningLevel: () => string | undefined;
   recordActiveMcpProviders: () => Promise<void>;
   actor?: Actor;
@@ -101,7 +96,6 @@ export function createResumeState(args: ResumeStateArgs) {
     source: args.runSource,
     sessionId: args.turnId,
     loadedSkillNames: args.getLoadedSkillNames(),
-    logContext: args.logContext,
     modelId: args.getModelId(),
     ...(args.getReasoningLevel()
       ? { reasoningLevel: args.getReasoningLevel() }

--- a/packages/junior/src/chat/agent/skills.ts
+++ b/packages/junior/src/chat/agent/skills.ts
@@ -5,7 +5,7 @@
  * handles from durable Pi history and explicit invocation, so resumed slices
  * keep the skill state the conversation already established.
  */
-import { logInfo, type LogContext } from "@/chat/logging";
+import { logInfo } from "@/chat/logging";
 import { discoverSkills, type Skill, type SkillMetadata } from "@/chat/skills";
 import { SkillSandbox } from "@/chat/sandbox/skill-sandbox";
 import { inferLoadedSkillNamesFromPiMessages } from "@/chat/pi/derived-state";
@@ -32,7 +32,6 @@ export function upsertActiveSkill(activeSkills: Skill[], next: Skill): void {
 /** Discover skills for one slice; emits the startup discovery summary once per process. */
 export async function discoverRunSkills(args: {
   skillDirs?: string[];
-  spanContext: LogContext;
 }): Promise<SkillMetadata[]> {
   const availableSkills = await discoverSkills({
     additionalRoots: args.skillDirs,
@@ -43,20 +42,13 @@ export async function discoverRunSkills(args: {
     const roots = [
       ...new Set(availableSkills.map((skill) => skill.skillPath)),
     ].sort();
-    logInfo(
-      "startup_discovery_summary",
-      args.spanContext,
-      {
-        "app.skill.count": availableSkills.length,
-        "app.skill.names": availableSkills.map((skill) => skill.name).sort(),
-        "app.file.directories": roots,
-        "app.plugin.count": plugins.length,
-        "app.plugin.names": plugins
-          .map((plugin) => plugin.manifest.name)
-          .sort(),
-      },
-      "Discovered startup SOUL/skills/plugins",
-    );
+    logInfo("startup.discovery.completed", {
+      "app.skill.count": availableSkills.length,
+      "app.skill.names": availableSkills.map((skill) => skill.name).sort(),
+      "app.file.directories": roots,
+      "app.plugin.count": plugins.length,
+      "app.plugin.names": plugins.map((plugin) => plugin.manifest.name).sort(),
+    });
   }
   return availableSkills;
 }

--- a/packages/junior/src/chat/agent/tools.ts
+++ b/packages/junior/src/chat/agent/tools.ts
@@ -97,7 +97,7 @@ interface ToolWiringArgs {
 }
 
 /** Record optional reporting without changing the loadSkill outcome. */
-async function tryRecordSkillLoadStat(skill: Skill, spanContext: LogContext) {
+async function tryRecordSkillLoadStat(skill: Skill) {
   if (!process.env.DATABASE_URL) return;
   try {
     await incrementStat({
@@ -106,17 +106,12 @@ async function tryRecordSkillLoadStat(skill: Skill, spanContext: LogContext) {
       name: skill.name,
     });
   } catch (error) {
-    logWarn(
-      "skill_load_stat_failed",
-      spanContext,
-      {
-        "app.skill.name": skill.name,
-        "app.plugin.name": skill.pluginProvider,
-        "exception.message":
-          error instanceof Error ? error.message : String(error),
-      },
-      "Failed to record skill load stat",
-    );
+    logWarn("skill.load.stat.failed", {
+      "app.skill.name": skill.name,
+      "app.plugin.name": skill.pluginProvider,
+      "exception.message":
+        error instanceof Error ? error.message : String(error),
+    });
   }
 }
 
@@ -320,7 +315,7 @@ export async function wireAgentTools(
         if (await mcpToolManager.activateForSkill(effective)) {
           await args.recordConnectedMcpProvider(effective.pluginProvider!);
         }
-        await tryRecordSkillLoadStat(effective, args.spanContext);
+        await tryRecordSkillLoadStat(effective);
         if (mcpAuth.getPendingPause()) {
           // Auth pause requested — suppress loadSkill failure and let the
           // aborted run park cleanly.
@@ -418,16 +413,11 @@ export async function wireAgentTools(
         toolName,
       });
     } catch (error) {
-      logWarn(
-        "tool_invocation_observer_failed",
-        args.spanContext,
-        {
-          "gen_ai.tool.name": toolName,
-          "exception.message":
-            error instanceof Error ? error.message : String(error),
-        },
-        "Tool invocation observer failed",
-      );
+      logWarn("tool.invocation.observer.failed", {
+        "gen_ai.tool.name": toolName,
+        "exception.message":
+          error instanceof Error ? error.message : String(error),
+      });
     }
   };
   const agentTools = createPiAgentTools(
@@ -461,18 +451,13 @@ export async function wireAgentTools(
       try {
         await mcpToolManager.close();
       } catch (closeError) {
-        logWarn(
-          "mcp_tool_manager_close_failed",
-          {},
-          {
-            ...getMcpProviderErrorAttributes(closeError),
-            "exception.message": getMcpAwareTelemetryMessage(
-              closeError,
-              args.conversationPrivacy,
-            ),
-          },
-          "Failed to close MCP tool manager",
-        );
+        logWarn("mcp.tool_manager.close.failed", {
+          ...getMcpProviderErrorAttributes(closeError),
+          "exception.message": getMcpAwareTelemetryMessage(
+            closeError,
+            args.conversationPrivacy,
+          ),
+        });
       }
     },
     toolGuidance,

--- a/packages/junior/src/chat/capabilities/jr-rpc-command.ts
+++ b/packages/junior/src/chat/capabilities/jr-rpc-command.ts
@@ -179,19 +179,14 @@ async function handleConfigCommand(
         updatedBy: deps.actorId,
         source: "jr-rpc",
       });
-      logInfo(
-        "jr_rpc_config_set",
-        {},
-        {
-          "app.config.key": entry.key,
-          "app.config.scope": entry.scope,
-          "app.config.source": entry.source ?? "jr-rpc",
-          ...(deps.activeSkill?.name
-            ? { "app.skill.name": deps.activeSkill.name }
-            : {}),
-        },
-        "Set channel configuration via jr-rpc",
-      );
+      logInfo("jr_rpc.config.updated", {
+        "app.config.key": entry.key,
+        "app.config.scope": entry.scope,
+        "app.config.source": entry.source ?? "jr-rpc",
+        ...(deps.activeSkill?.name
+          ? { "app.skill.name": deps.activeSkill.name }
+          : {}),
+      });
       deps.onConfigurationValueChanged?.(entry.key, entry.value);
       return commandResult({
         stdout: {
@@ -224,17 +219,12 @@ async function handleConfigCommand(
     }
     const deleted = await configuration.unset(key);
     if (deleted) {
-      logInfo(
-        "jr_rpc_config_unset",
-        {},
-        {
-          "app.config.key": key,
-          ...(deps.activeSkill?.name
-            ? { "app.skill.name": deps.activeSkill.name }
-            : {}),
-        },
-        "Unset channel configuration via jr-rpc",
-      );
+      logInfo("jr_rpc.config.removed", {
+        "app.config.key": key,
+        ...(deps.activeSkill?.name
+          ? { "app.skill.name": deps.activeSkill.name }
+          : {}),
+      });
       deps.onConfigurationValueChanged?.(key, undefined);
     }
     return commandResult({

--- a/packages/junior/src/chat/conversations/retention.ts
+++ b/packages/junior/src/chat/conversations/retention.ts
@@ -7,7 +7,7 @@
  * so no expiry is ever stored and a public↔private flip takes effect on the next
  * pass. Storage write paths own no TTLs.
  */
-import { logException, logInfo } from "@/chat/logging";
+import { logException, logInfo, withLogContext } from "@/chat/logging";
 import type { JuniorSqlDatabase } from "@/db/db";
 import { purgeConversationTree, selectExpiredRoots } from "./sql/purge";
 
@@ -56,42 +56,33 @@ export async function runRetentionPurge(
   let failed = 0;
   let conversations = 0;
   for (const root of roots) {
-    try {
-      const result = await purgeConversationTree(executor, {
-        rootConversationId: root.conversationId,
-        nowMs: args.nowMs,
-        retention: {
-          publicWindowMs: CONTENT_RETENTION_MS.public,
-          privateWindowMs: CONTENT_RETENTION_MS.private,
-        },
-      });
-      if (result.purged) {
-        purged += 1;
-        conversations += result.conversations;
+    await withLogContext({ conversationId: root.conversationId }, async () => {
+      try {
+        const result = await purgeConversationTree(executor, {
+          rootConversationId: root.conversationId,
+          nowMs: args.nowMs,
+          retention: {
+            publicWindowMs: CONTENT_RETENTION_MS.public,
+            privateWindowMs: CONTENT_RETENTION_MS.private,
+          },
+        });
+        if (result.purged) {
+          purged += 1;
+          conversations += result.conversations;
+        }
+      } catch (error) {
+        failed += 1;
+        logException(error, "retention.purge.tree.failed");
       }
-    } catch (error) {
-      failed += 1;
-      logException(
-        error,
-        "retention_purge_tree_failed",
-        { conversationId: root.conversationId },
-        {},
-        "Retention purge failed for one conversation tree",
-      );
-    }
+    });
   }
-  logInfo(
-    "retention_purge_completed",
-    {},
-    {
-      "app.retention.scanned": roots.length,
-      "app.retention.purged": purged,
-      "app.retention.failed": failed,
-      "app.retention.conversations": conversations,
-      "app.retention.duration_ms": Date.now() - startedAtMs,
-    },
-    "Retention purge batch completed",
-  );
+  logInfo("retention.purge.completed", {
+    "app.retention.scanned": roots.length,
+    "app.retention.purged": purged,
+    "app.retention.failed": failed,
+    "app.retention.conversations": conversations,
+    "app.retention.duration_ms": Date.now() - startedAtMs,
+  });
   return { scanned: roots.length, purged, failed, conversations };
 }
 

--- a/packages/junior/src/chat/egress/credentialed.ts
+++ b/packages/junior/src/chat/egress/credentialed.ts
@@ -284,26 +284,21 @@ function logSandboxEgressUpstreamRequest(input: {
     return;
   }
 
-  logInfo(
-    "sandbox_egress_upstream_request",
-    {},
-    {
-      ...egressAttributes({
-        egressId: input.egressId,
-        grantAccess: input.grantAccess,
-        grantName: input.grantName,
-        grantReason: input.grantReason,
-        host: input.upstreamUrl.hostname,
-        method: input.request.method,
-        path: input.upstreamUrl.pathname,
-        provider: input.provider,
-        status: input.upstream.status,
-      }),
-      ...routingAttributes(input.request, input.upstreamUrl),
-      "app.sandbox.egress.upstream_ok": input.upstream.ok,
-    },
-    `Sandbox egress ${input.request.method} ${input.upstreamUrl.hostname}${displayedUpstreamPath(input.upstreamUrl)} -> ${input.upstream.status}`,
-  );
+  logInfo("sandbox.egress.upstream.requested", {
+    ...egressAttributes({
+      egressId: input.egressId,
+      grantAccess: input.grantAccess,
+      grantName: input.grantName,
+      grantReason: input.grantReason,
+      host: input.upstreamUrl.hostname,
+      method: input.request.method,
+      path: input.upstreamUrl.pathname,
+      provider: input.provider,
+      status: input.upstream.status,
+    }),
+    ...routingAttributes(input.request, input.upstreamUrl),
+    "app.sandbox.egress.upstream_ok": input.upstream.ok,
+  });
 }
 
 async function requestBodyBytes(
@@ -607,22 +602,17 @@ export async function executeCredentialedEgressRequest(input: {
     });
   } catch (error) {
     if (isEgressPolicyDenied(error)) {
-      logWarn(
-        "sandbox_egress_policy_denied",
-        {},
-        {
-          ...egressAttributes({
-            egressId: activeEgressId,
-            host: upstreamUrl.hostname,
-            method: request.method,
-            path: upstreamUrl.pathname,
-            provider,
-            status: 403,
-          }),
-          ...routingAttributes(request, upstreamUrl),
-        },
-        error.message,
-      );
+      logWarn("sandbox.egress.policy.denied", {
+        ...egressAttributes({
+          egressId: activeEgressId,
+          host: upstreamUrl.hostname,
+          method: request.method,
+          path: upstreamUrl.pathname,
+          provider,
+          status: 403,
+        }),
+        ...routingAttributes(request, upstreamUrl),
+      });
       return policyDeniedResponse(error);
     }
     throw error;
@@ -656,9 +646,8 @@ export async function executeCredentialedEgressRequest(input: {
       const isAuthRequired = error.kind === "auth_required";
       logWarn(
         isAuthRequired
-          ? "sandbox_egress_credential_needed"
-          : "sandbox_egress_credential_unavailable",
-        {},
+          ? "sandbox.egress.credential.needed"
+          : "sandbox.egress.credential.unavailable",
         {
           ...egressAttributes({
             egressId: activeEgressId,
@@ -673,9 +662,6 @@ export async function executeCredentialedEgressRequest(input: {
           }),
           ...routingAttributes(request, upstreamUrl),
         },
-        isAuthRequired
-          ? "Sandbox egress grant needs user authorization before issuing a credential lease"
-          : "Sandbox egress credential lease is unavailable for selected grant",
       );
       return authRequiredResponse({
         provider: error.provider,
@@ -698,17 +684,12 @@ export async function executeCredentialedEgressRequest(input: {
     });
 
   if (!hasSandboxEgressLeaseTransformForHost(lease, upstreamUrl.hostname)) {
-    logWarn(
-      "sandbox_egress_transform_missing",
-      {},
-      {
-        ...attributes(403),
-        "app.sandbox.egress.transform_domains": lease.headerTransforms.map(
-          (transform) => transform.domain,
-        ),
-      },
-      "Sandbox egress credential lease does not cover forwarded host",
-    );
+    logWarn("sandbox.egress.transform.missing", {
+      ...attributes(403),
+      "app.sandbox.egress.transform_domains": lease.headerTransforms.map(
+        (transform) => transform.domain,
+      ),
+    });
     return Response.json(
       { error: "Credential lease does not cover forwarded host" },
       { status: 403 },
@@ -765,14 +746,9 @@ export async function executeCredentialedEgressRequest(input: {
         upstream,
         upstreamUrl,
       });
-      logWarn(
-        "sandbox_egress_upstream_permission_classified",
-        {},
-        {
-          ...attributes(upstream.status, upstream),
-        },
-        "Sandbox egress plugin classified upstream response as permission denied",
-      );
+      logWarn("sandbox.egress.upstream_permission.classified", {
+        ...attributes(upstream.status, upstream),
+      });
     }
   } catch (error) {
     if (!isEgressAuthRequired(error)) {
@@ -786,14 +762,9 @@ export async function executeCredentialedEgressRequest(input: {
       authorization: error.authorization ?? lease.authorization,
       message: error.message,
     });
-    logWarn(
-      "sandbox_egress_upstream_auth_required_classified",
-      {},
-      {
-        ...attributes(upstream.status, upstream),
-      },
-      "Sandbox egress plugin classified upstream response as auth required",
-    );
+    logWarn("sandbox.egress.upstream_auth_requirement.classified", {
+      ...attributes(upstream.status, upstream),
+    });
     await upstream.body?.cancel().catch(() => undefined);
     return authRequiredResponse({
       provider,
@@ -812,36 +783,24 @@ export async function executeCredentialedEgressRequest(input: {
     upstreamUrl,
   });
   if (upstream.status >= 400) {
-    logWarn(
-      "sandbox_egress_upstream_error_response",
-      {},
-      {
-        ...attributes(upstream.status, upstream),
-        "error.type": `http_${upstream.status}`,
-      },
-      `Sandbox egress upstream returned HTTP ${upstream.status}`,
-    );
+    logWarn("sandbox.egress.upstream_response.failed", {
+      ...attributes(upstream.status, upstream),
+      "error.type": `http_${upstream.status}`,
+    });
   }
   if (
     upstream.status === UPSTREAM_TOKEN_REJECTION_STATUS ||
     upstream.status === UPSTREAM_PERMISSION_REJECTION_STATUS
   ) {
-    logWarn(
-      "sandbox_egress_upstream_auth_rejected",
-      {},
-      {
-        ...attributes(upstream.status, upstream),
-        ...(upstream.status === UPSTREAM_TOKEN_REJECTION_STATUS
-          ? {
-              "app.sandbox.egress.www_authenticate":
-                upstream.headers.get("www-authenticate") ?? undefined,
-            }
-          : {}),
-      },
-      upstream.status === UPSTREAM_TOKEN_REJECTION_STATUS
-        ? "Sandbox egress upstream auth rejected injected credential"
-        : "Sandbox egress upstream permission denied",
-    );
+    logWarn("sandbox.egress.upstream_auth.rejected", {
+      ...attributes(upstream.status, upstream),
+      ...(upstream.status === UPSTREAM_TOKEN_REJECTION_STATUS
+        ? {
+            "app.sandbox.egress.www_authenticate":
+              upstream.headers.get("www-authenticate") ?? undefined,
+          }
+        : {}),
+    });
     if (upstream.status === UPSTREAM_TOKEN_REJECTION_STATUS) {
       await clearCredentialLease(provider, lease.grant, credentialContext);
       await recordAuthRequired({

--- a/packages/junior/src/chat/egress/credentialed.ts
+++ b/packages/junior/src/chat/egress/credentialed.ts
@@ -612,6 +612,7 @@ export async function executeCredentialedEgressRequest(input: {
           status: 403,
         }),
         ...routingAttributes(request, upstreamUrl),
+        "app.sandbox.egress.policy.reason": error.message,
       });
       return policyDeniedResponse(error);
     }

--- a/packages/junior/src/chat/ingress/slack-webhook.ts
+++ b/packages/junior/src/chat/ingress/slack-webhook.ts
@@ -34,7 +34,12 @@ import { unlinkProvider } from "@/chat/credentials/unlink-provider";
 import type { UserTokenStore } from "@/chat/credentials/user-token-store";
 import { publishAppHomeView } from "@/chat/slack/app-home";
 import { getSlackClient } from "@/chat/slack/client";
-import { logException, withSpan } from "@/chat/logging";
+import {
+  logException,
+  withLogContext,
+  withSpan,
+  type LogContext,
+} from "@/chat/logging";
 import type { WaitUntilFn } from "@/handlers/types";
 
 type SlackMessageEvent = {
@@ -57,6 +62,22 @@ type SlackEventEnvelope = {
   team_id?: string;
   type?: string;
 };
+
+function slackEventLogContext(
+  event: SlackMessageEvent | undefined,
+): LogContext {
+  const channelId = event?.channel?.trim() || undefined;
+  const threadTs = event?.thread_ts?.trim() || event?.ts?.trim() || undefined;
+  const conversationId =
+    channelId && threadTs ? `slack:${channelId}:${threadTs}` : undefined;
+  return {
+    platform: "slack",
+    conversationId,
+    messageConversationId: conversationId,
+    destinationName: channelId,
+    userId: event?.user?.trim() || undefined,
+  };
+}
 
 const IGNORED_MESSAGE_SUBTYPES = new Set([
   "message_changed",
@@ -330,17 +351,17 @@ async function handleSlackEvent(args: {
   const receivedAtMs = Date.now();
 
   async function publishAppHomeViewBestEffort(userId: string): Promise<void> {
-    try {
-      await publishAppHomeView(
-        getSlackClient(),
-        userId,
-        getUserTokenStore(args.services),
-      );
-    } catch (error) {
-      logException(error, "slack_app_home_publish_failed", {
-        userId,
-      });
-    }
+    await withLogContext({ platform: "slack", userId }, async () => {
+      try {
+        await publishAppHomeView(
+          getSlackClient(),
+          userId,
+          getUserTokenStore(args.services),
+        );
+      } catch (error) {
+        logException(error, "slack.app_home.publish.failed");
+      }
+    });
   }
 
   await runWithWorkspaceTeamId(installation.teamId, () =>
@@ -534,23 +555,17 @@ async function handleInteractivePayload(args: {
       try {
         await unlinkProvider(userId, provider, args.userTokenStore);
       } catch (error) {
-        logException(
-          error,
-          "app_home_disconnect_unlink_failed",
-          { userId: userId },
-          { "app.credential.provider": provider },
-        );
+        logException(error, "app_home.disconnect_unlink.failed", {
+          "app.credential.provider": provider,
+        });
       }
 
       try {
         await publishAppHomeView(getSlackClient(), userId, args.userTokenStore);
       } catch (error) {
-        logException(
-          error,
-          "app_home_disconnect_publish_failed",
-          { userId: userId },
-          { "app.credential.provider": provider },
-        );
+        logException(error, "app_home.disconnect_publish.failed", {
+          "app.credential.provider": provider,
+        });
       }
     },
   );
@@ -589,23 +604,28 @@ async function handleSlackForm(args: {
     const installation = installationFromForm(params);
     enqueue(
       args.waitUntil,
-      runWithWorkspaceTeamId(installation.teamId, () =>
-        runWithSlackInstallation({
-          adapter,
-          installation,
-          state,
-          task: () =>
-            handleSlashCommandForm({
+      withLogContext(
+        {
+          platform: "slack",
+          userId: params.get("user_id")?.trim() || undefined,
+        },
+        () =>
+          runWithWorkspaceTeamId(installation.teamId, () =>
+            runWithSlackInstallation({
               adapter,
-              params,
+              installation,
               state,
+              task: () =>
+                handleSlashCommandForm({
+                  adapter,
+                  params,
+                  state,
+                }),
             }),
-        }),
-      ).catch((error) => {
-        logException(error, "slash_command_failed", {
-          userId: params.get("user_id") ?? undefined,
-        });
-      }),
+          ).catch((error) => {
+            logException(error, "slash_command.failed");
+          }),
+      ),
     );
     return new Response("", { status: 200 });
   }
@@ -622,22 +642,27 @@ async function handleSlackForm(args: {
 
   enqueue(
     args.waitUntil,
-    runWithWorkspaceTeamId(installation.teamId, () =>
-      runWithSlackInstallation({
-        adapter,
-        installation,
-        state,
-        task: () =>
-          handleInteractivePayload({
-            payload,
-            userTokenStore: getUserTokenStore(args.services),
-          }),
-      }),
-    ).catch((error) => {
-      logException(error, "slack_interactive_payload_failed", {
+    withLogContext(
+      {
+        platform: "slack",
         userId: payload.user?.id?.trim() || undefined,
-      });
-    }),
+      },
+      () =>
+        runWithWorkspaceTeamId(installation.teamId, () =>
+          runWithSlackInstallation({
+            adapter,
+            installation,
+            state,
+            task: () =>
+              handleInteractivePayload({
+                payload,
+                userTokenStore: getUserTokenStore(args.services),
+              }),
+          }),
+        ).catch((error) => {
+          logException(error, "slack.interactive.payload.failed");
+        }),
+    ),
   );
   return new Response("", { status: 200 });
 }
@@ -675,30 +700,44 @@ export async function handleSlackWebhook(args: {
   }
 
   if (parsed.type === "event_callback") {
-    const eventTask = handleSlackEvent({
-      body: parsed,
-      services: args.services,
-    });
+    const eventLogContext = slackEventLogContext(parsed.event);
     if (shouldPersistBeforeAck(parsed)) {
-      try {
-        await eventTask;
-      } catch (error) {
-        // Any failure before durable mailbox append — installation/token
-        // resolution, routing-state reads, persistence — must be retryable.
-        // Acking 200 here would silently drop the user's message.
-        if (error instanceof SlackEventPersistenceError) {
-          logException(error.cause, "slack_event_persist_failed");
-        } else {
-          logException(error, "slack_event_routing_failed");
-        }
-        return new Response("Slack event handling failed", { status: 503 });
+      const failureResponse = await withLogContext(
+        eventLogContext,
+        async () => {
+          try {
+            await handleSlackEvent({
+              body: parsed,
+              services: args.services,
+            });
+          } catch (error) {
+            // Any failure before durable mailbox append — installation/token
+            // resolution, routing-state reads, persistence — must be retryable.
+            // Acking 200 here would silently drop the user's message.
+            if (error instanceof SlackEventPersistenceError) {
+              logException(error.cause, "slack.event.persist.failed");
+            } else {
+              logException(error, "slack.event.routing.failed");
+            }
+            return new Response("Slack event handling failed", { status: 503 });
+          }
+          return undefined;
+        },
+      );
+      if (failureResponse) {
+        return failureResponse;
       }
     } else {
       enqueue(
         args.waitUntil,
-        eventTask.catch((error) => {
-          logException(error, "slack_event_enqueue_failed");
-        }),
+        withLogContext(eventLogContext, () =>
+          handleSlackEvent({
+            body: parsed,
+            services: args.services,
+          }).catch((error) => {
+            logException(error, "slack.event.enqueue.failed");
+          }),
+        ),
       );
     }
   }

--- a/packages/junior/src/chat/ingress/slash-command.ts
+++ b/packages/junior/src/chat/ingress/slash-command.ts
@@ -88,12 +88,9 @@ async function handleUnlink(
   const tokenStore = createUserTokenStore();
   await tokenStore.delete(actorId, provider);
 
-  logInfo(
-    "slash_command_unlink",
-    { userId: actorId },
-    { "app.credential.provider": provider },
-    `Unlinked ${formatProviderLabel(provider)} account via ${getCommandName()} slash command`,
-  );
+  logInfo("slash_command.credential.unlinked", {
+    "app.credential.provider": provider,
+  });
 
   await postEphemeral(
     event,

--- a/packages/junior/src/chat/local/runner.ts
+++ b/packages/junior/src/chat/local/runner.ts
@@ -19,7 +19,7 @@ import {
   localDestinationSchema,
   type LocalDestination,
 } from "@sentry/junior-plugin-api";
-import { logException } from "@/chat/logging";
+import { logException, setTags, withLogContext } from "@/chat/logging";
 import {
   processPluginTask,
   scheduleSessionCompletedPluginTasks,
@@ -72,10 +72,10 @@ import type { SandboxEgressSignalTransport } from "@/chat/sandbox/egress/signals
 const SENTRY_EVENT_ID_PATTERN = /^[a-f0-9]{32}$/i;
 
 const LOCAL_FAILURE_EVENT_NAMES: Record<ConversationTurnFailureCode, string> = {
-  agent_run_failed: "local_agent_run_failed",
-  delivery_failed: "local_reply_delivery_failed",
-  model_execution_failed: "local_model_execution_failed",
-  persistence_failed: "local_turn_persistence_failed",
+  agent_run_failed: "local.agent_run.failed",
+  delivery_failed: "local.reply.delivery.failed",
+  model_execution_failed: "local.model.execution.failed",
+  persistence_failed: "local.turn.persistence.failed",
 };
 
 export interface LocalAgentTurnInput {
@@ -148,15 +148,14 @@ function captureLocalBoundaryFailure(args: {
   failureCode: ConversationTurnFailureCode;
   runId?: string;
 }): string | undefined {
+  setTags({
+    conversationId: args.conversationId,
+    ...(args.runId ? { runId: args.runId } : {}),
+  });
   const eventId = args.capture(
     args.error,
     LOCAL_FAILURE_EVENT_NAMES[args.failureCode],
-    {
-      conversationId: args.conversationId,
-      ...(args.runId ? { runId: args.runId } : {}),
-    },
     { "app.ai.failure_code": args.failureCode },
-    "Local agent turn failed at its owning runtime boundary",
   );
   return eventId && SENTRY_EVENT_ID_PATTERN.test(eventId) ? eventId : undefined;
 }
@@ -176,6 +175,23 @@ async function loadLocalPiMessages(args: {
 
 /** Run one local CLI message through Junior's shared agent-run boundary. */
 export async function runLocalAgentTurn(
+  input: LocalAgentTurnInput,
+  deps: LocalAgentTurnDeps,
+): Promise<LocalAgentTurnResult> {
+  return withLogContext(
+    {
+      conversationId: input.conversationId,
+      destinationName: input.conversationId,
+      messageConversationId: input.conversationId,
+      platform: "local",
+      userId: "local-cli",
+      userName: "local",
+    },
+    () => runLocalAgentTurnInContext(input, deps),
+  );
+}
+
+async function runLocalAgentTurnInContext(
   input: LocalAgentTurnInput,
   deps: LocalAgentTurnDeps,
 ): Promise<LocalAgentTurnResult> {
@@ -291,10 +307,8 @@ export async function runLocalAgentTurn(
     } catch (error) {
       logException(
         new Error("Accepted assistant message persistence failed"),
-        "local_assistant_message_post_delivery_persist_failed",
-        { conversationId: input.conversationId },
+        "local.assistant.message_post_delivery_persist.failed",
         { "error.type": error instanceof Error ? error.name : typeof error },
-        "Failed to persist an accepted local assistant message",
       );
     }
     failureCode = "agent_run_failed";
@@ -307,6 +321,7 @@ export async function runLocalAgentTurn(
     failureCode = "agent_run_failed";
     const runAgent = async (messages: PiMessage[] | undefined) => {
       currentRunId = localRunId();
+      setTags({ runId: currentRunId });
       const authorization = deps.authorization
         ? {
             createState: deps.authorization.createState,
@@ -431,7 +446,6 @@ export async function runLocalAgentTurn(
     const finalized = finalizeFailedTurnReplyWithEvent({
       reply,
       logException: deps.logException ?? logException,
-      context: { conversationId: input.conversationId },
     });
     reply = finalized.reply;
     modelFailureEventId = finalized.eventId;
@@ -577,31 +591,23 @@ export async function runLocalAgentTurn(
             } catch (error) {
               logException(
                 error,
-                "local_plugin_session_completed_task_failed",
-                {},
+                "local.plugin.session_completion_task.failed",
                 {
                   conversationId: input.conversationId,
                   pluginName: message.plugin,
                   taskName: message.name,
                   turnId,
                 },
-                "Local plugin session.completed task failed after reply delivery",
               );
             }
           },
         },
       );
     } catch (error) {
-      logException(
-        error,
-        "local_plugin_session_completed_task_failed",
-        {},
-        {
-          conversationId: input.conversationId,
-          turnId,
-        },
-        "Local plugin session.completed task failed after reply delivery",
-      );
+      logException(error, "local.plugin.session_completion_task.failed", {
+        conversationId: input.conversationId,
+        turnId,
+      });
     }
   }
 

--- a/packages/junior/src/chat/logging.ts
+++ b/packages/junior/src/chat/logging.ts
@@ -1,3 +1,32 @@
+/**
+ * Structured logging for Junior runtime events.
+ *
+ * Application code should call `logInfo`, `logWarn`, `logError`, or
+ * `logException` with a stable dot-namespaced event name and only attributes
+ * specific to that occurrence:
+ *
+ * `logWarn("agent.turn.reply_recovery.exhausted", { "app.retry.attempt": 2 })`
+ *
+ * Event names describe the semantic domain, operation, and outcome. They are
+ * lowercase, use dots for namespaces, use snake case within a namespace
+ * component, and never contain identifiers or other occurrence-specific data.
+ * Use singular domain and operation nouns unless one event represents a real
+ * collection. End completed events with a past participle such as `completed`,
+ * `failed`, or `skipped`; reserve present participles such as `retrying` for
+ * work currently underway, and adjectives such as `busy` for observed states.
+ *
+ * Correlation context is implicit. Bind authoritative request, conversation,
+ * actor, destination, and run context once with `withContext`,
+ * `withLogContext`, or `withSpan`; nested logs inherit it through
+ * AsyncLocalStorage, and active trace/span IDs are attached during emission.
+ * Durable boundaries such as queues and callbacks must still carry and
+ * reconstruct their context explicitly before binding it.
+ *
+ * Internal event calls do not provide a human-readable body. Export adapters
+ * derive any required display message from the event name. Free-form messages
+ * received from libraries or plugins belong in safe attributes at the adapter
+ * boundary.
+ */
 import path from "node:path";
 import { styleText } from "node:util";
 import {
@@ -65,6 +94,7 @@ interface SentryUserIdentity {
 }
 
 const MAX_STRING_VALUE = 1200;
+const EVENT_NAME_PATTERN = /^[a-z][a-z0-9_]*(?:\.[a-z][a-z0-9_]*)+$/;
 const SECRETS_RE = [
   /\b(sk-[A-Za-z0-9_-]{20,})\b/g,
   /\b(xox[baprs]-[A-Za-z0-9-]{10,})\b/g,
@@ -343,6 +373,25 @@ function toSnakeCase(value: string): string {
     .toLowerCase();
 }
 
+function normalizeEventName(value: string): string {
+  const segments = value.trim().split(".").map(toSnakeCase).filter(Boolean);
+  const normalized =
+    segments.length === 0
+      ? "log.record.emitted"
+      : segments.length === 1
+        ? `app.${segments[0]}`
+        : segments.join(".");
+  if (
+    process.env.NODE_ENV !== "production" &&
+    (!EVENT_NAME_PATTERN.test(value) || value !== normalized)
+  ) {
+    throw new Error(
+      `Invalid log event name "${value}"; use lowercase dot-delimited namespaces`,
+    );
+  }
+  return normalized;
+}
+
 function isSemanticKey(key: string): boolean {
   return /^[a-z][a-z0-9_]*(\.[a-z0-9_][a-z0-9_-]*)+$/.test(key);
 }
@@ -351,6 +400,9 @@ function normalizeAttributeKey(key: string): string {
   const mapped = LEGACY_KEY_MAP[key];
   if (mapped) {
     return mapped;
+  }
+  if (key === "trace_id" || key === "span_id" || key === "trace_flags") {
+    return key;
   }
 
   if (isSemanticKey(key)) {
@@ -496,7 +548,7 @@ function toEmittedLogRecord(record: LogTapeRecord): EmittedLogRecord {
       )
       .join("");
   const eventName =
-    toOptionalString(attributes["event.name"]) ?? "log_record_emitted";
+    toOptionalString(attributes["event.name"]) ?? "log.record.emitted";
 
   return {
     level: fromLogTapeLevel(record.level),
@@ -681,7 +733,7 @@ function formatConsoleValue(value: AttributeValue): string {
 }
 
 function shouldShowConsoleDestinationName(eventName: string): boolean {
-  return /^(app_home_|oauth_|queue_|slash_command_|slack_|webhook_)/.test(
+  return /^(app_home|oauth|queue|slash_command|slack|webhook)\./.test(
     eventName,
   );
 }
@@ -692,11 +744,11 @@ function shouldShowConsoleModel(level: LogLevel, eventName: string): boolean {
   }
 
   return (
-    eventName.startsWith("ai_") ||
-    eventName.startsWith("assistant_") ||
-    eventName === "agent_turn_started" ||
-    eventName === "agent_turn_completed" ||
-    eventName === "agent_turn_provider_error"
+    eventName.startsWith("ai.") ||
+    eventName.startsWith("assistant.") ||
+    eventName === "agent.turn.started" ||
+    eventName === "agent.turn.completed" ||
+    eventName === "agent.turn.provider_error"
   );
 }
 
@@ -738,7 +790,7 @@ function shouldHideConsoleAttribute(
   }
   if (
     key === "gen_ai.provider.name" &&
-    eventName.startsWith("agent_tool_call_") &&
+    eventName.startsWith("agent.tool_call.") &&
     level !== "warn" &&
     level !== "error"
   ) {
@@ -746,7 +798,7 @@ function shouldHideConsoleAttribute(
   }
   if (
     key === "gen_ai.operation.name" &&
-    eventName.startsWith("agent_tool_call_")
+    eventName.startsWith("agent.tool_call.")
   ) {
     return true;
   }
@@ -827,9 +879,9 @@ function booleanConsoleToken(
 
 function shouldShowPrettyCorrelation(eventName: string): boolean {
   return !(
-    eventName === "plugin_loaded" ||
-    eventName === "startup_discovery_summary" ||
-    eventName.endsWith("_loaded")
+    eventName === "plugin.loaded" ||
+    eventName === "startup.discovery.completed" ||
+    eventName.endsWith(".loaded")
   );
 }
 
@@ -845,7 +897,7 @@ function getPrettyConsoleSummaryTokens(
   );
   pushPrettyConsoleToken(
     tokens,
-    eventName.startsWith("plugin_heartbeat")
+    eventName.startsWith("plugin.heartbeat.")
       ? stringConsoleToken("plugin", attributes["app.plugin.name"])
       : (toOptionalString(attributes["app.plugin.name"]) ?? undefined),
   );
@@ -901,7 +953,7 @@ function getPrettyConsoleSummaryTokens(
   }
 
   const filePath = toOptionalString(attributes["file.path"]);
-  if (filePath && eventName.endsWith("_loaded")) {
+  if (filePath && eventName.endsWith(".loaded")) {
     pushPrettyConsoleToken(tokens, toRelativeConsolePath(filePath));
   }
 
@@ -1080,7 +1132,7 @@ function emitRecord(
 ): void {
   ensureLoggerBackend();
   const traceAttributes = getTraceCorrelationAttributes();
-  const normalizedEventName = toSnakeCase(eventName);
+  const normalizedEventName = normalizeEventName(eventName);
   const message = body ? redactSecrets(body) : normalizedEventName;
   const source = getLogSource([...ROOT_LOGGER_CATEGORY, ...category]);
   const contextAttributes = ownsLogTapeBackend
@@ -1133,6 +1185,12 @@ function emit(
   emitRecord([], level, eventName, attrs, body);
 }
 
+/**
+ * Low-level adapter logger.
+ *
+ * Application runtime code should use the severity helpers below. This surface
+ * exists for adapters that must preserve an external free-form body.
+ */
 export const log = {
   debug(
     eventName: string,
@@ -1167,7 +1225,6 @@ export const log = {
     error: unknown,
     attrs: Record<string, unknown> = {},
     body?: string,
-    context?: LogContext,
   ): string | undefined {
     const normalizedError =
       error instanceof Error ? error : new Error(String(error));
@@ -1181,7 +1238,7 @@ export const log = {
         "exception.message": normalizedError.message,
         "exception.stacktrace": normalizedError.stack,
       },
-      body ?? normalizedError.message,
+      body,
     );
 
     let eventId: string | undefined;
@@ -1201,10 +1258,7 @@ export const log = {
       typeof sentryCaptureException === "function"
     ) {
       sentryWithScope((scope) => {
-        setSentryScopeContext(scope, {
-          ...getBoundLogContext(),
-          ...context,
-        });
+        setSentryScopeContext(scope, getBoundLogContext());
         for (const [key, value] of Object.entries(
           mergeAttributes(getBoundLogAttributes(), attrs),
         )) {
@@ -1216,12 +1270,7 @@ export const log = {
     }
 
     if (typeof sentryCaptureException === "function") {
-      setSentryUser(
-        sentryUserIdentityFromContext({
-          ...getBoundLogContext(),
-          ...context,
-        }),
-      );
+      setSentryUser(sentryUserIdentityFromContext(getBoundLogContext()));
       eventId = sentryCaptureException(normalizedError);
     }
     return eventId;
@@ -1303,10 +1352,10 @@ function createChatSdkLoggerImpl(
       category,
       level === "warn" ? "warn" : level,
       level === "error"
-        ? "chat_sdk_error"
+        ? "chat_sdk.log.error"
         : level === "warn"
-          ? "chat_sdk_warning"
-          : "chat_sdk_log",
+          ? "chat_sdk.log.warn"
+          : "chat_sdk.log",
       args.length > 0
         ? {
             "app.log.args": args.length === 1 ? args[0] : args,
@@ -1340,10 +1389,13 @@ export function createChatSdkLogger(): ChatSdkLogger {
   return createChatSdkLoggerImpl(["chat-sdk"], resolveChatSdkLogLevel());
 }
 
-export function withLogContext<T>(
-  context: LogContext,
-  callback: () => Promise<T>,
-): Promise<T> {
+/**
+ * Run one operation with inherited correlation context.
+ *
+ * Call this at execution boundaries after reconstructing authoritative
+ * context. Nested application logs should not receive the same context again.
+ */
+export function withLogContext<T>(context: LogContext, callback: () => T): T {
   return runWithScopedLogContext(
     context,
     contextToAttributes(context),
@@ -1395,15 +1447,6 @@ export function createLogContextFromRequest(
     urlFull: url.toString(),
     userAgent: request.headers.get("user-agent") ?? undefined,
   };
-}
-
-export function toSpanAttributes(context: LogContext): Record<string, string> {
-  const attrs = contextToAttributes(context);
-  return Object.fromEntries(
-    Object.entries(attrs).filter(
-      ([, value]) => typeof value === "string" && value.length > 0,
-    ),
-  ) as Record<string, string>;
 }
 
 /** Attach filterable non-user context tags to Sentry. */
@@ -1526,69 +1569,68 @@ function setAttributesOnSpan(
   }
 }
 
-/** Capture an error to Sentry and emit an error log record. */
-export function captureException(
-  error: unknown,
-  context: LogContext = {},
-): void {
+/**
+ * Capture an error using context already bound to the current operation.
+ */
+export function captureException(error: unknown): void {
   const normalizedError =
     error instanceof Error ? error : new Error(String(error));
-  log.exception(
-    "exception_captured",
-    normalizedError,
-    toSpanAttributes(context),
-    "Captured exception",
-    context,
-  );
+  log.exception("exception.captured", normalizedError);
 }
 
-/** Log an info-level structured event. */
+/**
+ * Emit an informational event with occurrence-specific attributes.
+ *
+ * Bind correlation context at the owning operation boundary instead of
+ * passing it here.
+ */
 export function logInfo(
   eventName: string,
-  context: LogContext = {},
   attributes: Record<string, unknown> = {},
-  body?: string,
 ): void {
-  log.info(eventName, { ...toSpanAttributes(context), ...attributes }, body);
+  log.info(eventName, attributes);
 }
 
-/** Log a warning-level structured event. */
+/**
+ * Emit a warning event with occurrence-specific attributes.
+ *
+ * Bind correlation context at the owning operation boundary instead of
+ * passing it here.
+ */
 export function logWarn(
   eventName: string,
-  context: LogContext = {},
   attributes: Record<string, unknown> = {},
-  body?: string,
 ): void {
-  log.warn(eventName, { ...toSpanAttributes(context), ...attributes }, body);
+  log.warn(eventName, attributes);
 }
 
-/** Log an error-level structured event. */
+/**
+ * Emit an error event without capturing an exception.
+ *
+ * Use `logException` when an actual exception instance owns the failure.
+ */
 export function logError(
   eventName: string,
-  context: LogContext = {},
   attributes: Record<string, unknown> = {},
-  body?: string,
 ): void {
-  log.error(eventName, { ...toSpanAttributes(context), ...attributes }, body);
+  log.error(eventName, attributes);
 }
 
-/** Log an error with exception capture; returns the Sentry event ID if available. */
+/**
+ * Emit an exception event and capture the exception with bound context.
+ *
+ * Exception event names should end in `.exception` when they describe a
+ * generic operation exception. Existing domain failure events may retain a
+ * `.failed` outcome when the event also covers non-exception failures.
+ */
 export function logException(
   error: unknown,
   eventName: string,
-  context: LogContext = {},
   attributes: Record<string, unknown> = {},
-  body?: string,
 ): string | undefined {
   const normalizedError =
     error instanceof Error ? error : new Error(String(error));
-  return log.exception(
-    eventName,
-    normalizedError,
-    { ...toSpanAttributes(context), ...attributes },
-    body,
-    context,
-  );
+  return log.exception(eventName, normalizedError, attributes);
 }
 
 /** Add context to the current operation and Sentry scope. */

--- a/packages/junior/src/chat/mcp/tool-manager.ts
+++ b/packages/junior/src/chat/mcp/tool-manager.ts
@@ -615,12 +615,7 @@ export class McpToolManager {
               };
               setSpanAttributes(errorAttributes);
               if (error instanceof McpToolError) {
-                logWarn(
-                  "mcp_tool_call_failed",
-                  {},
-                  errorAttributes,
-                  "MCP tool call failed",
-                );
+                logWarn("mcp.tool_call.failed", errorAttributes);
               }
               throw error;
             }

--- a/packages/junior/src/chat/oauth-flow.ts
+++ b/packages/junior/src/chat/oauth-flow.ts
@@ -135,12 +135,9 @@ export async function deliverPrivateMessage(input: {
   try {
     client = getSlackClient();
   } catch {
-    logWarn(
-      "oauth_private_delivery_skip",
-      {},
-      { "app.reason": "missing_bot_token" },
-      "Skipped private message delivery — no SLACK_BOT_TOKEN",
-    );
+    logWarn("oauth.private_delivery.skipped", {
+      "app.reason": "missing_bot_token",
+    });
     return false;
   }
 
@@ -162,16 +159,11 @@ export async function deliverPrivateMessage(input: {
       }
       return "in_context";
     } catch (error) {
-      logWarn(
-        "oauth_private_delivery_failed",
-        {},
-        {
-          "app.slack.error":
-            error instanceof Error ? error.message : String(error),
-          "app.slack.channel": input.channelId,
-        },
-        "Private message delivery failed, falling back to DM",
-      );
+      logWarn("oauth.private_delivery.failed", {
+        "app.slack.error":
+          error instanceof Error ? error.message : String(error),
+        "app.slack.channel": input.channelId,
+      });
     }
   }
 
@@ -187,27 +179,16 @@ export async function deliverPrivateMessage(input: {
       )
     ).channel?.id;
     if (!dmChannelId) {
-      logWarn(
-        "oauth_dm_fallback_failed",
-        {},
-        { "app.reason": "no_dm_channel_id" },
-        "conversations.open returned no channel ID",
-      );
+      logWarn("oauth.dm.fallback.failed", { "app.reason": "no_dm_channel_id" });
       return false;
     }
 
     await postSlackMessage({ channelId: dmChannelId, text: input.text });
     return "fallback_dm";
   } catch (error) {
-    logWarn(
-      "oauth_dm_fallback_failed",
-      {},
-      {
-        "app.slack.error":
-          error instanceof Error ? error.message : String(error),
-      },
-      "DM fallback delivery failed",
-    );
+    logWarn("oauth.dm.fallback.failed", {
+      "app.slack.error": error instanceof Error ? error.message : String(error),
+    });
     return false;
   }
 }
@@ -306,17 +287,12 @@ export async function startOAuthFlow(
     authorizeParams.set(key, value);
   }
 
-  logInfo(
-    "jr_rpc_oauth_start",
-    {},
-    {
-      "app.credential.provider": provider,
-      ...(input.activeSkillName
-        ? { "app.skill.name": input.activeSkillName }
-        : {}),
-    },
-    "Initiated OAuth authorization code flow",
-  );
+  logInfo("jr_rpc.oauth.started", {
+    "app.credential.provider": provider,
+    ...(input.activeSkillName
+      ? { "app.skill.name": input.activeSkillName }
+      : {}),
+  });
 
   const authorizationUrl = `${providerConfig.authorizeEndpoint}?${authorizeParams.toString()}`;
   const authorizationRequest = {

--- a/packages/junior/src/chat/pi/client.ts
+++ b/packages/junior/src/chat/pi/client.ts
@@ -235,15 +235,10 @@ export async function completeText(params: {
       if (message.stopReason === "error") {
         const providerMessage =
           message.errorMessage?.trim() || "Unknown provider error";
-        logWarn(
-          "ai_completion_provider_error",
-          {},
-          {
-            ...baseAttributes,
-            "exception.message": providerMessage,
-          },
-          "AI completion returned provider error",
-        );
+        logWarn("ai.completion.provider_error", {
+          ...baseAttributes,
+          "exception.message": providerMessage,
+        });
         throw createProviderError(providerMessage, { modelId: params.modelId });
       }
 
@@ -428,17 +423,11 @@ export async function embedTexts(params: {
       throw providerError;
     }
 
-    logException(
-      providerError,
-      "ai_embeddings_failed",
-      {},
-      {
-        "gen_ai.provider.name": GEN_AI_PROVIDER_NAME,
-        "gen_ai.operation.name": GEN_AI_OPERATION_EMBEDDINGS,
-        "gen_ai.request.model": params.modelId,
-      },
-      "AI embeddings failed",
-    );
+    logException(providerError, "ai.embeddings.failed", {
+      "gen_ai.provider.name": GEN_AI_PROVIDER_NAME,
+      "gen_ai.operation.name": GEN_AI_OPERATION_EMBEDDINGS,
+      "gen_ai.request.model": params.modelId,
+    });
     throw providerError;
   }
 }

--- a/packages/junior/src/chat/plugins/agent-hooks.ts
+++ b/packages/junior/src/chat/plugins/agent-hooks.ts
@@ -279,16 +279,11 @@ function logInvalidPromptContributions(args: {
   hookName: "systemPrompt" | "userPrompt";
   pluginName: string;
 }): void {
-  logWarn(
-    "plugin_prompt_contribution_result_invalid",
-    {},
-    {
-      "app.plugin.hook": args.hookName,
-      "app.plugin.name": args.pluginName,
-      "app.plugin.validation_reason": "invalid_shape",
-    },
-    "Plugin prompt contribution result invalid",
-  );
+  logWarn("plugin.prompt.contribution_result.invalid", {
+    "app.plugin.hook": args.hookName,
+    "app.plugin.name": args.pluginName,
+    "app.plugin.validation_reason": "invalid_shape",
+  });
 }
 
 /** Validate plugin identity before it can affect process-wide hooks. */
@@ -379,28 +374,18 @@ export async function getPluginSystemPromptContributions(
         totalChars + pluginContributionChars >
         PLUGIN_PROMPT_CONTRIBUTION_TOTAL_MAX_CHARS
       ) {
-        logWarn(
-          "plugin_system_prompt_contribution_budget_exceeded",
-          {},
-          {
-            "app.plugin.name": pluginName,
-          },
-          "Plugin system prompt contributions exceeded budget",
-        );
+        logWarn("plugin.system_prompt.contribution_budget_exceeded", {
+          "app.plugin.name": pluginName,
+        });
         continue;
       }
       totalChars += pluginContributionChars;
       contributions.push(...acceptedContributions);
     } catch (error) {
-      logWarn(
-        "plugin_system_prompt_hook_failed",
-        {},
-        {
-          "app.plugin.name": pluginName,
-          "exception.message": safeErrorMessage(error),
-        },
-        "Plugin system prompt hook failed",
-      );
+      logWarn("plugin.system_prompt.hook.failed", {
+        "app.plugin.name": pluginName,
+        "exception.message": safeErrorMessage(error),
+      });
     }
   }
   return contributions;
@@ -472,29 +457,19 @@ export async function getPluginUserPromptContributions(args: {
         totalContextBytes + pluginContextBytes >
           PLUGIN_PROMPT_CONTEXT_TOTAL_MAX_BYTES
       ) {
-        logWarn(
-          "plugin_user_prompt_contribution_budget_exceeded",
-          {},
-          {
-            "app.plugin.name": pluginName,
-          },
-          "Plugin user prompt contributions exceeded budget",
-        );
+        logWarn("plugin.user_prompt.contribution_budget_exceeded", {
+          "app.plugin.name": pluginName,
+        });
         continue;
       }
       totalChars += pluginContributionChars;
       totalContextBytes += pluginContextBytes;
       contributions.push(...validContributions);
     } catch (error) {
-      logWarn(
-        "plugin_user_prompt_hook_failed",
-        {},
-        {
-          "app.plugin.name": pluginName,
-          "exception.message": safeErrorMessage(error),
-        },
-        "Plugin user prompt hook failed",
-      );
+      logWarn("plugin.user_prompt.hook.failed", {
+        "app.plugin.name": pluginName,
+        "exception.message": safeErrorMessage(error),
+      });
     }
   }
   return contributions;
@@ -1188,12 +1163,9 @@ export function createPluginHookRunner(
         if (!hook) {
           continue;
         }
-        logInfo(
-          "agent_plugin_hook_sandbox_prepare",
-          {},
-          { "app.plugin.name": pluginName },
-          "Running agent plugin sandbox prepare hook",
-        );
+        logInfo("agent.plugin.sandbox_preparation.started", {
+          "app.plugin.name": pluginName,
+        });
         await hook({
           ...basePluginContext(plugin),
           actor: input.actor,

--- a/packages/junior/src/chat/plugins/logging.ts
+++ b/packages/junior/src/chat/plugins/logging.ts
@@ -5,29 +5,24 @@ import { logException, logInfo, logWarn } from "@/chat/logging";
 export function createPluginLogger(plugin: string): PluginLogger {
   return {
     info(message, metadata) {
-      logInfo(
-        "agent_plugin_log_info",
-        {},
-        { "app.plugin.name": plugin, ...metadata },
-        message,
-      );
+      logInfo("plugin.log.info", {
+        "app.log.message": message,
+        "app.plugin.name": plugin,
+        ...metadata,
+      });
     },
     warn(message, metadata) {
-      logWarn(
-        "agent_plugin_log_warn",
-        {},
-        { "app.plugin.name": plugin, ...metadata },
-        message,
-      );
+      logWarn("plugin.log.warn", {
+        "app.log.message": message,
+        "app.plugin.name": plugin,
+        ...metadata,
+      });
     },
     error(message, metadata) {
-      logException(
-        new Error(message),
-        "agent_plugin_log_error",
-        {},
-        { "app.plugin.name": plugin, ...metadata },
-        message,
-      );
+      logException(new Error(message), "plugin.log.error", {
+        "app.plugin.name": plugin,
+        ...metadata,
+      });
     },
   };
 }

--- a/packages/junior/src/chat/plugins/registry.ts
+++ b/packages/junior/src/chat/plugins/registry.ts
@@ -331,16 +331,11 @@ function buildLoadedPluginState(
     try {
       rootStat = statSync(pluginsRoot);
     } catch (error) {
-      logWarn(
-        "plugin_root_read_failed",
-        {},
-        {
-          "file.directory": pluginsRoot,
-          "exception.message":
-            error instanceof Error ? error.message : String(error),
-        },
-        "Failed to read plugin root",
-      );
+      logWarn("plugin.root.read.failed", {
+        "file.directory": pluginsRoot,
+        "exception.message":
+          error instanceof Error ? error.message : String(error),
+      });
       continue;
     }
     if (rootStat.isDirectory()) {
@@ -360,16 +355,11 @@ function buildLoadedPluginState(
     try {
       entries = readdirSync(pluginsRoot);
     } catch (error) {
-      logWarn(
-        "plugin_root_read_failed",
-        {},
-        {
-          "file.directory": pluginsRoot,
-          "exception.message":
-            error instanceof Error ? error.message : String(error),
-        },
-        "Failed to read plugin root",
-      );
+      logWarn("plugin.root.read.failed", {
+        "file.directory": pluginsRoot,
+        "exception.message":
+          error instanceof Error ? error.message : String(error),
+      });
       continue;
     }
 
@@ -414,20 +404,15 @@ function logLoadedPlugins(state: LoadedPluginState): void {
       continue;
     }
     loggedPluginNames.add(plugin.manifest.name);
-    logInfo(
-      "plugin_loaded",
-      {},
-      {
-        "app.plugin.name": plugin.manifest.name,
-        "app.plugin.config_key_count": plugin.manifest.configKeys.length,
-        "app.plugin.has_mcp": Boolean(plugin.manifest.mcp),
-        "file.directory": plugin.dir,
-        ...(plugin.skillsDir
-          ? { "app.file.skill_directory": plugin.skillsDir }
-          : {}),
-      },
-      "Loaded plugin",
-    );
+    logInfo("plugin.loaded", {
+      "app.plugin.name": plugin.manifest.name,
+      "app.plugin.config_key_count": plugin.manifest.configKeys.length,
+      "app.plugin.has_mcp": Boolean(plugin.manifest.mcp),
+      "file.directory": plugin.dir,
+      ...(plugin.skillsDir
+        ? { "app.file.skill_directory": plugin.skillsDir }
+        : {}),
+    });
   }
 }
 

--- a/packages/junior/src/chat/plugins/task-callback.ts
+++ b/packages/junior/src/chat/plugins/task-callback.ts
@@ -28,18 +28,13 @@ function logPluginTaskQueueMessageRejected(
   reason: PluginTaskQueueRejectReason,
   metadata: MessageMetadata,
 ): void {
-  logWarn(
-    "plugin_task_queue_message_rejected",
-    {},
-    {
-      "app.queue.consumer_group": metadata.consumerGroup,
-      "app.queue.delivery_count": metadata.deliveryCount,
-      "app.queue.message_id": metadata.messageId,
-      "app.queue.reject_reason": reason,
-      "app.queue.topic_name": metadata.topicName,
-    },
-    "Plugin task queue message rejected without retry",
-  );
+  logWarn("plugin.task.queue_message.rejected", {
+    "app.queue.consumer_group": metadata.consumerGroup,
+    "app.queue.delivery_count": metadata.deliveryCount,
+    "app.queue.message_id": metadata.messageId,
+    "app.queue.reject_reason": reason,
+    "app.queue.topic_name": metadata.topicName,
+  });
 }
 
 /** Parse the queue payload and run only the referenced durable task. */

--- a/packages/junior/src/chat/prompt.ts
+++ b/packages/junior/src/chat/prompt.ts
@@ -48,6 +48,7 @@ function getLoggedMarkdownFiles(): Set<string> {
 function loadOptionalMarkdownFile(
   candidates: string[],
   fileName: string,
+  loadedEventName: string,
 ): string | null {
   for (const resolved of candidates) {
     try {
@@ -57,14 +58,9 @@ function loadOptionalMarkdownFile(
         const logKey = `${fileName}:${resolved}`;
         if (!loggedMarkdownFiles.has(logKey)) {
           loggedMarkdownFiles.add(logKey);
-          logInfo(
-            `${fileName.toLowerCase()}_loaded`,
-            {},
-            {
-              "file.path": resolved,
-            },
-            `Loaded ${fileName}`,
-          );
+          logInfo(loadedEventName, {
+            "file.path": resolved,
+          });
         }
         return raw;
       }
@@ -77,39 +73,37 @@ function loadOptionalMarkdownFile(
 }
 
 function loadSoul(): string {
-  const soul = loadOptionalMarkdownFile(soulPathCandidates(), "SOUL.md");
+  const soul = loadOptionalMarkdownFile(
+    soulPathCandidates(),
+    "SOUL.md",
+    "soul.loaded",
+  );
   if (soul) {
     return soul;
   }
 
-  logWarn(
-    "soul_load_fallback",
-    {},
-    {
-      "app.file.candidates": soulPathCandidates(),
-    },
-    "SOUL.md not found; using built-in default personality",
-  );
+  logWarn("soul.load.defaulted", {
+    "app.file.candidates": soulPathCandidates(),
+  });
   return DEFAULT_SOUL;
 }
 
 function loadWorld(): string | null {
-  return loadOptionalMarkdownFile(worldPathCandidates(), "WORLD.md");
+  return loadOptionalMarkdownFile(
+    worldPathCandidates(),
+    "WORLD.md",
+    "world.loaded",
+  );
 }
 
 export const JUNIOR_PERSONALITY = (() => {
   try {
     return loadSoul();
   } catch (error) {
-    logWarn(
-      "soul_load_failed",
-      {},
-      {
-        "exception.message":
-          error instanceof Error ? error.message : String(error),
-      },
-      "Failed to load SOUL.md; using built-in default personality",
-    );
+    logWarn("soul.load.failed", {
+      "exception.message":
+        error instanceof Error ? error.message : String(error),
+    });
     return DEFAULT_SOUL;
   }
 })();
@@ -118,15 +112,10 @@ export const JUNIOR_WORLD = (() => {
   try {
     return loadWorld();
   } catch (error) {
-    logWarn(
-      "world_load_failed",
-      {},
-      {
-        "exception.message":
-          error instanceof Error ? error.message : String(error),
-      },
-      "Failed to load WORLD.md; omitting world prompt context",
-    );
+    logWarn("world.load.failed", {
+      "exception.message":
+        error instanceof Error ? error.message : String(error),
+    });
     return null;
   }
 })();

--- a/packages/junior/src/chat/runtime/agent-continue-runner.ts
+++ b/packages/junior/src/chat/runtime/agent-continue-runner.ts
@@ -10,6 +10,7 @@ import {
   buildTurnFailureResponse,
   logException,
   logWarn,
+  withLogContext,
 } from "@/chat/logging";
 import {
   ResumeTurnBusyError,
@@ -152,13 +153,11 @@ async function failSessionRecordBestEffort(args: {
   } catch (error) {
     logException(
       error,
-      "agent_continue_session_record_fail_persist_failed",
-      {},
+      "agent.continue.session_record.failure_persistence.failed",
       {
         "app.ai.conversation_id": args.sessionRecord.conversationId,
         "app.ai.session_id": args.sessionRecord.sessionId,
       },
-      "Failed to mark paused agent run session record failed",
     );
   }
 }
@@ -210,13 +209,11 @@ async function failContinuationStartup(args: {
     });
     logException(
       persistError,
-      "agent_continue_startup_failure_persist_failed",
-      {},
+      "agent.continue.startup_failure_persist.failed",
       {
         "app.ai.conversation_id": args.sessionRecord.conversationId,
         "app.ai.session_id": args.sessionRecord.sessionId,
       },
-      "Failed to persist paused agent run startup failure",
     );
   }
 }
@@ -315,6 +312,16 @@ export async function continueSlackAgentRun(
   payload: AgentContinueRequest,
   options: AgentContinueRunnerOptions,
   runOptions: AgentContinueRunOptions = {},
+): Promise<boolean> {
+  return withLogContext({ conversationId: payload.conversationId }, () =>
+    continueSlackAgentRunInContext(payload, options, runOptions),
+  );
+}
+
+async function continueSlackAgentRunInContext(
+  payload: AgentContinueRequest,
+  options: AgentContinueRunnerOptions,
+  runOptions: AgentContinueRunOptions,
 ): Promise<boolean> {
   const thread = parseSlackThreadId(payload.conversationId);
   const destination = requireSlackDestination(
@@ -543,15 +550,10 @@ export async function continueSlackAgentRun(
               threadStateId: payload.conversationId,
             });
             await recordDispatchOutcome("blocked");
-            logWarn(
-              "agent_continue_reparked_for_auth",
-              {},
-              {
-                "app.ai.conversation_id": payload.conversationId,
-                "app.ai.session_id": payload.sessionId,
-              },
-              "Continued agent run parked for auth",
-            );
+            logWarn("agent.continue.reparked_for_auth", {
+              "app.ai.conversation_id": payload.conversationId,
+              "app.ai.session_id": payload.sessionId,
+            });
           },
           onSuspend: async (resumeVersion) => {
             await scheduleAgentContinue({
@@ -619,17 +621,11 @@ async function failStrandedSessionWithFallback(args: {
   });
   await persistThreadStateById(args.conversationId, { conversation });
 
-  const eventName = "agent_turn_stranded_session_failed";
-  const eventId = logException(
-    new Error(args.errorMessage),
-    eventName,
-    { conversationId: args.conversationId },
-    {
-      "app.ai.conversation_id": args.conversationId,
-      "app.ai.session_id": args.sessionRecord.sessionId,
-    },
-    "Stranded running agent session terminally failed",
-  );
+  const eventName = "agent.turn.stranded_session.failed";
+  const eventId = logException(new Error(args.errorMessage), eventName, {
+    "app.ai.conversation_id": args.conversationId,
+    "app.ai.session_id": args.sessionRecord.sessionId,
+  });
   const thread = parseSlackThreadId(args.conversationId);
   const channelId =
     thread?.channelId ??
@@ -693,7 +689,6 @@ async function recoverStrandedRunningSession(args: {
     source: sessionRecord.source,
     messages: sessionRecord.piMessages,
     errorMessage: "Recovered running session after hard worker death",
-    logContext: {},
     modelId,
     actor: sessionRecord.actor,
     surface: sessionRecord.surface,
@@ -745,6 +740,20 @@ export async function resumeAwaitingSlackContinuation(
   conversationId: string,
   options: AgentContinueRunnerOptions,
   runOptions: AgentContinueRunOptions = {},
+): Promise<boolean> {
+  return withLogContext({ conversationId }, () =>
+    resumeAwaitingSlackContinuationInContext(
+      conversationId,
+      options,
+      runOptions,
+    ),
+  );
+}
+
+async function resumeAwaitingSlackContinuationInContext(
+  conversationId: string,
+  options: AgentContinueRunnerOptions,
+  runOptions: AgentContinueRunOptions,
 ): Promise<boolean> {
   const summaries =
     await listAgentTurnSessionSummariesForConversation(conversationId);
@@ -810,6 +819,16 @@ export async function continueSlackAgentRunWithLockRetry(
   options: AgentContinueRunnerOptions,
   runOptions: AgentContinueRunOptions = {},
 ): Promise<boolean> {
+  return withLogContext({ conversationId: payload.conversationId }, () =>
+    continueSlackAgentRunWithLockRetryInContext(payload, options, runOptions),
+  );
+}
+
+async function continueSlackAgentRunWithLockRetryInContext(
+  payload: AgentContinueRequest,
+  options: AgentContinueRunnerOptions,
+  runOptions: AgentContinueRunOptions,
+): Promise<boolean> {
   const scheduleAgentContinue =
     options.scheduleAgentContinue ?? defaultScheduleAgentContinue;
   for (const [attempt, delayMs] of [
@@ -823,31 +842,21 @@ export async function continueSlackAgentRunWithLockRetry(
         throw error;
       }
       if (typeof delayMs !== "number") {
-        logWarn(
-          "agent_continue_lock_busy",
-          {},
-          {
-            "app.ai.conversation_id": payload.conversationId,
-            "app.ai.session_id": payload.sessionId,
-            "app.ai.resume_lock_retry_count": attempt,
-          },
-          "Rescheduling agent continuation because another run still owns the thread lock",
-        );
+        logWarn("agent.continue.lock.busy", {
+          "app.ai.conversation_id": payload.conversationId,
+          "app.ai.session_id": payload.sessionId,
+          "app.ai.resume_lock_retry_count": attempt,
+        });
         await scheduleAgentContinue(payload);
         return true;
       }
 
-      logWarn(
-        "agent_continue_lock_busy_retrying",
-        {},
-        {
-          "app.ai.conversation_id": payload.conversationId,
-          "app.ai.session_id": payload.sessionId,
-          "app.ai.resume_lock_retry_attempt": attempt + 1,
-          "app.ai.resume_lock_retry_delay_ms": delayMs,
-        },
-        "Agent continuation lock was busy; retrying",
-      );
+      logWarn("agent.continue.lock.retrying", {
+        "app.ai.conversation_id": payload.conversationId,
+        "app.ai.session_id": payload.sessionId,
+        "app.ai.resume_lock_retry_attempt": attempt + 1,
+        "app.ai.resume_lock_retry_delay_ms": delayMs,
+      });
       await sleep(delayMs);
     }
   }

--- a/packages/junior/src/chat/runtime/processing-reaction.ts
+++ b/packages/junior/src/chat/runtime/processing-reaction.ts
@@ -46,11 +46,8 @@ export async function startSlackProcessingReaction(args: {
   logException: (
     error: unknown,
     eventName: string,
-    context?: Record<string, unknown>,
     attributes?: Record<string, unknown>,
-    body?: string,
   ) => string | undefined;
-  logContext: Record<string, unknown>;
   message: Message;
   thread: Thread;
 }): Promise<ProcessingReactionSession> {
@@ -68,7 +65,6 @@ export async function startSlackProcessingReaction(args: {
     channelId,
     timestamp: messageTs,
     logException: args.logException,
-    logContext: args.logContext,
   });
 }
 
@@ -79,11 +75,8 @@ export async function startSlackProcessingReactionForMessage(args: {
   logException: (
     error: unknown,
     eventName: string,
-    context?: Record<string, unknown>,
     attributes?: Record<string, unknown>,
-    body?: string,
   ) => string | undefined;
-  logContext: Record<string, unknown>;
 }): Promise<ProcessingReactionSession> {
   try {
     await addReactionToMessage({
@@ -92,17 +85,11 @@ export async function startSlackProcessingReactionForMessage(args: {
       emoji: getChatConfig().slack.processingReactionEmoji,
     });
   } catch (error) {
-    args.logException(
-      error,
-      "slack_processing_reaction_add_failed",
-      args.logContext,
-      {
-        "app.slack.action": "reactions.add",
-        "messaging.message.id": args.timestamp,
-        ...getSlackErrorObservabilityAttributes(error),
-      },
-      "Failed to add Slack processing reaction",
-    );
+    args.logException(error, "slack.processing.reaction_add.failed", {
+      "app.slack.action": "reactions.add",
+      "messaging.message.id": args.timestamp,
+      ...getSlackErrorObservabilityAttributes(error),
+    });
     return noProcessingReaction;
   }
 
@@ -120,17 +107,11 @@ export async function startSlackProcessingReactionForMessage(args: {
       });
       return true;
     } catch (error) {
-      args.logException(
-        error,
-        "slack_processing_reaction_remove_failed",
-        args.logContext,
-        {
-          "app.slack.action": "reactions.remove",
-          "messaging.message.id": args.timestamp,
-          ...getSlackErrorObservabilityAttributes(error),
-        },
-        "Failed to remove Slack processing reaction",
-      );
+      args.logException(error, "slack.processing.reaction_remove.failed", {
+        "app.slack.action": "reactions.remove",
+        "messaging.message.id": args.timestamp,
+        ...getSlackErrorObservabilityAttributes(error),
+      });
       return false;
     }
   };
@@ -154,17 +135,11 @@ export async function startSlackProcessingReactionForMessage(args: {
           emoji: getChatConfig().slack.completedReactionEmoji,
         });
       } catch (error) {
-        args.logException(
-          error,
-          "slack_processing_reaction_complete_failed",
-          args.logContext,
-          {
-            "app.slack.action": "reactions.add",
-            "messaging.message.id": args.timestamp,
-            ...getSlackErrorObservabilityAttributes(error),
-          },
-          "Failed to add Slack completed reaction",
-        );
+        args.logException(error, "slack.processing.reaction_complete.failed", {
+          "app.slack.action": "reactions.add",
+          "messaging.message.id": args.timestamp,
+          ...getSlackErrorObservabilityAttributes(error),
+        });
       }
     },
     keep: () => {

--- a/packages/junior/src/chat/runtime/reply-executor.ts
+++ b/packages/junior/src/chat/runtime/reply-executor.ts
@@ -589,15 +589,6 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
         const slackMessageTs = getSlackMessageTs(message);
         const turnId =
           options.execution?.turnId ?? buildDeterministicTurnId(message.id);
-        const turnTraceContext = {
-          conversationId,
-          messageConversationId: threadId,
-          userId: message.author.userId,
-          destinationName: channelId,
-          runId,
-          assistantUserName: botConfig.userName,
-          modelId: standardModelId(botConfig),
-        };
         let beforeFirstResponsePostCalled = false;
         const beforeFirstResponsePost = async (): Promise<void> => {
           if (beforeFirstResponsePostCalled) {
@@ -631,17 +622,11 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
               await thread.post(buildSlackOutputMessage(text));
             }
           } catch (error) {
-            logException(
-              error,
-              "slack_auth_pause_notice_post_failed",
-              turnTraceContext,
-              {
-                "app.slack.reply_stage": "thread_reply_auth_pause_notice",
-                ...(messageTs ? { "messaging.message.id": messageTs } : {}),
-                ...getSlackErrorObservabilityAttributes(error),
-              },
-              "Failed to post auth pause notice",
-            );
+            logException(error, "slack.auth_pause.notice_post.failed", {
+              "app.slack.reply_stage": "thread_reply_auth_pause_notice",
+              ...(messageTs ? { "messaging.message.id": messageTs } : {}),
+              ...getSlackErrorObservabilityAttributes(error),
+            });
           }
         };
         let activeTurnId = preparedState.conversation.processing.activeTurnId;
@@ -820,18 +805,11 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
             try {
               await deps.services.scheduleAgentContinue(resumeRequest);
             } catch (error) {
-              logException(
-                error,
-                "agent_continue_schedule_failed",
-                turnTraceContext,
-                {
-                  "app.ai.resume_session_version":
-                    resumeRequest.expectedVersion,
-                  "app.ai.resume_session_id": resumeRequest.sessionId,
-                  ...(messageTs ? { "messaging.message.id": messageTs } : {}),
-                },
-                "Failed to reschedule active agent continuation",
-              );
+              logException(error, "agent.continue.schedule.failed", {
+                "app.ai.resume_session_version": resumeRequest.expectedVersion,
+                "app.ai.resume_session_id": resumeRequest.sessionId,
+                ...(messageTs ? { "messaging.message.id": messageTs } : {}),
+              });
               throw error;
             }
 
@@ -967,28 +945,19 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
             source,
             traceId: getActiveTraceId(),
           }).catch((error) => {
-            logException(
-              error,
-              "agent_turn_summary_record_failed",
-              turnTraceContext,
-              { "app.agent.turn.state": "running" },
-              "Failed to record running turn summary",
-            );
+            logException(error, "agent.turn.summary_record.failed", {
+              "app.agent.turn.state": "running",
+            });
           });
         }
         setTags({
           conversationId,
         });
         if (shouldEmitDevAgentTrace()) {
-          logInfo(
-            "agent_turn_started",
-            turnTraceContext,
-            {
-              "app.message.id": message.id,
-              ...(messageTs ? { "messaging.message.id": messageTs } : {}),
-            },
-            "Agent turn started",
-          );
+          logInfo("agent.turn.started", {
+            "app.message.id": message.id,
+            ...(messageTs ? { "messaging.message.id": messageTs } : {}),
+          });
         }
         await persistThreadState(thread, {
           conversation: preparedState.conversation,
@@ -1114,17 +1083,11 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
             if (isRetryableSlackPostError(error)) {
               throw new RetryableDeliveryError(error);
             }
-            const eventId = logException(
-              error,
-              "slack_thread_post_failed",
-              turnTraceContext,
-              {
-                "app.slack.reply_stage": "thread_reply",
-                ...(messageTs ? { "messaging.message.id": messageTs } : {}),
-                ...getSlackErrorObservabilityAttributes(error),
-              },
-              "Failed to post Slack thread reply",
-            );
+            const eventId = logException(error, "slack.thread.post.failed", {
+              "app.slack.reply_stage": "thread_reply",
+              ...(messageTs ? { "messaging.message.id": messageTs } : {}),
+              ...getSlackErrorObservabilityAttributes(error),
+            });
             throw new ConversationTurnBoundaryError({
               cause: error,
               ...(eventId ? { eventId } : {}),
@@ -1164,13 +1127,11 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
           } catch (error) {
             logException(
               new Error("Accepted assistant message persistence failed"),
-              "slack_assistant_message_post_delivery_persist_failed",
-              turnTraceContext,
+              "slack.assistant.message_post_delivery_persist.failed",
               {
                 "error.type":
                   error instanceof Error ? error.name : typeof error,
               },
-              "Failed to persist an accepted Slack assistant message",
             );
           }
           if (slackTs && options.execution?.dispatch?.id) {
@@ -1195,13 +1156,7 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
                 }),
               );
             } catch (error) {
-              logException(
-                error,
-                "agent_turn_delivery_receipt_persist_failed",
-                turnTraceContext,
-                {},
-                "Failed to persist accepted turn delivery receipt",
-              );
+              logException(error, "agent.turn.delivery_receipt_persist.failed");
             }
           }
           boundaryFailureCode = "agent_run_failed";
@@ -1331,13 +1286,7 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
                     title: titleUpdateResult.title,
                   });
                 } catch (error) {
-                  logException(
-                    error,
-                    "conversation_title_persist_failed",
-                    turnTraceContext,
-                    {},
-                    "Failed to persist generated conversation title",
-                  );
+                  logException(error, "conversation.title.persist.failed");
                 }
               }
 
@@ -1346,23 +1295,11 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
                   artifacts: latestArtifacts,
                 });
               } catch (error) {
-                logException(
-                  error,
-                  "assistant_title_artifact_persist_failed",
-                  turnTraceContext,
-                  {},
-                  "Failed to persist async assistant title artifact state",
-                );
+                logException(error, "assistant.title.artifact_persist.failed");
               }
             })
             .catch((error) => {
-              logException(
-                error,
-                "assistant_title_task_failed",
-                turnTraceContext,
-                {},
-                "Async assistant title task failed",
-              );
+              logException(error, "assistant.title.task.failed");
             });
           const toolChannelId =
             preparedState.artifacts.assistantContextChannelId ?? channelId;
@@ -1478,10 +1415,8 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
                 new Error(
                   `Subscribed Slack turn requires ${outcome.providerDisplayName} authorization`,
                 ),
-                "slack_subscribed_turn_authorization_required",
-                turnTraceContext,
+                "subscribed_message.authorization.required",
                 { "app.ai.failure_code": "agent_run_failed" },
-                "Subscribed Slack turn could not continue without user authorization",
               );
               const text = `I could not act on this subscribed event because ${outcome.providerDisplayName} needs user authorization. Ask me in this thread to connect ${outcome.providerDisplayName} before retrying.`;
               await deliverAssistantMessage(text);
@@ -1549,16 +1484,10 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
               });
               shouldPersistFailureState = false;
             } catch (scheduleError) {
-              logException(
-                scheduleError,
-                "agent_continue_schedule_failed",
-                turnTraceContext,
-                {
-                  ...(messageTs ? { "messaging.message.id": messageTs } : {}),
-                  "app.ai.resume_session_version": outcome.resumeVersion,
-                },
-                "Failed to schedule agent continuation",
-              );
+              logException(scheduleError, "agent.continue.schedule.failed", {
+                ...(messageTs ? { "messaging.message.id": messageTs } : {}),
+                "app.ai.resume_session_version": outcome.resumeVersion,
+              });
               shouldPersistFailureState = true;
               agentContinueScheduleError = scheduleError;
               throw scheduleError;
@@ -1567,14 +1496,7 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
           }
 
           let reply = outcome.result;
-          const diagnosticsContext = {
-            messageConversationId: threadId,
-            userId: message.author.userId,
-            destinationName: channelId,
-            runId,
-            assistantUserName: botConfig.userName,
-            modelId: reply.diagnostics.modelId,
-          };
+          setTags({ modelId: reply.diagnostics.modelId });
           const diagnosticsAttributes =
             getAgentTurnDiagnosticsAttributes(reply);
           setSpanAttributes(diagnosticsAttributes);
@@ -1582,7 +1504,6 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
             const finalized = finalizeFailedTurnReplyWithEvent({
               reply,
               logException,
-              context: diagnosticsContext,
             });
             reply = finalized.reply;
             finalizedFailureEventId = finalized.eventId;
@@ -1702,10 +1623,8 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
             // record the persistence failure for operators.
             const persistenceEventId = logException(
               commitError,
-              "slack_reply_post_delivery_commit_failed",
-              turnTraceContext,
+              "slack.reply.post_delivery_commit.failed",
               messageTs ? { "messaging.message.id": messageTs } : {},
-              "Post-delivery turn state persistence failed after Slack accepted the reply",
             );
             if (conversationId && !lifecycleTerminalized) {
               await deps.services.turnLifecycle.fail({
@@ -1743,16 +1662,11 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
             lifecycleTerminalized = true;
           }
           if (shouldEmitDevAgentTrace()) {
-            logInfo(
-              "agent_turn_completed",
-              turnTraceContext,
-              {
-                "app.ai.outcome": reply.diagnostics.outcome,
-                "app.ai.tool_call_count": reply.diagnostics.toolCalls.length,
-                "app.ai.tool_error_results": reply.diagnostics.toolErrorCount,
-              },
-              "Agent turn completed",
-            );
+            logInfo("agent.turn.completed", {
+              "app.ai.outcome": reply.diagnostics.outcome,
+              "app.ai.tool_call_count": reply.diagnostics.toolCalls.length,
+              "app.ai.tool_error_results": reply.diagnostics.toolErrorCount,
+            });
           }
           await notifyTurnCompleted();
           if (reply.diagnostics.outcome === "success" && conversationId) {
@@ -1764,10 +1678,7 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
             } catch (error) {
               logException(
                 error,
-                "plugin_session_completed_task_schedule_failed",
-                turnTraceContext,
-                {},
-                "Plugin session.completed task scheduling failed",
+                "plugin.session.completed_task_schedule.failed",
               );
             }
           }
@@ -1782,20 +1693,16 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
             shouldPersistFailureState = false;
             logException(
               error,
-              "slack_reply_post_delivery_commit_failed",
-              turnTraceContext,
+              "slack.reply.post_delivery_commit.failed",
               messageTs ? { "messaging.message.id": messageTs } : {},
-              "Post-delivery turn work failed after Slack accepted the reply",
             );
             try {
               await notifyTurnCompleted();
             } catch (completionError) {
               logException(
                 completionError,
-                "slack_reply_post_delivery_completion_callback_failed",
-                turnTraceContext,
+                "slack.reply.post_delivery_completion_callback.failed",
                 messageTs ? { "messaging.message.id": messageTs } : {},
-                "Post-delivery turn completion callback failed after Slack accepted the reply",
               );
             }
             return;
@@ -1824,13 +1731,9 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
             classifiedFailure?.failureCode ?? boundaryFailureCode;
           const failureEventId =
             classifiedFailure?.eventId ??
-            logException(
-              failureCause,
-              "slack_turn_execution_failed",
-              turnTraceContext,
-              { "app.ai.failure_code": failureCode },
-              "Slack turn failed at its reply execution boundary",
-            );
+            logException(failureCause, "slack.turn.execution.failed", {
+              "app.ai.failure_code": failureCode,
+            });
           const createdCanvasUrl = getCurrentTurnCanvasUrl({
             before: preparedState.artifacts,
             after: latestArtifacts,
@@ -1941,10 +1844,7 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
               } catch (recordError) {
                 logException(
                   recordError,
-                  "agent_turn_failed_session_record_persist_failed",
-                  turnTraceContext,
-                  {},
-                  "Failed to mark failed turn session record",
+                  "agent.turn.failed_session_record_persist.failed",
                 );
               }
             }
@@ -1952,12 +1852,7 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
               conversation: preparedState.conversation,
             });
             if (shouldEmitDevAgentTrace()) {
-              logWarn(
-                "agent_turn_failed",
-                turnTraceContext,
-                {},
-                "Agent turn failed",
-              );
+              logWarn("agent.turn.failed");
             }
           }
           await status.clear();

--- a/packages/junior/src/chat/runtime/slack-resume.ts
+++ b/packages/junior/src/chat/runtime/slack-resume.ts
@@ -22,6 +22,8 @@ import { scheduleSessionCompletedPluginTasks } from "@/chat/plugins/task-runner"
 import {
   buildTurnFailureResponse,
   logException,
+  setTags,
+  withLogContext,
   type LogContext,
 } from "@/chat/logging";
 import {
@@ -255,14 +257,7 @@ async function handleResumeFailure(args: {
   failureCode: ConversationTurnFailureCode;
   resumeArgs: ResumeSlackTurnArgs;
 }): Promise<void> {
-  const logContext = getResumeLogContext(args.resumeArgs, args.lockKey);
-  const capturedEventId = logException(
-    args.error,
-    args.eventName,
-    logContext,
-    {},
-    args.body,
-  );
+  const capturedEventId = logException(args.error, args.eventName);
   const eventId = requireTurnFailureEventId(capturedEventId, args.eventName);
   let failureStatePersistError: unknown;
   try {
@@ -270,10 +265,8 @@ async function handleResumeFailure(args: {
   } catch (persistError) {
     const persistEventId = logException(
       persistError,
-      "slack_resume_failure_state_persist_failed",
-      logContext,
+      "slack.resume.failure_state_persist.failed",
       { "app.error.original_event_id": eventId },
-      "Failed to persist resumed turn failure state",
     );
     try {
       await args.turnLifecycle.fail({
@@ -286,10 +279,8 @@ async function handleResumeFailure(args: {
     } catch (lifecycleError) {
       logException(
         lifecycleError,
-        "slack_resume_failure_lifecycle_persist_failed",
-        logContext,
+        "slack.resume.failure_lifecycle_persist.failed",
         { "app.error.original_event_id": eventId },
-        "Failed to record resumed turn persistence failure",
       );
     }
     failureStatePersistError = persistError;
@@ -304,10 +295,8 @@ async function handleResumeFailure(args: {
   } catch (deliveryError) {
     const deliveryEventId = logException(
       deliveryError,
-      "slack_resume_failure_delivery_failed",
-      logContext,
+      "slack.resume.failure_delivery.failed",
       { "app.error.original_event_id": eventId },
-      "Failed to deliver resumed turn failure state",
     );
     try {
       await args.turnLifecycle.fail({
@@ -320,10 +309,8 @@ async function handleResumeFailure(args: {
     } catch (lifecycleError) {
       logException(
         lifecycleError,
-        "slack_resume_failure_lifecycle_persist_failed",
-        logContext,
+        "slack.resume.failure_lifecycle_persist.failed",
         { "app.error.original_event_id": eventId },
-        "Failed to record resumed turn delivery failure",
       );
     }
     throw deliveryError;
@@ -424,6 +411,16 @@ function createResumeReplyContext(
 export async function resumeSlackTurn(
   args: ResumeSlackTurnArgs,
 ): Promise<boolean> {
+  const lockKey =
+    args.lockKey ?? getDefaultLockKey(args.channelId, args.threadTs);
+  return withLogContext(getResumeLogContext(args, lockKey), () =>
+    resumeSlackTurnInContext(args),
+  );
+}
+
+async function resumeSlackTurnInContext(
+  args: ResumeSlackTurnArgs,
+): Promise<boolean> {
   const stateAdapter = getStateAdapter();
   await stateAdapter.connect();
   const lockKey =
@@ -463,6 +460,7 @@ export async function resumeSlackTurn(
     if (preparedArgs) {
       runArgs = { ...args, ...preparedArgs };
     }
+    setTags(getResumeLogContext(runArgs, lockKey));
 
     const activeReplyContext = runArgs.replyContext;
     if (!activeReplyContext) {
@@ -502,7 +500,6 @@ export async function resumeSlackTurn(
         channelId: runArgs.channelId,
         timestamp: runArgs.messageTs,
         logException,
-        logContext: { ...getResumeLogContext(runArgs, lockKey) },
       });
     }
     if (runArgs.initialText) {
@@ -606,10 +603,8 @@ export async function resumeSlackTurn(
       } catch (error) {
         logException(
           new Error("Accepted assistant message persistence failed"),
-          "slack_resume_assistant_message_post_delivery_persist_failed",
-          getResumeLogContext(runArgs, lockKey),
+          "slack.resume.assistant_message_post_delivery_persist.failed",
           { "error.type": error instanceof Error ? error.name : typeof error },
-          "Failed to persist an accepted resumed assistant message",
         );
       }
       const routing = runArgs.replyContext?.routing;
@@ -631,13 +626,7 @@ export async function resumeSlackTurn(
             }),
           );
         } catch (error) {
-          logException(
-            error,
-            "agent_turn_delivery_receipt_persist_failed",
-            getResumeLogContext(runArgs, lockKey),
-            {},
-            "Failed to persist accepted resumed turn delivery receipt",
-          );
+          logException(error, "agent.turn.delivery_receipt_persist.failed");
         }
       }
       failureCode = "agent_run_failed";
@@ -708,7 +697,7 @@ export async function resumeSlackTurn(
             error: new Error(
               `Resumed run ended ${outcome.status} without a pause handler`,
             ),
-            eventName: "slack_resume_turn_failed",
+            eventName: "slack.resume.turn.failed",
             failureCode: "agent_run_failed",
             turnLifecycle,
             lockKey,
@@ -720,7 +709,6 @@ export async function resumeSlackTurn(
       const finalized = finalizeFailedTurnReplyWithEvent({
         reply: outcome.result,
         logException,
-        context: getResumeLogContext(runArgs, lockKey),
       });
       const reply = finalized.reply;
       const dispatchErrorMessage =
@@ -813,10 +801,7 @@ export async function resumeSlackTurn(
         } catch (scheduleError) {
           logException(
             scheduleError,
-            "plugin_session_completed_task_schedule_failed",
-            getResumeLogContext(runArgs, lockKey),
-            {},
-            "Plugin session.completed task scheduling failed",
+            "plugin.session.completed_task_schedule.failed",
           );
         }
       }
@@ -831,10 +816,7 @@ export async function resumeSlackTurn(
       } catch (terminalizeError) {
         logException(
           terminalizeError,
-          "slack_resume_post_delivery_terminalize_failed",
-          getResumeLogContext(runArgs, lockKey),
-          {},
-          "Failed to terminalize resumed turn after post-delivery commit failure",
+          "slack.resume.post_delivery_terminalize.failed",
         );
       }
     } else {
@@ -842,7 +824,7 @@ export async function resumeSlackTurn(
         await handleResumeFailure({
           body: "Failed to resume Slack turn",
           error,
-          eventName: "slack_resume_turn_failed",
+          eventName: "slack.resume.turn.failed",
           failureCode,
           turnLifecycle,
           lockKey,
@@ -862,10 +844,7 @@ export async function resumeSlackTurn(
   if (postDeliveryCommitError) {
     const eventId = logException(
       postDeliveryCommitError,
-      "slack_resume_success_handler_failed",
-      getResumeLogContext(runArgs, lockKey),
-      {},
-      "Failed to persist resumed turn state after assistant output handling",
+      "slack.resume.success_handler.failed",
     );
     await turnLifecycle.fail({
       conversationId: runArgs.conversationId,
@@ -897,7 +876,7 @@ export async function resumeSlackTurn(
       await handleResumeFailure({
         body: "Failed to handle resumed turn pause",
         error: pauseError,
-        eventName: "slack_resume_pause_handler_failed",
+        eventName: "slack.resume.pause_handler.failed",
         failureCode: "persistence_failed",
         turnLifecycle,
         lockKey,

--- a/packages/junior/src/chat/runtime/slack-runtime.ts
+++ b/packages/junior/src/chat/runtime/slack-runtime.ts
@@ -19,7 +19,7 @@ import {
   isTurnInputDeferredError,
   isTurnInputCommitLostError,
 } from "@/chat/runtime/turn";
-import { buildTurnFailureResponse } from "@/chat/logging";
+import { buildTurnFailureResponse, withLogContext } from "@/chat/logging";
 import { getSlackErrorObservabilityAttributes } from "@/chat/slack/errors";
 import type {
   SubscribedReplyDecision,
@@ -136,16 +136,9 @@ export interface SlackTurnRuntimeDependencies<TPreparedState> {
   logException: (
     error: unknown,
     eventName: string,
-    context?: Record<string, unknown>,
     attributes?: Record<string, unknown>,
-    body?: string,
   ) => string | undefined;
-  logWarn: (
-    eventName: string,
-    context?: Record<string, unknown>,
-    attributes?: Record<string, unknown>,
-    body?: string,
-  ) => void;
+  logWarn: (eventName: string, attributes?: Record<string, unknown>) => void;
   modelId: string;
   now: () => number;
   recordSkippedSteeringMessage: (args: {
@@ -473,7 +466,6 @@ export function createSlackTurnRuntime<
           thread,
           message: targetMessage,
           logException: deps.logException,
-          logContext: context,
         });
         processingReactions.push(started);
         if (reactionKey) {
@@ -488,25 +480,17 @@ export function createSlackTurnRuntime<
 
   const postFallbackErrorReplyWithLogging = async (args: {
     thread: Thread;
-    errorContext: RuntimeLogContext;
     eventId: string;
     postFailureEventName: string;
-    postFailureBody: string;
   }): Promise<void> => {
     try {
       await args.thread.post(buildTurnFailureResponse(args.eventId));
     } catch (postError) {
-      deps.logException(
-        postError,
-        args.postFailureEventName,
-        args.errorContext,
-        {
-          "app.slack.reply_stage": "error_fallback_post",
-          "app.error.original_event_id": args.eventId,
-          ...getSlackErrorObservabilityAttributes(postError),
-        },
-        args.postFailureBody,
-      );
+      deps.logException(postError, args.postFailureEventName, {
+        "app.slack.reply_stage": "error_fallback_post",
+        "app.error.original_event_id": args.eventId,
+        ...getSlackErrorObservabilityAttributes(postError),
+      });
       throw postError;
     }
   };
@@ -559,8 +543,7 @@ export function createSlackTurnRuntime<
     decision: SubscribedReplyDecision;
     message: Message;
   }): void => {
-    deps.logWarn(
-      "subscribed_message_reply_skipped",
+    withLogContext(
       logContext({
         threadId: args.context.threadId,
         actorId: args.context.actorId,
@@ -568,10 +551,11 @@ export function createSlackTurnRuntime<
         channelId: args.context.channelId,
         runId: args.context.runId,
       }),
-      {
-        "app.decision.reason": args.decision.reason,
+      () => {
+        deps.logWarn("subscribed_message.reply.skipped", {
+          "app.decision.reason": args.decision.reason,
+        });
       },
-      "Skipping subscribed message reply",
     );
   };
 
@@ -698,13 +682,9 @@ export function createSlackTurnRuntime<
         });
       }
     } catch (error) {
-      deps.logException(
-        error,
-        "skipped_steering_flush_failed",
-        args.context,
-        {},
-        "Failed to reapply skipped steering message records",
-      );
+      withLogContext(args.context, () => {
+        deps.logException(error, "agent.turn.steering_flush.failed");
+      });
     }
   };
 
@@ -811,18 +791,18 @@ export function createSlackTurnRuntime<
           });
         });
       } catch (error) {
-        const classifiedFailure = getConversationTurnBoundaryError(error);
-        const failureCause = classifiedFailure?.cause ?? error;
-        if (shouldRethrowTurnControlError(failureCause)) {
-          throw failureCause;
-        }
-        const errorContext = logContext({
+        const failureLogContext = logContext({
           threadId: deps.getThreadId(thread, message),
           actorId: message.author.userId,
           actorUserName: actorUserName(message),
           channelId: deps.getChannelId(thread, message),
           runId: deps.getRunId(thread, message),
         });
+        const classifiedFailure = getConversationTurnBoundaryError(error);
+        const failureCause = classifiedFailure?.cause ?? error;
+        if (shouldRethrowTurnControlError(failureCause)) {
+          throw failureCause;
+        }
         if (failureCause instanceof AuthorizationFlowDisabledError) {
           return;
         }
@@ -832,28 +812,17 @@ export function createSlackTurnRuntime<
           failureCause instanceof SlackActionError &&
           failureCause.code === "read_only_channel"
         ) {
-          deps.logWarn(
-            "mention_handler_read_only_channel",
-            logContext({
-              threadId: deps.getThreadId(thread, message),
-              actorId: message.author.userId,
-              actorUserName: actorUserName(message),
-              channelId: deps.getChannelId(thread, message),
-              runId: deps.getRunId(thread, message),
-            }),
-            {},
-            "Skipping reply to read-only channel",
-          );
+          withLogContext(failureLogContext, () => {
+            deps.logWarn("mention.handler.skipped", {
+              "app.decision.reason": "read_only_channel",
+            });
+          });
           return;
         }
         const eventId =
           classifiedFailure?.eventId ??
-          deps.logException(
-            failureCause,
-            "mention_handler_failed",
-            errorContext,
-            {},
-            "onNewMention failed",
+          withLogContext(failureLogContext, () =>
+            deps.logException(failureCause, "mention.handler.failed"),
           );
         if (!acked && hooks.isFinalAttempt === false) {
           // The mailbox redelivers this message; only the final bounded
@@ -862,7 +831,7 @@ export function createSlackTurnRuntime<
         }
         if (!eventId) {
           throw new Error(
-            "Sentry did not return an event ID for mention_handler_failed",
+            "Sentry did not return an event ID for mention.handler.failed",
           );
         }
         let lifecycleError: unknown;
@@ -879,11 +848,8 @@ export function createSlackTurnRuntime<
         await hooks.beforeFirstResponsePost?.();
         await postFallbackErrorReplyWithLogging({
           thread,
-          errorContext,
           eventId,
-          postFailureEventName: "mention_handler_failure_reply_post_failed",
-          postFailureBody:
-            "Failed to post fallback error reply for mention handler",
+          postFailureEventName: "mention.handler.failure_reply_post.failed",
         });
         if (lifecycleError) throw lifecycleError;
       } finally {
@@ -1134,18 +1100,18 @@ export function createSlackTurnRuntime<
           });
         });
       } catch (error) {
-        const classifiedFailure = getConversationTurnBoundaryError(error);
-        const failureCause = classifiedFailure?.cause ?? error;
-        if (shouldRethrowTurnControlError(failureCause)) {
-          throw failureCause;
-        }
-        const errorContext = logContext({
+        const failureLogContext = logContext({
           threadId: deps.getThreadId(thread, message),
           actorId: message.author.userId,
           actorUserName: actorUserName(message),
           channelId: deps.getChannelId(thread, message),
           runId: deps.getRunId(thread, message),
         });
+        const classifiedFailure = getConversationTurnBoundaryError(error);
+        const failureCause = classifiedFailure?.cause ?? error;
+        if (shouldRethrowTurnControlError(failureCause)) {
+          throw failureCause;
+        }
         if (failureCause instanceof AuthorizationFlowDisabledError) {
           return;
         }
@@ -1155,28 +1121,20 @@ export function createSlackTurnRuntime<
           failureCause instanceof SlackActionError &&
           failureCause.code === "read_only_channel"
         ) {
-          deps.logWarn(
-            "subscribed_message_handler_read_only_channel",
-            logContext({
-              threadId: deps.getThreadId(thread, message),
-              actorId: message.author.userId,
-              actorUserName: actorUserName(message),
-              channelId: deps.getChannelId(thread, message),
-              runId: deps.getRunId(thread, message),
-            }),
-            {},
-            "Skipping reply to read-only channel",
-          );
+          withLogContext(failureLogContext, () => {
+            deps.logWarn("subscribed_message.handler.skipped", {
+              "app.decision.reason": "read_only_channel",
+            });
+          });
           return;
         }
         const eventId =
           classifiedFailure?.eventId ??
-          deps.logException(
-            failureCause,
-            "subscribed_message_handler_failed",
-            errorContext,
-            {},
-            "onSubscribedMessage failed",
+          withLogContext(failureLogContext, () =>
+            deps.logException(
+              failureCause,
+              "subscribed_message.handler.failed",
+            ),
           );
         if (!acked && hooks.isFinalAttempt === false) {
           // The mailbox redelivers this message; only the final bounded
@@ -1185,7 +1143,7 @@ export function createSlackTurnRuntime<
         }
         if (!eventId) {
           throw new Error(
-            "Sentry did not return an event ID for subscribed_message_handler_failed",
+            "Sentry did not return an event ID for subscribed_message.handler.failed",
           );
         }
         let lifecycleError: unknown;
@@ -1202,12 +1160,9 @@ export function createSlackTurnRuntime<
         await hooks.beforeFirstResponsePost?.();
         await postFallbackErrorReplyWithLogging({
           thread,
-          errorContext,
           eventId,
           postFailureEventName:
-            "subscribed_message_handler_failure_reply_post_failed",
-          postFailureBody:
-            "Failed to post fallback error reply for subscribed message handler",
+            "subscribed_message.handler.failure_reply_post.failed",
         });
         if (lifecycleError) throw lifecycleError;
       } finally {
@@ -1231,53 +1186,47 @@ export function createSlackTurnRuntime<
     },
 
     async handleAssistantThreadStarted(event: TAssistantEvent): Promise<void> {
-      try {
-        await deps.initializeAssistantThread({
+      await withLogContext(
+        logContext({
           threadId: event.threadId,
+          actorId: event.userId,
           channelId: event.channelId,
-          threadTs: event.threadTs,
-          sourceChannelId: event.context?.channelId,
-        });
-      } catch (error) {
-        deps.logException(
-          error,
-          "assistant_thread_started_handler_failed",
-          {
-            messageConversationId: event.threadId,
-            userId: event.userId,
-            destinationName: event.channelId,
-            assistantUserName: deps.assistantUserName,
-            modelId: deps.modelId,
-          },
-          {},
-          "onAssistantThreadStarted failed",
-        );
-      }
+        }),
+        async () => {
+          try {
+            await deps.initializeAssistantThread({
+              threadId: event.threadId,
+              channelId: event.channelId,
+              threadTs: event.threadTs,
+              sourceChannelId: event.context?.channelId,
+            });
+          } catch (error) {
+            deps.logException(error, "assistant.thread.initialization.failed");
+          }
+        },
+      );
     },
 
     async handleAssistantContextChanged(event: TAssistantEvent): Promise<void> {
-      try {
-        await deps.refreshAssistantThreadContext({
+      await withLogContext(
+        logContext({
           threadId: event.threadId,
+          actorId: event.userId,
           channelId: event.channelId,
-          threadTs: event.threadTs,
-          sourceChannelId: event.context?.channelId,
-        });
-      } catch (error) {
-        deps.logException(
-          error,
-          "assistant_context_changed_handler_failed",
-          {
-            messageConversationId: event.threadId,
-            userId: event.userId,
-            destinationName: event.channelId,
-            assistantUserName: deps.assistantUserName,
-            modelId: deps.modelId,
-          },
-          {},
-          "onAssistantContextChanged failed",
-        );
-      }
+        }),
+        async () => {
+          try {
+            await deps.refreshAssistantThreadContext({
+              threadId: event.threadId,
+              channelId: event.channelId,
+              threadTs: event.threadTs,
+              sourceChannelId: event.context?.channelId,
+            });
+          } catch (error) {
+            deps.logException(error, "assistant.context.refresh.failed");
+          }
+        },
+      );
     },
   };
 }

--- a/packages/junior/src/chat/sandbox/egress/proxy.ts
+++ b/packages/junior/src/chat/sandbox/egress/proxy.ts
@@ -284,29 +284,19 @@ export async function proxySandboxEgressRequest(
       oidcToken,
     );
   } catch (error) {
-    logWarn(
-      "sandbox_egress_oidc_verification_failed",
-      {},
-      {
-        "app.sandbox.oidc_error":
-          error instanceof Error ? error.message : String(error),
-      },
-      "Sandbox egress OIDC verification failed",
-    );
+    logWarn("sandbox.egress.oidc_verification.failed", {
+      "app.sandbox.oidc_error":
+        error instanceof Error ? error.message : String(error),
+    });
     return jsonError("Invalid Vercel Sandbox OIDC token", 401);
   }
 
   const activeEgressId = sandboxIdFromPayload(oidcPayload);
   if (!activeEgressId) {
-    logWarn(
-      "sandbox_egress_oidc_session_missing",
-      {},
-      {
-        "http.request.method": request.method,
-        "url.path": redactedProxyPath(new URL(request.url).pathname),
-      },
-      "Sandbox egress OIDC payload did not include a VM session id",
-    );
+    logWarn("sandbox.egress.oidc_session.missing", {
+      "http.request.method": request.method,
+      "url.path": redactedProxyPath(new URL(request.url).pathname),
+    });
     return jsonError(
       "Vercel Sandbox OIDC token did not include sandbox_id",
       401,
@@ -315,41 +305,31 @@ export async function proxySandboxEgressRequest(
 
   const upstreamResult = buildUpstreamUrl(request);
   if (!upstreamResult.ok) {
-    logWarn(
-      "sandbox_egress_upstream_url_invalid",
-      {},
-      {
-        ...egressAttributes({
-          egressId: activeEgressId,
-          method: request.method,
-          path: redactedProxyPath(new URL(request.url).pathname),
-          status: 400,
-        }),
-        ...routingAttributes(request),
-      },
-      "Sandbox egress forwarded request had invalid upstream routing headers",
-    );
+    logWarn("sandbox.egress.upstream_url.invalid", {
+      ...egressAttributes({
+        egressId: activeEgressId,
+        method: request.method,
+        path: redactedProxyPath(new URL(request.url).pathname),
+        status: 400,
+      }),
+      ...routingAttributes(request),
+    });
     return jsonError(upstreamResult.error, 400);
   }
   const upstreamUrl = upstreamResult.url;
 
   const provider = resolveSandboxEgressProviderForHost(upstreamUrl.hostname);
   if (!provider) {
-    logWarn(
-      "sandbox_egress_provider_unresolved",
-      {},
-      {
-        ...egressAttributes({
-          egressId: activeEgressId,
-          host: upstreamUrl.hostname,
-          method: request.method,
-          path: upstreamUrl.pathname,
-          status: 403,
-        }),
-        ...routingAttributes(request, upstreamUrl),
-      },
-      "Sandbox egress forwarded host is not owned by any credential provider",
-    );
+    logWarn("sandbox.egress.provider.unresolved", {
+      ...egressAttributes({
+        egressId: activeEgressId,
+        host: upstreamUrl.hostname,
+        method: request.method,
+        path: upstreamUrl.pathname,
+        status: 403,
+      }),
+      ...routingAttributes(request, upstreamUrl),
+    });
     return jsonError("No provider owns forwarded host", 403);
   }
 
@@ -360,22 +340,17 @@ export async function proxySandboxEgressRequest(
     credentialTokenFromRequest(request),
   );
   if (!credentialContext || credentialContext.egressId !== activeEgressId) {
-    logWarn(
-      "sandbox_egress_credential_context_unauthorized",
-      {},
-      {
-        ...egressAttributes({
-          egressId: activeEgressId,
-          host: upstreamUrl.hostname,
-          method: request.method,
-          path: upstreamUrl.pathname,
-          provider,
-          status: 403,
-        }),
-        ...routingAttributes(request, upstreamUrl),
-      },
-      "Sandbox egress request did not include a valid credential context for the VM session",
-    );
+    logWarn("sandbox.egress.credential_context.unauthorized", {
+      ...egressAttributes({
+        egressId: activeEgressId,
+        host: upstreamUrl.hostname,
+        method: request.method,
+        path: upstreamUrl.pathname,
+        provider,
+        status: 403,
+      }),
+      ...routingAttributes(request, upstreamUrl),
+    });
     return jsonError(
       "Sandbox egress credential context is not authorized",
       403,

--- a/packages/junior/src/chat/sandbox/sandbox.ts
+++ b/packages/junior/src/chat/sandbox/sandbox.ts
@@ -306,15 +306,10 @@ export function createSandbox(options: SandboxOptions): SandboxAccess {
       return;
     }
 
-    logInfo(
-      "sandbox_boot_requested",
-      traceContext,
-      {
-        "app.sandbox.boot.trigger": trigger,
-        ...details,
-      },
-      "Sandbox boot requested",
-    );
+    logInfo("sandbox.boot.requested", {
+      "app.sandbox.boot.trigger": trigger,
+      ...details,
+    });
   };
 
   const executeBashTool = async <T>(

--- a/packages/junior/src/chat/sandbox/session.ts
+++ b/packages/junior/src/chat/sandbox/session.ts
@@ -525,21 +525,17 @@ export function createSandboxRuntime(
         ? { "app.sandbox.current_profile_hash": dependencyProfileHash }
         : {}),
     });
-    logInfo(
-      "sandbox_hint_discarded_profile_mismatch",
-      traceContext,
-      {
-        ...(sandboxRef.profileHash
-          ? {
-              "app.sandbox.previous_profile_hash": sandboxRef.profileHash,
-            }
-          : {}),
-        ...(dependencyProfileHash
-          ? { "app.sandbox.current_profile_hash": dependencyProfileHash }
-          : {}),
-      },
-      "Dependency profile changed; discarding sandbox hint and creating fresh session",
-    );
+    logInfo("sandbox.hint.discarded", {
+      "app.decision.reason": "dependency_profile_mismatch",
+      ...(sandboxRef.profileHash
+        ? {
+            "app.sandbox.previous_profile_hash": sandboxRef.profileHash,
+          }
+        : {}),
+      ...(dependencyProfileHash
+        ? { "app.sandbox.current_profile_hash": dependencyProfileHash }
+        : {}),
+    });
     sandboxRef = undefined;
   };
 

--- a/packages/junior/src/chat/services/context-compaction.ts
+++ b/packages/junior/src/chat/services/context-compaction.ts
@@ -479,22 +479,10 @@ async function maybeCompactWithDeps(
       deps,
     );
   } catch (error) {
-    logWarn(
-      "context_compaction_summary_failed",
-      {
-        messageConversationId: args.metadata?.threadId,
-        userId: args.metadata?.actorId,
-        destinationName: args.metadata?.channelId,
-        runId: args.metadata?.runId,
-        assistantUserName: botConfig.userName,
-        modelId: botConfig.fastModelId,
-      },
-      {
-        "exception.message":
-          error instanceof Error ? error.message : String(error),
-      },
-      "Context compaction failed; continuing with prior history",
-    );
+    logWarn("context_compaction.summary.failed", {
+      "exception.message":
+        error instanceof Error ? error.message : String(error),
+    });
     return { compacted: false, reason: "summary_failed" };
   }
 
@@ -683,24 +671,12 @@ export async function compactActiveContextIfNeeded(
         inputLimitTokens,
       );
     }
-    logWarn(
-      "active_context_compaction_summary_failed",
-      {
-        messageConversationId: args.metadata?.threadId,
-        userId: args.metadata?.actorId,
-        destinationName: args.metadata?.channelId,
-        runId: args.metadata?.runId,
-        assistantUserName: botConfig.userName,
-        modelId: args.modelId,
-      },
-      {
-        "app.context_input_limit_tokens": inputLimitTokens,
-        "app.context_tokens_estimated": source.estimatedTokens,
-        "exception.message":
-          error instanceof Error ? error.message : String(error),
-      },
-      "Active context compaction failed below the hard input limit",
-    );
+    logWarn("context_compaction.active.summary.failed", {
+      "app.context_input_limit_tokens": inputLimitTokens,
+      "app.context_tokens_estimated": source.estimatedTokens,
+      "exception.message":
+        error instanceof Error ? error.message : String(error),
+    });
     return { compacted: false, reason: "summary_failed" };
   }
 

--- a/packages/junior/src/chat/services/conversation-memory.ts
+++ b/packages/junior/src/chat/services/conversation-memory.ts
@@ -355,23 +355,11 @@ async function summarizeConversationChunk(
       return summary.slice(0, 3500);
     }
   } catch (error) {
-    logWarn(
-      "conversation_compaction_summary_failed",
-      {
-        messageConversationId: context.threadId,
-        userId: context.actorId,
-        destinationName: context.channelId,
-        runId: context.runId,
-        assistantUserName: botConfig.userName,
-        modelId: botConfig.fastModelId,
-      },
-      {
-        "exception.message":
-          error instanceof Error ? error.message : String(error),
-        "app.compaction_messages_covered": messages.length,
-      },
-      "Compaction summarization failed; using fallback summary",
-    );
+    logWarn("conversation.compaction.summary.failed", {
+      "exception.message":
+        error instanceof Error ? error.message : String(error),
+      "app.compaction_messages_covered": messages.length,
+    });
   }
 
   return transcript.slice(0, 2800);

--- a/packages/junior/src/chat/services/subscribed-reply-policy.ts
+++ b/packages/junior/src/chat/services/subscribed-reply-policy.ts
@@ -29,23 +29,11 @@ export function createSubscribedReplyPolicy(
       modelId: botConfig.fastModelId,
       input: args,
       completeObject: deps.completeObject,
-      logClassifierFailure: (error, input) => {
-        logWarn(
-          "subscribed_message_classifier_failed",
-          {
-            messageConversationId: input.context.threadId,
-            userId: input.context.actorId,
-            destinationName: input.context.channelId,
-            runId: input.context.runId,
-            assistantUserName: botConfig.userName,
-            modelId: botConfig.fastModelId,
-          },
-          {
-            "exception.message":
-              error instanceof Error ? error.message : String(error),
-          },
-          "Subscribed-message classifier failed; skipping reply",
-        );
+      logClassifierFailure: (error) => {
+        logWarn("subscribed_message.classifier.failed", {
+          "exception.message":
+            error instanceof Error ? error.message : String(error),
+        });
       },
     });
 

--- a/packages/junior/src/chat/services/turn-failure-response.ts
+++ b/packages/junior/src/chat/services/turn-failure-response.ts
@@ -1,4 +1,3 @@
-import type { LogContext } from "@/chat/logging";
 import { buildTurnFailureResponse } from "@/chat/logging";
 import { getInterruptionMarker } from "@/chat/interruption-marker";
 import {
@@ -11,9 +10,7 @@ import type { AgentRunResult } from "@/chat/services/turn-result";
 type LogException = (
   error: unknown,
   eventName: string,
-  context?: LogContext,
   attributes?: Record<string, unknown>,
-  body?: string,
 ) => string | undefined;
 
 /** Require captured turn failures to carry a real Sentry event reference. */
@@ -55,7 +52,7 @@ function getFailureCapture(reply: AgentRunResult): {
 } {
   if (reply.diagnostics.outcome === "provider_error") {
     return {
-      eventName: "agent_turn_provider_error",
+      eventName: "agent.turn.provider_error",
       error:
         reply.diagnostics.providerError ??
         new Error(
@@ -72,7 +69,7 @@ function getFailureCapture(reply: AgentRunResult): {
 
   const failureReason = getExecutionFailureReason(reply);
   return {
-    eventName: "agent_turn_execution_failure",
+    eventName: "agent.turn.execution.failed",
     error: new Error(`Agent turn execution failure: ${failureReason}`),
     attributes: {
       "app.ai.execution_failure_reason": failureReason,
@@ -119,7 +116,6 @@ export interface FinalizedTurnFailure {
 export function finalizeFailedTurnReplyWithEvent(args: {
   reply: AgentRunResult;
   logException: LogException;
-  context: LogContext;
   attributes?: Record<string, unknown>;
 }): FinalizedTurnFailure {
   if (args.reply.diagnostics.outcome === "success") {
@@ -128,17 +124,11 @@ export function finalizeFailedTurnReplyWithEvent(args: {
 
   const capture = getFailureCapture(args.reply);
   const eventId = requireTurnFailureEventId(
-    args.logException(
-      capture.error,
-      capture.eventName,
-      args.context,
-      {
-        ...getAgentTurnDiagnosticsAttributes(args.reply),
-        ...args.attributes,
-        ...capture.attributes,
-      },
-      capture.body,
-    ),
+    args.logException(capture.error, capture.eventName, {
+      ...getAgentTurnDiagnosticsAttributes(args.reply),
+      ...args.attributes,
+      ...capture.attributes,
+    }),
     capture.eventName,
   );
 

--- a/packages/junior/src/chat/services/turn-result.ts
+++ b/packages/junior/src/chat/services/turn-result.ts
@@ -1,6 +1,5 @@
 import { isRetryableAssistantError } from "@earendil-works/pi-ai";
 import { logInfo, logWarn, summarizeMessageText } from "@/chat/logging";
-import type { LogContext } from "@/chat/logging";
 import { containsNoReplyMarker, isNoReplyMarker } from "@/chat/no-reply";
 import type { PiMessage } from "@/chat/pi/messages";
 import { createProviderError } from "@/chat/services/provider-error";
@@ -131,7 +130,6 @@ export interface TurnResultInput {
   durationMs?: number;
   generatedFileCount: number;
   shouldTrace: boolean;
-  spanContext: LogContext;
   usage?: AgentTurnUsage;
   executionProfile: TurnRoute;
   assistantUserName?: string;
@@ -192,10 +190,8 @@ export function buildTurnResult(input: TurnResultInput): AgentRunResult {
     sandboxRef,
     durationMs,
     shouldTrace,
-    spanContext,
     usage,
     executionProfile,
-    assistantUserName,
     modelId,
   } = input;
 
@@ -226,11 +222,6 @@ export function buildTurnResult(input: TurnResultInput): AgentRunResult {
       normalizeToolNameFromResult(result) === "addReaction",
   );
   const completedWithoutTerminalText = noReplyRequested;
-  const resultLogContext = {
-    ...spanContext,
-    assistantUserName,
-    modelId,
-  };
   const lastAssistant = terminalAssistantMessages.at(-1) as
     | { stopReason?: unknown; errorMessage?: unknown }
     | undefined;
@@ -246,7 +237,6 @@ export function buildTurnResult(input: TurnResultInput): AgentRunResult {
 
   if (exactNoReplyMarker) {
     const markerCategory = reactionPerformed ? "reaction" : "none";
-    const markerContext = resultLogContext;
     const markerAttributes = {
       "app.ai.no_reply_marker": true,
       "app.ai.no_reply_marker_category": markerCategory,
@@ -254,36 +244,21 @@ export function buildTurnResult(input: TurnResultInput): AgentRunResult {
     };
 
     if (!isProviderError) {
-      logInfo(
-        "ai_no_reply_marker_accepted",
-        markerContext,
-        markerAttributes,
-        "No-reply marker suppressed visible thread text",
-      );
+      logInfo("ai.no_reply_marker.accepted", markerAttributes);
     }
   } else if (mixedNoReplyMarker) {
-    logWarn(
-      "ai_no_reply_marker_mixed_text",
-      resultLogContext,
-      {
-        "app.ai.no_reply_marker": true,
-        "app.ai.no_reply_marker_mode": "mixed",
-      },
-      "No-reply marker appeared with visible assistant text",
-    );
+    logWarn("ai.no_reply_marker.mixed_text", {
+      "app.ai.no_reply_marker": true,
+      "app.ai.no_reply_marker_mode": "mixed",
+    });
   }
 
   if (!primaryText && !completedWithoutTerminalText && !isProviderError) {
-    logWarn(
-      "ai_model_response_empty",
-      resultLogContext,
-      {
-        "app.ai.tool_results": toolResults.length,
-        "app.ai.tool_error_results": toolErrorCount,
-        "app.ai.generated_files": input.generatedFileCount,
-      },
-      "Model returned empty text response",
-    );
+    logWarn("ai.model_response.empty", {
+      "app.ai.tool_results": toolResults.length,
+      "app.ai.tool_error_results": toolErrorCount,
+      "app.ai.generated_files": input.generatedFileCount,
+    });
   }
 
   const usedPrimaryText = Boolean(rawPrimaryText);
@@ -303,21 +278,14 @@ export function buildTurnResult(input: TurnResultInput): AgentRunResult {
     : outcome;
 
   if (shouldTrace) {
-    logInfo(
-      "agent_message_out",
-      spanContext,
-      {
-        "app.message.kind": "assistant_outbound",
-        "app.message.length": primaryText.length,
-        "app.message.output": summarizeMessageText(primaryText),
-        "app.ai.outcome": resolvedOutcome,
-        "app.ai.assistant_messages": assistantMessages.length,
-        ...(stopReason
-          ? { "gen_ai.response.finish_reasons": [stopReason] }
-          : {}),
-      },
-      "Agent message sent",
-    );
+    logInfo("agent.message.generated", {
+      "app.message.kind": "assistant_outbound",
+      "app.message.length": primaryText.length,
+      "app.message.output": summarizeMessageText(primaryText),
+      "app.ai.outcome": resolvedOutcome,
+      "app.ai.assistant_messages": assistantMessages.length,
+      ...(stopReason ? { "gen_ai.response.finish_reasons": [stopReason] } : {}),
+    });
   }
 
   const resolvedDiagnostics: AgentTurnDiagnostics = {

--- a/packages/junior/src/chat/services/turn-router.ts
+++ b/packages/junior/src/chat/services/turn-router.ts
@@ -355,21 +355,10 @@ async function classifyTurn(args: {
       source: "router",
     };
   } catch (error) {
-    logWarn(
-      "turn_router_classifier_failed",
-      {
-        messageConversationId: args.metadata.threadId,
-        destinationName: args.metadata.channelId,
-        userId: args.metadata.actorId,
-        runId: args.metadata.runId,
-        modelId: args.fastModelId,
-      },
-      {
-        "exception.message":
-          error instanceof Error ? error.message : String(error),
-      },
-      "Turn router classifier failed; using the default route",
-    );
+    logWarn("turn.router.classifier.failed", {
+      "exception.message":
+        error instanceof Error ? error.message : String(error),
+    });
     return {
       profile: STANDARD_MODEL_PROFILE,
       reasoningLevel: CLASSIFIER_FALLBACK_REASONING_LEVEL,

--- a/packages/junior/src/chat/services/turn-session-record.ts
+++ b/packages/junior/src/chat/services/turn-session-record.ts
@@ -32,44 +32,20 @@ export interface TurnSessionState {
   existingSessionRecord?: AgentTurnSessionRecord;
 }
 
-interface SessionRecordLogContext {
-  threadId?: string;
-  actorId?: string;
-  channelId?: string;
-  runId?: string;
-  assistantUserName?: string;
-}
-
 function logSessionRecordError(
   error: unknown,
   eventName: string,
   args: {
     conversationId: string;
     sessionId: string;
-    logContext: SessionRecordLogContext;
-    modelId: string;
   },
   attributes: Record<string, string | number>,
-  message: string,
 ): void {
-  logException(
-    error,
-    eventName,
-    {
-      messageConversationId: args.logContext.threadId,
-      userId: args.logContext.actorId,
-      destinationName: args.logContext.channelId,
-      runId: args.logContext.runId,
-      assistantUserName: args.logContext.assistantUserName,
-      modelId: args.modelId,
-    },
-    {
-      "app.ai.resume_conversation_id": args.conversationId,
-      "app.ai.resume_session_id": args.sessionId,
-      ...attributes,
-    },
-    message,
-  );
+  logException(error, eventName, {
+    "app.ai.resume_conversation_id": args.conversationId,
+    "app.ai.resume_session_id": args.sessionId,
+    ...attributes,
+  });
 }
 
 function addDurationMs(
@@ -134,7 +110,6 @@ export async function persistRunningSessionRecord(args: {
   /** Provenance for trailing newly committed messages, such as steering. */
   trailingMessageProvenance?: ConversationMessageProvenance[];
   loadedSkillNames?: string[];
-  logContext: SessionRecordLogContext;
   modelId: string;
   actor?: Actor;
   reasoningLevel?: string;
@@ -202,12 +177,11 @@ export async function persistRunningSessionRecord(args: {
   } catch (recordError) {
     logSessionRecordError(
       recordError,
-      "agent_turn_running_session_record_failed",
+      "agent.turn.running_session_record.failed",
       args,
       {
         "app.ai.resume_slice_id": args.sliceId,
       },
-      "Failed to persist running turn session record",
     );
     return false;
   }
@@ -403,7 +377,6 @@ export async function persistAuthPauseSessionRecord(args: {
   loadedSkillNames?: string[];
   modelId: string;
   errorMessage: string;
-  logContext: SessionRecordLogContext;
   actor?: Actor;
   reasoningLevel?: string;
   surface?: AgentTurnSurface;
@@ -473,13 +446,12 @@ export async function persistAuthPauseSessionRecord(args: {
   } catch (recordError) {
     logSessionRecordError(
       recordError,
-      "agent_turn_auth_resume_session_record_failed",
+      "agent.turn.auth_resume_session_record.failed",
       args,
       {
         "app.ai.resume_from_slice_id": args.currentSliceId,
         "app.ai.resume_next_slice_id": nextSliceId,
       },
-      "Failed to persist auth session record before retry",
     );
   }
   return undefined;
@@ -499,7 +471,6 @@ interface ContinuationRecordInput {
   loadedSkillNames?: string[];
   modelId: string;
   errorMessage: string;
-  logContext: SessionRecordLogContext;
   actor?: Actor;
   reasoningLevel?: string;
   surface?: AgentTurnSurface;
@@ -630,13 +601,12 @@ export async function persistContinuationSessionRecord(
   } catch (recordError) {
     logSessionRecordError(
       recordError,
-      "agent_continue_session_record_failed",
+      "agent.continue.session_record.failed",
       args,
       {
         "app.ai.resume_from_slice_id": args.currentSliceId,
         "app.ai.resume_next_slice_id": nextSliceId,
       },
-      "Failed to persist session record before scheduling agent continuation",
     );
     return undefined;
   }
@@ -659,7 +629,6 @@ export async function persistYieldSessionRecord(args: {
   loadedSkillNames?: string[];
   modelId: string;
   errorMessage: string;
-  logContext: SessionRecordLogContext;
   actor?: Actor;
   reasoningLevel?: string;
   surface?: AgentTurnSurface;
@@ -727,12 +696,11 @@ export async function persistYieldSessionRecord(args: {
   } catch (recordError) {
     logSessionRecordError(
       recordError,
-      "agent_turn_yield_session_record_failed",
+      "agent.turn.yield_session_record.failed",
       args,
       {
         "app.ai.resume_slice_id": args.currentSliceId,
       },
-      "Failed to persist cooperative yield session record",
     );
     return undefined;
   }

--- a/packages/junior/src/chat/skills.ts
+++ b/packages/junior/src/chat/skills.ts
@@ -331,15 +331,10 @@ async function readSkillDirectory(
     const raw = await fs.readFile(skillFile, "utf8");
     const parsed = parseSkillFile(raw, path.basename(skillDir));
     if (!parsed.ok) {
-      logWarn(
-        "skill_frontmatter_invalid",
-        {},
-        {
-          "file.path": skillDir,
-          "exception.message": parsed.error,
-        },
-        "Invalid skill frontmatter",
-      );
+      logWarn("skill.frontmatter.invalid", {
+        "file.path": skillDir,
+        "exception.message": parsed.error,
+      });
       return null;
     }
 
@@ -356,16 +351,11 @@ async function readSkillDirectory(
       ...(disableModelInvocation ? { disableModelInvocation } : {}),
     };
   } catch (error) {
-    logWarn(
-      "skill_directory_read_failed",
-      {},
-      {
-        "file.path": skillDir,
-        "exception.message":
-          error instanceof Error ? error.message : String(error),
-      },
-      "Failed to read skill directory",
-    );
+    logWarn("skill.directory.read.failed", {
+      "file.path": skillDir,
+      "exception.message":
+        error instanceof Error ? error.message : String(error),
+    });
     return null;
   }
 }
@@ -404,16 +394,11 @@ export async function discoverSkills(
         }
       }
     } catch (error) {
-      logWarn(
-        "skill_root_read_failed",
-        {},
-        {
-          "file.directory": root,
-          "exception.message":
-            error instanceof Error ? error.message : String(error),
-        },
-        "Failed to read skill root",
-      );
+      logWarn("skill.root.read.failed", {
+        "file.directory": root,
+        "exception.message":
+          error instanceof Error ? error.message : String(error),
+      });
     }
   }
 

--- a/packages/junior/src/chat/slack/assistant-thread/status-send.ts
+++ b/packages/junior/src/chat/slack/assistant-thread/status-send.ts
@@ -153,17 +153,12 @@ function logAssistantStatusFailure(args: {
   normalizedChannelId: string;
   threadTs: string;
 }): void {
-  logWarn(
-    "assistant_status_update_failed",
-    {},
-    {
-      "app.slack.status_text": args.status || "(clear)",
-      "app.slack.channel_id_raw": args.channelId,
-      "app.slack.channel_id": args.normalizedChannelId,
-      "app.slack.thread_ts": args.threadTs,
-      "exception.message":
-        args.error instanceof Error ? args.error.message : String(args.error),
-    },
-    `Failed to update assistant status channel=${args.normalizedChannelId} raw=${args.channelId} thread=${args.threadTs}`,
-  );
+  logWarn("assistant.status.update.failed", {
+    "app.slack.status_text": args.status || "(clear)",
+    "app.slack.channel_id_raw": args.channelId,
+    "app.slack.channel_id": args.normalizedChannelId,
+    "app.slack.thread_ts": args.threadTs,
+    "exception.message":
+      args.error instanceof Error ? args.error.message : String(args.error),
+  });
 }

--- a/packages/junior/src/chat/slack/assistant-thread/title.ts
+++ b/packages/junior/src/chat/slack/assistant-thread/title.ts
@@ -61,22 +61,10 @@ export function maybeUpdateAssistantTitle(args: {
     try {
       title = await args.generateThreadTitle(titleSourceMessage.text);
     } catch (error) {
-      logWarn(
-        "thread_title_generation_failed",
-        {
-          messageConversationId: args.threadId,
-          userId: args.actorId,
-          destinationName: args.channelId,
-          runId: args.runId,
-          assistantUserName: args.assistantUserName,
-          modelId: args.modelId,
-        },
-        {
-          "exception.message":
-            error instanceof Error ? error.message : String(error),
-        },
-        "Thread title generation failed",
-      );
+      logWarn("thread.title.generation.failed", {
+        "exception.message":
+          error instanceof Error ? error.message : String(error),
+      });
       return undefined;
     }
 
@@ -106,35 +94,14 @@ export function maybeUpdateAssistantTitle(args: {
           // title is still returned for dashboard reporting.
           setSpanAttributes(assistantTitleErrorAttributes);
           logError(
-            "thread_title_generation_permission_denied",
-            {
-              messageConversationId: args.threadId,
-              userId: args.actorId,
-              destinationName: args.channelId,
-              runId: args.runId,
-              assistantUserName: args.assistantUserName,
-              modelId: args.modelId,
-            },
+            "thread.title.generation_permission.denied",
             assistantTitleErrorAttributes,
-            "Skipping Slack thread title update due to permission error",
           );
         } else {
-          logWarn(
-            "thread_title_slack_update_failed",
-            {
-              messageConversationId: args.threadId,
-              userId: args.actorId,
-              destinationName: args.channelId,
-              runId: args.runId,
-              assistantUserName: args.assistantUserName,
-              modelId: args.modelId,
-            },
-            {
-              "exception.message":
-                error instanceof Error ? error.message : String(error),
-            },
-            "Slack thread title update failed",
-          );
+          logWarn("thread.title.slack_update.failed", {
+            "exception.message":
+              error instanceof Error ? error.message : String(error),
+          });
         }
       }
     }

--- a/packages/junior/src/chat/slack/client.ts
+++ b/packages/junior/src/chat/slack/client.ts
@@ -550,30 +550,20 @@ export async function withSlackRetries<T>(
         attempt >= maxAttempts ||
         remainingDelayBudgetMs <= 0
       ) {
-        logWarn(
-          "slack_action_failed",
-          {},
-          {
-            ...baseLogAttributes,
-            ...(mapped.errorData
-              ? { "app.slack.error_data": mapped.errorData }
-              : {}),
-          },
-          "Slack action failed",
-        );
+        logWarn("slack.action.failed", {
+          ...baseLogAttributes,
+          ...(mapped.errorData
+            ? { "app.slack.error_data": mapped.errorData }
+            : {}),
+        });
         throw mapped;
       }
 
-      logWarn(
-        "slack_action_retrying",
-        {},
-        {
-          ...baseLogAttributes,
-          "app.slack.retry_attempt": attempt,
-          "app.slack.retry_class": retryClass,
-        },
-        "Retrying Slack action after transient failure",
-      );
+      logWarn("slack.action.retrying", {
+        ...baseLogAttributes,
+        "app.slack.retry_attempt": attempt,
+        "app.slack.retry_class": retryClass,
+      });
 
       const retryAfterMs =
         retryClass === "rate_limited" &&

--- a/packages/junior/src/chat/slack/tools/canvas/api.ts
+++ b/packages/junior/src/chat/slack/tools/canvas/api.ts
@@ -124,20 +124,13 @@ async function grantChannelCanvasAccess(
         },
       },
     );
-  } catch (error) {
-    logWarn(
-      "slack_canvas_access_set_failed",
-      {},
-      {
-        "app.slack.action": "canvases.access.set",
-        "app.slack.canvas.canvas_id_prefix": canvasId.slice(0, 1),
-        "app.slack.canvas.channel_id_prefix": channelId.slice(0, 1),
-        "app.slack.canvas.access_level": "write",
-      },
-      error instanceof Error
-        ? error.message
-        : "Failed to grant channel access to canvas",
-    );
+  } catch {
+    logWarn("slack.canvas.access_set.failed", {
+      "app.slack.action": "canvases.access.set",
+      "app.slack.canvas.canvas_id_prefix": canvasId.slice(0, 1),
+      "app.slack.canvas.channel_id_prefix": channelId.slice(0, 1),
+      "app.slack.canvas.access_level": "write",
+    });
   }
 }
 

--- a/packages/junior/src/chat/slack/tools/canvas/create.ts
+++ b/packages/junior/src/chat/slack/tools/canvas/create.ts
@@ -25,16 +25,11 @@ export function createSlackCanvasCreateTool(
     execute: async ({ title, markdown }) => {
       const targetChannelId = context.destinationChannelId;
       if (!isConversationScopedChannel(targetChannelId)) {
-        logError(
-          "slack_canvas_create_invalid_context",
-          {},
-          {
-            "gen_ai.tool.name": "slackCanvasCreate",
-            "messaging.destination.name": targetChannelId ?? "none",
-            "app.slack.canvas.has_channel_context": Boolean(targetChannelId),
-          },
-          "Canvas create failed due to missing or invalid assistant channel context",
-        );
+        logError("slack.canvas.create.context_invalid", {
+          "gen_ai.tool.name": "slackCanvasCreate",
+          "messaging.destination.name": targetChannelId ?? "none",
+          "app.slack.canvas.has_channel_context": Boolean(targetChannelId),
+        });
         throw new Error(
           "Cannot create a canvas without an active assistant channel context (C/G/D).",
         );

--- a/packages/junior/src/chat/slack/tools/canvas/edit.ts
+++ b/packages/junior/src/chat/slack/tools/canvas/edit.ts
@@ -1,8 +1,5 @@
 import { logWarn } from "@/chat/logging";
-import {
-  readCanvas,
-  writeCanvasMarkdown,
-} from "@/chat/slack/tools/canvas/api";
+import { readCanvas, writeCanvasMarkdown } from "@/chat/slack/tools/canvas/api";
 import { resolveCanvasTarget } from "@/chat/slack/tools/canvas/context";
 import { normalizeCanvasMarkdown } from "@/chat/slack/tools/canvas/markdown";
 import { z } from "zod";
@@ -132,15 +129,10 @@ export function createSlackCanvasEditTool(state: ToolState) {
       } catch (error) {
         const message =
           error instanceof Error ? error.message : "canvas edit failed";
-        logWarn(
-          "slack_canvas_edit_failed",
-          {},
-          {
-            "gen_ai.tool.name": "slackCanvasEdit",
-            "app.slack.canvas.canvas_id_prefix": target.canvasId.slice(0, 1),
-          },
-          message,
-        );
+        logWarn("slack.canvas.edit.failed", {
+          "gen_ai.tool.name": "slackCanvasEdit",
+          "app.slack.canvas.canvas_id_prefix": target.canvasId.slice(0, 1),
+        });
         return {
           ok: false,
           status: "error" as const,

--- a/packages/junior/src/chat/slack/tools/canvas/read.ts
+++ b/packages/junior/src/chat/slack/tools/canvas/read.ts
@@ -89,15 +89,10 @@ export function createSlackCanvasReadTool() {
       } catch (error) {
         const message =
           error instanceof Error ? error.message : "canvas read failed";
-        logWarn(
-          "slack_canvas_read_failed",
-          {},
-          {
-            "gen_ai.tool.name": "slackCanvasRead",
-            "app.slack.canvas.canvas_id_prefix": target.canvasId.slice(0, 1),
-          },
-          message,
-        );
+        logWarn("slack.canvas.read.failed", {
+          "gen_ai.tool.name": "slackCanvasRead",
+          "app.slack.canvas.canvas_id_prefix": target.canvasId.slice(0, 1),
+        });
         return {
           ok: false,
           status: "error" as const,

--- a/packages/junior/src/chat/slack/tools/canvas/write.ts
+++ b/packages/junior/src/chat/slack/tools/canvas/write.ts
@@ -68,15 +68,10 @@ export function createSlackCanvasWriteTool(state: ToolState) {
       } catch (error) {
         const message =
           error instanceof Error ? error.message : "canvas write failed";
-        logWarn(
-          "slack_canvas_write_failed",
-          {},
-          {
-            "gen_ai.tool.name": "slackCanvasWrite",
-            "app.slack.canvas.canvas_id_prefix": target.canvasId.slice(0, 1),
-          },
-          message,
-        );
+        logWarn("slack.canvas.write.failed", {
+          "gen_ai.tool.name": "slackCanvasWrite",
+          "app.slack.canvas.canvas_id_prefix": target.canvasId.slice(0, 1),
+        });
         return {
           ok: false,
           status: "error" as const,

--- a/packages/junior/src/chat/slack/user.ts
+++ b/packages/junior/src/chat/slack/user.ts
@@ -86,16 +86,11 @@ export async function lookupSlackUser(
     );
 
     if (!response.ok) {
-      logWarn(
-        "slack_user_lookup_failed",
-        {},
-        {
-          "enduser.id": userId,
-          "app.slack.team_id": teamId,
-          "http.response.status_code": response.status,
-        },
-        "Slack user lookup request failed",
-      );
+      logWarn("slack.user.lookup.failed", {
+        "enduser.id": userId,
+        "app.slack.team_id": teamId,
+        "http.response.status_code": response.status,
+      });
       return null;
     }
 
@@ -115,17 +110,12 @@ export async function lookupSlackUser(
     writeToCache(teamId, userId, result);
     return result;
   } catch (error) {
-    logWarn(
-      "slack_user_lookup_failed",
-      {},
-      {
-        "enduser.id": userId,
-        "app.slack.team_id": teamId,
-        "exception.message":
-          error instanceof Error ? error.message : String(error),
-      },
-      "Slack user lookup failed with exception",
-    );
+    logWarn("slack.user.lookup.failed", {
+      "enduser.id": userId,
+      "app.slack.team_id": teamId,
+      "exception.message":
+        error instanceof Error ? error.message : String(error),
+    });
     return null;
   }
 }

--- a/packages/junior/src/chat/slack/vision-context.ts
+++ b/packages/junior/src/chat/slack/vision-context.ts
@@ -1,6 +1,5 @@
 import type { Attachment } from "chat";
 import { botConfig } from "@/chat/config";
-import { standardModelId } from "@/chat/model-profile";
 import type { completeText } from "@/chat/pi/client";
 import type { ThreadConversationState } from "@/chat/state/conversation";
 import { toOptionalString } from "@/chat/coerce";
@@ -328,22 +327,10 @@ async function resolveUserAttachmentsWithDeps(
 
       if (!data) continue;
       if (data.byteLength > MAX_USER_ATTACHMENT_BYTES) {
-        logWarn(
-          "attachment_skipped_size_limit",
-          {
-            messageConversationId: context.threadId,
-            userId: context.actorId,
-            destinationName: context.channelId,
-            runId: context.runId,
-            assistantUserName: botConfig.userName,
-            modelId: standardModelId(botConfig),
-          },
-          {
-            "file.size": data.byteLength,
-            "app.file.mime_type": mediaType,
-          },
-          "Skipping user attachment that exceeds size limit",
-        );
+        logWarn("attachment.size_limit.skipped", {
+          "file.size": data.byteLength,
+          "app.file.mime_type": mediaType,
+        });
         continue;
       }
 
@@ -357,24 +344,12 @@ async function resolveUserAttachmentsWithDeps(
             : createImageAttachmentProcessingError({
                 filename: attachment.name,
               });
-        logWarn(
-          "image_attachment_processing_failed",
-          {
-            messageConversationId: context.threadId,
-            userId: context.actorId,
-            destinationName: context.channelId,
-            runId: context.runId,
-            assistantUserName: botConfig.userName,
-            modelId: botConfig.visionModelId ?? standardModelId(botConfig),
-          },
-          {
-            "exception.message":
-              error instanceof Error ? error.message : String(error),
-            "app.file.mime_type": mediaType,
-            ...(attachment.name ? { "file.name": attachment.name } : {}),
-          },
-          "Image attachment processing failed",
-        );
+        logWarn("image.attachment.processing.failed", {
+          "exception.message":
+            error instanceof Error ? error.message : String(error),
+          "app.file.mime_type": mediaType,
+          ...(attachment.name ? { "file.name": attachment.name } : {}),
+        });
         results.push({
           mediaType,
           filename: attachment.name,
@@ -387,23 +362,11 @@ async function resolveUserAttachmentsWithDeps(
         continue;
       }
 
-      logWarn(
-        "attachment_resolution_failed",
-        {
-          messageConversationId: context.threadId,
-          userId: context.actorId,
-          destinationName: context.channelId,
-          runId: context.runId,
-          assistantUserName: botConfig.userName,
-          modelId: standardModelId(botConfig),
-        },
-        {
-          "exception.message":
-            error instanceof Error ? error.message : String(error),
-          "app.file.mime_type": mediaType,
-        },
-        "Failed to resolve user attachment",
-      );
+      logWarn("attachment.resolution.failed", {
+        "exception.message":
+          error instanceof Error ? error.message : String(error),
+        "app.file.mime_type": mediaType,
+      });
     }
   }
 
@@ -454,24 +417,12 @@ async function summarizeConversationImage(
     }
     return truncateVisionSummary(summary);
   } catch (error) {
-    logWarn(
-      "conversation_image_vision_failed",
-      {
-        messageConversationId: args.context.threadId,
-        userId: args.context.actorId,
-        destinationName: args.context.channelId,
-        runId: args.context.runId,
-        assistantUserName: botConfig.userName,
-        modelId: visionModelId,
-      },
-      {
-        "exception.message":
-          error instanceof Error ? error.message : String(error),
-        "app.file.id": args.fileId,
-        "app.file.mime_type": args.mimeType,
-      },
-      "Image analysis failed while hydrating conversation context",
-    );
+    logWarn("conversation.image.vision.failed", {
+      "exception.message":
+        error instanceof Error ? error.message : String(error),
+      "app.file.id": args.fileId,
+      "app.file.mime_type": args.mimeType,
+    });
     return undefined;
   }
 }
@@ -528,22 +479,10 @@ async function hydrateConversationVisionContextWithDeps(
       targetMessageTs: [...messagesByTs.keys()],
     });
   } catch (error) {
-    logWarn(
-      "conversation_image_replies_fetch_failed",
-      {
-        messageConversationId: context.threadId,
-        userId: context.actorId,
-        destinationName: context.channelId,
-        runId: context.runId,
-        assistantUserName: botConfig.userName,
-        modelId: standardModelId(botConfig),
-      },
-      {
-        "exception.message":
-          error instanceof Error ? error.message : String(error),
-      },
-      "Failed to fetch thread replies for image context hydration",
-    );
+    logWarn("conversation.image.replies_fetch.failed", {
+      "exception.message":
+        error instanceof Error ? error.message : String(error),
+    });
     return;
   }
 
@@ -612,23 +551,11 @@ async function hydrateConversationVisionContextWithDeps(
           ? file.size
           : undefined;
       if (fileSize && fileSize > MAX_USER_ATTACHMENT_BYTES) {
-        logWarn(
-          "conversation_image_skipped_size_limit",
-          {
-            messageConversationId: context.threadId,
-            userId: context.actorId,
-            destinationName: context.channelId,
-            runId: context.runId,
-            assistantUserName: botConfig.userName,
-            modelId: standardModelId(botConfig),
-          },
-          {
-            "app.file.id": fileId,
-            "file.size": fileSize,
-            "app.file.mime_type": mimeType,
-          },
-          "Skipping thread image that exceeds size limit",
-        );
+        logWarn("conversation.image.size_limit.skipped", {
+          "app.file.id": fileId,
+          "file.size": fileSize,
+          "app.file.mime_type": mimeType,
+        });
         continue;
       }
 
@@ -643,45 +570,21 @@ async function hydrateConversationVisionContextWithDeps(
       try {
         imageData = await deps.downloadFile(downloadUrl);
       } catch (error) {
-        logWarn(
-          "conversation_image_download_failed",
-          {
-            messageConversationId: context.threadId,
-            userId: context.actorId,
-            destinationName: context.channelId,
-            runId: context.runId,
-            assistantUserName: botConfig.userName,
-            modelId: standardModelId(botConfig),
-          },
-          {
-            "exception.message":
-              error instanceof Error ? error.message : String(error),
-            "app.file.id": fileId,
-            "app.file.mime_type": mimeType,
-          },
-          "Failed to download thread image for context hydration",
-        );
+        logWarn("conversation.image.download.failed", {
+          "exception.message":
+            error instanceof Error ? error.message : String(error),
+          "app.file.id": fileId,
+          "app.file.mime_type": mimeType,
+        });
         continue;
       }
 
       if (imageData.byteLength > MAX_USER_ATTACHMENT_BYTES) {
-        logWarn(
-          "conversation_image_skipped_size_limit",
-          {
-            messageConversationId: context.threadId,
-            userId: context.actorId,
-            destinationName: context.channelId,
-            runId: context.runId,
-            assistantUserName: botConfig.userName,
-            modelId: standardModelId(botConfig),
-          },
-          {
-            "app.file.id": fileId,
-            "file.size": imageData.byteLength,
-            "app.file.mime_type": mimeType,
-          },
-          "Skipping downloaded thread image that exceeds size limit",
-        );
+        logWarn("conversation.image.size_limit.skipped", {
+          "app.file.id": fileId,
+          "file.size": imageData.byteLength,
+          "app.file.mime_type": mimeType,
+        });
         continue;
       }
 
@@ -717,24 +620,12 @@ async function hydrateConversationVisionContextWithDeps(
     analyzed > 0 ||
     hydratedMessageIds.size > 0
   ) {
-    logInfo(
-      "conversation_image_context_hydrated",
-      {
-        messageConversationId: context.threadId,
-        userId: context.actorId,
-        destinationName: context.channelId,
-        runId: context.runId,
-        assistantUserName: botConfig.userName,
-        modelId: standardModelId(botConfig),
-      },
-      {
-        "app.conversation_image.cache_hits": cacheHits,
-        "app.conversation_image.cache_misses": cacheMisses,
-        "app.conversation_image.analyzed": analyzed,
-        "app.conversation_image.messages_hydrated": hydratedMessageIds.size,
-      },
-      "Hydrated conversation image context",
-    );
+    logInfo("conversation.image.context.hydrated", {
+      "app.conversation_image.cache_hits": cacheHits,
+      "app.conversation_image.cache_misses": cacheMisses,
+      "app.conversation_image.analyzed": analyzed,
+      "app.conversation_image.messages_hydrated": hydratedMessageIds.size,
+    });
   }
 
   if (!conversation.vision.backfillCompletedAtMs) {

--- a/packages/junior/src/chat/state/turn-session.ts
+++ b/packages/junior/src/chat/state/turn-session.ts
@@ -1002,16 +1002,11 @@ async function readAgentTurnSessionSummariesFromIndex(
     try {
       summary = parseAgentTurnSessionSummary(value);
     } catch (error) {
-      logWarn(
-        "agent_turn_session_summary_parse_failed",
-        {},
-        {
-          "app.state.key": key,
-          "exception.message":
-            error instanceof Error ? error.message : String(error),
-        },
-        "Skipping an invalid turn-session summary index entry",
-      );
+      logWarn("agent.turn.session_summary_parse.failed", {
+        "app.state.key": key,
+        "exception.message":
+          error instanceof Error ? error.message : String(error),
+      });
       continue;
     }
     const summaryKey = `${summary.conversationId}:${summary.sessionId}`;

--- a/packages/junior/src/chat/task-execution/heartbeat.ts
+++ b/packages/junior/src/chat/task-execution/heartbeat.ts
@@ -1,5 +1,5 @@
 import type { StateAdapter } from "chat";
-import { logException, logInfo } from "@/chat/logging";
+import { logException, logInfo, withLogContext } from "@/chat/logging";
 import type { ConversationWorkQueue } from "./queue";
 import {
   clearExpiredConversationLease,
@@ -47,117 +47,97 @@ export async function recoverConversationWork(args: {
   });
 
   for (const conversationId of ids) {
-    let work: ConversationWorkState | undefined;
-    try {
-      work = await getConversationWorkState({
-        conversationId,
-        state: args.state,
-      });
-    } catch (error) {
-      logException(
-        error,
-        "conversation_work_recovery_failed",
-        { conversationId },
-        {},
-        "Conversation work heartbeat recovery failed",
-      );
-      // An invalid record can never become runnable again; drop it from the
-      // bounded oldest-first scan so it cannot starve recovery for every
-      // other conversation.
-      if (isInvalidConversationRecordError(error)) {
-        await removeActiveConversation({
+    await withLogContext({ conversationId }, async () => {
+      let work: ConversationWorkState | undefined;
+      try {
+        work = await getConversationWorkState({
           conversationId,
           state: args.state,
         });
-      }
-      continue;
-    }
-    try {
-      if (!work) {
-        await removeActiveConversation({
-          conversationId,
-          state: args.state,
-        });
-        continue;
-      }
-
-      if (work.execution.status === "idle") {
-        await removeActiveConversation({
-          conversationId,
-          state: args.state,
-        });
-        continue;
-      }
-
-      if (
-        work.execution.lease &&
-        work.execution.lease.expiresAtMs <= args.nowMs
-      ) {
-        const cleared = await clearExpiredConversationLease({
-          conversationId,
-          nowMs: args.nowMs,
-          state: args.state,
-        });
-        if (!cleared) {
-          continue;
+      } catch (error) {
+        logException(error, "conversation.work.recovery.failed");
+        // An invalid record can never become runnable again; drop it from the
+        // bounded oldest-first scan so it cannot starve recovery for every
+        // other conversation.
+        if (isInvalidConversationRecordError(error)) {
+          await removeActiveConversation({
+            conversationId,
+            state: args.state,
+          });
         }
+        return;
+      }
+      try {
+        if (!work) {
+          await removeActiveConversation({
+            conversationId,
+            state: args.state,
+          });
+          return;
+        }
+
+        if (work.execution.status === "idle") {
+          await removeActiveConversation({
+            conversationId,
+            state: args.state,
+          });
+          return;
+        }
+
+        if (
+          work.execution.lease &&
+          work.execution.lease.expiresAtMs <= args.nowMs
+        ) {
+          const cleared = await clearExpiredConversationLease({
+            conversationId,
+            nowMs: args.nowMs,
+            state: args.state,
+          });
+          if (!cleared) {
+            return;
+          }
+          const wake = await ensureConversationWake({
+            conversationId,
+            idempotencyKey: heartbeatIdempotencyKey(
+              "lease",
+              conversationId,
+              args.nowMs,
+            ),
+            nowMs: args.nowMs,
+            queue: args.queue,
+            replaceExistingWake: true,
+            state: args.state,
+          });
+          if (wake.status === "enqueued") {
+            result.expiredLeaseCount += 1;
+            logInfo("conversation.work.lease_expired.requeued");
+          }
+          return;
+        }
+
+        if (work.execution.lease || !hasRunnableConversationWork(work)) {
+          return;
+        }
+
         const wake = await ensureConversationWake({
           conversationId,
           idempotencyKey: heartbeatIdempotencyKey(
-            "lease",
+            "pending",
             conversationId,
             args.nowMs,
           ),
           nowMs: args.nowMs,
           queue: args.queue,
-          replaceExistingWake: true,
           state: args.state,
         });
         if (wake.status === "enqueued") {
-          result.expiredLeaseCount += 1;
-          logInfo(
-            "conversation_work_lease_expired_requeued",
-            { conversationId },
-            {},
-            "Heartbeat requeued expired conversation work lease",
-          );
+          result.pendingCount += 1;
+          logInfo("conversation.work.pending.requeued");
         }
-        continue;
+      } catch (error) {
+        logException(error, "conversation.work.recovery.failed");
       }
-
-      if (work.execution.lease || !hasRunnableConversationWork(work)) {
-        continue;
-      }
-
-      const wake = await ensureConversationWake({
-        conversationId,
-        idempotencyKey: heartbeatIdempotencyKey(
-          "pending",
-          conversationId,
-          args.nowMs,
-        ),
-        nowMs: args.nowMs,
-        queue: args.queue,
-        state: args.state,
-      });
-      if (wake.status === "enqueued") {
-        result.pendingCount += 1;
-        logInfo(
-          "conversation_work_pending_requeued",
-          { conversationId },
-          {},
-          "Heartbeat requeued pending conversation work",
-        );
-      }
-    } catch (error) {
-      logException(
-        error,
-        "conversation_work_recovery_failed",
-        { conversationId },
-        {},
-        "Conversation work heartbeat recovery failed",
-      );
-    }
+    });
   }
 
   return result;

--- a/packages/junior/src/chat/task-execution/vercel-callback.ts
+++ b/packages/junior/src/chat/task-execution/vercel-callback.ts
@@ -6,7 +6,7 @@ import {
 } from "@vercel/queue";
 import type { StateAdapter } from "chat";
 import { getChatConfig } from "@/chat/config";
-import { logWarn } from "@/chat/logging";
+import { logWarn, withLogContext } from "@/chat/logging";
 import { createVercelQueueClient } from "@/chat/vercel-queue-client";
 import type { ConversationStore } from "@/chat/conversations/store";
 import { runWithTurnRequestDeadline } from "@/chat/runtime/request-deadline";
@@ -122,18 +122,15 @@ function logConversationQueueMessageRejected(
   metadata: MessageMetadata,
   context: { conversationId?: string } = {},
 ): void {
-  logWarn(
-    "conversation_queue_message_rejected",
-    context.conversationId ? { conversationId: context.conversationId } : {},
-    {
+  withLogContext({ conversationId: context.conversationId }, () => {
+    logWarn("conversation.queue.message.rejected", {
       "app.queue.consumer_group": metadata.consumerGroup,
       "app.queue.delivery_count": metadata.deliveryCount,
       "app.queue.message_id": metadata.messageId,
       "app.queue.reject_reason": reason,
       "app.queue.topic_name": metadata.topicName,
-    },
-    "Conversation queue message rejected without retry",
-  );
+    });
+  });
 }
 
 /** Acknowledge permanently rejected queue messages while preserving normal retries. */

--- a/packages/junior/src/chat/task-execution/worker.ts
+++ b/packages/junior/src/chat/task-execution/worker.ts
@@ -1,7 +1,7 @@
 import type { StateAdapter } from "chat";
 import type { Destination } from "@sentry/junior-plugin-api";
 import { getChatConfig } from "@/chat/config";
-import { logException, logInfo, logWarn } from "@/chat/logging";
+import { logException, logInfo, logWarn, withLogContext } from "@/chat/logging";
 import type { ConversationStore } from "@/chat/conversations/store";
 import { isProviderRetryError } from "@/chat/services/provider-error";
 import {
@@ -167,7 +167,7 @@ async function requestLostLeaseRecovery(args: {
  * Record one failed delivery attempt and surface dead-lettered messages.
  *
  * Consumption is logged here so every dead-lettered message leaves a
- * `conversation_work_dead_lettered` trail with its terminal attempt count.
+ * `conversation.work.dead_lettered` trail with its terminal attempt count.
  */
 async function recordFailedDeliveryAttempt(args: {
   conversationId: string;
@@ -185,17 +185,12 @@ async function recordFailedDeliveryAttempt(args: {
     state: args.options.state,
   });
   for (const message of failure.deadLetteredMessages) {
-    logWarn(
-      "conversation_work_dead_lettered",
-      { conversationId: args.conversationId },
-      {
-        "app.conversation.source": message.source,
-        "app.inbound.attempt_count": message.attemptCount ?? 0,
-        "app.inbound.message_id": message.inboundMessageId,
-        "app.inbound.pending_count": failure.pendingCount,
-      },
-      "Conversation work message consumed after exceeding the delivery attempt limit",
-    );
+    logWarn("conversation.work.dead_lettered", {
+      "app.conversation.source": message.source,
+      "app.inbound.attempt_count": message.attemptCount ?? 0,
+      "app.inbound.message_id": message.inboundMessageId,
+      "app.inbound.pending_count": failure.pendingCount,
+    });
   }
   return failure;
 }
@@ -227,22 +222,11 @@ function startLeaseCheckIn(args: {
       (checkedIn) => {
         if (!checkedIn) {
           args.onLostLease();
-          logWarn(
-            "conversation_work_check_in_failed",
-            { conversationId: args.conversationId },
-            {},
-            "Conversation work check-in lost its lease",
-          );
+          logWarn("conversation.work.check_in.failed");
         }
       },
       (error) => {
-        logException(
-          error,
-          "conversation_work_check_in_failed",
-          { conversationId: args.conversationId },
-          {},
-          "Conversation work check-in failed",
-        );
+        logException(error, "conversation.work.check_in.failed");
       },
     );
   }, args.options.checkInIntervalMs ?? CONVERSATION_WORK_CHECK_IN_INTERVAL_MS);
@@ -252,6 +236,15 @@ function startLeaseCheckIn(args: {
 
 /** Process one queue wake-up for a conversation. */
 export async function processConversationWork(
+  message: ConversationQueueMessage,
+  options: ProcessConversationWorkOptions,
+): Promise<ConversationWorkProcessResult> {
+  return withLogContext({ conversationId: message.conversationId }, () =>
+    processConversationWorkInContext(message, options),
+  );
+}
+
+async function processConversationWorkInContext(
   message: ConversationQueueMessage,
   options: ProcessConversationWorkOptions,
 ): Promise<ConversationWorkProcessResult> {
@@ -326,14 +319,9 @@ export async function processConversationWork(
       replaceExistingWake: true,
       state: options.state,
     });
-    logInfo(
-      "conversation_work_nudge_deferred_for_active_lease",
-      { conversationId },
-      {
-        "app.lease.expires_at_ms": lease.leaseExpiresAtMs,
-      },
-      "Conversation work nudge deferred for active lease",
-    );
+    logInfo("conversation.work.nudge.deferred", {
+      "app.lease.expires_at_ms": lease.leaseExpiresAtMs,
+    });
     return { status: "active" };
   }
 
@@ -355,15 +343,10 @@ export async function processConversationWork(
     onLostLease: markLeaseLost,
     options,
   });
-  logInfo(
-    "conversation_work_lease_acquired",
-    { conversationId },
-    {
-      "app.lease.expires_at_ms": lease.leaseExpiresAtMs,
-      "app.worker.soft_yield_deadline_ms": softYieldDeadlineMs,
-    },
-    "Conversation work lease acquired",
-  );
+  logInfo("conversation.work.lease.acquired", {
+    "app.lease.expires_at_ms": lease.leaseExpiresAtMs,
+    "app.worker.soft_yield_deadline_ms": softYieldDeadlineMs,
+  });
 
   const drain = (
     handle: (messages: InboundMessage[]) => Promise<readonly string[] | void>,
@@ -430,15 +413,10 @@ export async function processConversationWork(
     if (!released) {
       return { status: "lost_lease" };
     }
-    logInfo(
-      "conversation_work_cooperative_yield",
-      { conversationId },
-      {
-        "app.worker.elapsed_ms": now(options) - startedAtMs,
-        "app.worker.soft_yield_deadline_ms": softYieldDeadlineMs,
-      },
-      "Conversation work yielded cooperatively",
-    );
+    logInfo("conversation.work.yielded", {
+      "app.worker.elapsed_ms": now(options) - startedAtMs,
+      "app.worker.soft_yield_deadline_ms": softYieldDeadlineMs,
+    });
     return { status: "yielded" };
   };
 
@@ -675,14 +653,9 @@ export async function processConversationWork(
         : { status: "completed" };
     }
 
-    logInfo(
-      "conversation_work_completed",
-      { conversationId },
-      {
-        "app.worker.elapsed_ms": now(options) - startedAtMs,
-      },
-      "Conversation work completed",
-    );
+    logInfo("conversation.work.completed", {
+      "app.worker.elapsed_ms": now(options) - startedAtMs,
+    });
     return { status: "completed" };
   } catch (error) {
     const errorNowMs = now(options);
@@ -744,24 +717,12 @@ export async function processConversationWork(
       }
       recoveryRecorded = true;
     } catch (recoveryError) {
-      logException(
-        recoveryError,
-        "conversation_work_requeue_failed",
-        { conversationId },
-        {},
-        "Conversation work recovery failed after runner error",
-      );
+      logException(recoveryError, "conversation.work.requeue.failed");
     }
     if (!isProviderRetryError(error)) {
-      logException(
-        error,
-        "conversation_work_failed",
-        { conversationId },
-        {
-          "app.worker.elapsed_ms": now(options) - startedAtMs,
-        },
-        "Conversation work failed",
-      );
+      logException(error, "conversation.work.failed", {
+        "app.worker.elapsed_ms": now(options) - startedAtMs,
+      });
     }
     if (!recoveryRecorded) {
       throw error;

--- a/packages/junior/src/chat/tool-support/pi-tool-adapter.ts
+++ b/packages/junior/src/chat/tool-support/pi-tool-adapter.ts
@@ -87,16 +87,11 @@ export function createPiAgentTools(
     try {
       await onToolResult?.(report);
     } catch (error) {
-      logWarn(
-        "tool_result_observer_failed",
-        spanContext,
-        {
-          "gen_ai.tool.name": report.toolName,
-          "exception.message":
-            error instanceof Error ? error.message : String(error),
-        },
-        "Tool result observer failed",
-      );
+      logWarn("tool.result.observer.failed", {
+        "gen_ai.tool.name": report.toolName,
+        "exception.message":
+          error instanceof Error ? error.message : String(error),
+      });
     }
   };
   const toolResultOk = (details: unknown): boolean => {
@@ -191,15 +186,10 @@ export function createPiAgentTools(
           toolDef.privateTraceResult(resultAttributeValue);
         hasProjectedPrivateResult = projectedPrivateResult !== undefined;
       } catch (error) {
-        logWarn(
-          "tool_private_trace_projection_failed",
-          spanContext,
-          {
-            "error.type": error instanceof Error ? error.name : typeof error,
-            "gen_ai.tool.name": toolName,
-          },
-          "Tool private trace projection failed",
-        );
+        logWarn("tool.private.trace_projection.failed", {
+          "error.type": error instanceof Error ? error.name : typeof error,
+          "gen_ai.tool.name": toolName,
+        });
       }
     }
     const toolResultAttribute =
@@ -335,7 +325,6 @@ export function createPiAgentTools(
               executionToolName,
               toolCallId,
               shouldTrace,
-              spanContext,
               effectiveConversationPrivacy,
               setSpanAttributes,
             );

--- a/packages/junior/src/chat/tools/execution/tool-error-handler.ts
+++ b/packages/junior/src/chat/tools/execution/tool-error-handler.ts
@@ -3,7 +3,6 @@ import {
   logInfo,
   logWarn,
   setSpanAttributes,
-  type LogContext,
   type SetSpanAttributes,
 } from "@/chat/logging";
 import { PluginToolInputError } from "@sentry/junior-plugin-api";
@@ -64,7 +63,6 @@ export function handleToolExecutionError(
   toolName: string,
   toolCallId: string | undefined,
   shouldTrace: boolean,
-  traceContext: LogContext,
   conversationPrivacy?: ConversationPrivacy,
   setExecutionSpanAttributes?: SetSpanAttributes,
 ): never {
@@ -86,35 +84,25 @@ export function handleToolExecutionError(
 
   if (error instanceof PluginCredentialFailureError) {
     if (shouldTrace) {
-      logInfo(
-        "plugin_credential_rejected",
-        traceContext,
-        {
-          "app.credential.provider": error.provider,
-          "gen_ai.operation.name": "execute_tool",
-          "gen_ai.tool.name": toolName,
-          ...(toolCallId ? { "gen_ai.tool.call.id": toolCallId } : {}),
-          "error.type": errorType,
-        },
-        "Plugin credentials were rejected during tool execution",
-      );
+      logInfo("plugin.credential.rejected", {
+        "app.credential.provider": error.provider,
+        "gen_ai.operation.name": "execute_tool",
+        "gen_ai.tool.name": toolName,
+        ...(toolCallId ? { "gen_ai.tool.call.id": toolCallId } : {}),
+        "error.type": errorType,
+      });
     }
     throw error;
   }
 
   if (shouldTrace) {
-    logWarn(
-      "agent_tool_call_failed",
-      traceContext,
-      {
-        "gen_ai.operation.name": "execute_tool",
-        "gen_ai.tool.name": toolName,
-        ...(toolCallId ? { "gen_ai.tool.call.id": toolCallId } : {}),
-        ...errorAttributes,
-        "exception.message": errorMessage,
-      },
-      "Agent tool call failed",
-    );
+    logWarn("agent.tool_call.failed", {
+      "gen_ai.operation.name": "execute_tool",
+      "gen_ai.tool.name": toolName,
+      ...(toolCallId ? { "gen_ai.tool.call.id": toolCallId } : {}),
+      ...errorAttributes,
+      "exception.message": errorMessage,
+    });
   }
 
   // Expected tool failures (MCP errors, model input errors) are not Sentry exceptions.
@@ -123,19 +111,13 @@ export function handleToolExecutionError(
     error instanceof ToolInputError ||
     isPluginToolInputError(error);
   if (!isExpectedToolFailure) {
-    logException(
-      error,
-      "agent_tool_call_failed",
-      {},
-      {
-        "gen_ai.operation.name": "execute_tool",
-        "gen_ai.tool.name": toolName,
-        ...(toolCallId ? { "gen_ai.tool.call.id": toolCallId } : {}),
-        ...errorAttributes,
-        ...getToolErrorAttributes(error),
-      },
-      "Agent tool call failed",
-    );
+    logException(error, "agent.tool_call.failed", {
+      "gen_ai.operation.name": "execute_tool",
+      "gen_ai.tool.name": toolName,
+      ...(toolCallId ? { "gen_ai.tool.call.id": toolCallId } : {}),
+      ...errorAttributes,
+      ...getToolErrorAttributes(error),
+    });
   }
 
   throw error;

--- a/packages/junior/src/chat/tools/web/image-generate.ts
+++ b/packages/junior/src/chat/tools/web/image-generate.ts
@@ -40,22 +40,16 @@ async function enrichImagePrompt(rawPrompt: string): Promise<string> {
       maxTokens: 1024,
     });
     if (text && text.trim().length > 0) {
-      logInfo(
-        "image_prompt_enriched",
-        {},
-        { "app.image.enriched_prompt_length": text.trim().length },
-        "Image prompt enriched with persona",
-      );
+      logInfo("image.prompt.enriched", {
+        "app.image.enriched_prompt_length": text.trim().length,
+      });
       return text.trim();
     }
     return rawPrompt;
   } catch (error) {
-    logWarn(
-      "image_prompt_enrichment_failed",
-      {},
-      { "exception.message": String(error) },
-      "Image prompt enrichment failed, using raw prompt",
-    );
+    logWarn("image.prompt.enrichment.failed", {
+      "exception.message": String(error),
+    });
     return rawPrompt;
   }
 }

--- a/packages/junior/src/chat/tools/web/search.ts
+++ b/packages/junior/src/chat/tools/web/search.ts
@@ -144,18 +144,12 @@ export function createWebSearchTool(
         // Every ok:false path surfaces to Sentry. The tool swallows the
         // exception for the model, so without an explicit capture the
         // failure is otherwise invisible to us.
-        logException(
-          error,
-          "web_search_failed",
-          {},
-          {
-            "gen_ai.tool.name": "webSearch",
-            "app.web_search.timeout": timeout,
-            "app.web_search.retryable": retryable,
-            "app.web_search.query": query,
-          },
-          message,
-        );
+        logException(error, "web.search.failed", {
+          "gen_ai.tool.name": "webSearch",
+          "app.web_search.timeout": timeout,
+          "app.web_search.retryable": retryable,
+          "app.web_search.query": query,
+        });
         return {
           ok: false,
           status: "error" as const,

--- a/packages/junior/src/handlers/agent-dispatch.ts
+++ b/packages/junior/src/handlers/agent-dispatch.ts
@@ -40,13 +40,9 @@ export async function POST(
         queue: options.conversationWorkQueue,
       });
     })().catch((error) => {
-      logException(
-        error,
-        "agent_dispatch_callback_failed",
-        {},
-        { "app.dispatch.id": payload.id },
-        "Legacy dispatch callback failed",
-      );
+      logException(error, "agent.dispatch.callback.failed", {
+        "app.dispatch.id": payload.id,
+      });
     }),
   );
   return new Response("Accepted", { status: 202 });

--- a/packages/junior/src/handlers/heartbeat.ts
+++ b/packages/junior/src/handlers/heartbeat.ts
@@ -46,13 +46,9 @@ export async function GET(
       conversationWorkQueue: options.conversationWorkQueue,
       nowMs,
     }).catch((error) => {
-      logException(
-        error,
-        "heartbeat_failed",
-        {},
-        { "app.heartbeat.now_ms": nowMs },
-        "Heartbeat failed",
-      );
+      logException(error, "heartbeat.failed", {
+        "app.heartbeat.now_ms": nowMs,
+      });
     }),
   );
 

--- a/packages/junior/src/handlers/mcp-oauth-callback.ts
+++ b/packages/junior/src/handlers/mcp-oauth-callback.ts
@@ -180,13 +180,11 @@ async function failSessionRecordBestEffort(args: {
   } catch (error) {
     logException(
       error,
-      "mcp_oauth_callback_session_record_fail_persist_failed",
-      {},
+      "mcp.oauth_callback.session_record.failure_persistence.failed",
       {
         "app.ai.conversation_id": args.conversationId,
         "app.ai.session_id": args.sessionId,
       },
-      "Failed to mark MCP OAuth-resumed turn session record failed",
     );
   }
 }
@@ -455,10 +453,8 @@ async function resumeAuthorizedMcpTurn(args: {
           } catch (persistError) {
             logException(
               persistError,
-              "mcp_oauth_callback_resume_failure_persist_failed",
-              {},
+              "mcp.oauth_callback.resume_failure_persist.failed",
               { "app.credential.provider": provider },
-              "Failed to persist failed MCP resume state",
             );
           }
         },
@@ -467,12 +463,9 @@ async function resumeAuthorizedMcpTurn(args: {
             sessionId: lockedSessionId,
             threadStateId: threadId,
           });
-          logWarn(
-            "mcp_oauth_callback_resume_reparked_for_auth",
-            {},
-            { "app.credential.provider": provider },
-            "Resumed MCP turn requested another authorization flow",
-          );
+          logWarn("mcp.oauth_callback.resume.reparked_for_auth", {
+            "app.credential.provider": provider,
+          });
         },
         onSuspend: async (resumeVersion) => {
           await scheduleAgentContinue({
@@ -604,13 +597,9 @@ export async function GET(
     try {
       await deleteMcpAuthSession(authSession.authSessionId);
     } catch (cleanupError) {
-      logException(
-        cleanupError,
-        "mcp_oauth_callback_session_cleanup_failed",
-        {},
-        { "app.credential.provider": provider },
-        "Failed to delete completed MCP auth session",
-      );
+      logException(cleanupError, "mcp.oauth_callback.session_cleanup.failed", {
+        "app.credential.provider": provider,
+      });
     }
 
     if (authSession.destination?.platform !== "local") {
@@ -631,16 +620,10 @@ export async function GET(
       await deleteMcpAuthSession(state);
       return htmlResponse("expired");
     }
-    logException(
-      callbackError,
-      "mcp_oauth_callback_failed",
-      {},
-      {
-        "app.credential.provider": provider,
-        ...getMcpProviderErrorAttributes(callbackError),
-      },
-      "Failed to process MCP OAuth callback",
-    );
+    logException(callbackError, "mcp.oauth_callback.failed", {
+      "app.credential.provider": provider,
+      ...getMcpProviderErrorAttributes(callbackError),
+    });
     return htmlResponse("failure");
   }
 }

--- a/packages/junior/src/handlers/oauth-callback.ts
+++ b/packages/junior/src/handlers/oauth-callback.ts
@@ -19,7 +19,7 @@ import {
   resumeSlackTurn,
 } from "@/chat/runtime/slack-resume";
 import { persistAuthPauseTurnState } from "@/chat/runtime/auth-pause-state";
-import { logException, logInfo, logWarn } from "@/chat/logging";
+import { logException, logInfo, logWarn, withLogContext } from "@/chat/logging";
 import { htmlCallbackResponse } from "@/handlers/oauth-html";
 import {
   getChannelConfigurationServiceById,
@@ -150,13 +150,11 @@ async function failSessionRecordBestEffort(args: {
   } catch (error) {
     logException(
       error,
-      "oauth_callback_session_record_fail_persist_failed",
-      {},
+      "oauth.callback.session_record.failure_persistence.failed",
       {
         "app.ai.conversation_id": args.conversationId,
         "app.ai.session_id": args.sessionId,
       },
-      "Failed to mark OAuth-resumed turn session record failed",
     );
   }
 }
@@ -448,16 +446,11 @@ async function resumeOAuthSessionRecordTurn(
           },
         },
         commitResult: async (reply: AgentRunResult) => {
-          logInfo(
-            "oauth_callback_resume_complete",
-            {},
-            {
-              "app.credential.provider": stored.provider,
-              "app.ai.outcome": reply.diagnostics.outcome,
-              "app.ai.tool_calls": reply.diagnostics.toolCalls.length,
-            },
-            "OAuth callback auto-resumed session record finished replying",
-          );
+          logInfo("oauth.callback.resume.completed", {
+            "app.credential.provider": stored.provider,
+            "app.ai.outcome": reply.diagnostics.outcome,
+            "app.ai.tool_calls": reply.diagnostics.toolCalls.length,
+          });
           await persistCompletedOAuthReplyState({
             conversationId: stored.resumeConversationId!,
             sessionId: lockedSessionId,
@@ -615,10 +608,8 @@ export async function GET(
     });
   } catch {
     logWarn(
-      "oauth_token_exchange_failed",
-      {},
+      "oauth.token_exchange.failed",
       oauthTokenErrorAttributes(provider, providerConfig.tokenEndpoint),
-      "OAuth token exchange request failed",
     );
     return htmlErrorResponse(
       "Connection failed",
@@ -629,14 +620,12 @@ export async function GET(
 
   if (!tokenResponse.ok) {
     logWarn(
-      "oauth_token_exchange_failed",
-      {},
+      "oauth.token_exchange.failed",
       oauthTokenErrorAttributes(
         provider,
         providerConfig.tokenEndpoint,
         tokenResponse.status,
       ),
-      "OAuth token exchange was rejected",
     );
     return htmlErrorResponse(
       "Connection failed",
@@ -653,14 +642,12 @@ export async function GET(
     });
   } catch {
     logWarn(
-      "oauth_token_exchange_failed",
-      {},
+      "oauth.token_exchange.failed",
       oauthTokenErrorAttributes(
         provider,
         providerConfig.tokenEndpoint,
         tokenResponse.status,
       ),
-      "OAuth token exchange returned an invalid response",
     );
     return htmlErrorResponse(
       "Connection failed",
@@ -716,35 +703,30 @@ export async function GET(
     stored.resumeSessionId,
   );
   if (resumesAgentTurn) {
-    waitUntil(async () => {
-      try {
-        // Agent OAuth links resume their durable session record. Do not rebuild
-        // a turn from pending message text when that record is missing.
-        await resumeOAuthSessionRecordTurn(stored, options);
-      } catch (error) {
-        if (error instanceof ResumeTurnBusyError) {
-          logWarn(
-            "oauth_callback_resume_busy",
-            {
-              ...(stored.resumeConversationId && {
-                conversationId: stored.resumeConversationId,
-              }),
-              ...(stored.userId && { actorId: stored.userId }),
-              ...(stored.channelId && { channelId: stored.channelId }),
-            },
-            {
-              "app.credential.provider": stored.provider,
-              ...(stored.resumeSessionId && {
-                "app.ai.session_id": stored.resumeSessionId,
-              }),
-            },
-            "OAuth callback resume was busy; user must send another message to continue",
-          );
-          return;
-        }
-        throw error;
-      }
-    });
+    waitUntil(() =>
+      withLogContext(
+        { conversationId: stored.resumeConversationId },
+        async () => {
+          try {
+            // Agent OAuth links resume their durable session record. Do not
+            // rebuild a turn from pending message text when that record is
+            // missing.
+            await resumeOAuthSessionRecordTurn(stored, options);
+          } catch (error) {
+            if (error instanceof ResumeTurnBusyError) {
+              logWarn("oauth.callback.resume.busy", {
+                "app.credential.provider": stored.provider,
+                ...(stored.resumeSessionId && {
+                  "app.ai.session_id": stored.resumeSessionId,
+                }),
+              });
+              return;
+            }
+            throw error;
+          }
+        },
+      ),
+    );
   } else if (stored.channelId && stored.threadTs) {
     const { channelId, threadTs } = stored;
     waitUntil(() =>

--- a/packages/junior/src/handlers/retention.ts
+++ b/packages/junior/src/handlers/retention.ts
@@ -41,13 +41,7 @@ export async function GET(request: Request): Promise<Response> {
     });
     return Response.json(result, { status: 200 });
   } catch (error) {
-    logException(
-      error,
-      "retention_run_failed",
-      {},
-      {},
-      "Retention purge run failed",
-    );
+    logException(error, "retention.run.failed");
     return new Response("Retention purge failed", { status: 500 });
   }
 }

--- a/packages/junior/src/handlers/webhooks.ts
+++ b/packages/junior/src/handlers/webhooks.ts
@@ -194,22 +194,16 @@ export async function handleWebhookRequest(
               } catch {
                 responseBodySnippet = undefined;
               }
-              logWarn(
-                "webhook_non_success_response",
-                {},
-                {
-                  "http.response.status_code": response.status,
-                  "http.request.header.x_slack_signature":
-                    request.headers.get("x-slack-signature") ?? undefined,
-                  "http.request.header.x_slack_request_timestamp":
-                    request.headers.get("x-slack-request-timestamp") ??
-                    undefined,
-                  ...(responseBodySnippet
-                    ? { "app.webhook.response_body": responseBodySnippet }
-                    : {}),
-                },
-                `Webhook ${platform} returned ${response.status}`,
-              );
+              logWarn("webhook.response.unsuccessful", {
+                "http.response.status_code": response.status,
+                "http.request.header.x_slack_signature":
+                  request.headers.get("x-slack-signature") ?? undefined,
+                "http.request.header.x_slack_request_timestamp":
+                  request.headers.get("x-slack-request-timestamp") ?? undefined,
+                ...(responseBodySnippet
+                  ? { "app.webhook.response_body": responseBodySnippet }
+                  : {}),
+              });
             }
 
             setSpanAttributes({
@@ -228,7 +222,7 @@ export async function handleWebhookRequest(
         },
       );
     } catch (error) {
-      logException(error, "webhook_handler_failed");
+      logException(error, "webhook.handler.failed");
       throw error;
     }
   });

--- a/packages/junior/tests/component/runtime/agent-continue.test.ts
+++ b/packages/junior/tests/component/runtime/agent-continue.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { scheduleAgentContinue } from "@/chat/services/agent-continue";
+import { registerLogRecordSink, type EmittedLogRecord } from "@/chat/logging";
 import { getConversationWorkState } from "@/chat/task-execution/store";
 import { disconnectStateAdapter, getStateAdapter } from "@/chat/state/adapter";
 import {
@@ -116,6 +117,8 @@ describe("agent continuation scheduling", () => {
     await state.connect();
     const lock = await state.acquireLock(conversationId, 90_000);
     expect(lock).toBeTruthy();
+    const records: EmittedLogRecord[] = [];
+    const unregister = registerLogRecordSink((record) => records.push(record));
     const scheduleAgentContinue = vi.fn().mockResolvedValue(undefined);
     const { continueSlackAgentRunWithLockRetry } =
       await import("@/chat/runtime/agent-continue-runner");
@@ -130,13 +133,23 @@ describe("agent continuation scheduling", () => {
       { agentRunner: agentRunnerShouldNotRun, scheduleAgentContinue },
     );
 
-    await vi.advanceTimersByTimeAsync(4_000);
-    await expect(continued).resolves.toBe(true);
+    try {
+      await vi.advanceTimersByTimeAsync(4_000);
+      await expect(continued).resolves.toBe(true);
+    } finally {
+      unregister();
+    }
     expect(scheduleAgentContinue).toHaveBeenCalledWith({
       conversationId,
       destination: SLACK_DESTINATION,
       sessionId: "turn_msg_2",
       expectedVersion: 1,
+    });
+    expect(
+      records.find((record) => record.eventName === "agent.continue.lock.busy")
+        ?.attributes,
+    ).toMatchObject({
+      "gen_ai.conversation.id": conversationId,
     });
     if (lock) {
       await state.releaseLock(lock);

--- a/packages/junior/tests/component/runtime/agent-resume.test.ts
+++ b/packages/junior/tests/component/runtime/agent-resume.test.ts
@@ -33,7 +33,6 @@ describe("agent resume", () => {
       getLoadedSkillNames: () => [],
       getModelId: () => "test/model",
       getReasoningLevel: () => undefined,
-      logContext: {},
       recordActiveMcpProviders: async () => {
         throw new Error("provider metadata unavailable");
       },

--- a/packages/junior/tests/component/runtime/agent-run-error-path.test.ts
+++ b/packages/junior/tests/component/runtime/agent-run-error-path.test.ts
@@ -85,7 +85,7 @@ describe("executeAgentRun error path", () => {
     }
 
     const failure = records.find(
-      (record) => record.eventName === "assistant_reply_generation_failed",
+      (record) => record.eventName === "assistant.reply.generation.failed",
     );
     expect(failure?.attributes).toMatchObject({
       "app.platform": "local",

--- a/packages/junior/tests/component/services/turn-session-record.test.ts
+++ b/packages/junior/tests/component/services/turn-session-record.test.ts
@@ -140,7 +140,6 @@ describe("persistAuthPauseSessionRecord", () => {
       currentSliceId: 1,
       messages: [],
       errorMessage: "plugin auth pause",
-      logContext: {},
     });
 
     expect(authSessionRecord?.sliceId).toBe(2);
@@ -593,7 +592,6 @@ describe("persistAuthPauseSessionRecord", () => {
       sliceId: 1,
       messages: [aliceMessage],
       actor: alice,
-      logContext: {},
     });
     // A second human steers the same run; their message commits as an
     // instruction attributed to bob, while Alice remains the bound run actor.
@@ -605,7 +603,6 @@ describe("persistAuthPauseSessionRecord", () => {
       messages: [aliceMessage, bobMessage],
       actor: alice,
       trailingMessageProvenance: [{ authority: "instruction", actor: bob }],
-      logContext: {},
     });
 
     // getAgentTurnSessionRecord re-materializes from the stored record and the
@@ -693,7 +690,6 @@ describe("persistAuthPauseSessionRecord", () => {
       },
       messages: [],
       errorMessage: "timed out again",
-      logContext: {},
     });
 
     const sessionRecord = await getAgentTurnSessionRecord(
@@ -753,7 +749,6 @@ describe("persistAuthPauseSessionRecord", () => {
         currentDurationMs: 3_000,
         messages: piMessages,
         errorMessage: "timed out again",
-        logContext: {},
       }),
     ).resolves.toMatchObject({
       state: "failed",
@@ -828,7 +823,6 @@ describe("persistAuthPauseSessionRecord", () => {
         },
       ],
       errorMessage: "plugin auth pause",
-      logContext: {},
     });
 
     expect(authSessionRecord).toMatchObject({
@@ -863,7 +857,6 @@ describe("persistAuthPauseSessionRecord", () => {
       modelId: "openai/gpt-5.5",
       reasoningLevel: "high",
       errorMessage: "auth pause",
-      logContext: {},
     });
 
     expect(authRecord).toMatchObject({
@@ -894,7 +887,6 @@ describe("persistAuthPauseSessionRecord", () => {
         currentSliceId: 1,
         messages: [],
         errorMessage: "timeout",
-        logContext: {},
       }),
     ).resolves.toBeUndefined();
 
@@ -1093,7 +1085,6 @@ describe("persistAuthPauseSessionRecord", () => {
         sessionId: "turn-1",
         sliceId: 1,
         messages: userBoundary,
-        logContext: {},
       }),
     ).resolves.toBe(true);
 
@@ -1104,7 +1095,6 @@ describe("persistAuthPauseSessionRecord", () => {
         sessionId: "turn-1",
         sliceId: 1,
         messages: unsafeAssistantBoundary,
-        logContext: {},
       }),
     ).resolves.toBe(false);
 
@@ -1124,7 +1114,6 @@ describe("persistAuthPauseSessionRecord", () => {
         sessionId: "turn-1",
         sliceId: 1,
         messages: toolResultBoundary,
-        logContext: {},
       }),
     ).resolves.toBe(true);
 
@@ -1162,7 +1151,6 @@ describe("persistAuthPauseSessionRecord", () => {
             timestamp: 1,
           },
         ],
-        logContext: {},
       }),
     ).resolves.toBe(false);
   });
@@ -1186,7 +1174,6 @@ describe("persistAuthPauseSessionRecord", () => {
       sessionId: "turn-1",
       sliceId: 1,
       messages,
-      logContext: {},
     });
 
     await persistContinuationSessionRecord({
@@ -1197,7 +1184,6 @@ describe("persistAuthPauseSessionRecord", () => {
       currentSliceId: 1,
       messages: [],
       errorMessage: "provider stream interrupted",
-      logContext: {},
     });
 
     const sessionRecord = await getAgentTurnSessionRecord(

--- a/packages/junior/tests/component/task-execution/conversation-work.test.ts
+++ b/packages/junior/tests/component/task-execution/conversation-work.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { StateAdapter } from "chat";
 import { scheduleAgentContinue } from "@/chat/services/agent-continue";
+import { registerLogRecordSink, type EmittedLogRecord } from "@/chat/logging";
 import { recoverConversationWork } from "@/chat/task-execution/heartbeat";
 import { runHeartbeat } from "@/chat/agent-dispatch/heartbeat";
 import {
@@ -793,6 +794,8 @@ describe("conversation work execution", () => {
 
   it("loads queue routing from persisted conversation work", async () => {
     const queue = createConversationWorkQueueTestAdapter();
+    const records: EmittedLogRecord[] = [];
+    const unregister = registerLogRecordSink((record) => records.push(record));
     const run = vi.fn(async (context) => {
       expect(context.destination).toEqual(SLACK_DESTINATION);
       await context.attempt.ack();
@@ -800,11 +803,22 @@ describe("conversation work execution", () => {
     });
     await appendInboundMessage({ message: inboundMessage("m1"), nowMs: 1_000 });
 
-    await expect(
-      processConversationWork(conversationQueueMessage(), { queue, run }),
-    ).resolves.toEqual({ status: "completed" });
+    try {
+      await expect(
+        processConversationWork(conversationQueueMessage(), { queue, run }),
+      ).resolves.toEqual({ status: "completed" });
+    } finally {
+      unregister();
+    }
 
     expect(run).toHaveBeenCalledOnce();
+    expect(
+      records.find(
+        (record) => record.eventName === "conversation.work.completed",
+      )?.attributes,
+    ).toMatchObject({
+      "gen_ai.conversation.id": CONVERSATION_ID,
+    });
     const work = await getConversationWorkState({
       conversationId: CONVERSATION_ID,
     });
@@ -1807,12 +1821,18 @@ describe("conversation work execution", () => {
 
   it("runs conversation work recovery from the core heartbeat", async () => {
     const queue = createConversationWorkQueueTestAdapter();
+    const records: EmittedLogRecord[] = [];
+    const unregister = registerLogRecordSink((record) => records.push(record));
     await appendInboundMessage({ message: inboundMessage("m1"), nowMs: 1_000 });
 
-    await runHeartbeat({
-      nowMs: 62_000,
-      conversationWorkQueue: queue,
-    });
+    try {
+      await runHeartbeat({
+        nowMs: 62_000,
+        conversationWorkQueue: queue,
+      });
+    } finally {
+      unregister();
+    }
 
     expect(queue.sentRecords()).toEqual([
       {
@@ -1820,6 +1840,13 @@ describe("conversation work execution", () => {
         idempotencyKey: `heartbeat:pending:${CONVERSATION_ID}:62000`,
       },
     ]);
+    expect(
+      records.find(
+        (record) => record.eventName === "conversation.work.pending.requeued",
+      )?.attributes,
+    ).toMatchObject({
+      "gen_ai.conversation.id": CONVERSATION_ID,
+    });
   });
 
   it("injects messages that arrive during active execution at a safe boundary", async () => {

--- a/packages/junior/tests/integration/agent-dispatch-work.test.ts
+++ b/packages/junior/tests/integration/agent-dispatch-work.test.ts
@@ -729,7 +729,6 @@ describe("agent dispatch conversation work", () => {
             destination: dispatch.destination,
             dispatchId: dispatch.id,
             errorMessage: "Conversation worker yielded",
-            logContext: {},
             messages: [
               {
                 role: "user",

--- a/packages/junior/tests/integration/local-agent-runner.test.ts
+++ b/packages/junior/tests/integration/local-agent-runner.test.ts
@@ -8,6 +8,7 @@ import {
   type PluginRunContext,
 } from "@sentry/junior-plugin-api";
 import { normalizeLocalConversationId } from "@/chat/local/conversation";
+import { getLogContextAttributes } from "@/chat/logging";
 import {
   runLocalAgentTurn,
   type LocalAgentReply,
@@ -161,7 +162,6 @@ async function persistRunningSessionForFakeReply(
     sessionId,
     sliceId: 1,
     messages: piMessages.slice(0, -1),
-    logContext: {},
     surface: context.surface,
     turnStartMessageIndex: context.piMessages?.length ?? 0,
   });
@@ -528,7 +528,17 @@ describe("local agent runner", () => {
     });
     const rawError = "raw-run-error-sentinel token=secret";
     const eventId = "11111111111111111111111111111111";
-    const capture = vi.fn().mockReturnValue(eventId);
+    let capturedLogContext: ReturnType<typeof getLogContextAttributes>;
+    const capture = vi.fn(
+      (
+        _error: unknown,
+        _eventName: string,
+        _attributes?: Record<string, unknown>,
+      ) => {
+        capturedLogContext = getLogContextAttributes();
+        return eventId;
+      },
+    );
     const cancelAuthorization = vi.fn();
 
     await expect(
@@ -559,8 +569,12 @@ describe("local agent runner", () => {
       eventId,
     });
     expect(capture).toHaveBeenCalledOnce();
-    expect(capture.mock.calls[0]?.[2]).toMatchObject({
-      runId: expect.stringMatching(/^local-run-[0-9a-f-]{36}$/),
+    expect(capture.mock.calls[0]?.[2]).toEqual({
+      "app.ai.failure_code": "agent_run_failed",
+    });
+    expect(capturedLogContext!).toMatchObject({
+      "app.run.id": expect.stringMatching(/^local-run-[0-9a-f-]{36}$/),
+      "gen_ai.conversation.id": conversationId,
     });
     expect(cancelAuthorization).toHaveBeenCalledOnce();
     expect(JSON.stringify(lifecycle)).not.toContain(rawError);

--- a/packages/junior/tests/integration/oauth-callback.test.ts
+++ b/packages/junior/tests/integration/oauth-callback.test.ts
@@ -199,7 +199,6 @@ describe("oauth callback integration", () => {
             currentSliceId: 1,
             destination: request.routing.destination,
             errorMessage: "eval-oauth authorization required",
-            logContext: {},
             messages: [],
             modelId: "fake-local-oauth",
             sessionId: request.turnId,

--- a/packages/junior/tests/integration/sandbox-egress-proxy.test.ts
+++ b/packages/junior/tests/integration/sandbox-egress-proxy.test.ts
@@ -17,6 +17,7 @@ import {
 } from "../fixtures/plugin-app";
 import { githubPlugin } from "@sentry/junior-github";
 import { StateAdapterTokenStore } from "@/chat/credentials/state-adapter-token-store";
+import type { EmittedLogRecord } from "@/chat/logging";
 import { mswServer } from "../msw/server";
 
 const ORIGINAL_ENV = { ...process.env };
@@ -50,9 +51,11 @@ const managedEgressReadResultSchema = pluginToolResultSchema.extend({
 type EgressPolicyModule = typeof import("@/chat/sandbox/egress/policy");
 type EgressProxyModule = typeof import("@/chat/sandbox/egress/proxy");
 type EgressSessionModule = typeof import("@/chat/sandbox/egress/session");
+type LoggingModule = typeof import("@/chat/logging");
 type StateAdapterModule = typeof import("@/chat/state/adapter");
 
 interface LoadedModules {
+  logging: LoggingModule;
   policy: EgressPolicyModule;
   proxy: EgressProxyModule;
   session: EgressSessionModule;
@@ -61,7 +64,8 @@ interface LoadedModules {
 
 async function loadModules(): Promise<LoadedModules> {
   vi.resetModules();
-  const [policy, proxy, session, state] = await Promise.all([
+  const [logging, policy, proxy, session, state] = await Promise.all([
+    import("@/chat/logging"),
     import("@/chat/sandbox/egress/policy"),
     import("@/chat/sandbox/egress/proxy"),
     import("@/chat/sandbox/egress/session"),
@@ -69,7 +73,7 @@ async function loadModules(): Promise<LoadedModules> {
   ]);
   await state.disconnectStateAdapter();
   await state.getStateAdapter().connect();
-  return { policy, proxy, session, state };
+  return { logging, policy, proxy, session, state };
 }
 
 function forwardUrlFor(policy: unknown, host: string): string {
@@ -1316,6 +1320,10 @@ describe("sandbox egress proxy integration", () => {
 
   it("denies oversized raw GitHub GraphQL before credential injection", async () => {
     await registerGitHubPlugin();
+    const records: EmittedLogRecord[] = [];
+    const unregister = modules.logging.registerLogRecordSink((record) => {
+      records.push(record);
+    });
     const credentialToken = modules.session.createSandboxEgressCredentialToken({
       credentials: { actor: { type: "user", userId: ACTOR_ID } },
       egressId: EGRESS_ID,
@@ -1327,26 +1335,31 @@ describe("sandbox egress proxy integration", () => {
     const forwardURL = forwardUrlFor(networkPolicy, GITHUB_API_HOST);
     const upstreamFetch = vi.fn();
 
-    const response = await modules.proxy.proxySandboxEgressRequest(
-      proxiedRequest({
-        body: JSON.stringify({
-          query:
-            "mutation CreateIssue($input: CreateIssueInput!) { createIssue(input: $input) { issue { number } } }",
-          variables: {
-            input: { repositoryId: "repo", title: "test" },
-            filler: "x".repeat(70 * 1024),
-          },
+    let response: Response;
+    try {
+      response = await modules.proxy.proxySandboxEgressRequest(
+        proxiedRequest({
+          body: JSON.stringify({
+            query:
+              "mutation CreateIssue($input: CreateIssueInput!) { createIssue(input: $input) { issue { number } } }",
+            variables: {
+              input: { repositoryId: "repo", title: "test" },
+              filler: "x".repeat(70 * 1024),
+            },
+          }),
+          forwardURL,
+          method: "POST",
+          upstreamHost: GITHUB_API_HOST,
+          upstreamPath: "/graphql",
         }),
-        forwardURL,
-        method: "POST",
-        upstreamHost: GITHUB_API_HOST,
-        upstreamPath: "/graphql",
-      }),
-      {
-        fetch: upstreamFetch as typeof fetch,
-        verifyOidc: async () => ({ sandbox_id: EGRESS_ID }),
-      },
-    );
+        {
+          fetch: upstreamFetch as typeof fetch,
+          verifyOidc: async () => ({ sandbox_id: EGRESS_ID }),
+        },
+      );
+    } finally {
+      unregister();
+    }
 
     expect(response.status).toBe(403);
     await expect(response.json()).resolves.toEqual({
@@ -1354,6 +1367,14 @@ describe("sandbox egress proxy integration", () => {
         "GitHub GraphQL request body is too large for Junior to inspect before issuing credentials.",
     });
     expect(upstreamFetch).not.toHaveBeenCalled();
+    expect(
+      records.find(
+        (record) => record.eventName === "sandbox.egress.policy.denied",
+      )?.attributes,
+    ).toMatchObject({
+      "app.sandbox.egress.policy.reason":
+        "GitHub GraphQL request body is too large for Junior to inspect before issuing credentials.",
+    });
   });
 
   it("records plugin write auth needs over earlier read failures", async () => {

--- a/packages/junior/tests/integration/slack-canvases.test.ts
+++ b/packages/junior/tests/integration/slack-canvases.test.ts
@@ -174,8 +174,7 @@ describe("createCanvas", () => {
 
     await createCanvas({
       title: "Title",
-      markdown:
-        "#### Deep heading\n1. Parent\n   - Child\n   > Quoted child",
+      markdown: "#### Deep heading\n1. Parent\n   - Child\n   > Quoted child",
       channelId: "C12345",
     });
 
@@ -184,8 +183,7 @@ describe("createCanvas", () => {
     expect(canvasCreateCalls[0]?.params).toMatchObject({
       document_content: {
         type: "markdown",
-        markdown:
-          "### Deep heading\n1. Parent\n   • Child\n   Quoted child",
+        markdown: "### Deep heading\n1. Parent\n   • Child\n   Quoted child",
       },
     });
   });

--- a/packages/junior/tests/unit/handlers/mcp-oauth-callback.test.ts
+++ b/packages/junior/tests/unit/handlers/mcp-oauth-callback.test.ts
@@ -154,15 +154,13 @@ describe("mcp oauth callback handler", () => {
     );
     expect(logExceptionMock).toHaveBeenCalledWith(
       expect.any(McpProviderError),
-      "mcp_oauth_callback_failed",
-      {},
+      "mcp.oauth_callback.failed",
       expect.objectContaining({
         "app.credential.provider": "demo",
         "app.mcp.error.phase": "oauth_callback",
         "http.response.status_code": 502,
         "server.address": "mcp.example.com",
       }),
-      "Failed to process MCP OAuth callback",
     );
     expect(waitUntil.pendingCount()).toBe(0);
   });

--- a/packages/junior/tests/unit/logging/console-format.test.ts
+++ b/packages/junior/tests/unit/logging/console-format.test.ts
@@ -66,7 +66,7 @@ describe("console log formatting", () => {
     const { log } = await loadLoggingModule();
 
     log.info(
-      "plugin_loaded",
+      "plugin.loaded",
       {
         "app.plugin.name": "github",
         "app.plugin.config_key_count": 1,
@@ -100,7 +100,7 @@ describe("console log formatting", () => {
     const { log } = await loadLoggingModule();
 
     log.info(
-      "plugin_heartbeat_dispatched",
+      "plugin.heartbeat.dispatched",
       {
         "app.dispatch.count": 1,
         "app.plugin.name": "scheduler",
@@ -129,9 +129,10 @@ describe("console log formatting", () => {
     const { log } = await loadLoggingModule();
 
     log.info(
-      "plugin_loaded",
+      "plugin.loaded",
       {
         "app.plugin.name": "github",
+        "messaging.destination.name": "C123",
       },
       "Loaded plugin",
     );
@@ -139,7 +140,16 @@ describe("console log formatting", () => {
     expect(infoSpy).toHaveBeenCalledTimes(1);
     const line = stripAnsi(String(infoSpy.mock.calls[0]?.[0] ?? ""));
     expect(line).toContain("2026-04-14T16:29:00.133Z INF Loaded plugin");
-    expect(line).toContain("event.name=plugin_loaded");
+    expect(line).toContain("event.name=plugin.loaded");
     expect(line).toContain("app.plugin.name=github");
+    expect(line).not.toContain("messaging.destination.name=C123");
+
+    infoSpy.mockClear();
+    log.info("oauth.callback.completed", {
+      "messaging.destination.name": "C123",
+    });
+    expect(String(infoSpy.mock.calls[0]?.[0] ?? "")).toContain(
+      "messaging.destination.name=C123",
+    );
   });
 });

--- a/packages/junior/tests/unit/logging/deployment-attributes.test.ts
+++ b/packages/junior/tests/unit/logging/deployment-attributes.test.ts
@@ -60,7 +60,7 @@ describe("deployment log attributes", () => {
 
     try {
       log.warn(
-        "deployment_context_test",
+        "deployment.context.test",
         {
           "deployment.id": "caller-deployment",
           "service.version": "caller-version",

--- a/packages/junior/tests/unit/logging/sentry-context.test.ts
+++ b/packages/junior/tests/unit/logging/sentry-context.test.ts
@@ -162,14 +162,11 @@ describe("Sentry context", () => {
         userEmail: "Alice@Example.COM",
       },
       async () => {
-        setTags({ assistantUserName: "junior" });
-        return logException(
-          new Error("boom"),
-          "turn_failed",
-          { modelId: "openai/gpt-5.4" },
-          {},
-          "Turn failed",
-        );
+        setTags({
+          assistantUserName: "junior",
+          modelId: "openai/gpt-5.4",
+        });
+        return logException(new Error("boom"), "turn.failed");
       },
     );
 

--- a/packages/junior/tests/unit/logging/structured-event.test.ts
+++ b/packages/junior/tests/unit/logging/structured-event.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { EmittedLogRecord } from "@/chat/logging";
+
+async function loadLoggingModule() {
+  vi.resetModules();
+  vi.doMock("@/chat/sentry", () => ({
+    captureException: undefined,
+    captureMessage: undefined,
+    getActiveSpan: () => ({ sampled: true }),
+    logger: {},
+    setTag: undefined,
+    setUser: undefined,
+    spanToJSON: () => ({
+      span_id: "span-123",
+      trace_id: "trace-123",
+    }),
+    withScope: undefined,
+  }));
+  return await import("@/chat/logging");
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.resetModules();
+  vi.doUnmock("@/chat/sentry");
+});
+
+describe("structured log events", () => {
+  it("inherits bound context and active trace correlation", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const { logWarn, registerLogRecordSink, withLogContext } =
+      await loadLoggingModule();
+    const records: EmittedLogRecord[] = [];
+    const unregister = registerLogRecordSink((record) => records.push(record));
+
+    try {
+      await withLogContext(
+        {
+          conversationId: "conversation-123",
+          runId: "run-123",
+        },
+        async () => {
+          logWarn("agent.turn.reply_recovery.exhausted", {
+            "app.retry.attempt": 2,
+          });
+        },
+      );
+    } finally {
+      unregister();
+    }
+
+    expect(records).toEqual([
+      expect.objectContaining({
+        body: "agent.turn.reply_recovery.exhausted",
+        eventName: "agent.turn.reply_recovery.exhausted",
+        level: "warn",
+        attributes: expect.objectContaining({
+          "app.retry.attempt": 2,
+          "app.run.id": "run-123",
+          "event.name": "agent.turn.reply_recovery.exhausted",
+          "gen_ai.conversation.id": "conversation-123",
+          span_id: "span-123",
+          trace_id: "trace-123",
+        }),
+      }),
+    ]);
+  });
+
+  it("rejects non-namespaced application event names", async () => {
+    const { logWarn } = await loadLoggingModule();
+
+    expect(() => logWarn("agent_turn_failed")).toThrow(
+      "use lowercase dot-delimited namespaces",
+    );
+  });
+});

--- a/packages/junior/tests/unit/runtime/processing-reaction.test.ts
+++ b/packages/junior/tests/unit/runtime/processing-reaction.test.ts
@@ -45,7 +45,6 @@ describe("processing reaction session", () => {
       channelId: "C0PROCESSING",
       timestamp: slackTs("1700007301.000000"),
       logException: () => undefined,
-      logContext: {},
     });
 
     await session.complete();
@@ -79,7 +78,6 @@ describe("processing reaction session", () => {
       channelId: "C0PROCESSING",
       timestamp: slackTs("1700007302.000000"),
       logException: () => undefined,
-      logContext: {},
     });
 
     await session.complete();
@@ -97,7 +95,6 @@ describe("processing reaction session", () => {
       channelId: "C0PROCESSING",
       timestamp: slackTs("1700007303.000000"),
       logException: () => undefined,
-      logContext: {},
     });
 
     session.keep();

--- a/packages/junior/tests/unit/services/turn-failure-response.test.ts
+++ b/packages/junior/tests/unit/services/turn-failure-response.test.ts
@@ -39,7 +39,6 @@ describe("finalizeFailedTurnReply", () => {
         text: "Error: ECONNRESET at redis.js:42",
       }),
       logException,
-      context: {},
     });
 
     expect(finalized.text).not.toContain("ECONNRESET");
@@ -61,10 +60,9 @@ describe("finalizeFailedTurnReply", () => {
         text: "",
       }),
       logException,
-      context: {},
     });
 
-    const attributes = logException.mock.calls[0]?.[3];
+    const attributes = logException.mock.calls[0]?.[2];
     expect(attributes).toMatchObject({
       "app.ai.provider_error.kind": "server",
       "app.ai.provider_error.retryable": true,
@@ -103,7 +101,6 @@ describe("finalizeFailedTurnReply", () => {
           text: "",
         }),
         logException: vi.fn().mockReturnValue("evt_terminal"),
-        context: {},
       });
 
       expect(finalized.text).toContain(explanation);
@@ -121,7 +118,6 @@ describe("finalizeFailedTurnReply", () => {
         text: "Here is what I found so far",
       }),
       logException,
-      context: {},
     });
 
     expect(finalized.text).toBe(

--- a/packages/junior/tests/unit/services/turn-router.test.ts
+++ b/packages/junior/tests/unit/services/turn-router.test.ts
@@ -215,14 +215,10 @@ describe("selectTurnRoute", () => {
       reason: "classifier_error_default",
     });
     expect(mocks.logWarn).toHaveBeenCalledWith(
-      "turn_router_classifier_failed",
-      expect.objectContaining({
-        modelId: "openai/gpt-5.4-mini",
-      }),
+      "turn.router.classifier.failed",
       {
         "exception.message": "router failed",
       },
-      "Turn router classifier failed; using the default route",
     );
   });
 

--- a/packages/junior/tests/unit/tools/execution/tool-error-handler.test.ts
+++ b/packages/junior/tests/unit/tools/execution/tool-error-handler.test.ts
@@ -29,7 +29,7 @@ describe("handleToolExecutionError", () => {
   it("reports system errors to Sentry via logException", () => {
     const error = new Error("sandbox API failed");
     expect(() =>
-      handleToolExecutionError(error, "editFile", "call_1", true, {}),
+      handleToolExecutionError(error, "editFile", "call_1", true),
     ).toThrow(error);
 
     expect(logExceptionMock).toHaveBeenCalledTimes(1);
@@ -41,7 +41,7 @@ describe("handleToolExecutionError", () => {
   it("does not report ToolInputError to Sentry", () => {
     const error = new ToolInputError("Could not find edits[0] in file.ts");
     expect(() =>
-      handleToolExecutionError(error, "editFile", "call_1", true, {}),
+      handleToolExecutionError(error, "editFile", "call_1", true),
     ).toThrow(error);
 
     expect(logExceptionMock).not.toHaveBeenCalled();
@@ -54,7 +54,7 @@ describe("handleToolExecutionError", () => {
   it("does not report McpToolError to Sentry", () => {
     const error = new McpToolError("mcp tool failed");
     expect(() =>
-      handleToolExecutionError(error, "mcpTool", "call_1", true, {}),
+      handleToolExecutionError(error, "mcpTool", "call_1", true),
     ).toThrow(error);
 
     expect(logExceptionMock).not.toHaveBeenCalled();

--- a/packages/junior/tests/unit/tools/tool-error-handler.test.ts
+++ b/packages/junior/tests/unit/tools/tool-error-handler.test.ts
@@ -37,7 +37,6 @@ describe("handleToolExecutionError", () => {
         "callMcpTool",
         "tool-call-id",
         true,
-        {},
         "private",
       ),
     ).toThrow(error);
@@ -46,8 +45,7 @@ describe("handleToolExecutionError", () => {
       "error.type": "tool_error",
     });
     expect(logWarnMock).toHaveBeenCalledWith(
-      "agent_tool_call_failed",
-      {},
+      "agent.tool_call.failed",
       expect.objectContaining({
         "gen_ai.operation.name": "execute_tool",
         "gen_ai.tool.name": "callMcpTool",
@@ -55,7 +53,6 @@ describe("handleToolExecutionError", () => {
         "error.type": "tool_error",
         "exception.message": "MCP tool call failed",
       }),
-      "Agent tool call failed",
     );
     expect(JSON.stringify(logWarnMock.mock.calls)).not.toContain(
       "remote tool failed",
@@ -72,12 +69,11 @@ describe("handleToolExecutionError", () => {
     });
 
     expect(() =>
-      handleToolExecutionError(error, "bash", "tool-call-id", true, {}),
+      handleToolExecutionError(error, "bash", "tool-call-id", true),
     ).toThrow(error);
 
     expect(logWarnMock).toHaveBeenCalledWith(
-      "agent_tool_call_failed",
-      {},
+      "agent.tool_call.failed",
       expect.objectContaining({
         "app.credential.provider": "sentry",
         "app.oauth.error.phase": "token_refresh",
@@ -86,19 +82,16 @@ describe("handleToolExecutionError", () => {
         "http.response.status_code": 503,
         "server.address": "sentry.io",
       }),
-      "Agent tool call failed",
     );
     expect(logExceptionMock).toHaveBeenCalledWith(
       error,
-      "agent_tool_call_failed",
-      {},
+      "agent.tool_call.failed",
       expect.objectContaining({
         "app.credential.provider": "sentry",
         "app.oauth.error.phase": "token_refresh",
         "http.response.status_code": 503,
         "server.address": "sentry.io",
       }),
-      "Agent tool call failed",
     );
   });
 
@@ -109,7 +102,7 @@ describe("handleToolExecutionError", () => {
     );
 
     expect(() =>
-      handleToolExecutionError(error, "bash", "tool-call-id", true, {}),
+      handleToolExecutionError(error, "bash", "tool-call-id", true),
     ).toThrow(error);
 
     expect(setSpanAttributesMock).toHaveBeenCalledWith({
@@ -117,8 +110,7 @@ describe("handleToolExecutionError", () => {
       "error.type": "PluginCredentialFailureError",
     });
     expect(logInfoMock).toHaveBeenCalledWith(
-      "plugin_credential_rejected",
-      {},
+      "plugin.credential.rejected",
       expect.objectContaining({
         "app.credential.provider": "github",
         "gen_ai.operation.name": "execute_tool",
@@ -126,7 +118,6 @@ describe("handleToolExecutionError", () => {
         "gen_ai.tool.call.id": "tool-call-id",
         "error.type": "PluginCredentialFailureError",
       }),
-      "Plugin credentials were rejected during tool execution",
     );
     expect(logWarnMock).not.toHaveBeenCalled();
     expect(logExceptionMock).not.toHaveBeenCalled();

--- a/packages/junior/tests/unit/turn-result.test.ts
+++ b/packages/junior/tests/unit/turn-result.test.ts
@@ -126,7 +126,6 @@ describe("buildTurnResult", () => {
       toolCalls: [],
       generatedFileCount: 0,
       shouldTrace: false,
-      spanContext: {},
       modelId: "test-model",
       executionProfile,
     });
@@ -159,7 +158,6 @@ describe("buildTurnResult", () => {
       toolCalls: ["webSearch"],
       generatedFileCount: 0,
       shouldTrace: false,
-      spanContext: {},
       modelId: "test-model",
       executionProfile,
     });
@@ -196,7 +194,6 @@ describe("buildTurnResult", () => {
       toolCalls: ["sendFiles"],
       generatedFileCount: 1,
       shouldTrace: false,
-      spanContext: {},
       modelId: "test-model",
       executionProfile,
     });
@@ -230,7 +227,6 @@ describe("buildTurnResult", () => {
       toolCalls: ["webSearch"],
       generatedFileCount: 0,
       shouldTrace: false,
-      spanContext: {},
       modelId: "test-model",
       executionProfile,
     });
@@ -267,7 +263,6 @@ describe("buildTurnResult", () => {
       toolCalls: [],
       generatedFileCount: 0,
       shouldTrace: false,
-      spanContext: {},
       modelId: "test-model",
       executionProfile,
     });
@@ -306,7 +301,6 @@ describe("buildTurnResult", () => {
       toolCalls: [],
       generatedFileCount: 0,
       shouldTrace: false,
-      spanContext: {},
       modelId: "test-model",
       executionProfile,
     });
@@ -345,7 +339,6 @@ describe("buildTurnResult", () => {
       toolCalls: ["bash"],
       generatedFileCount: 0,
       shouldTrace: false,
-      spanContext: {},
       modelId: "test-model",
       executionProfile,
     });
@@ -378,7 +371,6 @@ describe("buildTurnResult", () => {
       toolCalls: ["addReaction"],
       generatedFileCount: 0,
       shouldTrace: false,
-      spanContext: {},
       modelId: "test-model",
       executionProfile,
     });
@@ -417,7 +409,6 @@ describe("buildTurnResult", () => {
       toolCalls: ["addReaction"],
       generatedFileCount: 0,
       shouldTrace: false,
-      spanContext: {},
       modelId: "test-model",
       executionProfile,
     });
@@ -441,7 +432,6 @@ describe("buildTurnResult", () => {
       toolCalls: [],
       generatedFileCount: 0,
       shouldTrace: false,
-      spanContext: {},
       modelId: "test-model",
       executionProfile,
     });
@@ -465,7 +455,6 @@ describe("buildTurnResult", () => {
       toolCalls: [],
       generatedFileCount: 0,
       shouldTrace: false,
-      spanContext: {},
       modelId: "test-model",
       executionProfile,
     });
@@ -494,7 +483,6 @@ describe("buildTurnResult", () => {
       toolCalls: ["sendFiles"],
       generatedFileCount: 0,
       shouldTrace: false,
-      spanContext: {},
       modelId: "test-model",
       executionProfile,
     });
@@ -530,7 +518,6 @@ describe("buildTurnResult", () => {
       toolCalls: ["sendFiles"],
       generatedFileCount: 1,
       shouldTrace: false,
-      spanContext: {},
       modelId: "test-model",
       executionProfile,
     });
@@ -554,7 +541,6 @@ describe("buildTurnResult", () => {
       durationMs: 1532,
       generatedFileCount: 0,
       shouldTrace: false,
-      spanContext: {},
       modelId: "test-model",
       executionProfile,
       usage: {

--- a/policies/observability.md
+++ b/policies/observability.md
@@ -15,11 +15,47 @@ contract and should not drive mocks or assertions outside instrumentation tests.
 
 - Use OpenTelemetry semantic attributes when one exists.
 - Use `app.*` for Junior-owned attributes.
+- Name events `<domain>.<operation>[.<suboperation>].<outcome>`, using lowercase
+  dot-delimited namespaces and snake case only within a namespace component.
+- Use singular count nouns for domains and operations (`message`, `tool_call`,
+  `zebra`). Use a plural only when one event represents a collection or batch,
+  or when preserving a canonical external term such as `embeddings`.
+- The final component says what was observed:
+  - Use a past participle for a completed transition: `started`, `completed`,
+    `failed`, `accepted`, `rejected`, `skipped`, `requeued`, `yielded`.
+  - Use a present participle only for work currently underway: `retrying`.
+  - Use an adjective or established state term for an observation rather than
+    a transition: `busy`, `empty`, `missing`, `invalid`, `provider_error`.
+- Do not end event names with imperative/base verbs (`retry`, `start`, `unlink`)
+  or directional shorthand (`in`, `out`). Event names describe observations,
+  not commands.
+- Event names identify one stable event structure. Never include identifiers,
+  provider names, user-controlled values, or other occurrence-specific data in
+  an event name; record them as attributes.
+- Prefer consistent outcomes such as `started`, `completed`, `failed`,
+  `exception`, `timed_out`, `retrying`, `exhausted`, `rejected`, `denied`, and
+  `skipped`. Use `.exception` for an actual captured exception and `.failed`
+  for an unsuccessful domain outcome that may not be exceptional.
 - Keep operation names stable and low-cardinality.
 - Record correlation identifiers such as conversation, run, task, plugin,
   provider, and sandbox session IDs when they are relevant and safe.
 - Do not encode identifiers or user-controlled values into span operation names.
 - Set error status and capture exceptions at the boundary that owns the failure.
+
+## Emission
+
+- Runtime code emits a stable event name plus occurrence-specific attributes.
+  Do not duplicate the event with a human-readable message.
+- Bind request, conversation, actor, destination, and run correlation once at
+  the owning operation boundary. Nested logs inherit that context and the
+  active trace/span identifiers.
+- Async log context is not durable runtime context. Queues, callbacks, resumed
+  work, and other durable boundaries must carry authoritative context
+  explicitly and bind it again when execution starts.
+- Free-form messages received from providers, libraries, or plugins may be
+  retained as safe attributes by their adapter; they are not event names.
+- Backend adapters own compatibility projections such as Sentry's
+  `event.name`. The provider-neutral record owns the canonical event name.
 
 ## Ownership
 


### PR DESCRIPTION
Runtime logs now emit a stable dot-namespaced event name plus occurrence-specific attributes, while request, conversation, run, and active trace/span correlation are inherited from context bound at the owning async boundary. This removes repeated context and human-readable message arguments from application call sites, and ensures core queue, callback, continuation, Slack, and local-runtime boundaries consistently attach `gen_ai.conversation.id` without bloating each log statement.

This is a hard cutover of the internal logging API and event taxonomy. The logging module now documents and validates the contract in non-production environments; observability policy standardizes singular nouns and outcome tense (`completed` for a finished transition, `retrying` for work underway, and state terms such as `busy`); an AST rule rejects common imperative endings; and operational queries and runbooks use the renamed events. Low-level adapters can still preserve external free-form messages as safe attributes when needed.

Focused logging and runtime coverage verifies inherited correlation across worker, heartbeat, continuation, OAuth, Slack, and local-agent paths. Type checking, structured-event linting, focused Vitest suites, diff checks, and the repository commit hooks pass.
