### PR TITLE
fix(dashboard): attribute transcript messages to Slack actors

### DIFF
--- a/packages/junior-dashboard/src/client/components/ConversationTranscript.tsx
+++ b/packages/junior-dashboard/src/client/components/ConversationTranscript.tsx
@@ -14,11 +14,11 @@ import {
   transcriptRoleKind,
   formatMessageTimestamp,
   formatTranscriptDuration,
-  actorLabel,
   summarizeCost,
   summarizeTurns,
   summarizeToolCalls,
   summarizeUsage,
+  transcriptMessageActorLabel,
   unavailableTranscriptLabel,
   visualStatusForSummary,
 } from "../format";
@@ -142,15 +142,10 @@ function turnMarkerClass(
 }
 
 function transcriptRoleLabel(
-  role: string,
+  message: TranscriptViewMessage,
   conversation: ConversationTranscript,
 ): string {
-  const kind = transcriptRoleKind(role);
-  if (kind === "assistant") return getDashboardAgentName();
-  if (kind === "user") return transcriptActorLabel(conversation);
-  if (kind === "system") return "System";
-  if (kind === "tool") return "Tool";
-  return role;
+  return transcriptMessageActorLabel(conversation, message);
 }
 
 function transcriptMessageClass(role: string): string {
@@ -214,7 +209,7 @@ function TranscriptMessageShell(props: {
 
 function TranscriptMessageHeader(props: {
   meta?: Array<string | undefined>;
-  role: string;
+  message: TranscriptViewMessage;
   conversation: ConversationTranscript;
 }) {
   const metaText = props.meta?.filter(isString).join(" · ");
@@ -222,11 +217,11 @@ function TranscriptMessageHeader(props: {
   return (
     <TranscriptHeadingRow
       left={
-        <span className={transcriptRoleLabelClass(props.role)}>
-          {transcriptRoleLabel(props.role, props.conversation)}
+        <span className={transcriptRoleLabelClass(props.message.role)}>
+          {transcriptRoleLabel(props.message, props.conversation)}
         </span>
       }
-      leftClassName={transcriptRoleClass(props.role)}
+      leftClassName={transcriptRoleClass(props.message.role)}
       right={
         metaText ? (
           <TranscriptHeadingMeta className="text-[0.78rem] text-dashboard-text-muted">
@@ -600,7 +595,7 @@ function RedactedMessageView(props: {
     <TranscriptMessageShell role={props.message.role}>
       <TranscriptMessageHeader
         meta={meta}
-        role={props.message.role}
+        message={props.message}
         conversation={props.conversation}
       />
       <div className="grid min-w-0 grid-cols-[minmax(0,1fr)] gap-1 font-mono text-[0.9rem] leading-snug text-dashboard-text-muted">
@@ -631,10 +626,6 @@ function RedactedMarker() {
       {"<redacted>"}
     </code>
   );
-}
-
-function transcriptActorLabel(conversation: ConversationTranscript): string {
-  return actorLabel(conversation.actorIdentity) ?? "User";
 }
 
 function transcriptMeta(
@@ -783,7 +774,7 @@ function TranscriptMessageView(props: {
             : undefined,
           formatMessageTimestamp(props.message.timestamp),
         ]}
-        role={props.message.role}
+        message={props.message}
         conversation={props.conversation}
       />
       {props.view === "raw" ? (

--- a/packages/junior-dashboard/src/client/conversations/eventTranscript.ts
+++ b/packages/junior-dashboard/src/client/conversations/eventTranscript.ts
@@ -120,6 +120,7 @@ export function conversationTranscriptMessages(
             ? { type: "text", redacted: true }
             : { type: "text", text: data.text! },
         ]),
+        ...(data.actorIdentity ? { actorIdentity: data.actorIdentity } : {}),
         ...(data.eventType ? { eventType: data.eventType } : {}),
       };
       messages.push(message);

--- a/packages/junior-dashboard/src/client/format.ts
+++ b/packages/junior-dashboard/src/client/format.ts
@@ -286,14 +286,19 @@ export type MessageSummary = {
   total: number;
 };
 
-function transcriptMessageAuthor(
+/** Return the best available actor label for one transcript message. */
+export function transcriptMessageActorLabel(
   conversation: ConversationTranscript,
   message: TranscriptViewMessage,
 ): string {
   const kind = transcriptRoleKind(message.role);
   if (kind === "assistant") return getDashboardAgentName();
   if (kind === "user") {
-    return actorLabel(conversation.actorIdentity) ?? "User";
+    return (
+      actorLabel(message.actorIdentity) ??
+      actorLabel(conversation.actorIdentity) ??
+      "User"
+    );
   }
   if (kind === "system") return "System";
   if (kind === "tool") return "Tool";
@@ -315,7 +320,7 @@ export function summarizeMessages(
   for (const message of transcriptSource(conversation)) {
     if (!isConversationMessage(message)) continue;
     items.push({
-      author: transcriptMessageAuthor(conversation, message),
+      author: transcriptMessageActorLabel(conversation, message),
       bytes: message.parts.reduce(
         (sum, part) => sum + transcriptPartBytes(part),
         0,
@@ -339,7 +344,7 @@ export function summarizeTurns(
   if (userMessages.length > 0) {
     return {
       items: userMessages.map((message) => ({
-        author: transcriptMessageAuthor(conversation, message),
+        author: transcriptMessageActorLabel(conversation, message),
         bytes: message.parts.reduce(
           (sum, part) => sum + transcriptPartBytes(part),
           0,

--- a/packages/junior-dashboard/src/client/markdownExport.ts
+++ b/packages/junior-dashboard/src/client/markdownExport.ts
@@ -7,7 +7,7 @@ import {
   actorLabel,
   slackLocationLabel,
   stringifyPartValue,
-  transcriptRoleKind,
+  transcriptMessageActorLabel,
   unavailableTranscriptLabel,
 } from "./format";
 import {
@@ -412,13 +412,9 @@ function messageRoleLabel(
   message: TranscriptViewMessage,
   conversationTranscript: ConversationTranscript,
 ): string {
-  const kind = transcriptRoleKind(message.role);
-  if (kind === "assistant") return getDashboardAgentName();
-  if (kind === "user")
-    return actorLabel(conversationTranscript.actorIdentity) ?? "User";
-  if (kind === "system") return "System";
-  if (kind === "tool") return "Tool";
-  return headingText(message.role || "Unknown");
+  return headingText(
+    transcriptMessageActorLabel(conversationTranscript, message),
+  );
 }
 
 function eventTimestamp(timestamp: number | undefined): string {

--- a/packages/junior-dashboard/src/client/types.ts
+++ b/packages/junior-dashboard/src/client/types.ts
@@ -5,6 +5,7 @@ import type {
   SkillReport,
 } from "@sentry/junior/api/schema";
 import type {
+  ActorIdentity,
   ConversationStatsReport,
   ConversationSummaryReport,
 } from "@sentry/junior/api/schema";
@@ -84,6 +85,7 @@ export type TranscriptViewTurnContext = {
 };
 
 export type TranscriptViewMessage = {
+  actorIdentity?: ActorIdentity;
   contexts?: TranscriptViewTurnContext[];
   eventType?: string;
   route?: {

--- a/packages/junior-dashboard/src/mock-reporting/fixtures.ts
+++ b/packages/junior-dashboard/src/mock-reporting/fixtures.ts
@@ -201,6 +201,7 @@ function dashboardQaConversation(nowMs: number): ConversationDetailReport {
         messageId: "qa-user",
         role: "user",
         text: "Review the dashboard plan before editing.",
+        actorIdentity: actor(undefined, "Taylor Chen", "taylor"),
       }),
       reportEvent(1, iso(Date.parse(startedAt), 2_000), {
         type: "tool_calls",

--- a/packages/junior-dashboard/tests/dashboard-mock-routes.test.ts
+++ b/packages/junior-dashboard/tests/dashboard-mock-routes.test.ts
@@ -225,6 +225,13 @@ describe("dashboard canonical-event mock routes", () => {
     ).toContain("webSearch");
 
     const dashboardQa = await readDetail(DASHBOARD_QA_CONVERSATION_ID);
+    expect(dashboardQa.events[0]?.data).toMatchObject({
+      type: "message",
+      actorIdentity: {
+        fullName: "Taylor Chen",
+        slackUserName: "taylor",
+      },
+    });
     expect(
       dashboardQa.events.some(
         (event) =>

--- a/packages/junior-dashboard/tests/format.test.ts
+++ b/packages/junior-dashboard/tests/format.test.ts
@@ -159,6 +159,10 @@ describe("dashboard conversation formatting", () => {
           messageId: "user",
           role: "user",
           text: "run search",
+          actorIdentity: {
+            fullName: "Taylor Chen",
+            slackUserName: "taylor",
+          },
         }),
         event(1, {
           type: "tool_calls",
@@ -196,13 +200,13 @@ describe("dashboard conversation formatting", () => {
     });
     expect(summarizeMessages(conversation)).toEqual({
       items: [
-        { author: "Alice", bytes: 10 },
+        { author: "Taylor Chen", bytes: 10 },
         { author: "Junior", bytes: 4 },
       ],
       total: 2,
     });
     expect(summarizeTurns(conversation)).toEqual({
-      items: [{ author: "Alice", bytes: 10 }],
+      items: [{ author: "Taylor Chen", bytes: 10 }],
       total: 1,
     });
   });

--- a/packages/junior-dashboard/tests/markdownExport.test.ts
+++ b/packages/junior-dashboard/tests/markdownExport.test.ts
@@ -59,6 +59,10 @@ describe("dashboard canonical-event Markdown export", () => {
           messageId: "user-1",
           role: "user",
           text: "please investigate",
+          actorIdentity: {
+            fullName: "Taylor Chen",
+            slackUserName: "taylor",
+          },
         }),
         event(2, {
           type: "message",
@@ -70,7 +74,8 @@ describe("dashboard canonical-event Markdown export", () => {
     );
 
     expect(markdown).toContain("# Canonical conversation");
-    expect(markdown).toContain("### alice@example.com");
+    expect(markdown).toContain("### Taylor Chen");
+    expect(markdown).not.toContain("### alice@example.com");
     expect(markdown).toContain("please investigate");
     expect(markdown).toContain("### Junior");
     expect(markdown.match(/investigation complete/g)).toHaveLength(1);

--- a/packages/junior-dashboard/tests/telemetry-components.test.tsx
+++ b/packages/junior-dashboard/tests/telemetry-components.test.tsx
@@ -345,6 +345,29 @@ describe("dashboard canonical-event components", () => {
     expect(completeHtml).toContain("1 tool call");
   });
 
+  it("renders each user message with its own actor", () => {
+    const html = renderTranscript(
+      conversation(
+        [
+          event(0, {
+            type: "message",
+            messageId: "user-1",
+            role: "user",
+            text: "Good catch.",
+            actorIdentity: {
+              fullName: "Taylor Chen",
+              slackUserName: "taylor",
+            },
+          }),
+        ],
+        { actorIdentity: { fullName: "Morgan Lee" } },
+      ),
+    );
+
+    expect(html).toContain("Taylor Chen");
+    expect(html).not.toContain("Morgan Lee");
+  });
+
   it("omits status badges from conversation detail while retaining progress", () => {
     const activeClient = conversationQueryClient();
     activeClient.setQueryData(

--- a/packages/junior/src/api/conversations/events.ts
+++ b/packages/junior/src/api/conversations/events.ts
@@ -79,6 +79,14 @@ const reportingMediaPartSchema = z
   })
   .passthrough();
 
+const reportingMessageAuthorSchema = z
+  .object({
+    fullName: z.string().min(1).optional(),
+    userId: z.string().min(1).optional(),
+    userName: z.string().min(1).optional(),
+  })
+  .passthrough();
+
 type ReportingModelContentPart =
   | { type: "text"; text: string }
   | { type: "image" | "audio"; mimeType?: string };
@@ -114,6 +122,20 @@ function modelVisibleToolOutput(content: unknown[]): unknown {
 
   const only = sanitized[0]!;
   return only.type === "text" ? only.text : only;
+}
+
+function reportMessageActorIdentity(
+  data: Extract<ConversationEvent["data"], { type: "message" }>,
+): Extract<ConversationReportEventData, { type: "message" }>["actorIdentity"] {
+  if (data.role !== "user") return undefined;
+  const author = reportingMessageAuthorSchema.safeParse(data.meta?.author);
+  if (!author.success) return undefined;
+  const actorIdentity = {
+    ...(author.data.fullName ? { fullName: author.data.fullName } : {}),
+    ...(author.data.userId ? { slackUserId: author.data.userId } : {}),
+    ...(author.data.userName ? { slackUserName: author.data.userName } : {}),
+  };
+  return Object.keys(actorIdentity).length > 0 ? actorIdentity : undefined;
 }
 
 /** Project native assistant tool calls through the existing reporting shape. */
@@ -268,11 +290,15 @@ function reportEventData(args: {
 }): ConversationReportEventData | undefined {
   const { data } = args;
   switch (data.type) {
-    case "message":
+    case "message": {
+      const actorIdentity = args.canExposePayload
+        ? reportMessageActorIdentity(data)
+        : undefined;
       return {
         type: "message",
         messageId: data.messageId,
         role: data.role,
+        ...(actorIdentity ? { actorIdentity } : {}),
         ...(typeof data.meta?.eventType === "string"
           ? { eventType: data.meta.eventType }
           : {}),
@@ -280,6 +306,7 @@ function reportEventData(args: {
           ? { text: data.text }
           : { redacted: true as const }),
       };
+    }
     case "message_handled":
       return {
         type: "message_handled",

--- a/packages/junior/src/api/schema/conversation.ts
+++ b/packages/junior/src/api/schema/conversation.ts
@@ -92,6 +92,7 @@ const conversationReportMessageEventDataSchema = z
     type: z.literal("message"),
     messageId: z.string().min(1),
     role: z.enum(["assistant", "system", "user"]),
+    actorIdentity: actorIdentitySchema.optional(),
     eventType: z.string().min(1).optional(),
     text: z.string().optional(),
     redacted: z.literal(true).optional(),
@@ -102,6 +103,12 @@ const conversationReportMessageEventDataSchema = z
       context.addIssue({
         code: "custom",
         message: "message content must be text or explicitly redacted",
+      });
+    }
+    if (data.redacted && data.actorIdentity) {
+      context.addIssue({
+        code: "custom",
+        message: "redacted messages must not expose actor identity",
       });
     }
   });

--- a/packages/junior/tests/unit/api/conversation-events.test.ts
+++ b/packages/junior/tests/unit/api/conversation-events.test.ts
@@ -61,6 +61,64 @@ describe("conversation report event projection", () => {
     ).toEqual([]);
   });
 
+  it("projects the stored actor identity for each visible user message", () => {
+    const message = event(1, {
+      type: "message",
+      messageId: "message-1",
+      role: "user",
+      text: "good catch",
+      meta: {
+        author: {
+          fullName: "Taylor Chen",
+          isBot: false,
+          userId: "U0TAYLOR",
+          userName: "taylor",
+        },
+      },
+    });
+
+    expect(
+      projectConversationReportEventPage({
+        canExposePayload: true,
+        events: [message],
+      }),
+    ).toEqual([
+      {
+        seq: 1,
+        createdAt: "1970-01-01T00:00:01.000Z",
+        data: {
+          type: "message",
+          messageId: "message-1",
+          role: "user",
+          text: "good catch",
+          actorIdentity: {
+            fullName: "Taylor Chen",
+            slackUserId: "U0TAYLOR",
+            slackUserName: "taylor",
+          },
+        },
+      },
+    ]);
+
+    expect(
+      projectConversationReportEventPage({
+        canExposePayload: false,
+        events: [message],
+      }),
+    ).toEqual([
+      {
+        seq: 1,
+        createdAt: "1970-01-01T00:00:01.000Z",
+        data: {
+          type: "message",
+          messageId: "message-1",
+          role: "user",
+          redacted: true,
+        },
+      },
+    ]);
+  });
+
   it("projects turn context only across the authorized payload boundary", () => {
     const context = event(1, {
       type: "turn_context",


### PR DESCRIPTION
Transcript user rows now carry the actor stored on each message event through reporting into dashboard rendering, summaries, and Markdown exports. This fixes multi-participant Slack threads where every human message was labeled as the conversation starter.

The projection only exposes message actor identity when transcript payloads are authorized, so redacted history remains fail-closed. Regression coverage exercises API privacy, rendered transcript labels, exports, summaries, and mock reporting fixtures.