### PR TITLE
fix(slack): continue after image analysis failures

### DIFF
--- a/packages/junior/src/chat/slack/vision-context.ts
+++ b/packages/junior/src/chat/slack/vision-context.ts
@@ -132,6 +132,23 @@ function buildImageAttachmentPromptText(args: {
   ].join("\n");
 }
 
+function buildImageAttachmentFailurePromptText(args: {
+  filename?: string;
+  mediaType: string;
+  message: string;
+}): string {
+  return [
+    "<image-attachment>",
+    `filename: ${args.filename ?? "unnamed"}`,
+    `media_type: ${args.mediaType}`,
+    "<analysis-error>",
+    args.message,
+    "The image contents are unavailable.",
+    "</analysis-error>",
+    "</image-attachment>",
+  ].join("\n");
+}
+
 async function summarizeImageWithVision(args: {
   completeText: typeof completeText;
   imageData: Buffer;
@@ -358,7 +375,16 @@ async function resolveUserAttachmentsWithDeps(
           },
           "Image attachment processing failed",
         );
-        throw attachmentError;
+        results.push({
+          mediaType,
+          filename: attachment.name,
+          promptText: buildImageAttachmentFailurePromptText({
+            filename: attachment.name,
+            mediaType,
+            message: attachmentError.message,
+          }),
+        });
+        continue;
       }
 
       logWarn(

--- a/packages/junior/tests/integration/slack/attachment-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/attachment-behavior.test.ts
@@ -129,14 +129,30 @@ describe("Slack behavior: attachment handling", () => {
     expect(toPostedText(thread.posts[0])).toContain("chart trend is upward");
   }, 10_000);
 
-  it("posts a fallback error reply when required image analysis fails", async () => {
+  it("lets the agent respond when image analysis fails", async () => {
     const attachmentFetch = vi.fn(async () => Buffer.from("image-bytes"));
     const completeTextMock = vi.fn(async () => {
       throw new Error("vision unavailable");
     });
-    const executeAgentRun = vi.fn(async () =>
-      completedAgentRun({
-        text: "should not post",
+    const executeAgentRun = vi.fn(async (request) => {
+      const attachments =
+        flattenAgentRunRequestForTest(request)?.userAttachments ?? [];
+      expect(attachments).toEqual([
+        expect.objectContaining({
+          filename: "error.png",
+          mediaType: "image/png",
+          promptText: expect.stringContaining(
+            'Image attachment "error.png" could not be analyzed',
+          ),
+        }),
+      ]);
+      await deliverAssistantMessagesForTest(request, [
+        {
+          text: "I couldn’t inspect the attached image. Please try uploading it again.",
+        },
+      ]);
+      return completedAgentRun({
+        text: "I couldn’t inspect the attached image. Please try uploading it again.",
         diagnostics: {
           assistantMessageCount: 1,
           modelId: "fake-agent-model",
@@ -146,8 +162,8 @@ describe("Slack behavior: attachment handling", () => {
           toolResultCount: 0,
           usedPrimaryText: true,
         },
-      }),
-    );
+      });
+    });
 
     const { slackRuntime } = await createRuntime({
       services: {
@@ -184,10 +200,10 @@ describe("Slack behavior: attachment handling", () => {
 
     expect(attachmentFetch).toHaveBeenCalledTimes(1);
     expect(completeTextMock).toHaveBeenCalledTimes(1);
-    expect(executeAgentRun).not.toHaveBeenCalled();
+    expect(executeAgentRun).toHaveBeenCalledTimes(1);
     expect(thread.posts).toHaveLength(1);
     expect(toPostedText(thread.posts[0])).toContain(
-      "I ran into an internal error while processing that.",
+      "I couldn’t inspect the attached image.",
     );
   });
 });


### PR DESCRIPTION
Slack turns now continue when dedicated vision analysis cannot process an image. Junior passes a structured attachment error to the main agent, allowing it to explain the limitation using the remaining context, while retaining warning telemetry instead of escalating an expected attachment failure into a generic internal error.

The integration scenario now verifies that a failed vision request reaches the main agent and produces a normal reply; successful attachment handling remains unchanged.
