### PR TITLE
feat(dashboard): add Guardian stats to System

### DIFF
--- a/packages/junior-dashboard/src/client/pages/system/GuardianActivity.tsx
+++ b/packages/junior-dashboard/src/client/pages/system/GuardianActivity.tsx
@@ -1,0 +1,175 @@
+import type { GuardianMetricDay } from "@sentry/junior/api/schema";
+
+import { Tooltip } from "../../components/Tooltip";
+import { Card } from "../../components/layout/Card";
+import { formatCompactNumber, formatCostSummary } from "../../format";
+
+function shortDate(date: string): string {
+  return new Date(`${date}T00:00:00.000Z`).toLocaleDateString(undefined, {
+    day: "numeric",
+    month: "short",
+    timeZone: "UTC",
+  });
+}
+
+function totals(days: GuardianMetricDay[]) {
+  return days.reduce(
+    (result, day) => ({
+      allow: result.allow + day.allow,
+      ask: result.ask + day.ask,
+      costUsd: result.costUsd + (day.costUsd ?? 0),
+      deny: result.deny + day.deny,
+      requests: result.requests + day.requests,
+    }),
+    { allow: 0, ask: 0, costUsd: 0, deny: 0, requests: 0 },
+  );
+}
+
+function Stat(props: {
+  label: string;
+  value: string;
+  valueClassName?: string;
+}) {
+  return (
+    <div className="rounded-md border border-white/[0.05] bg-black/10 px-3 py-3">
+      <div className="font-display text-xl font-light text-dashboard-text">
+        <span className={props.valueClassName}>{props.value}</span>
+      </div>
+      <div className="mt-1 font-mono text-[0.56rem] uppercase tracking-[0.1em] text-dashboard-text-muted">
+        {props.label}
+      </div>
+    </div>
+  );
+}
+
+/** Show Guardian request volume, result mix, and estimated cost by day. */
+export function GuardianActivity(props: { days: GuardianMetricDay[] }) {
+  const period = totals(props.days);
+  const maximum = Math.max(1, ...props.days.map((day) => day.requests));
+  const labels = [
+    0,
+    Math.floor((props.days.length - 1) / 2),
+    props.days.length - 1,
+  ].filter(
+    (index, position, indexes) =>
+      index >= 0 && indexes.indexOf(index) === position,
+  );
+
+  return (
+    <Card>
+      <div className="border-b border-white/[0.06] px-4 py-4">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <h3 className="m-0 font-mono text-[0.68rem] font-medium uppercase tracking-[0.14em] text-dashboard-text-muted">
+              Guardian reviews
+            </h3>
+            <p className="mt-1 mb-0 font-mono text-[0.64rem] leading-relaxed text-dashboard-text-muted">
+              Daily decisions before reviewed actions execute.
+            </p>
+          </div>
+          <div className="font-mono text-[0.58rem] uppercase tracking-[0.1em] text-dashboard-text-muted">
+            <span className="mr-3 text-emerald-200/75">Allow</span>
+            <span className="mr-3 text-amber-200/75">Ask</span>
+            <span className="text-rose-200/75">Deny</span>
+          </div>
+        </div>
+        <div className="mt-4 grid grid-cols-2 gap-2 sm:grid-cols-5">
+          <Stat label="Requests" value={formatCompactNumber(period.requests)} />
+          <Stat
+            label="Allowed"
+            value={formatCompactNumber(period.allow)}
+            valueClassName="text-emerald-100"
+          />
+          <Stat
+            label="Asked"
+            value={formatCompactNumber(period.ask)}
+            valueClassName="text-amber-100"
+          />
+          <Stat
+            label="Denied"
+            value={formatCompactNumber(period.deny)}
+            valueClassName="text-rose-100"
+          />
+          <Stat
+            label="Estimated cost"
+            value={formatCostSummary({ total: period.costUsd })}
+          />
+        </div>
+      </div>
+      <div className="px-4 pt-5 pb-3">
+        <div
+          aria-label="Daily Guardian review results"
+          className="flex h-36 items-end gap-px"
+          role="img"
+        >
+          {props.days.map((day) => {
+            const height = Math.max(2, (day.requests / maximum) * 100);
+            return (
+              <Tooltip
+                content={
+                  <div className="grid grid-cols-[auto_auto] gap-x-4">
+                    <span>Allow</span>
+                    <span className="text-right">{day.allow}</span>
+                    <span>Ask</span>
+                    <span className="text-right">{day.ask}</span>
+                    <span>Deny</span>
+                    <span className="text-right">{day.deny}</span>
+                    <span>Cost</span>
+                    <span className="text-right">
+                      {formatCostSummary({ total: day.costUsd ?? 0 })}
+                    </span>
+                  </div>
+                }
+                key={day.date}
+                label={shortDate(day.date)}
+              >
+                <button
+                  aria-label={`${shortDate(day.date)}: ${day.allow} allowed, ${day.ask} asked, ${day.deny} denied, ${formatCostSummary({ total: day.costUsd ?? 0 })}`}
+                  className="flex min-w-0 flex-1 flex-col justify-end overflow-hidden rounded-t-sm bg-white/[0.035] focus-visible:outline-1 focus-visible:outline-cyan-300"
+                  style={{ height: `${height}%` }}
+                  type="button"
+                >
+                  {day.deny ? (
+                    <span
+                      className="block w-full bg-rose-400/75"
+                      style={{ flex: day.deny }}
+                    />
+                  ) : null}
+                  {day.ask ? (
+                    <span
+                      className="block w-full bg-amber-300/75"
+                      style={{ flex: day.ask }}
+                    />
+                  ) : null}
+                  {day.allow ? (
+                    <span
+                      className="block w-full bg-emerald-300/70"
+                      style={{ flex: day.allow }}
+                    />
+                  ) : null}
+                </button>
+              </Tooltip>
+            );
+          })}
+        </div>
+        <div className="relative mt-2 h-4 font-mono text-[0.56rem] text-dashboard-text-muted">
+          {labels.map((index) => {
+            const day = props.days[index];
+            if (!day) return null;
+            return (
+              <span
+                className="absolute -translate-x-1/2"
+                key={day.date}
+                style={{
+                  left: `${((index + 0.5) / props.days.length) * 100}%`,
+                }}
+              >
+                {shortDate(day.date)}
+              </span>
+            );
+          })}
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/packages/junior-dashboard/src/client/pages/system/SystemActivity.tsx
+++ b/packages/junior-dashboard/src/client/pages/system/SystemActivity.tsx
@@ -4,6 +4,7 @@ import { EmptyTelemetry } from "../../components/EmptyTelemetry";
 import type { TimeRangeDays } from "../../components/controls/TimeRangeSelector";
 import { Card } from "../../components/layout/Card";
 import { SystemMetricCharts } from "../../components/charts/SystemMetricCharts";
+import { GuardianActivity } from "./GuardianActivity";
 
 /** Present selectable daily runtime and model-usage trends. */
 export function SystemActivity(props: {
@@ -27,6 +28,7 @@ export function SystemActivity(props: {
   }
 
   const days = props.stats.metricDays.slice(-props.range);
+  const guardianDays = props.stats.guardian.metricDays.slice(-props.range);
   return (
     <section className="grid gap-4" aria-labelledby="system-metrics-title">
       <div className="flex flex-wrap items-end justify-between gap-3">
@@ -48,6 +50,7 @@ export function SystemActivity(props: {
         </div>
       </div>
       <SystemMetricCharts days={days} />
+      <GuardianActivity days={guardianDays} />
     </section>
   );
 }

--- a/packages/junior-dashboard/src/mock-reporting/fixtures.ts
+++ b/packages/junior-dashboard/src/mock-reporting/fixtures.ts
@@ -872,6 +872,38 @@ function conversationMetricDays(
   return [...days.values()];
 }
 
+function mockGuardianStats(nowMs: number): ConversationStatsReport["guardian"] {
+  const metricDays = Array.from({ length: 90 }, (_, index) => {
+    const date = new Date(nowMs);
+    date.setUTCHours(0, 0, 0, 0);
+    date.setUTCDate(date.getUTCDate() - (89 - index));
+    const recentIndex = index - 59;
+    const requests = recentIndex > 0 ? (recentIndex % 5) + 1 : 0;
+    const deny = requests > 2 && recentIndex % 8 === 0 ? 1 : 0;
+    const ask = requests > 1 && recentIndex % 4 === 0 ? 1 : 0;
+    const allow = requests - ask - deny;
+    return {
+      allow,
+      ask,
+      ...(requests ? { costUsd: requests * 0.0009 } : {}),
+      date: date.toISOString().slice(0, 10),
+      deny,
+      requests,
+    };
+  });
+  return metricDays.reduce<ConversationStatsReport["guardian"]>(
+    (result, day) => ({
+      allow: result.allow + day.allow,
+      ask: result.ask + day.ask,
+      costUsd: (result.costUsd ?? 0) + (day.costUsd ?? 0),
+      deny: result.deny + day.deny,
+      metricDays,
+      requests: result.requests + day.requests,
+    }),
+    { allow: 0, ask: 0, costUsd: 0, deny: 0, metricDays, requests: 0 },
+  );
+}
+
 /** Return the explicit canonical-event visual-QA feed, optionally scoped by actor. */
 export function readMockConversationFeed(
   actorEmail?: string,
@@ -1002,6 +1034,7 @@ export function readMockConversationStats(): ConversationStatsReport {
     durationMs: total.durationMs,
     failed: total.failed,
     generatedAt: iso(nowMs),
+    guardian: mockGuardianStats(nowMs),
     locations: [...locationItems.values()],
     metricDays: conversationMetricDays(nowMs, summaries),
     source: "conversation_index",

--- a/packages/junior-dashboard/tests/telemetry-components.test.tsx
+++ b/packages/junior-dashboard/tests/telemetry-components.test.tsx
@@ -98,6 +98,23 @@ function systemData(): SystemData {
       durationMs: 2_000,
       failed: 0,
       generatedAt: "2026-01-01T00:00:00.000Z",
+      guardian: {
+        allow: 3,
+        ask: 1,
+        costUsd: 0.08,
+        deny: 1,
+        metricDays: [
+          {
+            allow: 3,
+            ask: 1,
+            costUsd: 0.08,
+            date: "2026-01-01",
+            deny: 1,
+            requests: 5,
+          },
+        ],
+        requests: 5,
+      },
       metricDays: [
         {
           costUsd: 4.56,
@@ -1202,6 +1219,9 @@ describe("dashboard canonical-event components", () => {
     expect(systemHtml).toContain("Token usage");
     expect(systemHtml).toContain("Model spend");
     expect(systemHtml).toContain("Runtime");
+    expect(systemHtml).toContain("Guardian reviews");
+    expect(systemHtml).toContain("Daily Guardian review results");
+    expect(systemHtml).toContain("Estimated cost");
     expect(
       systemHtml.match(/aria-label="Reporting period"/g) ?? [],
     ).toHaveLength(1);

--- a/packages/junior/src/api/conversations/stats.query.ts
+++ b/packages/junior/src/api/conversations/stats.query.ts
@@ -3,6 +3,7 @@ import { alias } from "drizzle-orm/pg-core";
 import { getDb } from "@/chat/db";
 import type { JuniorDatabase } from "@/db/db";
 import {
+  juniorConversationEvents,
   juniorConversations,
   juniorDestinations,
   juniorIdentities,
@@ -13,6 +14,8 @@ import type {
   ConversationMetricDay,
   ConversationStatsItem,
   ConversationStatsReport,
+  GuardianMetricDay,
+  GuardianStats,
 } from "../schema/conversation";
 
 const WINDOW_DAYS = 90;
@@ -174,6 +177,65 @@ function metricDays(
   return days;
 }
 
+function guardianStats(
+  rows: Array<{
+    allow: number;
+    ask: number;
+    costUsd: number | null;
+    date: string;
+    deny: number;
+    requests: number;
+  }>,
+  endMs: number,
+): GuardianStats {
+  const byDate = new Map(rows.map((row) => [row.date, row]));
+  const end = new Date(endMs);
+  end.setUTCHours(0, 0, 0, 0);
+  const start = new Date(end);
+  start.setUTCDate(start.getUTCDate() - (WINDOW_DAYS - 1));
+  const metricDays: GuardianMetricDay[] = [];
+  let allow = 0;
+  let ask = 0;
+  let deny = 0;
+  let requests = 0;
+  let costUsd: number | undefined;
+
+  for (
+    const cursor = new Date(start);
+    cursor.getTime() <= end.getTime();
+    cursor.setUTCDate(cursor.getUTCDate() + 1)
+  ) {
+    const date = cursor.toISOString().slice(0, 10);
+    const row = byDate.get(date);
+    allow += row?.allow ?? 0;
+    ask += row?.ask ?? 0;
+    deny += row?.deny ?? 0;
+    requests += row?.requests ?? 0;
+    if (row?.costUsd !== null && row?.costUsd !== undefined) {
+      costUsd = addUsd(costUsd, row.costUsd);
+    }
+    metricDays.push({
+      allow: row?.allow ?? 0,
+      ask: row?.ask ?? 0,
+      date,
+      deny: row?.deny ?? 0,
+      requests: row?.requests ?? 0,
+      ...(row?.costUsd !== null && row?.costUsd !== undefined
+        ? { costUsd: row.costUsd }
+        : {}),
+    });
+  }
+
+  return {
+    allow,
+    ask,
+    deny,
+    metricDays,
+    requests,
+    ...(costUsd !== undefined ? { costUsd } : {}),
+  };
+}
+
 async function aggregateStats(db: JuniorDatabase, start: Date, end: Date) {
   const where = statsWhere(start, end);
   const activityDate = sql<string>`TO_CHAR(
@@ -276,15 +338,51 @@ async function aggregateStats(db: JuniorDatabase, start: Date, end: Date) {
   return { actorRows, locationRows, metricRows, totals: totalsRows[0] };
 }
 
+async function aggregateGuardianStats(
+  db: JuniorDatabase,
+  start: Date,
+  end: Date,
+) {
+  const date = sql<string>`TO_CHAR(
+    ${juniorConversationEvents.createdAt} AT TIME ZONE 'UTC',
+    'YYYY-MM-DD'
+  )`;
+  const decision = sql`${juniorConversationEvents.payload}->>'decision'`;
+  const cost = sql<number | null>`CASE
+    WHEN jsonb_typeof(${juniorConversationEvents.payload}->'costUsd') = 'number'
+      THEN (${juniorConversationEvents.payload}->>'costUsd')::double precision
+    ELSE NULL
+  END`;
+  return await db
+    .select({
+      allow: sql<number>`COUNT(*) FILTER (WHERE ${decision} = 'allow')::integer`,
+      ask: sql<number>`COUNT(*) FILTER (WHERE ${decision} = 'ask')::integer`,
+      costUsd: sql<number | null>`SUM(${cost})::double precision`,
+      date,
+      deny: sql<number>`COUNT(*) FILTER (WHERE ${decision} = 'deny')::integer`,
+      requests: sql<number>`COUNT(*)::integer`,
+    })
+    .from(juniorConversationEvents)
+    .where(
+      and(
+        eq(juniorConversationEvents.type, "guardian_action_reviewed"),
+        gte(juniorConversationEvents.createdAt, start),
+        lte(juniorConversationEvents.createdAt, end),
+      ),
+    )
+    .groupBy(date);
+}
+
 /** Build complete 90-day dashboard stats from normalized durable SQL records. */
 export async function readConversationStatsFromSql(): Promise<ConversationStatsReport> {
   const nowMs = Date.now();
   const { end, start } = statsWindow(nowMs);
-  const { actorRows, locationRows, metricRows, totals } = await aggregateStats(
-    getDb(),
-    start,
-    end,
-  );
+  const db = getDb();
+  const [{ actorRows, locationRows, metricRows, totals }, guardianRows] =
+    await Promise.all([
+      aggregateStats(db, start, end),
+      aggregateGuardianStats(db, start, end),
+    ]);
   const actors = new Map<string, ConversationStatsItem>();
   const locations = new Map<string, ConversationStatsItem>();
 
@@ -301,6 +399,7 @@ export async function readConversationStatsFromSql(): Promise<ConversationStatsR
     durationMs: totals?.durationMs ?? 0,
     failed: totals?.failed ?? 0,
     generatedAt: new Date(nowMs).toISOString(),
+    guardian: guardianStats(guardianRows, nowMs),
     metricDays: metricDays(metricRows, nowMs),
     locations: statsItems(locations),
     actors: statsItems(actors),

--- a/packages/junior/src/api/schema.ts
+++ b/packages/junior/src/api/schema.ts
@@ -36,6 +36,8 @@ export type {
   ConversationSummaryReport,
   ConversationSurface,
   ConversationUsage,
+  GuardianMetricDay,
+  GuardianStats,
 } from "./schema/conversation";
 export {
   actorDirectoryReportSchema,

--- a/packages/junior/src/api/schema/conversation.ts
+++ b/packages/junior/src/api/schema/conversation.ts
@@ -527,6 +527,28 @@ export const conversationMetricDaySchema = z
   })
   .strict();
 
+export const guardianMetricDaySchema = z
+  .object({
+    allow: z.number(),
+    ask: z.number(),
+    costUsd: z.number().optional(),
+    date: z.string(),
+    deny: z.number(),
+    requests: z.number(),
+  })
+  .strict();
+
+export const guardianStatsSchema = z
+  .object({
+    allow: z.number(),
+    ask: z.number(),
+    costUsd: z.number().optional(),
+    deny: z.number(),
+    metricDays: z.array(guardianMetricDaySchema),
+    requests: z.number(),
+  })
+  .strict();
+
 export const conversationStatsReportSchema = z
   .object({
     active: z.number(),
@@ -534,6 +556,7 @@ export const conversationStatsReportSchema = z
     durationMs: z.number(),
     failed: z.number(),
     generatedAt: z.string(),
+    guardian: guardianStatsSchema,
     metricDays: z.array(conversationMetricDaySchema),
     locations: z.array(conversationStatsItemSchema),
     actors: z.array(conversationStatsItemSchema),
@@ -574,6 +597,8 @@ export type ConversationEventPage = z.infer<typeof conversationEventPageSchema>;
 export type ConversationFeed = z.infer<typeof conversationFeedSchema>;
 export type ConversationStatsItem = z.infer<typeof conversationStatsItemSchema>;
 export type ConversationMetricDay = z.infer<typeof conversationMetricDaySchema>;
+export type GuardianMetricDay = z.infer<typeof guardianMetricDaySchema>;
+export type GuardianStats = z.infer<typeof guardianStatsSchema>;
 export type ConversationStatsReport = z.infer<
   typeof conversationStatsReportSchema
 >;

--- a/packages/junior/src/chat/agent/tools.ts
+++ b/packages/junior/src/chat/agent/tools.ts
@@ -330,6 +330,7 @@ export async function wireAgentTools(
         turnId: args.turnId,
         toolCallId,
         toolName,
+        costUsd: decision.costUsd,
         decision: decision.decision,
         riskLevel: decision.riskLevel,
         userAuthorization: decision.userAuthorization,

--- a/packages/junior/src/chat/conversations/history.ts
+++ b/packages/junior/src/chat/conversations/history.ts
@@ -171,6 +171,7 @@ const guardianActionReviewedEventDataSchema = z
     turnId: z.string().min(1),
     toolCallId: z.string().min(1),
     toolName: z.string().min(1),
+    costUsd: z.number().finite().nonnegative().optional(),
     decision: z.enum(["allow", "ask", "deny"]),
     riskLevel: z.enum(["low", "medium", "high", "critical"]),
     userAuthorization: z.enum(["high", "medium", "low", "unknown"]),

--- a/packages/junior/src/chat/conversations/projection.ts
+++ b/packages/junior/src/chat/conversations/projection.ts
@@ -535,6 +535,7 @@ export async function recordGuardianActionReviewed(args: {
   turnId: string;
   toolCallId: string;
   toolName: string;
+  costUsd?: number;
   decision: "allow" | "ask" | "deny";
   riskLevel: "low" | "medium" | "high" | "critical";
   userAuthorization: "high" | "medium" | "low" | "unknown";
@@ -546,6 +547,7 @@ export async function recordGuardianActionReviewed(args: {
         turnId: args.turnId,
         toolCallId: args.toolCallId,
         toolName: args.toolName,
+        ...(args.costUsd !== undefined ? { costUsd: args.costUsd } : {}),
         decision: args.decision,
         riskLevel: args.riskLevel,
         userAuthorization: args.userAuthorization,

--- a/packages/junior/src/chat/pi/client.ts
+++ b/packages/junior/src/chat/pi/client.ts
@@ -1,4 +1,5 @@
 import {
+  calculateCost,
   completeSimple,
   getEnvApiKey,
   getModels,
@@ -10,7 +11,12 @@ import {
   type ThinkingLevel,
 } from "@/chat/pi/sdk";
 import { createGatewayProvider } from "@ai-sdk/gateway";
-import { embedMany, generateObject, NoObjectGeneratedError } from "ai";
+import {
+  embedMany,
+  generateObject,
+  NoObjectGeneratedError,
+  type LanguageModelUsage,
+} from "ai";
 
 // Directly register the anthropic provider at import time. pi-ai's built-in
 // registration relies on opaque dynamic import() calls that break under
@@ -277,6 +283,44 @@ function logContextFromMetadata(
   };
 }
 
+function objectCompletionCost(
+  modelId: string,
+  usage: LanguageModelUsage,
+): number | undefined {
+  const cacheRead = usage.inputTokenDetails.cacheReadTokens;
+  const cacheWrite = usage.inputTokenDetails.cacheWriteTokens;
+  const input =
+    usage.inputTokenDetails.noCacheTokens ??
+    (usage.inputTokens === undefined
+      ? undefined
+      : Math.max(0, usage.inputTokens - (cacheRead ?? 0) - (cacheWrite ?? 0)));
+  if (
+    input === undefined &&
+    usage.outputTokens === undefined &&
+    cacheRead === undefined &&
+    cacheWrite === undefined
+  ) {
+    return undefined;
+  }
+
+  return calculateCost(resolveGatewayModel(modelId), {
+    input: input ?? 0,
+    output: usage.outputTokens ?? 0,
+    cacheRead: cacheRead ?? 0,
+    cacheWrite: cacheWrite ?? 0,
+    ...(usage.outputTokenDetails.reasoningTokens !== undefined
+      ? { reasoning: usage.outputTokenDetails.reasoningTokens }
+      : {}),
+    totalTokens:
+      usage.totalTokens ??
+      (input ?? 0) +
+        (usage.outputTokens ?? 0) +
+        (cacheRead ?? 0) +
+        (cacheWrite ?? 0),
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+  }).total;
+}
+
 /** Execute a schema-constrained completion using the AI SDK structured output path. */
 export async function completeObject<TSchema extends ZodTypeAny>(params: {
   modelId: string;
@@ -293,7 +337,7 @@ export async function completeObject<TSchema extends ZodTypeAny>(params: {
   recordTelemetryPayloads?: boolean;
   signal?: AbortSignal;
   metadata?: Record<string, unknown>;
-}): Promise<{ object: z.infer<TSchema> }> {
+}): Promise<{ costUsd?: number; object: z.infer<TSchema> }> {
   const apiKey = getGatewayApiKey();
   const provider = createGatewayProvider(apiKey ? { apiKey } : {});
   try {
@@ -350,7 +394,11 @@ export async function completeObject<TSchema extends ZodTypeAny>(params: {
           : {}),
       },
     );
-    return { object: result.object as z.infer<TSchema> };
+    const costUsd = objectCompletionCost(params.modelId, result.usage);
+    return {
+      object: result.object as z.infer<TSchema>,
+      ...(costUsd !== undefined ? { costUsd } : {}),
+    };
   } catch (error) {
     const providerError = createProviderError(error, {
       ...(NoObjectGeneratedError.isInstance(error)

--- a/packages/junior/src/chat/pi/client.ts
+++ b/packages/junior/src/chat/pi/client.ts
@@ -15,6 +15,7 @@ import {
   embedMany,
   generateObject,
   NoObjectGeneratedError,
+  type GenerateObjectResult,
   type LanguageModelUsage,
 } from "ai";
 
@@ -321,6 +322,7 @@ function objectCompletionCost(
   }).total;
 }
 
+/** Estimate cost without changing the outcome of a successful completion. */
 function bestEffortObjectCompletionCost(
   modelId: string,
   usage: LanguageModelUsage,
@@ -356,8 +358,9 @@ export async function completeObject<TSchema extends ZodTypeAny>(params: {
 }): Promise<{ costUsd?: number; object: z.infer<TSchema> }> {
   const apiKey = getGatewayApiKey();
   const provider = createGatewayProvider(apiKey ? { apiKey } : {});
+  let result: GenerateObjectResult<unknown>;
   try {
-    const result = await withSpan(
+    result = await withSpan(
       `${GEN_AI_OPERATION_CHAT} ${params.modelId}`,
       "gen_ai.chat",
       logContextFromMetadata(params.modelId, params.metadata),
@@ -410,14 +413,6 @@ export async function completeObject<TSchema extends ZodTypeAny>(params: {
           : {}),
       },
     );
-    const costUsd = bestEffortObjectCompletionCost(
-      params.modelId,
-      result.usage,
-    );
-    return {
-      object: result.object as z.infer<TSchema>,
-      ...(costUsd !== undefined ? { costUsd } : {}),
-    };
   } catch (error) {
     const providerError = createProviderError(error, {
       ...(NoObjectGeneratedError.isInstance(error)
@@ -427,6 +422,11 @@ export async function completeObject<TSchema extends ZodTypeAny>(params: {
     });
     throw providerError;
   }
+  const costUsd = bestEffortObjectCompletionCost(params.modelId, result.usage);
+  return {
+    object: result.object as z.infer<TSchema>,
+    ...(costUsd !== undefined ? { costUsd } : {}),
+  };
 }
 
 /** Generate text embeddings through the host-owned AI Gateway provider. */

--- a/packages/junior/src/chat/pi/client.ts
+++ b/packages/junior/src/chat/pi/client.ts
@@ -321,6 +321,22 @@ function objectCompletionCost(
   }).total;
 }
 
+function bestEffortObjectCompletionCost(
+  modelId: string,
+  usage: LanguageModelUsage,
+): number | undefined {
+  try {
+    return objectCompletionCost(modelId, usage);
+  } catch (error) {
+    logWarn("ai.completion.cost_estimate.failed", {
+      "exception.message":
+        error instanceof Error ? error.message : String(error),
+      "gen_ai.request.model": modelId,
+    });
+    return undefined;
+  }
+}
+
 /** Execute a schema-constrained completion using the AI SDK structured output path. */
 export async function completeObject<TSchema extends ZodTypeAny>(params: {
   modelId: string;
@@ -394,7 +410,10 @@ export async function completeObject<TSchema extends ZodTypeAny>(params: {
           : {}),
       },
     );
-    const costUsd = objectCompletionCost(params.modelId, result.usage);
+    const costUsd = bestEffortObjectCompletionCost(
+      params.modelId,
+      result.usage,
+    );
     return {
       object: result.object as z.infer<TSchema>,
       ...(costUsd !== undefined ? { costUsd } : {}),

--- a/packages/junior/src/chat/pi/sdk.ts
+++ b/packages/junior/src/chat/pi/sdk.ts
@@ -4,6 +4,7 @@
  * of Pi's internal subpath layout, which changes across SDK versions.
  */
 export {
+  calculateCost,
   completeSimple,
   getEnvApiKey,
   getModel,

--- a/packages/junior/src/chat/services/guardian-action-review.ts
+++ b/packages/junior/src/chat/services/guardian-action-review.ts
@@ -62,7 +62,10 @@ export function createGuardianActionReviewer(options: {
           guardianRole: "tool_action_review",
         },
       });
-      return guardianDecisionSchema.parse(result.object);
+      return {
+        ...guardianDecisionSchema.parse(result.object),
+        ...(result.costUsd !== undefined ? { costUsd: result.costUsd } : {}),
+      };
     },
   };
 }

--- a/packages/junior/src/chat/tool-support/action-review.ts
+++ b/packages/junior/src/chat/tool-support/action-review.ts
@@ -25,6 +25,7 @@ import { projectToolActionRejection } from "@/chat/tool-support/action-review-hi
 export type ToolActionDecision = "allow" | "ask" | "deny";
 
 export interface ToolActionReviewDecision {
+  costUsd?: number;
   decision: ToolActionDecision;
   reason: string;
   riskLevel: "low" | "medium" | "high" | "critical";

--- a/packages/junior/tests/integration/api/conversations/stats.test.ts
+++ b/packages/junior/tests/integration/api/conversations/stats.test.ts
@@ -4,6 +4,7 @@ import { createJuniorApi } from "@/api";
 import { readConversationStatsFromSql } from "@/api/conversations/stats.query";
 import { conversationStatsReportSchema } from "@/api/schema";
 import { migrateSchema } from "@/chat/conversations/sql/migrations";
+import { createSqlConversationEventStore } from "@/chat/conversations/sql/history";
 import { createSqlStore } from "@/chat/conversations/sql/store";
 import { juniorConversations } from "@/db/schema";
 import {
@@ -165,6 +166,50 @@ describe("conversation stats API", () => {
           updatedAt: childAt,
           executionStatus: "idle",
         });
+      const eventStore = createSqlConversationEventStore(fixture.sql);
+      await eventStore.append("slack:C1:recent", [
+        {
+          createdAtMs: Date.parse("2026-06-15T11:52:00.000Z"),
+          data: {
+            type: "guardian_action_reviewed",
+            turnId: "turn-recent",
+            toolCallId: "tool-allow",
+            toolName: "publishReport",
+            costUsd: 0.001,
+            decision: "allow",
+            riskLevel: "low",
+            userAuthorization: "high",
+          },
+        },
+        {
+          createdAtMs: Date.parse("2026-06-15T11:53:00.000Z"),
+          data: {
+            type: "guardian_action_reviewed",
+            turnId: "turn-recent",
+            toolCallId: "tool-ask",
+            toolName: "publishReport",
+            costUsd: 0.002,
+            decision: "ask",
+            riskLevel: "medium",
+            userAuthorization: "low",
+          },
+        },
+      ]);
+      await eventStore.append("advisor:child", [
+        {
+          createdAtMs: Date.parse("2026-06-15T11:56:00.000Z"),
+          data: {
+            type: "guardian_action_reviewed",
+            turnId: "turn-child",
+            toolCallId: "tool-deny",
+            toolName: "deleteReport",
+            costUsd: 0.003,
+            decision: "deny",
+            riskLevel: "high",
+            userAuthorization: "unknown",
+          },
+        },
+      ]);
 
       const report = await readConversationStatsFromSql();
 
@@ -174,6 +219,13 @@ describe("conversation stats API", () => {
         costUsd: 0.0045,
         durationMs: 2_004,
         failed: 1,
+        guardian: {
+          allow: 1,
+          ask: 1,
+          costUsd: 0.006,
+          deny: 1,
+          requests: 3,
+        },
         tokens: 157,
         source: "conversation_index",
       });
@@ -207,6 +259,14 @@ describe("conversation stats API", () => {
           expect.objectContaining({ label: "Scheduler" }),
         ]),
       );
+      expect(report.guardian.metricDays.at(-1)).toEqual({
+        allow: 1,
+        ask: 1,
+        costUsd: 0.006,
+        date: "2026-06-15",
+        deny: 1,
+        requests: 3,
+      });
     } finally {
       vi.useRealTimers();
       await fixture.close();

--- a/packages/junior/tests/unit/pi/client.test.ts
+++ b/packages/junior/tests/unit/pi/client.test.ts
@@ -310,13 +310,6 @@ describe("completeText", () => {
     });
 
     expect(result).toEqual({ object: { ok: true } });
-    expect(mocks.logWarn).toHaveBeenCalledWith(
-      "ai.completion.cost_estimate.failed",
-      {
-        "exception.message": "pricing unavailable",
-        "gen_ai.request.model": "openai/gpt-4o-mini",
-      },
-    );
   });
 
   it("rethrows retryable object provider failures without capturing", async () => {

--- a/packages/junior/tests/unit/pi/client.test.ts
+++ b/packages/junior/tests/unit/pi/client.test.ts
@@ -282,6 +282,43 @@ describe("completeText", () => {
     );
   });
 
+  it("keeps a successful object when cost estimation fails", async () => {
+    mocks.generateObject.mockResolvedValue({
+      object: { ok: true },
+      finishReason: "stop",
+      usage: {
+        inputTokens: 10,
+        inputTokenDetails: {
+          noCacheTokens: 10,
+          cacheReadTokens: 0,
+          cacheWriteTokens: 0,
+        },
+        outputTokens: 3,
+        outputTokenDetails: { textTokens: 3, reasoningTokens: 0 },
+        totalTokens: 13,
+      },
+    });
+    mocks.calculateCost.mockImplementationOnce(() => {
+      throw new Error("pricing unavailable");
+    });
+
+    const { completeObject } = await import("@/chat/pi/client");
+    const result = await completeObject({
+      modelId: "openai/gpt-4o-mini",
+      schema: z.object({ ok: z.boolean() }),
+      prompt: "return json",
+    });
+
+    expect(result).toEqual({ object: { ok: true } });
+    expect(mocks.logWarn).toHaveBeenCalledWith(
+      "ai.completion.cost_estimate.failed",
+      {
+        "exception.message": "pricing unavailable",
+        "gen_ai.request.model": "openai/gpt-4o-mini",
+      },
+    );
+  });
+
   it("rethrows retryable object provider failures without capturing", async () => {
     mocks.generateObject.mockRejectedValue(
       new Error("Anthropic stream ended before message_stop"),

--- a/packages/junior/tests/unit/pi/client.test.ts
+++ b/packages/junior/tests/unit/pi/client.test.ts
@@ -2,6 +2,13 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 
 const mocks = vi.hoisted(() => ({
+  calculateCost: vi.fn(() => ({
+    input: 0.001,
+    output: 0.002,
+    cacheRead: 0,
+    cacheWrite: 0,
+    total: 0.003,
+  })),
   completeSimple: vi.fn(),
   createGatewayProvider: vi.fn(() => ({
     chat: vi.fn((modelId: string) => ({ modelId })),
@@ -32,6 +39,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("@/chat/pi/sdk", () => ({
+  calculateCost: mocks.calculateCost,
   completeSimple: mocks.completeSimple,
   getEnvApiKey: mocks.getEnvApiKey,
   getModels: mocks.getModels,
@@ -226,7 +234,17 @@ describe("completeText", () => {
     mocks.generateObject.mockResolvedValue({
       object: { ok: true },
       finishReason: "stop",
-      usage: { inputTokens: 10, outputTokens: 3, totalTokens: 13 },
+      usage: {
+        inputTokens: 10,
+        inputTokenDetails: {
+          noCacheTokens: 8,
+          cacheReadTokens: 2,
+          cacheWriteTokens: 0,
+        },
+        outputTokens: 3,
+        outputTokenDetails: { textTokens: 3, reasoningTokens: 1 },
+        totalTokens: 13,
+      },
     });
 
     const { completeObject } = await import("@/chat/pi/client");
@@ -240,7 +258,10 @@ describe("completeText", () => {
       system: "structured only",
     });
 
-    expect(result).toEqual({ object: { ok: true } });
+    expect(result).toEqual({
+      costUsd: 0.003,
+      object: { ok: true },
+    });
     expect(mocks.generateObject).toHaveBeenCalledWith(
       expect.objectContaining({
         model: { modelId: "openai/gpt-4o-mini" },

--- a/packages/junior/tests/unit/services/guardian-action-review.test.ts
+++ b/packages/junior/tests/unit/services/guardian-action-review.test.ts
@@ -38,6 +38,7 @@ describe("Guardian action review", () => {
         riskLevel: "medium" as const,
         userAuthorization: "low" as const,
       },
+      costUsd: 0.0042,
     }));
     const reviewer = createGuardianActionReviewer({
       modelId: "test/guardian",
@@ -45,6 +46,7 @@ describe("Guardian action review", () => {
     });
 
     await expect(reviewer.review(proposal)).resolves.toEqual({
+      costUsd: 0.0042,
       decision: "ask",
       reason: "Recurring work should be confirmed.",
       riskLevel: "medium",


### PR DESCRIPTION
Guardian action reviews now carry their estimated model cost into the durable decision event. The conversation stats report aggregates daily review volume, `allow` / `ask` / `deny` outcomes, and cost, and the System overview displays them in a responsive card using the existing 7/30/90-day control.

The event adds only an optional `costUsd`, so this needs no migration or backfill; older decisions still count and simply have no cost. Guardian cost remains separate from the existing model spend metric so that metric does not silently change meaning. Focus review on structured-completion cost calculation and the event-based SQL aggregation.
