### PR TITLE
feat(dashboard): animate archived conversations

### DIFF
--- a/packages/junior-dashboard/e2e/conversations.spec.ts
+++ b/packages/junior-dashboard/e2e/conversations.spec.ts
@@ -495,3 +495,48 @@ test("shows archive failures after the row returns", async ({ page }) => {
     }),
   ).toBeVisible();
 });
+
+test("keeps undo available when another archive fails", async ({ page }) => {
+  await page.setViewportSize({ height: 900, width: 1600 });
+  let archiveRequests = 0;
+  await page.route("**/api/conversations/*/archive", async (route) => {
+    archiveRequests += 1;
+    if (archiveRequests === 1) {
+      await route.fulfill({ json: { archived: true } });
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    await route.fulfill({
+      json: { error: "Archive failed" },
+      status: 500,
+    });
+  });
+  await page.goto(server.baseURL);
+
+  const firstConversation = page.getByRole("link", {
+    name: /Dashboard QA edge cases/,
+  });
+  await firstConversation.hover();
+  await page
+    .getByRole("button", { name: "Archive Dashboard QA edge cases" })
+    .click();
+  const undo = page.getByRole("button", {
+    name: "Undo archive for Dashboard QA edge cases",
+  });
+  await expect(undo).toBeVisible();
+
+  const secondConversation = page.getByRole("link", {
+    name: /Checkout latency triage/,
+  });
+  await secondConversation.hover();
+  await page
+    .getByRole("button", { name: "Archive Checkout latency triage" })
+    .click();
+
+  await expect(
+    page.getByRole("alert").filter({
+      hasText: "Could not archive Checkout latency triage.",
+    }),
+  ).toBeVisible();
+  await expect(undo).toBeVisible();
+});

--- a/packages/junior-dashboard/e2e/conversations.spec.ts
+++ b/packages/junior-dashboard/e2e/conversations.spec.ts
@@ -381,9 +381,9 @@ test("archives and restores a conversation from the sidebar", async ({
   });
   await page.route("**/api/conversations/*/archive", async (route) => {
     const request = route.request().postDataJSON();
-    if (!request.archived) {
-      await new Promise((resolve) => setTimeout(resolve, 500));
-    }
+    await new Promise((resolve) =>
+      setTimeout(resolve, request.archived ? 100 : 500),
+    );
     archived = request.archived;
     await route.fulfill({ json: { archived } });
   });
@@ -411,6 +411,8 @@ test("archives and restores a conversation from the sidebar", async ({
   await archiveButton.click();
   const emptyView = page.getByText("No conversations match this view.");
   await expect(emptyView).toHaveCount(0);
+  await page.waitForTimeout(220);
+  await expect(emptyView).toBeVisible();
   const archiveRequest = await archiveRequestPromise;
 
   expect(archiveRequest.postDataJSON()).toMatchObject({ archived: true });
@@ -420,7 +422,6 @@ test("archives and restores a conversation from the sidebar", async ({
       hasText: "Dashboard QA edge cases archived",
     }),
   ).toBeVisible();
-  await expect(emptyView).toBeVisible();
 
   const restoreRequestPromise = page.waitForRequest(
     (request) =>

--- a/packages/junior-dashboard/e2e/conversations.spec.ts
+++ b/packages/junior-dashboard/e2e/conversations.spec.ts
@@ -363,8 +363,29 @@ test("archives and restores a conversation from the sidebar", async ({
   page,
 }) => {
   await page.setViewportSize({ height: 900, width: 1600 });
+  let archived = false;
+  await page.route(/\/api\/conversations(?:\?.*)?$/, async (route) => {
+    const response = await route.fetch();
+    const feed = await response.json();
+    await route.fulfill({
+      response,
+      json: {
+        ...feed,
+        conversations: feed.conversations.filter(
+          (conversation: { displayTitle: string }) =>
+            !archived ||
+            conversation.displayTitle !== "Dashboard QA edge cases",
+        ),
+      },
+    });
+  });
   await page.route("**/api/conversations/*/archive", async (route) => {
-    await route.fulfill({ json: { archived: true } });
+    const request = route.request().postDataJSON();
+    if (!request.archived) {
+      await new Promise((resolve) => setTimeout(resolve, 500));
+    }
+    archived = request.archived;
+    await route.fulfill({ json: { archived } });
   });
   await page.goto(server.baseURL);
   await expect(
@@ -377,6 +398,9 @@ test("archives and restores a conversation from the sidebar", async ({
   const archiveButton = page.getByRole("button", {
     name: "Archive Dashboard QA edge cases",
   });
+  await page
+    .getByRole("searchbox", { name: "Search your conversations" })
+    .fill("Dashboard QA edge cases");
   await conversationLink.hover();
 
   const currentUrl = page.url();
@@ -385,6 +409,8 @@ test("archives and restores a conversation from the sidebar", async ({
       request.method() === "PATCH" && request.url().endsWith("/archive"),
   );
   await archiveButton.click();
+  const emptyView = page.getByText("No conversations match this view.");
+  await expect(emptyView).toHaveCount(0);
   const archiveRequest = await archiveRequestPromise;
 
   expect(archiveRequest.postDataJSON()).toMatchObject({ archived: true });
@@ -394,6 +420,7 @@ test("archives and restores a conversation from the sidebar", async ({
       hasText: "Dashboard QA edge cases archived",
     }),
   ).toBeVisible();
+  await expect(emptyView).toBeVisible();
 
   const restoreRequestPromise = page.waitForRequest(
     (request) =>
@@ -404,6 +431,12 @@ test("archives and restores a conversation from the sidebar", async ({
       name: "Undo archive for Dashboard QA edge cases",
     })
     .click();
+  await expect(conversationLink).toBeVisible();
+  await expect(
+    page.getByRole("button", {
+      name: "Undo archive for Dashboard QA edge cases",
+    }),
+  ).toHaveText("Restoring…");
   const restoreRequest = await restoreRequestPromise;
 
   expect(restoreRequest.postDataJSON()).toMatchObject({ archived: false });
@@ -413,4 +446,31 @@ test("archives and restores a conversation from the sidebar", async ({
     }),
   ).toHaveCount(0);
   expect(page.url()).toBe(currentUrl);
+});
+
+test("shows archive failures after the row returns", async ({ page }) => {
+  await page.setViewportSize({ height: 900, width: 1600 });
+  await page.route("**/api/conversations/*/archive", async (route) => {
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    await route.fulfill({
+      json: { error: "Archive failed" },
+      status: 500,
+    });
+  });
+  await page.goto(server.baseURL);
+
+  const conversationLink = page.getByRole("link", {
+    name: /Dashboard QA edge cases/,
+  });
+  await conversationLink.hover();
+  await page
+    .getByRole("button", { name: "Archive Dashboard QA edge cases" })
+    .click();
+
+  await expect(conversationLink).toBeVisible();
+  await expect(
+    page.getByRole("alert").filter({
+      hasText: "Could not archive Dashboard QA edge cases.",
+    }),
+  ).toBeVisible();
 });

--- a/packages/junior-dashboard/e2e/conversations.spec.ts
+++ b/packages/junior-dashboard/e2e/conversations.spec.ts
@@ -381,9 +381,7 @@ test("archives and restores a conversation from the sidebar", async ({
   });
   await page.route("**/api/conversations/*/archive", async (route) => {
     const request = route.request().postDataJSON();
-    await new Promise((resolve) =>
-      setTimeout(resolve, request.archived ? 100 : 500),
-    );
+    await new Promise((resolve) => setTimeout(resolve, 1_000));
     archived = request.archived;
     await route.fulfill({ json: { archived } });
   });
@@ -411,6 +409,17 @@ test("archives and restores a conversation from the sidebar", async ({
   await archiveButton.click();
   const emptyView = page.getByText("No conversations match this view.");
   await expect(emptyView).toHaveCount(0);
+  const archiveFocusRefetch = page.waitForResponse(
+    (response) =>
+      response.request().method() === "GET" &&
+      /\/api\/conversations(?:\?.*)?$/.test(response.url()),
+  );
+  await page.evaluate(() => {
+    window.dispatchEvent(new Event("focus"));
+    window.dispatchEvent(new Event("visibilitychange"));
+  });
+  await archiveFocusRefetch;
+  await expect(conversationLink).toHaveCount(0);
   await page.waitForTimeout(220);
   await expect(emptyView).toBeVisible();
   const archiveRequest = await archiveRequestPromise;
@@ -432,6 +441,17 @@ test("archives and restores a conversation from the sidebar", async ({
       name: "Undo archive for Dashboard QA edge cases",
     })
     .click();
+  await expect(conversationLink).toBeVisible();
+  const restoreFocusRefetch = page.waitForResponse(
+    (response) =>
+      response.request().method() === "GET" &&
+      /\/api\/conversations(?:\?.*)?$/.test(response.url()),
+  );
+  await page.evaluate(() => {
+    window.dispatchEvent(new Event("focus"));
+    window.dispatchEvent(new Event("visibilitychange"));
+  });
+  await restoreFocusRefetch;
   await expect(conversationLink).toBeVisible();
   await expect(
     page.getByRole("button", {

--- a/packages/junior-dashboard/src/client/components/AnimatedList.tsx
+++ b/packages/junior-dashboard/src/client/components/AnimatedList.tsx
@@ -1,0 +1,148 @@
+import {
+  useEffect,
+  useLayoutEffect,
+  useState,
+  type AriaRole,
+  type ReactNode,
+} from "react";
+
+import { cn } from "../styles";
+
+type AnimatedItem<T> = {
+  item: T;
+  key: string;
+  state: "entering" | "present" | "exiting";
+};
+
+/** Keep added and removed list items mounted long enough for standard UI motion. */
+export function AnimatedList<T>(props: {
+  ariaLabel?: string;
+  className?: string;
+  durationMs?: number;
+  getKey(item: T): string;
+  items: T[];
+  renderItem(item: T): ReactNode;
+  role?: AriaRole;
+}) {
+  const reducedMotion = usePrefersReducedMotion();
+  const durationMs = reducedMotion ? 0 : (props.durationMs ?? 180);
+  const [animatedItems, setAnimatedItems] = useState<AnimatedItem<T>[]>(() =>
+    props.items.map((item) => ({
+      item,
+      key: props.getKey(item),
+      state: "present",
+    })),
+  );
+  const exiting = animatedItems.some((item) => item.state === "exiting");
+
+  useLayoutEffect(() => {
+    setAnimatedItems((current) =>
+      mergeAnimatedItems(current, props.items, props.getKey),
+    );
+  }, [props.getKey, props.items]);
+
+  useEffect(() => {
+    if (!animatedItems.some((item) => item.state === "entering")) return;
+    if (reducedMotion) {
+      setAnimatedItems((current) => markEnteredItemsPresent(current));
+      return;
+    }
+    const frame = window.requestAnimationFrame(() => {
+      setAnimatedItems((current) => markEnteredItemsPresent(current));
+    });
+    return () => window.cancelAnimationFrame(frame);
+  }, [animatedItems, reducedMotion]);
+
+  useEffect(() => {
+    if (!exiting) return;
+    const timeout = window.setTimeout(() => {
+      setAnimatedItems((current) =>
+        current.filter((item) => item.state !== "exiting"),
+      );
+    }, durationMs);
+    return () => window.clearTimeout(timeout);
+  }, [animatedItems, durationMs, exiting]);
+
+  return (
+    <div
+      aria-label={props.ariaLabel}
+      className={cn(props.className, exiting && "pointer-events-none")}
+      role={props.role}
+    >
+      {animatedItems.map((animatedItem) => (
+        <div
+          aria-hidden={animatedItem.state === "exiting" ? true : undefined}
+          className={cn(
+            "grid min-w-0 origin-center transition-[grid-template-rows,opacity,transform] motion-reduce:transition-none",
+            animatedItem.state === "present"
+              ? "grid-rows-[1fr] translate-x-0 scale-100 opacity-100"
+              : "pointer-events-none grid-rows-[0fr] translate-x-2 scale-[0.98] opacity-0",
+          )}
+          data-presence={animatedItem.state}
+          inert={animatedItem.state === "exiting" ? true : undefined}
+          key={animatedItem.key}
+          style={{
+            transitionDuration: `${durationMs}ms`,
+            transitionTimingFunction: "cubic-bezier(0.2, 0.8, 0.2, 1)",
+          }}
+        >
+          <div className="min-h-0 min-w-0 overflow-hidden">
+            {props.renderItem(animatedItem.item)}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function mergeAnimatedItems<T>(
+  current: AnimatedItem<T>[],
+  items: T[],
+  getKey: (item: T) => string,
+): AnimatedItem<T>[] {
+  const currentByKey = new Map(current.map((item) => [item.key, item]));
+  const nextKeys = new Set(items.map(getKey));
+  const next: AnimatedItem<T>[] = items.map((item) => {
+    const key = getKey(item);
+    const previous = currentByKey.get(key);
+    return {
+      item,
+      key,
+      state:
+        previous?.state === "exiting"
+          ? "entering"
+          : (previous?.state ?? "entering"),
+    } satisfies AnimatedItem<T>;
+  });
+
+  current.forEach((item, index) => {
+    if (nextKeys.has(item.key)) return;
+    next.splice(Math.min(index, next.length), 0, {
+      ...item,
+      state: "exiting",
+    });
+  });
+  return next;
+}
+
+function markEnteredItemsPresent<T>(
+  items: AnimatedItem<T>[],
+): AnimatedItem<T>[] {
+  return items.map((item) =>
+    item.state === "entering" ? { ...item, state: "present" } : item,
+  );
+}
+
+function usePrefersReducedMotion(): boolean {
+  const [reducedMotion, setReducedMotion] = useState(false);
+
+  useEffect(() => {
+    const media = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const update = () => setReducedMotion(media.matches);
+    update();
+    media.addEventListener("change", update);
+    return () => media.removeEventListener("change", update);
+  }, []);
+
+  return reducedMotion;
+}

--- a/packages/junior-dashboard/src/client/components/AnimatedList.tsx
+++ b/packages/junior-dashboard/src/client/components/AnimatedList.tsx
@@ -19,6 +19,7 @@ export function AnimatedList<T>(props: {
   ariaLabel?: string;
   className?: string;
   durationMs?: number;
+  empty?: ReactNode;
   getKey(item: T): string;
   items: T[];
   renderItem(item: T): ReactNode;
@@ -65,32 +66,34 @@ export function AnimatedList<T>(props: {
 
   return (
     <div
-      aria-label={props.ariaLabel}
+      aria-label={animatedItems.length > 0 ? props.ariaLabel : undefined}
       className={cn(props.className, exiting && "pointer-events-none")}
-      role={props.role}
+      role={animatedItems.length > 0 ? props.role : undefined}
     >
-      {animatedItems.map((animatedItem) => (
-        <div
-          aria-hidden={animatedItem.state === "exiting" ? true : undefined}
-          className={cn(
-            "grid min-w-0 origin-center transition-[grid-template-rows,opacity,transform] motion-reduce:transition-none",
-            animatedItem.state === "present"
-              ? "grid-rows-[1fr] translate-x-0 scale-100 opacity-100"
-              : "pointer-events-none grid-rows-[0fr] translate-x-2 scale-[0.98] opacity-0",
-          )}
-          data-presence={animatedItem.state}
-          inert={animatedItem.state === "exiting" ? true : undefined}
-          key={animatedItem.key}
-          style={{
-            transitionDuration: `${durationMs}ms`,
-            transitionTimingFunction: "cubic-bezier(0.2, 0.8, 0.2, 1)",
-          }}
-        >
-          <div className="min-h-0 min-w-0 overflow-hidden">
-            {props.renderItem(animatedItem.item)}
-          </div>
-        </div>
-      ))}
+      {animatedItems.length > 0
+        ? animatedItems.map((animatedItem) => (
+            <div
+              aria-hidden={animatedItem.state === "exiting" ? true : undefined}
+              className={cn(
+                "grid min-w-0 origin-center transition-[grid-template-rows,opacity,transform] motion-reduce:transition-none",
+                animatedItem.state === "present"
+                  ? "grid-rows-[1fr] translate-x-0 scale-100 opacity-100"
+                  : "pointer-events-none grid-rows-[0fr] translate-x-2 scale-[0.98] opacity-0",
+              )}
+              data-presence={animatedItem.state}
+              inert={animatedItem.state === "exiting" ? true : undefined}
+              key={animatedItem.key}
+              style={{
+                transitionDuration: `${durationMs}ms`,
+                transitionTimingFunction: "cubic-bezier(0.2, 0.8, 0.2, 1)",
+              }}
+            >
+              <div className="min-h-0 min-w-0 overflow-hidden">
+                {props.renderItem(animatedItem.item)}
+              </div>
+            </div>
+          ))
+        : props.empty}
     </div>
   );
 }

--- a/packages/junior-dashboard/src/client/components/AnimatedList.tsx
+++ b/packages/junior-dashboard/src/client/components/AnimatedList.tsx
@@ -1,6 +1,8 @@
 import {
+  useCallback,
   useEffect,
   useLayoutEffect,
+  useRef,
   useState,
   type AriaRole,
   type ReactNode,
@@ -34,12 +36,22 @@ export function AnimatedList<T>(props: {
       state: "present",
     })),
   );
+  const hasPresentedItems = useRef(props.items.length > 0);
   const exiting = animatedItems.some((item) => item.state === "exiting");
+  const removeAnimatedItem = useCallback((key: string) => {
+    setAnimatedItems((current) => current.filter((item) => item.key !== key));
+  }, []);
 
   useLayoutEffect(() => {
     setAnimatedItems((current) =>
-      mergeAnimatedItems(current, props.items, props.getKey),
+      mergeAnimatedItems(
+        current,
+        props.items,
+        props.getKey,
+        hasPresentedItems.current,
+      ),
     );
+    if (props.items.length > 0) hasPresentedItems.current = true;
   }, [props.getKey, props.items]);
 
   useEffect(() => {
@@ -54,16 +66,6 @@ export function AnimatedList<T>(props: {
     return () => window.cancelAnimationFrame(frame);
   }, [animatedItems, reducedMotion]);
 
-  useEffect(() => {
-    if (!exiting) return;
-    const timeout = window.setTimeout(() => {
-      setAnimatedItems((current) =>
-        current.filter((item) => item.state !== "exiting"),
-      );
-    }, durationMs);
-    return () => window.clearTimeout(timeout);
-  }, [animatedItems, durationMs, exiting]);
-
   return (
     <div
       aria-label={animatedItems.length > 0 ? props.ariaLabel : undefined}
@@ -72,26 +74,13 @@ export function AnimatedList<T>(props: {
     >
       {animatedItems.length > 0
         ? animatedItems.map((animatedItem) => (
-            <div
-              aria-hidden={animatedItem.state === "exiting" ? true : undefined}
-              className={cn(
-                "grid min-w-0 origin-center transition-[grid-template-rows,opacity,transform] motion-reduce:transition-none",
-                animatedItem.state === "present"
-                  ? "grid-rows-[1fr] translate-x-0 scale-100 opacity-100"
-                  : "pointer-events-none grid-rows-[0fr] translate-x-2 scale-[0.98] opacity-0",
-              )}
-              data-presence={animatedItem.state}
-              inert={animatedItem.state === "exiting" ? true : undefined}
+            <AnimatedListRow
+              animatedItem={animatedItem}
+              durationMs={durationMs}
               key={animatedItem.key}
-              style={{
-                transitionDuration: `${durationMs}ms`,
-                transitionTimingFunction: "cubic-bezier(0.2, 0.8, 0.2, 1)",
-              }}
-            >
-              <div className="min-h-0 min-w-0 overflow-hidden">
-                {props.renderItem(animatedItem.item)}
-              </div>
-            </div>
+              onExited={removeAnimatedItem}
+              renderItem={props.renderItem}
+            />
           ))
         : props.empty}
     </div>
@@ -102,6 +91,7 @@ function mergeAnimatedItems<T>(
   current: AnimatedItem<T>[],
   items: T[],
   getKey: (item: T) => string,
+  animateNewItems: boolean,
 ): AnimatedItem<T>[] {
   const currentByKey = new Map(current.map((item) => [item.key, item]));
   const nextKeys = new Set(items.map(getKey));
@@ -114,7 +104,7 @@ function mergeAnimatedItems<T>(
       state:
         previous?.state === "exiting"
           ? "entering"
-          : (previous?.state ?? "entering"),
+          : (previous?.state ?? (animateNewItems ? "entering" : "present")),
     } satisfies AnimatedItem<T>;
   });
 
@@ -126,6 +116,45 @@ function mergeAnimatedItems<T>(
     });
   });
   return next;
+}
+
+function AnimatedListRow<T>(props: {
+  animatedItem: AnimatedItem<T>;
+  durationMs: number;
+  onExited(key: string): void;
+  renderItem(item: T): ReactNode;
+}) {
+  const { animatedItem } = props;
+  useEffect(() => {
+    if (animatedItem.state !== "exiting") return;
+    const timeout = window.setTimeout(
+      () => props.onExited(animatedItem.key),
+      props.durationMs,
+    );
+    return () => window.clearTimeout(timeout);
+  }, [animatedItem.key, animatedItem.state, props.durationMs, props.onExited]);
+
+  return (
+    <div
+      aria-hidden={animatedItem.state === "exiting" ? true : undefined}
+      className={cn(
+        "grid min-w-0 origin-center transition-[grid-template-rows,opacity,transform] motion-reduce:transition-none",
+        animatedItem.state === "present"
+          ? "grid-rows-[1fr] translate-x-0 scale-100 opacity-100"
+          : "pointer-events-none grid-rows-[0fr] translate-x-2 scale-[0.98] opacity-0",
+      )}
+      data-presence={animatedItem.state}
+      inert={animatedItem.state === "exiting" ? true : undefined}
+      style={{
+        transitionDuration: `${props.durationMs}ms`,
+        transitionTimingFunction: "cubic-bezier(0.2, 0.8, 0.2, 1)",
+      }}
+    >
+      <div className="min-h-0 min-w-0 overflow-hidden">
+        {props.renderItem(animatedItem.item)}
+      </div>
+    </div>
+  );
 }
 
 function markEnteredItemsPresent<T>(

--- a/packages/junior-dashboard/src/client/components/ConversationSidebar.tsx
+++ b/packages/junior-dashboard/src/client/components/ConversationSidebar.tsx
@@ -27,10 +27,9 @@ export function ConversationSidebar(props: {
   selectedId?: string;
   onQueryChange(value: string): void;
 }) {
-  const [notice, setNotice] = useState<{
-    conversation: Conversation;
-    kind: "archived" | "archive_error";
-  }>();
+  const [archivedConversation, setArchivedConversation] =
+    useState<Conversation>();
+  const [archiveError, setArchiveError] = useState<Conversation>();
   return (
     <aside className="relative grid h-full min-h-0 min-w-0 grid-rows-[auto_auto_minmax(0,1fr)] overflow-hidden border-r border-white/[0.07] bg-white/[0.02]">
       <div className="px-5 pb-3 pt-5">
@@ -79,18 +78,13 @@ export function ConversationSidebar(props: {
             renderItem={(conversation) => (
               <ConversationSidebarRow
                 conversation={conversation}
-                onArchiveError={(failedConversation) =>
-                  setNotice({
-                    conversation: failedConversation,
-                    kind: "archive_error",
-                  })
-                }
-                onArchived={(archivedConversation) =>
-                  setNotice({
-                    conversation: archivedConversation,
-                    kind: "archived",
-                  })
-                }
+                onArchiveError={setArchiveError}
+                onArchived={(conversation) => {
+                  setArchiveError((current) =>
+                    current?.id === conversation.id ? undefined : current,
+                  );
+                  setArchivedConversation(conversation);
+                }}
                 selected={conversation.id === props.selectedId}
               />
             )}
@@ -98,16 +92,21 @@ export function ConversationSidebar(props: {
           />
         )}
       </div>
-      {notice?.kind === "archived" ? (
-        <ArchivedConversationNotice
-          conversation={notice.conversation}
-          onRestored={() => setNotice(undefined)}
-        />
-      ) : notice?.kind === "archive_error" ? (
-        <ArchiveConversationErrorNotice
-          conversation={notice.conversation}
-          onDismiss={() => setNotice(undefined)}
-        />
+      {archivedConversation || archiveError ? (
+        <div className="absolute bottom-3 left-3 right-3 z-20 grid gap-2">
+          {archiveError ? (
+            <ArchiveConversationErrorNotice
+              conversation={archiveError}
+              onDismiss={() => setArchiveError(undefined)}
+            />
+          ) : null}
+          {archivedConversation ? (
+            <ArchivedConversationNotice
+              conversation={archivedConversation}
+              onRestored={() => setArchivedConversation(undefined)}
+            />
+          ) : null}
+        </div>
       ) : null}
     </aside>
   );
@@ -192,7 +191,7 @@ function ArchiveConversationErrorNotice(props: {
 }) {
   const title = conversationDisplayTitle(props.conversation);
   return (
-    <div className="absolute bottom-3 left-3 right-3 z-20 rounded-lg border border-rose-300/25 bg-[#111719] px-3 py-2.5 shadow-[0_12px_32px_rgba(0,0,0,0.45)]">
+    <div className="rounded-lg border border-rose-300/25 bg-[#111719] px-3 py-2.5 shadow-[0_12px_32px_rgba(0,0,0,0.45)]">
       <div className="flex min-w-0 items-center gap-3">
         <div
           className="min-w-0 flex-1 font-mono text-[0.68rem] text-rose-200/80"
@@ -223,7 +222,7 @@ function ArchivedConversationNotice(props: {
   });
   const title = conversationDisplayTitle(props.conversation);
   return (
-    <div className="absolute bottom-3 left-3 right-3 z-20 rounded-lg border border-white/15 bg-[#111719] px-3 py-2.5 shadow-[0_12px_32px_rgba(0,0,0,0.45)]">
+    <div className="rounded-lg border border-white/15 bg-[#111719] px-3 py-2.5 shadow-[0_12px_32px_rgba(0,0,0,0.45)]">
       <div className="flex min-w-0 items-center gap-3">
         <div
           className="min-w-0 flex-1 truncate font-mono text-[0.68rem] text-dashboard-text-muted"

--- a/packages/junior-dashboard/src/client/components/ConversationSidebar.tsx
+++ b/packages/junior-dashboard/src/client/components/ConversationSidebar.tsx
@@ -27,8 +27,10 @@ export function ConversationSidebar(props: {
   selectedId?: string;
   onQueryChange(value: string): void;
 }) {
-  const [archivedConversation, setArchivedConversation] =
-    useState<Conversation>();
+  const [notice, setNotice] = useState<{
+    conversation: Conversation;
+    kind: "archived" | "archive_error";
+  }>();
   return (
     <aside className="relative grid h-full min-h-0 min-w-0 grid-rows-[auto_auto_minmax(0,1fr)] overflow-hidden border-r border-white/[0.07] bg-white/[0.02]">
       <div className="px-5 pb-3 pt-5">
@@ -59,20 +61,36 @@ export function ConversationSidebar(props: {
           <div className="p-3">
             <EmptyTelemetry>{props.error}</EmptyTelemetry>
           </div>
-        ) : !props.loading && props.conversations.length === 0 ? (
-          <div className="p-3">
-            <EmptyTelemetry>No conversations match this view.</EmptyTelemetry>
-          </div>
         ) : (
           <AnimatedList
             ariaLabel="Your conversations"
             className="grid gap-1"
+            empty={
+              !props.loading ? (
+                <div className="p-3">
+                  <EmptyTelemetry>
+                    No conversations match this view.
+                  </EmptyTelemetry>
+                </div>
+              ) : undefined
+            }
             getKey={conversationKey}
             items={props.conversations}
             renderItem={(conversation) => (
               <ConversationSidebarRow
                 conversation={conversation}
-                onArchived={setArchivedConversation}
+                onArchiveError={(failedConversation) =>
+                  setNotice({
+                    conversation: failedConversation,
+                    kind: "archive_error",
+                  })
+                }
+                onArchived={(archivedConversation) =>
+                  setNotice({
+                    conversation: archivedConversation,
+                    kind: "archived",
+                  })
+                }
                 selected={conversation.id === props.selectedId}
               />
             )}
@@ -80,10 +98,15 @@ export function ConversationSidebar(props: {
           />
         )}
       </div>
-      {archivedConversation ? (
+      {notice?.kind === "archived" ? (
         <ArchivedConversationNotice
-          conversation={archivedConversation}
-          onRestored={() => setArchivedConversation(undefined)}
+          conversation={notice.conversation}
+          onRestored={() => setNotice(undefined)}
+        />
+      ) : notice?.kind === "archive_error" ? (
+        <ArchiveConversationErrorNotice
+          conversation={notice.conversation}
+          onDismiss={() => setNotice(undefined)}
         />
       ) : null}
     </aside>
@@ -92,10 +115,12 @@ export function ConversationSidebar(props: {
 
 function ConversationSidebarRow(props: {
   conversation: Conversation;
+  onArchiveError(conversation: Conversation): void;
   onArchived(conversation: Conversation): void;
   selected: boolean;
 }) {
   const archive = useArchiveConversation(props.conversation.id, {
+    onError: () => props.onArchiveError(props.conversation),
     onSuccess: (archived) => {
       if (archived) props.onArchived(props.conversation);
     },
@@ -144,10 +169,7 @@ function ConversationSidebarRow(props: {
       </Link>
       <button
         aria-label={`Archive ${title}`}
-        className={cn(
-          "pointer-events-none absolute right-2 top-1/2 z-10 grid size-8 -translate-y-1/2 place-items-center rounded-md border border-white/15 bg-[#111719] text-dashboard-text-muted opacity-0 shadow-[-8px_0_12px_rgba(9,12,14,0.8)] transition hover:border-white/30 hover:text-dashboard-text focus:pointer-events-auto focus:opacity-100 focus:outline-none focus:ring-2 focus:ring-cyan-300/35 group-focus-within:pointer-events-auto group-focus-within:opacity-100 group-hover:pointer-events-auto group-hover:opacity-100",
-          archive.error && "border-rose-300/30 text-rose-200/80",
-        )}
+        className="pointer-events-none absolute right-2 top-1/2 z-10 grid size-8 -translate-y-1/2 place-items-center rounded-md border border-white/15 bg-[#111719] text-dashboard-text-muted opacity-0 shadow-[-8px_0_12px_rgba(9,12,14,0.8)] transition hover:border-white/30 hover:text-dashboard-text focus:pointer-events-auto focus:opacity-100 focus:outline-none focus:ring-2 focus:ring-cyan-300/35 group-focus-within:pointer-events-auto group-focus-within:opacity-100 group-hover:pointer-events-auto group-hover:opacity-100"
         disabled={archive.isPending}
         onClick={() =>
           archive.mutate({
@@ -155,13 +177,37 @@ function ConversationSidebarRow(props: {
             lastSeenAt: props.conversation.lastSeenAt,
           })
         }
-        title={
-          archive.error ? `Could not archive ${title}` : `Archive ${title}`
-        }
+        title={`Archive ${title}`}
         type="button"
       >
         <Archive aria-hidden="true" size={15} />
       </button>
+    </div>
+  );
+}
+
+function ArchiveConversationErrorNotice(props: {
+  conversation: Conversation;
+  onDismiss(): void;
+}) {
+  const title = conversationDisplayTitle(props.conversation);
+  return (
+    <div className="absolute bottom-3 left-3 right-3 z-20 rounded-lg border border-rose-300/25 bg-[#111719] px-3 py-2.5 shadow-[0_12px_32px_rgba(0,0,0,0.45)]">
+      <div className="flex min-w-0 items-center gap-3">
+        <div
+          className="min-w-0 flex-1 font-mono text-[0.68rem] text-rose-200/80"
+          role="alert"
+        >
+          Could not archive {title}.
+        </div>
+        <button
+          className="shrink-0 rounded border border-white/15 px-2 py-1 font-mono text-[0.65rem] text-dashboard-text-muted transition hover:border-white/30 hover:text-dashboard-text focus:outline-none focus:ring-2 focus:ring-cyan-300/35"
+          onClick={props.onDismiss}
+          type="button"
+        >
+          Dismiss
+        </button>
+      </div>
     </div>
   );
 }

--- a/packages/junior-dashboard/src/client/components/ConversationSidebar.tsx
+++ b/packages/junior-dashboard/src/client/components/ConversationSidebar.tsx
@@ -12,8 +12,11 @@ import {
 } from "../format";
 import { cn } from "../styles";
 import type { Conversation } from "../types";
+import { AnimatedList } from "./AnimatedList";
 import { EmptyTelemetry } from "./EmptyTelemetry";
 import { SearchInput } from "./SearchInput";
+
+const conversationKey = (conversation: Conversation) => conversation.id;
 
 /** Render the compact personal conversation picker used by the home workspace. */
 export function ConversationSidebar(props: {
@@ -61,16 +64,20 @@ export function ConversationSidebar(props: {
             <EmptyTelemetry>No conversations match this view.</EmptyTelemetry>
           </div>
         ) : (
-          <nav aria-label="Your conversations" className="grid gap-1">
-            {props.conversations.map((conversation) => (
+          <AnimatedList
+            ariaLabel="Your conversations"
+            className="grid gap-1"
+            getKey={conversationKey}
+            items={props.conversations}
+            renderItem={(conversation) => (
               <ConversationSidebarRow
                 conversation={conversation}
-                key={conversation.id}
                 onArchived={setArchivedConversation}
                 selected={conversation.id === props.selectedId}
               />
-            ))}
-          </nav>
+            )}
+            role="navigation"
+          />
         )}
       </div>
       {archivedConversation ? (
@@ -88,7 +95,11 @@ function ConversationSidebarRow(props: {
   onArchived(conversation: Conversation): void;
   selected: boolean;
 }) {
-  const archive = useArchiveConversation(props.conversation.id);
+  const archive = useArchiveConversation(props.conversation.id, {
+    onSuccess: (archived) => {
+      if (archived) props.onArchived(props.conversation);
+    },
+  });
   const status = visualStatusForConversation(props.conversation);
   const location = slackLocationLabel(props.conversation, {
     includeId: false,
@@ -139,15 +150,10 @@ function ConversationSidebarRow(props: {
         )}
         disabled={archive.isPending}
         onClick={() =>
-          archive.mutate(
-            {
-              archived: true,
-              lastSeenAt: props.conversation.lastSeenAt,
-            },
-            {
-              onSuccess: () => props.onArchived(props.conversation),
-            },
-          )
+          archive.mutate({
+            archived: true,
+            lastSeenAt: props.conversation.lastSeenAt,
+          })
         }
         title={
           archive.error ? `Could not archive ${title}` : `Archive ${title}`
@@ -164,7 +170,11 @@ function ArchivedConversationNotice(props: {
   conversation: Conversation;
   onRestored(): void;
 }) {
-  const restore = useArchiveConversation(props.conversation.id);
+  const restore = useArchiveConversation(props.conversation.id, {
+    onSuccess: (archived) => {
+      if (!archived) props.onRestored();
+    },
+  });
   const title = conversationDisplayTitle(props.conversation);
   return (
     <div className="absolute bottom-3 left-3 right-3 z-20 rounded-lg border border-white/15 bg-[#111719] px-3 py-2.5 shadow-[0_12px_32px_rgba(0,0,0,0.45)]">
@@ -180,13 +190,10 @@ function ArchivedConversationNotice(props: {
           className="shrink-0 rounded border border-white/15 px-2 py-1 font-mono text-[0.65rem] text-cyan-100/75 transition hover:border-white/30 hover:text-cyan-50 focus:outline-none focus:ring-2 focus:ring-cyan-300/35 disabled:opacity-40"
           disabled={restore.isPending}
           onClick={() =>
-            restore.mutate(
-              {
-                archived: false,
-                lastSeenAt: props.conversation.lastSeenAt,
-              },
-              { onSuccess: props.onRestored },
-            )
+            restore.mutate({
+              archived: false,
+              lastSeenAt: props.conversation.lastSeenAt,
+            })
           }
           type="button"
         >

--- a/packages/junior-dashboard/src/client/conversations/queries.ts
+++ b/packages/junior-dashboard/src/client/conversations/queries.ts
@@ -10,6 +10,7 @@ import type {
   ConversationDetailReport,
   ConversationEventPage,
   ConversationFeed,
+  ConversationSummaryReport,
 } from "@sentry/junior/api/schema";
 import {
   archiveConversationResponseSchema,
@@ -33,6 +34,15 @@ export function conversationDetailQueryKey(conversationId: string | undefined) {
   return ["conversation", conversationId, "detail"] as const;
 }
 
+function archivedConversationQueryKey(conversationId: string) {
+  return ["dashboard", "archived-conversation", conversationId] as const;
+}
+
+type ArchivedConversationSnapshot = {
+  conversation: ConversationSummaryReport;
+  feedQueryHashes: string[];
+};
+
 /** Define the bounded, polling conversation-detail resource. */
 export function conversationDetailQueryOptions(
   conversationId: string | undefined,
@@ -50,7 +60,10 @@ export function conversationDetailQueryOptions(
 /** Archive or restore one conversation with an immediate reversible cache update. */
 export function useArchiveConversation(
   conversationId: string,
-  options?: { onSuccess?(archived: boolean): void },
+  options?: {
+    onError?(): void;
+    onSuccess?(archived: boolean): void;
+  },
 ) {
   const queryClient = useQueryClient();
   return useMutation({
@@ -63,6 +76,7 @@ export function useArchiveConversation(
     onMutate: async (args) => {
       const conversationQueries = { queryKey: ["dashboard", "conversations"] };
       const detailQueryKey = conversationDetailQueryKey(conversationId);
+      const archivedQueryKey = archivedConversationQueryKey(conversationId);
       await Promise.all([
         queryClient.cancelQueries(conversationQueries),
         queryClient.cancelQueries({ queryKey: detailQueryKey }),
@@ -71,27 +85,58 @@ export function useArchiveConversation(
         queryClient.getQueriesData<ConversationFeed>(conversationQueries);
       const previousDetail =
         queryClient.getQueryData<ConversationDetailReport>(detailQueryKey);
+      const previousArchivedSnapshot =
+        queryClient.getQueryData<ArchivedConversationSnapshot>(
+          archivedQueryKey,
+        );
       const archivedAt = args.archived ? new Date().toISOString() : undefined;
+      const archivedSnapshot = args.archived
+        ? (buildArchivedConversationSnapshot(previousFeeds, conversationId) ??
+          previousArchivedSnapshot)
+        : previousArchivedSnapshot;
 
-      queryClient.setQueriesData<ConversationFeed>(
-        conversationQueries,
-        (feed) =>
-          feed
-            ? {
-                ...feed,
-                conversations: feed.conversations.map((conversation) =>
-                  conversation.conversationId === conversationId
-                    ? { ...conversation, archivedAt }
-                    : conversation,
-                ),
-              }
-            : feed,
-      );
+      previousFeeds.forEach(([queryKey, feed]) => {
+        if (!feed) return;
+        const conversationExists = feed.conversations.some(
+          (conversation) => conversation.conversationId === conversationId,
+        );
+        const shouldRestore =
+          !args.archived &&
+          !conversationExists &&
+          Boolean(
+            archivedSnapshot?.feedQueryHashes.includes(
+              JSON.stringify(queryKey),
+            ),
+          );
+        const conversations = shouldRestore
+          ? [
+              ...feed.conversations,
+              { ...archivedSnapshot!.conversation, archivedAt: undefined },
+            ].sort((a, b) => b.lastSeenAt.localeCompare(a.lastSeenAt))
+          : feed.conversations.map((conversation) =>
+              conversation.conversationId === conversationId
+                ? { ...conversation, archivedAt }
+                : conversation,
+            );
+        queryClient.setQueryData<ConversationFeed>(queryKey, {
+          ...feed,
+          conversations,
+        });
+      });
       queryClient.setQueryData<ConversationDetailReport>(
         detailQueryKey,
         (detail) => (detail ? { ...detail, archivedAt } : detail),
       );
-      return { detailQueryKey, previousDetail, previousFeeds };
+      if (archivedSnapshot) {
+        queryClient.setQueryData(archivedQueryKey, archivedSnapshot);
+      }
+      return {
+        archivedQueryKey,
+        detailQueryKey,
+        previousArchivedSnapshot,
+        previousDetail,
+        previousFeeds,
+      };
     },
     onError: (_error, _args, context) => {
       context?.previousFeeds.forEach(([queryKey, feed]) => {
@@ -102,9 +147,29 @@ export function useArchiveConversation(
           context.detailQueryKey,
           context.previousDetail,
         );
+        if (context.previousArchivedSnapshot) {
+          queryClient.setQueryData(
+            context.archivedQueryKey,
+            context.previousArchivedSnapshot,
+          );
+        } else {
+          queryClient.removeQueries({
+            exact: true,
+            queryKey: context.archivedQueryKey,
+          });
+        }
       }
+      options?.onError?.();
     },
-    onSuccess: (_result, args) => options?.onSuccess?.(args.archived),
+    onSuccess: (_result, args) => {
+      if (!args.archived) {
+        queryClient.removeQueries({
+          exact: true,
+          queryKey: archivedConversationQueryKey(conversationId),
+        });
+      }
+      options?.onSuccess?.(args.archived);
+    },
     onSettled: async () => {
       await Promise.all([
         queryClient.invalidateQueries({
@@ -121,6 +186,23 @@ export function useArchiveConversation(
       ]);
     },
   });
+}
+
+function buildArchivedConversationSnapshot(
+  feeds: Array<[readonly unknown[], ConversationFeed | undefined]>,
+  conversationId: string,
+): ArchivedConversationSnapshot | undefined {
+  let conversation: ConversationSummaryReport | undefined;
+  const feedQueryHashes: string[] = [];
+  for (const [queryKey, feed] of feeds) {
+    const feedConversation = feed?.conversations.find(
+      (item) => item.conversationId === conversationId,
+    );
+    if (!feedConversation) continue;
+    conversation ??= feedConversation;
+    feedQueryHashes.push(JSON.stringify(queryKey));
+  }
+  return conversation ? { conversation, feedQueryHashes } : undefined;
 }
 
 /** Fetch a bounded conversation snapshot and older pages on demand. */

--- a/packages/junior-dashboard/src/client/conversations/queries.ts
+++ b/packages/junior-dashboard/src/client/conversations/queries.ts
@@ -9,6 +9,7 @@ import {
 import type {
   ConversationDetailReport,
   ConversationEventPage,
+  ConversationFeed,
 } from "@sentry/junior/api/schema";
 import {
   archiveConversationResponseSchema,
@@ -46,8 +47,11 @@ export function conversationDetailQueryOptions(
   });
 }
 
-/** Archive or restore one conversation and refresh its related resources. */
-export function useArchiveConversation(conversationId: string) {
+/** Archive or restore one conversation with an immediate reversible cache update. */
+export function useArchiveConversation(
+  conversationId: string,
+  options?: { onSuccess?(archived: boolean): void },
+) {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (args: { archived: boolean; lastSeenAt: string }) =>
@@ -56,6 +60,51 @@ export function useArchiveConversation(conversationId: string) {
         `/api/conversations/${encodeURIComponent(conversationId)}/archive`,
         args,
       ),
+    onMutate: async (args) => {
+      const conversationQueries = { queryKey: ["dashboard", "conversations"] };
+      const detailQueryKey = conversationDetailQueryKey(conversationId);
+      await Promise.all([
+        queryClient.cancelQueries(conversationQueries),
+        queryClient.cancelQueries({ queryKey: detailQueryKey }),
+      ]);
+      const previousFeeds =
+        queryClient.getQueriesData<ConversationFeed>(conversationQueries);
+      const previousDetail =
+        queryClient.getQueryData<ConversationDetailReport>(detailQueryKey);
+      const archivedAt = args.archived ? new Date().toISOString() : undefined;
+
+      queryClient.setQueriesData<ConversationFeed>(
+        conversationQueries,
+        (feed) =>
+          feed
+            ? {
+                ...feed,
+                conversations: feed.conversations.map((conversation) =>
+                  conversation.conversationId === conversationId
+                    ? { ...conversation, archivedAt }
+                    : conversation,
+                ),
+              }
+            : feed,
+      );
+      queryClient.setQueryData<ConversationDetailReport>(
+        detailQueryKey,
+        (detail) => (detail ? { ...detail, archivedAt } : detail),
+      );
+      return { detailQueryKey, previousDetail, previousFeeds };
+    },
+    onError: (_error, _args, context) => {
+      context?.previousFeeds.forEach(([queryKey, feed]) => {
+        queryClient.setQueryData(queryKey, feed);
+      });
+      if (context) {
+        queryClient.setQueryData(
+          context.detailQueryKey,
+          context.previousDetail,
+        );
+      }
+    },
+    onSuccess: (_result, args) => options?.onSuccess?.(args.archived),
     onSettled: async () => {
       await Promise.all([
         queryClient.invalidateQueries({

--- a/packages/junior-dashboard/src/client/conversations/queries.ts
+++ b/packages/junior-dashboard/src/client/conversations/queries.ts
@@ -3,6 +3,7 @@ import {
   queryOptions,
   useInfiniteQuery,
   useMutation,
+  useMutationState,
   useQuery,
   useQueryClient,
 } from "@tanstack/react-query";
@@ -43,6 +44,55 @@ type ArchivedConversationSnapshot = {
   feedQueryHashes: string[];
 };
 
+const archiveConversationMutationKey = [
+  "dashboard",
+  "archive-conversation",
+] as const;
+
+type ArchiveConversationVariables = {
+  archived: boolean;
+  lastSeenAt: string;
+};
+
+type ArchiveConversationMutationContext = {
+  archivedQueryKey: ReturnType<typeof archivedConversationQueryKey>;
+  archivedSnapshot?: ArchivedConversationSnapshot;
+  detailQueryKey: ReturnType<typeof conversationDetailQueryKey>;
+  previousArchivedSnapshot?: ArchivedConversationSnapshot;
+  previousDetail?: ConversationDetailReport;
+  previousFeeds: Array<[readonly unknown[], ConversationFeed | undefined]>;
+};
+
+export type PendingArchiveConversationUpdate = {
+  archived: boolean;
+  conversation?: ConversationSummaryReport;
+  conversationId: string;
+};
+
+/** Read pending archive state so refetches cannot visually replace optimistic UI. */
+export function usePendingArchiveConversationUpdates() {
+  return useMutationState({
+    filters: {
+      mutationKey: archiveConversationMutationKey,
+      status: "pending",
+    },
+    select: (mutation) => {
+      const variables = mutation.state
+        .variables as ArchiveConversationVariables;
+      const context = mutation.state.context as
+        | ArchiveConversationMutationContext
+        | undefined;
+      const conversationId = mutation.options.mutationKey?.[2];
+      return {
+        archived: variables.archived,
+        conversation: context?.archivedSnapshot?.conversation,
+        conversationId:
+          typeof conversationId === "string" ? conversationId : "",
+      } satisfies PendingArchiveConversationUpdate;
+    },
+  });
+}
+
 /** Define the bounded, polling conversation-detail resource. */
 export function conversationDetailQueryOptions(
   conversationId: string | undefined,
@@ -67,7 +117,8 @@ export function useArchiveConversation(
 ) {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (args: { archived: boolean; lastSeenAt: string }) =>
+    mutationKey: [...archiveConversationMutationKey, conversationId],
+    mutationFn: (args: ArchiveConversationVariables) =>
       patch(
         archiveConversationResponseSchema,
         `/api/conversations/${encodeURIComponent(conversationId)}/archive`,
@@ -132,11 +183,12 @@ export function useArchiveConversation(
       }
       return {
         archivedQueryKey,
+        archivedSnapshot,
         detailQueryKey,
         previousArchivedSnapshot,
         previousDetail,
         previousFeeds,
-      };
+      } satisfies ArchiveConversationMutationContext;
     },
     onError: (_error, _args, context) => {
       context?.previousFeeds.forEach(([queryKey, feed]) => {

--- a/packages/junior-dashboard/src/client/pages/ConversationPage.tsx
+++ b/packages/junior-dashboard/src/client/pages/ConversationPage.tsx
@@ -13,6 +13,7 @@ import type { ConversationFeed } from "@sentry/junior/api/schema";
 import {
   useArchiveConversation,
   useConversationData,
+  type PendingArchiveConversationUpdate,
 } from "../conversations/queries";
 import { buildConversationMarkdown } from "../markdownExport";
 import { CopyMarkdownButton } from "../components/CopyMarkdownButton";
@@ -51,6 +52,7 @@ import type { Conversation } from "../types";
 export function ConversationPage(props: {
   conversationId: string;
   data?: { conversations: ConversationFeed };
+  pendingArchiveUpdate?: PendingArchiveConversationUpdate;
 }) {
   const [subagentTarget, setSubagentTarget] =
     useState<SubagentTranscriptTarget>();
@@ -62,7 +64,10 @@ export function ConversationPage(props: {
   const feedConversation = conversations.find(
     (item) => item.id === conversationId,
   );
-  const conversation = conversationFromDetail(detail.data) ?? feedConversation;
+  const conversation = applyPendingArchiveUpdate(
+    conversationFromDetail(detail.data) ?? feedConversation,
+    props.pendingArchiveUpdate,
+  );
   const conversationDetail = detail.data;
   const visualStatus = conversation
     ? visualStatusForConversation(conversation)
@@ -177,6 +182,24 @@ export function ConversationPage(props: {
       />
     </div>
   );
+}
+
+function applyPendingArchiveUpdate(
+  conversation: Conversation | undefined,
+  update: PendingArchiveConversationUpdate | undefined,
+): Conversation | undefined {
+  const updatedConversation =
+    conversation ??
+    (update?.conversation
+      ? buildConversations([update.conversation])[0]
+      : undefined);
+  if (!updatedConversation || !update) return updatedConversation;
+  return {
+    ...updatedConversation,
+    archivedAt: update.archived
+      ? (updatedConversation.archivedAt ?? updatedConversation.lastSeenAt)
+      : undefined,
+  };
 }
 
 function ConversationAnnotations(props: {

--- a/packages/junior-dashboard/src/client/pages/ConversationWorkspace.tsx
+++ b/packages/junior-dashboard/src/client/pages/ConversationWorkspace.tsx
@@ -5,11 +5,16 @@ import { Link, useNavigate, useParams } from "react-router";
 import { useConversationsData } from "../api";
 import { ConversationSidebar } from "../components/ConversationSidebar";
 import {
+  usePendingArchiveConversationUpdates,
+  type PendingArchiveConversationUpdate,
+} from "../conversations/queries";
+import {
   buildConversations,
   conversationPath,
   filterConversationList,
 } from "../format";
 import type { DashboardCoreData } from "../types";
+import type { Conversation } from "../types";
 import { cn, dashboardContainerClass } from "../styles";
 import { ConversationPage } from "./ConversationPage";
 
@@ -23,9 +28,14 @@ export function ConversationWorkspace(props: { data: DashboardCoreData }) {
   const feed = useConversationsData(
     props.data.config.authRequired ? props.data.me.user.email : undefined,
   );
+  const pendingArchiveUpdates = usePendingArchiveConversationUpdates();
   const conversations = useMemo(
-    () => buildConversations(feed.data?.conversations ?? []),
-    [feed.data?.conversations],
+    () =>
+      applyPendingArchiveUpdates(
+        buildConversations(feed.data?.conversations ?? []),
+        pendingArchiveUpdates,
+      ),
+    [feed.data?.conversations, pendingArchiveUpdates],
   );
   const visibleConversations = useMemo(
     () =>
@@ -108,6 +118,9 @@ export function ConversationWorkspace(props: { data: DashboardCoreData }) {
                       }
                     : undefined
                 }
+                pendingArchiveUpdate={pendingArchiveUpdates.find(
+                  (update) => update.conversationId === selectedId,
+                )}
               />
             </div>
           </>
@@ -125,5 +138,32 @@ export function ConversationWorkspace(props: { data: DashboardCoreData }) {
         )}
       </section>
     </div>
+  );
+}
+
+function applyPendingArchiveUpdates(
+  conversations: Conversation[],
+  updates: PendingArchiveConversationUpdate[],
+): Conversation[] {
+  const byId = new Map(
+    conversations.map((conversation) => [conversation.id, conversation]),
+  );
+  for (const update of updates) {
+    const existing = byId.get(update.conversationId);
+    const conversation =
+      existing ??
+      (update.conversation
+        ? buildConversations([update.conversation])[0]
+        : undefined);
+    if (!conversation) continue;
+    byId.set(update.conversationId, {
+      ...conversation,
+      archivedAt: update.archived
+        ? (conversation.archivedAt ?? conversation.lastSeenAt)
+        : undefined,
+    });
+  }
+  return [...byId.values()].sort((a, b) =>
+    b.lastSeenAt.localeCompare(a.lastSeenAt),
   );
 }


### PR DESCRIPTION
Conversation rows now leave the sidebar immediately with a short collapse and fade animation when archived, and restored rows animate back in. Archive mutations update cached conversation data optimistically and roll back on failure, so the motion starts on click instead of waiting for a refetch.

The shared animated-list primitive honors reduced-motion preferences, makes exiting content inert, and briefly blocks list interaction so the row moving under the cursor cannot be archived accidentally. Existing archive, undo, navigation, and error behavior remain unchanged.

Validated in Chromium with deterministic dashboard data, including a captured intermediate animation frame and reduced-motion behavior. The existing archive and restore browser scenario continues to pass.
