### PR TITLE
fix(dashboard): show ellipsis for long conversation titles

### DIFF
--- a/packages/junior-dashboard/src/client/pages/ConversationPage.tsx
+++ b/packages/junior-dashboard/src/client/pages/ConversationPage.tsx
@@ -82,7 +82,7 @@ export function ConversationPage(props: {
               Conversation
             </div>
             <div className="min-w-0">
-              <h2 className="m-0 font-display text-2xl font-medium leading-tight tracking-[-0.03em] md:text-[1.75rem]">
+              <h2 className="m-0 truncate font-display text-2xl font-medium leading-tight tracking-[-0.03em] md:text-[1.75rem]">
                 {conversationDisplayTitle(conversation)}
               </h2>
             </div>


### PR DESCRIPTION
Long conversation titles in the dashboard transcript header now use the same single-line ellipsis treatment as titles in the conversation sidebar. The header previously clipped overflowing text because its container hid overflow without applying text-overflow styling. Validated with the dashboard typecheck and the repository commit checks.
