### PR TITLE
fix(agent): require tool behavior annotations

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -166,6 +166,7 @@ Attributes: `gen_ai.operation.name`, `gen_ai.request.model`,
 A tool failed, an MCP call failed, a command exited non-zero, or sandbox startup was slow.
 
 Events: `agent.tool_call.failed`, `mcp.tool_call.failed`,
+`mcp.tool_annotations.missing`, `plugin.tool_annotations.missing`,
 `mcp.tool_manager.close.failed`, `sandbox.boot.requested`,
 `sandbox.network_policy_restore.failed`
 
@@ -179,7 +180,7 @@ Attributes: `gen_ai.tool.name`, `gen_ai.tool.call.id`,
 `app.sandbox.search.parsed_records`,
 `app.sandbox.search.result_count`, `app.sandbox.search.emitted_lines`,
 `app.sandbox.search.result_bytes`, `app.sandbox.search.limit`,
-`app.sandbox.search.limit_reached`
+`app.sandbox.search.limit_reached`, `app.tool.missing_annotations`
 
 ### Auth And Resume
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "worktree:setup": "node scripts/worktree.mjs setup",
     "cloudflare:token": "node scripts/refresh-cloudflare-tunnel-token.mjs",
     "prepare": "simple-git-hooks",
-    "lint": "pnpm file-length:check && pnpm test-architecture:check && pnpm dashboard-style:check && pnpm --filter @sentry/junior lint && pnpm --filter @sentry/junior-memory lint && pnpm --filter @sentry/junior-github lint && pnpm --filter @sentry/junior-linear lint && pnpm --filter @sentry/junior-vercel lint && pnpm ast-grep:lint && pnpm package:lint",
+    "lint": "pnpm file-length:check && pnpm test-architecture:check && pnpm dashboard-style:check && pnpm --filter @sentry/junior tool-annotations:check && pnpm --filter @sentry/junior lint && pnpm --filter @sentry/junior-memory lint && pnpm --filter @sentry/junior-github lint && pnpm --filter @sentry/junior-linear lint && pnpm --filter @sentry/junior-vercel lint && pnpm ast-grep:lint && pnpm package:lint",
     "lint:fix": "pnpm --filter @sentry/junior lint:fix",
     "file-length:check": "node --test scripts/check-file-length.test.mjs && node scripts/check-file-length.mjs",
     "test-architecture:check": "node --test scripts/check-test-architecture.test.mjs && node scripts/check-test-architecture.mjs",

--- a/packages/junior-github/src/tools/create-issue.ts
+++ b/packages/junior-github/src/tools/create-issue.ts
@@ -293,6 +293,12 @@ async function annotateIssue(
 /** Own issue creation so provider writes use host egress and the footer stays deterministic. */
 export function createGitHubIssueTool(ctx: ToolRegistrationHookContext) {
   return definePluginTool({
+    annotations: {
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+      readOnlyHint: false,
+    },
     description:
       "Create a GitHub issue with a runtime-owned Junior conversation footer. Use this instead of shelling out to gh issue create when creating issues.",
     inputSchema: createIssueToolInputSchema,

--- a/packages/junior-github/src/tools/create-pull-request.ts
+++ b/packages/junior-github/src/tools/create-pull-request.ts
@@ -364,6 +364,12 @@ function gitHubPullRequestStructuredResult(
 /** Own PR creation so provider writes use host egress and the footer stays deterministic. */
 export function createGitHubPullRequestTool(ctx: ToolRegistrationHookContext) {
   return definePluginTool({
+    annotations: {
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+      readOnlyHint: false,
+    },
     description:
       "Create a GitHub pull request with a runtime-owned Junior conversation footer. Use this instead of shelling out to gh pr create when creating pull requests.",
     inputSchema: createPullRequestToolInputSchema,

--- a/packages/junior-github/src/tools/get-deployment.ts
+++ b/packages/junior-github/src/tools/get-deployment.ts
@@ -157,6 +157,12 @@ export function createGitHubGetDeploymentTool(
   ctx: ToolRegistrationHookContext,
 ) {
   return definePluginTool({
+    annotations: {
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+      readOnlyHint: true,
+    },
     description:
       "Get the latest GitHub deployment and status for an exact repository and full commit SHA, optionally limited to one environment. The result remains subscribable when no deployment exists yet, so use it before waiting for a deployment outcome.",
     inputSchema,

--- a/packages/junior-github/src/tools/get-pull-request.ts
+++ b/packages/junior-github/src/tools/get-pull-request.ts
@@ -66,6 +66,12 @@ export function createGitHubGetPullRequestTool(
   ctx: ToolRegistrationHookContext,
 ) {
   return definePluginTool({
+    annotations: {
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+      readOnlyHint: true,
+    },
     description:
       "Get a GitHub pull request. Use this when an existing PR may need resource-event monitoring; the result includes a subscribable hint when GitHub webhooks are configured.",
     inputSchema,

--- a/packages/junior-github/src/tools/update-pull-request.ts
+++ b/packages/junior-github/src/tools/update-pull-request.ts
@@ -114,6 +114,12 @@ export function createGitHubUpdatePullRequestTool(
   ctx: ToolRegistrationHookContext,
 ) {
   return definePluginTool({
+    annotations: {
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: true,
+      readOnlyHint: false,
+    },
     description:
       "Update an existing GitHub pull request's title, body, base branch, or open/closed state. Use this instead of raw GitHub API calls when changing PR metadata.",
     inputSchema,

--- a/packages/junior-memory/src/tools.ts
+++ b/packages/junior-memory/src/tools.ts
@@ -420,6 +420,12 @@ function memoryToolResult<TData extends Record<string, unknown>>(
 /** Create a tool that submits an explicit memory candidate for storage. */
 export function createMemoryCreateTool(context: MemoryCreateToolContext) {
   return definePluginTool({
+    annotations: {
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+      readOnlyHint: false,
+    },
     description:
       "Explicit memory-write tool. Use only when the latest user message directly asks Junior to remember, store, save, or forget-and-replace a public/shareable fact. Do not use for ordinary statements like 'I prefer X', 'I use Y', or 'X goes before Y' unless the user also asks you to remember/store/save it; passive memory learning handles those after the visible reply. Pass one self-contained natural-language candidate preserving the user's explicit memory intent. Do not ask the user to rephrase ordinary first-person facts, and do not rewrite them into display-name or third-person wording. Do not include secrets, private personal details, medical/legal/financial/sensitive facts, or another person's personal preference, opinion, habit, identity, relationship, workflow, or private life. Runtime context derives actor, scope, source, and subject ids; the memory agent decides canonical stored content and memory kind, then the plugin derives storage target from kind.",
     executionMode: "sequential",
@@ -506,6 +512,12 @@ export function createMemoryCreateTool(context: MemoryCreateToolContext) {
 /** Create a tool that archives a visible memory in the active context. */
 export function createMemoryRemoveTool(context: MemoryToolContext) {
   return definePluginTool({
+    annotations: {
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: false,
+      readOnlyHint: false,
+    },
     description:
       "Forget one memory visible in the active context. Use only ids or short id prefixes returned by listMemories or searchMemories. Never remove memories by hidden actor, Slack, scope, or subject identifiers.",
     executionMode: "sequential",
@@ -535,7 +547,12 @@ export function createMemoryListTool(context: MemoryToolContext) {
   return definePluginTool({
     description:
       "List active memories visible in the current context. Use when the user asks what Junior remembers or when memory ids are needed before removing a memory.",
-    annotations: { readOnlyHint: true, destructiveHint: false },
+    annotations: {
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+      readOnlyHint: true,
+    },
     inputSchema: listMemoriesInputSchema,
     outputSchema: memoryManyOutputSchema,
     execute: async (input) => {
@@ -555,7 +572,12 @@ export function createMemorySearchTool(context: MemoryToolContext) {
   return definePluginTool({
     description:
       "Search active memories visible in the current context. Use when the model needs targeted memory recall. The tool searches only the current actor and active conversation scopes.",
-    annotations: { readOnlyHint: true, destructiveHint: false },
+    annotations: {
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+      readOnlyHint: true,
+    },
     inputSchema: searchMemoriesInputSchema,
     outputSchema: memoryManyOutputSchema,
     execute: async (input) => {

--- a/packages/junior-plugin-api/src/tools.ts
+++ b/packages/junior-plugin-api/src/tools.ts
@@ -227,8 +227,7 @@ export type PluginToolExecute<TInput = unknown, TOutput = unknown> = {
  * Tool-declared approval mode.
  *
  * `auto` delegates to core policy, `review` enters Guardian review, and
- * `approve` permits execution without review. Omission leaves the tool outside
- * action review.
+ * `approve` permits execution without review. Omission behaves like `auto`.
  *
  * Core resolves the effective mode immediately before execution.
  */
@@ -252,11 +251,30 @@ export interface ToolAnnotations {
   title?: string;
 }
 
+export const REQUIRED_TOOL_ANNOTATION_KEYS = [
+  "destructiveHint",
+  "idempotentHint",
+  "openWorldHint",
+  "readOnlyHint",
+] as const;
+
+export type RequiredToolAnnotationKey =
+  (typeof REQUIRED_TOOL_ANNOTATION_KEYS)[number];
+
+/** Return behavioral annotation keys that a tool did not declare. */
+export function missingToolAnnotationKeys(
+  annotations: ToolAnnotations | undefined,
+): RequiredToolAnnotationKey[] {
+  return REQUIRED_TOOL_ANNOTATION_KEYS.filter(
+    (key) => typeof annotations?.[key] !== "boolean",
+  );
+}
+
 /**
  * Canonical approval metadata declared by core and plugin tools.
  */
 export interface ToolApprovalMetadata<TInput = unknown> {
-  /** Optional declared approval mode; omission leaves the tool outside review. */
+  /** Optional declared approval mode; omission delegates to core auto policy. */
   approvalMode?: ToolApprovalMode;
   annotations?: ToolAnnotations;
   /**
@@ -399,6 +417,7 @@ function createZodTool<
   }
   return {
     ...tool,
+    approvalMode: tool.approvalMode ?? "auto",
     inputSchema: modelInputSchema,
     outputSchema: modelOutputSchema,
     prepareArguments(args) {

--- a/packages/junior-plugin-api/src/tools.ts
+++ b/packages/junior-plugin-api/src/tools.ts
@@ -227,7 +227,8 @@ export type PluginToolExecute<TInput = unknown, TOutput = unknown> = {
  * Tool-declared approval mode.
  *
  * `auto` delegates to core policy, `review` enters Guardian review, and
- * `approve` permits execution without review. Omission behaves like `auto`.
+ * `approve` permits execution without review. Plugin tool helpers normalize
+ * omission to `auto`.
  *
  * Core resolves the effective mode immediately before execution.
  */
@@ -274,7 +275,7 @@ export function missingToolAnnotationKeys(
  * Canonical approval metadata declared by core and plugin tools.
  */
 export interface ToolApprovalMetadata<TInput = unknown> {
-  /** Optional declared approval mode; omission delegates to core auto policy. */
+  /** Optional declared approval mode; the owning tool boundary selects defaults. */
   approvalMode?: ToolApprovalMode;
   annotations?: ToolAnnotations;
   /**

--- a/packages/junior-scheduler/src/tools/create-task.ts
+++ b/packages/junior-scheduler/src/tools/create-task.ts
@@ -27,6 +27,12 @@ export function createSlackScheduleCreateTaskTool(
   context: SchedulerToolContext,
 ) {
   return definePluginTool({
+    annotations: {
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+      readOnlyHint: false,
+    },
     description:
       "Create a one-time or recurring Junior task in the active Slack conversation when the user asks Junior to do work later or repeatedly.",
     executionMode: "sequential",

--- a/packages/junior-scheduler/src/tools/delete-task.ts
+++ b/packages/junior-scheduler/src/tools/delete-task.ts
@@ -15,6 +15,12 @@ export function createSlackScheduleDeleteTaskTool(
   context: SchedulerToolContext,
 ) {
   return definePluginTool({
+    annotations: {
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: false,
+      readOnlyHint: false,
+    },
     description:
       "Delete one scheduled Junior task from the active Slack conversation. Use only task IDs returned for this conversation. Do not delete schedules from threads, other channels, or another user's DM.",
     executionMode: "sequential",

--- a/packages/junior-scheduler/src/tools/list-tasks.ts
+++ b/packages/junior-scheduler/src/tools/list-tasks.ts
@@ -18,7 +18,12 @@ export function createSlackScheduleListTasksTool(
   return definePluginTool({
     description:
       "List scheduled Junior tasks for the active Slack conversation. Use when the user asks what is scheduled here, or when task IDs are needed before editing, deleting, or running schedules. Only manages tasks for the active Slack DM or channel.",
-    annotations: { readOnlyHint: true, destructiveHint: false },
+    annotations: {
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+      readOnlyHint: true,
+    },
     inputSchema: z.object({}),
     outputSchema: scheduleListToolResultSchema,
     execute: async () => {

--- a/packages/junior-scheduler/src/tools/run-task-now.ts
+++ b/packages/junior-scheduler/src/tools/run-task-now.ts
@@ -16,6 +16,12 @@ export function createSlackScheduleRunTaskNowTool(
   context: SchedulerToolContext,
 ) {
   return definePluginTool({
+    annotations: {
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+      readOnlyHint: false,
+    },
     description:
       "Queue an existing active scheduled Junior task to run as soon as possible, without changing its cadence. Use when the user asks to run an existing scheduled task now. Use only task IDs returned for this conversation.",
     executionMode: "sequential",

--- a/packages/junior-scheduler/src/tools/update-task.ts
+++ b/packages/junior-scheduler/src/tools/update-task.ts
@@ -24,6 +24,12 @@ export function createSlackScheduleUpdateTaskTool(
   context: SchedulerToolContext,
 ) {
   return definePluginTool({
+    annotations: {
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: true,
+      readOnlyHint: false,
+    },
     description:
       "Edit, pause, resume, reschedule, or change credential use for an existing Junior scheduled task in the active Slack conversation.",
     executionMode: "sequential",

--- a/packages/junior-vercel/src/tools/deployment-source.ts
+++ b/packages/junior-vercel/src/tools/deployment-source.ts
@@ -76,6 +76,12 @@ export function createVercelDeploymentSourceTool(
   ctx: ToolRegistrationHookContext,
 ) {
   return definePluginTool({
+    annotations: {
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+      readOnlyHint: true,
+    },
     description:
       "Resolve a Vercel project name or ID and describe its deployment target and full Git commit SHA as a subscribable deployment source. Use the user's explicit project and team, otherwise the vercel.project and vercel.team conversation defaults. Use this after the final deployed commit is known and before waiting for a deployment outcome.",
     inputSchema,

--- a/packages/junior/package.json
+++ b/packages/junior/package.json
@@ -62,6 +62,7 @@
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
     "skills:check": "node --test scripts/check-skills.test.mjs && node scripts/check-skills.mjs",
+    "tool-annotations:check": "node --test scripts/check-tool-annotations.test.mjs && node scripts/check-tool-annotations.mjs",
     "test:coverage": "vitest run --maxWorkers=4 --coverage --reporter=default --reporter=junit --outputFile.junit=coverage/results.junit.xml"
   },
   "dependencies": {

--- a/packages/junior/scripts/check-tool-annotations.mjs
+++ b/packages/junior/scripts/check-tool-annotations.mjs
@@ -1,0 +1,174 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+
+const TOOL_CONSTRUCTORS = new Set(["definePluginTool", "tool", "zodTool"]);
+const REQUIRED_HINTS = [
+  "destructiveHint",
+  "idempotentHint",
+  "openWorldHint",
+  "readOnlyHint",
+];
+
+function propertyName(property, sourceFile) {
+  if (!property.name) {
+    return undefined;
+  }
+  if (
+    ts.isIdentifier(property.name) ||
+    ts.isStringLiteral(property.name) ||
+    ts.isNumericLiteral(property.name)
+  ) {
+    return property.name.text;
+  }
+  return property.name.getText(sourceFile);
+}
+
+function annotationErrors(call, sourceFile, filePath) {
+  const line =
+    sourceFile.getLineAndCharacterOfPosition(call.getStart(sourceFile)).line +
+    1;
+  const prefix = `${filePath}:${line}`;
+  const definition = call.arguments[0];
+  if (!definition || !ts.isObjectLiteralExpression(definition)) {
+    return [`${prefix}: repo tool definition must use an object literal`];
+  }
+
+  const annotationsProperty = definition.properties.find(
+    (property) => propertyName(property, sourceFile) === "annotations",
+  );
+  if (
+    !annotationsProperty ||
+    !ts.isPropertyAssignment(annotationsProperty) ||
+    !ts.isObjectLiteralExpression(annotationsProperty.initializer)
+  ) {
+    return [
+      `${prefix}: repo tool must declare annotations with ${REQUIRED_HINTS.join(", ")}`,
+    ];
+  }
+
+  const values = new Map();
+  for (const property of annotationsProperty.initializer.properties) {
+    if (!ts.isPropertyAssignment(property)) {
+      continue;
+    }
+    const name = propertyName(property, sourceFile);
+    if (!name || !REQUIRED_HINTS.includes(name)) {
+      continue;
+    }
+    if (
+      property.initializer.kind !== ts.SyntaxKind.TrueKeyword &&
+      property.initializer.kind !== ts.SyntaxKind.FalseKeyword
+    ) {
+      values.set(name, "non-boolean");
+      continue;
+    }
+    values.set(name, property.initializer.kind === ts.SyntaxKind.TrueKeyword);
+  }
+
+  const errors = [];
+  const missing = REQUIRED_HINTS.filter((hint) => !values.has(hint));
+  if (missing.length > 0) {
+    errors.push(
+      `${prefix}: repo tool annotations missing ${missing.join(", ")}`,
+    );
+  }
+  const nonBoolean = REQUIRED_HINTS.filter(
+    (hint) => values.get(hint) === "non-boolean",
+  );
+  if (nonBoolean.length > 0) {
+    errors.push(
+      `${prefix}: repo tool annotations must use boolean literals for ${nonBoolean.join(", ")}`,
+    );
+  }
+  if (
+    values.get("readOnlyHint") === true &&
+    values.get("destructiveHint") === true
+  ) {
+    errors.push(
+      `${prefix}: read-only tools cannot declare destructiveHint: true`,
+    );
+  }
+  return errors;
+}
+
+/** Check one source file for complete repo-owned tool annotations. */
+export function checkToolAnnotationSource(source, filePath = "tool.ts") {
+  const sourceFile = ts.createSourceFile(
+    filePath,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+  );
+  const errors = [];
+
+  function visit(node) {
+    if (
+      ts.isCallExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      TOOL_CONSTRUCTORS.has(node.expression.text)
+    ) {
+      errors.push(...annotationErrors(node, sourceFile, filePath));
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return errors;
+}
+
+async function sourceFiles(directory) {
+  const entries = await fs.readdir(directory, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await sourceFiles(entryPath)));
+    } else if (entry.name.endsWith(".ts") && !entry.name.endsWith(".d.ts")) {
+      files.push(entryPath);
+    }
+  }
+  return files;
+}
+
+/** Check every repo package source file for complete tool annotations. */
+export async function checkRepoToolAnnotations(repoRoot) {
+  const packagesRoot = path.join(repoRoot, "packages");
+  const packageEntries = await fs.readdir(packagesRoot, {
+    withFileTypes: true,
+  });
+  const errors = [];
+  for (const packageEntry of packageEntries) {
+    if (!packageEntry.isDirectory()) {
+      continue;
+    }
+    const sourceRoot = path.join(packagesRoot, packageEntry.name, "src");
+    try {
+      for (const filePath of await sourceFiles(sourceRoot)) {
+        const source = await fs.readFile(filePath, "utf8");
+        errors.push(
+          ...checkToolAnnotationSource(
+            source,
+            path.relative(repoRoot, filePath),
+          ),
+        );
+      }
+    } catch (error) {
+      if (error?.code !== "ENOENT") {
+        throw error;
+      }
+    }
+  }
+  return errors;
+}
+
+const scriptPath = fileURLToPath(import.meta.url);
+if (process.argv[1] && path.resolve(process.argv[1]) === scriptPath) {
+  const repoRoot = path.resolve(path.dirname(scriptPath), "../../..");
+  const errors = await checkRepoToolAnnotations(repoRoot);
+  if (errors.length > 0) {
+    console.error(errors.join("\n"));
+    process.exitCode = 1;
+  }
+}

--- a/packages/junior/scripts/check-tool-annotations.test.mjs
+++ b/packages/junior/scripts/check-tool-annotations.test.mjs
@@ -1,0 +1,46 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { checkToolAnnotationSource } from "./check-tool-annotations.mjs";
+
+describe("checkToolAnnotationSource", () => {
+  it("accepts complete behavioral hints", () => {
+    const errors = checkToolAnnotationSource(`
+      zodTool({
+        annotations: {
+          destructiveHint: false,
+          idempotentHint: true,
+          openWorldHint: false,
+          readOnlyHint: true,
+        },
+      });
+    `);
+
+    assert.deepEqual(errors, []);
+  });
+
+  it("rejects missing and inconsistent hints", () => {
+    const errors = checkToolAnnotationSource(`
+      definePluginTool({
+        annotations: {
+          destructiveHint: true,
+          readOnlyHint: true,
+        },
+      });
+    `);
+
+    assert.deepEqual(errors, [
+      "tool.ts:2: repo tool annotations missing idempotentHint, openWorldHint",
+      "tool.ts:2: read-only tools cannot declare destructiveHint: true",
+    ]);
+  });
+
+  it("rejects omitted annotations", () => {
+    const errors = checkToolAnnotationSource(
+      `zodTool({ description: "demo" });`,
+    );
+
+    assert.deepEqual(errors, [
+      "tool.ts:1: repo tool must declare annotations with destructiveHint, idempotentHint, openWorldHint, readOnlyHint",
+    ]);
+  });
+});

--- a/packages/junior/src/chat/README.md
+++ b/packages/junior/src/chat/README.md
@@ -102,11 +102,12 @@ delegation without becoming the execution actor or a general task owner.
   across asynchronous boundaries.
 - Action review sees the validated, hook-adjusted semantic input immediately
   before execution; hook-injected environment values stay execution-only.
-  Omitted approval modes use auto policy. Every execution attempt that enters
-  review reaches Guardian; prior rejections are context rather than binding
-  decisions. Each Guardian decision is committed to the conversation event log
-  before the reviewed action can continue. `ask` and `deny` become expected tool
-  failures, and three consecutive rejections interrupt the execution slice.
+  Plugin tools with omitted approval modes use auto policy; core tools must opt
+  in explicitly. Every execution attempt that enters review reaches Guardian;
+  prior rejections are context rather than binding decisions. Each Guardian
+  decision is committed to the conversation event log before the reviewed
+  action can continue. `ask` and `deny` become expected tool failures, and three
+  consecutive rejections interrupt the execution slice.
 - Guardian receives a projection of credential authority, never signed
   credential bindings, plus bounded user, assistant, tool-call, and tool-result
   evidence selected with the Codex Guardian transcript rules. It cannot override

--- a/packages/junior/src/chat/README.md
+++ b/packages/junior/src/chat/README.md
@@ -77,6 +77,9 @@ delegation without becoming the execution actor or a general task owner.
 - Retry continuations retain an exact transcript prefix. Usage from discarded
   assistant tails is carried forward separately so retained messages are
   counted once.
+- Repo-owned tools declare `readOnlyHint`, `destructiveHint`, `openWorldHint`,
+  and `idempotentHint`. External plugin and MCP tools with missing hints are
+  logged and enter action review conservatively.
 - Tool-bearing assistant text stays in agent history but is not destination
   output; explicit progress uses the runtime status surface.
 - Tool failures remain internal agent-loop data unless the final result exposes
@@ -99,12 +102,11 @@ delegation without becoming the execution actor or a general task owner.
   across asynchronous boundaries.
 - Action review sees the validated, hook-adjusted semantic input immediately
   before execution; hook-injected environment values stay execution-only.
-  Unclassified tools retain compatibility behavior. Every execution attempt
-  that enters review reaches Guardian; prior rejections are context rather than
-  binding decisions. Each Guardian decision is committed to the conversation
-  event log before the reviewed action can continue. `ask` and `deny` become
-  expected tool failures, and three consecutive rejections interrupt the
-  execution slice.
+  Omitted approval modes use auto policy. Every execution attempt that enters
+  review reaches Guardian; prior rejections are context rather than binding
+  decisions. Each Guardian decision is committed to the conversation event log
+  before the reviewed action can continue. `ask` and `deny` become expected tool
+  failures, and three consecutive rejections interrupt the execution slice.
 - Guardian receives a projection of credential authority, never signed
   credential bindings, plus bounded user, assistant, tool-call, and tool-result
   evidence selected with the Codex Guardian transcript rules. It cannot override

--- a/packages/junior/src/chat/mcp/tool-manager.ts
+++ b/packages/junior/src/chat/mcp/tool-manager.ts
@@ -8,9 +8,10 @@
  */
 import type { ImageContent, TextContent } from "@earendil-works/pi-ai";
 import type { OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js";
-import type {
-  PluginMcpToolResult,
-  ToolAnnotations,
+import {
+  missingToolAnnotationKeys,
+  type PluginMcpToolResult,
+  type ToolAnnotations,
 } from "@sentry/junior-plugin-api";
 import {
   logWarn,
@@ -280,9 +281,7 @@ export interface McpToolManagerOptions {
    * Optional post-success processor for model-facing MCP tool calls.
    * Failures are logged by the host caller and must not fail the tool result.
    */
-  onToolSuccess?: (
-    input: McpToolSuccessHookInput,
-  ) => Promise<void> | void;
+  onToolSuccess?: (input: McpToolSuccessHookInput) => Promise<void> | void;
 }
 
 export interface ManagedMcpToolResult {
@@ -526,6 +525,14 @@ export class McpToolManager {
   ): ManagedMcpTool {
     const outputSchema = toOptionalRecord(tool.outputSchema);
     const annotations = tool.annotations;
+    const missingAnnotationKeys = missingToolAnnotationKeys(annotations);
+    if (missingAnnotationKeys.length > 0) {
+      logWarn("mcp.tool_annotations.missing", {
+        "app.plugin.name": plugin.manifest.name,
+        "gen_ai.tool.name": tool.name,
+        "app.tool.missing_annotations": missingAnnotationKeys.join(","),
+      });
+    }
     return {
       name: normalizeMcpToolName(plugin.manifest.name, tool.name),
       description: describeMcpTool(plugin.manifest.name, tool),

--- a/packages/junior/src/chat/plugins/agent-hooks.ts
+++ b/packages/junior/src/chat/plugins/agent-hooks.ts
@@ -1,4 +1,5 @@
 import {
+  missingToolAnnotationKeys,
   promptContextSchema,
   promptMessageSchema,
   resourceEventSchema,
@@ -586,6 +587,17 @@ export function getPluginTools(
         );
       }
       const definition = tool as unknown as AnyToolDefinition;
+      const missingAnnotationKeys = missingToolAnnotationKeys(
+        definition.annotations,
+      );
+      if (missingAnnotationKeys.length > 0) {
+        logWarn("plugin.tool_annotations.missing", {
+          "app.plugin.name": pluginName,
+          "gen_ai.tool.name": localName,
+          "app.tool.missing_annotations": missingAnnotationKeys.join(","),
+        });
+      }
+      definition.approvalMode ??= "auto";
       definition.identity = {
         id: `${pluginName}.${localName}`,
         name: localName,

--- a/packages/junior/src/chat/slack/tools/canvas/create.ts
+++ b/packages/junior/src/chat/slack/tools/canvas/create.ts
@@ -15,6 +15,12 @@ export function createSlackCanvasCreateTool(
   state: ToolState,
 ) {
   return zodTool({
+    annotations: {
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+      readOnlyHint: false,
+    },
     description:
       "Create a Slack canvas for long-form output in the active assistant context channel. Use when the answer is better as a reusable document than a thread reply: long-form research, timelines, bios/profiles, structured notes, plans, comparisons, or anything likely to exceed one compact Slack reply. After creating it, reply with one or two short sentences plus the canvas link; do not recap the canvas contents. Do not use for short answers that fit cleanly in one normal thread reply.",
     inputSchema: z.object({

--- a/packages/junior/src/chat/slack/tools/canvas/edit.ts
+++ b/packages/junior/src/chat/slack/tools/canvas/edit.ts
@@ -49,6 +49,12 @@ const slackCanvasEditOutputSchema = juniorToolResultSchema
 /** Create a tool that edits a Slack canvas like a markdown file. */
 export function createSlackCanvasEditTool(state: ToolState) {
   return zodTool({
+    annotations: {
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: true,
+      readOnlyHint: false,
+    },
     description:
       "Edit one Slack canvas with exact markdown replacements. Use for precise changes to existing Canvas content; prefer this over slackCanvasWrite for targeted changes. Each oldText must match exactly, be unique, and not overlap another edit. Returns a diff. Multiple changes to the same canvas: use one edits[] call.",
     prepareArguments: prepareCanvasEditArguments,

--- a/packages/junior/src/chat/slack/tools/canvas/read.ts
+++ b/packages/junior/src/chat/slack/tools/canvas/read.ts
@@ -31,7 +31,12 @@ export function createSlackCanvasReadTool() {
   return zodTool({
     description:
       "Read a bounded line range from a Slack canvas as markdown. Use when you need exact Canvas contents to verify facts or make edits safely. Do not use for generic web pages — use webFetch for those.",
-    annotations: { readOnlyHint: true, destructiveHint: false },
+    annotations: {
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+      readOnlyHint: true,
+    },
     inputSchema: z.object({
       canvas: z
         .string()

--- a/packages/junior/src/chat/slack/tools/canvas/write.ts
+++ b/packages/junior/src/chat/slack/tools/canvas/write.ts
@@ -13,6 +13,12 @@ import type { ToolState } from "@/chat/tools/types";
 /** Create a tool that deliberately replaces a Slack canvas body. */
 export function createSlackCanvasWriteTool(state: ToolState) {
   return zodTool({
+    annotations: {
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: true,
+      readOnlyHint: false,
+    },
     description:
       "Write UTF-8 markdown content to a Slack canvas. Use for deliberate full-Canvas replacement after validation; use slackCanvasEdit for targeted changes to existing canvas content.",
     executionMode: "sequential",

--- a/packages/junior/src/chat/slack/tools/channel-list-messages.ts
+++ b/packages/junior/src/chat/slack/tools/channel-list-messages.ts
@@ -64,7 +64,12 @@ export function createSlackChannelListMessagesTool(context: SlackToolContext) {
   return zodTool({
     description:
       "List channel messages from Slack history in the active channel context. Use when the user asks for recent or historical channel context outside this thread. Do not use for live monitoring or when current thread context already answers the question.",
-    annotations: { readOnlyHint: true, destructiveHint: false },
+    annotations: {
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+      readOnlyHint: true,
+    },
     inputSchema: z.object({
       limit: z.coerce
         .number()

--- a/packages/junior/src/chat/slack/tools/conversation-search.ts
+++ b/packages/junior/src/chat/slack/tools/conversation-search.ts
@@ -49,7 +49,12 @@ export function createSlackConversationSearchTool(
       description:
         "Search retained public Junior conversation threads in the current Slack workspace.",
     },
-    annotations: { readOnlyHint: true, destructiveHint: false },
+    annotations: {
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+      readOnlyHint: true,
+    },
     inputSchema: z.object({
       query: z
         .string()

--- a/packages/junior/src/chat/slack/tools/list/add-items.ts
+++ b/packages/junior/src/chat/slack/tools/list/add-items.ts
@@ -13,6 +13,12 @@ import type { ToolState } from "@/chat/tools/types";
 /** Create a tool that appends items to the active Slack list. */
 export function createSlackListAddItemsTool(state: ToolState) {
   return zodTool({
+    annotations: {
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+      readOnlyHint: false,
+    },
     description:
       "Add tasks to the active Slack list tracked in artifact context. Use when the user wants actionable items recorded in the current thread list. Do not use when no list exists and list creation was not requested.",
     inputSchema: z.object({

--- a/packages/junior/src/chat/slack/tools/list/create.ts
+++ b/packages/junior/src/chat/slack/tools/list/create.ts
@@ -8,6 +8,12 @@ import type { ToolState } from "@/chat/tools/types";
 /** Create a tool that provisions a new Slack todo list. */
 export function createSlackListCreateTool(state: ToolState) {
   return zodTool({
+    annotations: {
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+      readOnlyHint: false,
+    },
     description:
       "Create a Slack todo list for action tracking. Use when the user needs structured tasks with ownership/completion tracking. Do not use for one-off notes without task management needs.",
     inputSchema: z.object({

--- a/packages/junior/src/chat/slack/tools/list/get-items.ts
+++ b/packages/junior/src/chat/slack/tools/list/get-items.ts
@@ -9,7 +9,12 @@ export function createSlackListGetItemsTool(state: ToolState) {
   return zodTool({
     description:
       "Read items from the active Slack list tracked in artifact context. Use when the user asks for task status, open items, or list contents. Do not use when list state is already known from the immediately prior result.",
-    annotations: { readOnlyHint: true, destructiveHint: false },
+    annotations: {
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+      readOnlyHint: true,
+    },
     inputSchema: z.object({
       limit: z.coerce
         .number()

--- a/packages/junior/src/chat/slack/tools/list/update-item.ts
+++ b/packages/junior/src/chat/slack/tools/list/update-item.ts
@@ -29,6 +29,12 @@ const updateListItemInputSchema = z.union([
 /** Create a tool that updates an item in the active Slack list. */
 export function createSlackListUpdateItemTool(state: ToolState) {
   return zodTool({
+    annotations: {
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: true,
+      readOnlyHint: false,
+    },
     description:
       "Update an item in the active Slack list tracked in artifact context (title/completion). Use when the user asks to mark progress or rename a tracked task. Do not use to add new tasks.",
     inputSchema: updateListItemInputSchema,

--- a/packages/junior/src/chat/slack/tools/message-add-reaction.ts
+++ b/packages/junior/src/chat/slack/tools/message-add-reaction.ts
@@ -14,6 +14,12 @@ export function createSlackMessageAddReactionTool(
   state: ToolState,
 ) {
   return zodTool({
+    annotations: {
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+      readOnlyHint: false,
+    },
     description:
       "Add an emoji reaction to the current inbound Slack message. Use when the user asks for a reaction on the current message without another target. Provide a Slack emoji alias name (for example `thumbsup`, `white_check_mark`, or `thumbsup::skin-tone-6`), not a unicode emoji glyph. The target message is injected by runtime context; do not use this for arbitrary historical messages.",
     inputSchema: z.object({

--- a/packages/junior/src/chat/slack/tools/public-search.ts
+++ b/packages/junior/src/chat/slack/tools/public-search.ts
@@ -71,7 +71,12 @@ export function createSlackPublicSearchTool(actionToken: SlackActionToken) {
   return zodTool({
     description:
       "Search public Slack channel messages across the current workspace. Use when the user asks about company activity, announcements, public mentions, or context outside the active channel. Search only when requested or clearly needed, prefer focused keywords and time bounds, and cite returned permalinks. This never searches private channels or DMs.",
-    annotations: { readOnlyHint: true, destructiveHint: false },
+    annotations: {
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+      readOnlyHint: true,
+    },
     inputSchema: z.object({
       query: z
         .string()

--- a/packages/junior/src/chat/slack/tools/send-files.ts
+++ b/packages/junior/src/chat/slack/tools/send-files.ts
@@ -68,6 +68,12 @@ export function createSendFilesTool(
   materializeFile: MaterializeFile,
 ) {
   return zodTool({
+    annotations: {
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+      readOnlyHint: false,
+    },
     description:
       "Send one or more sandbox files into the active Slack conversation. Use when the user asks to attach, send, or share files here, in this conversation, or in this thread. Do not use for ordinary assistant text, top-level channel posts, other named channels, inline @mentions, or pinging mentioned users.",
     inputSchema: z.object({

--- a/packages/junior/src/chat/slack/tools/thread-read.ts
+++ b/packages/junior/src/chat/slack/tools/thread-read.ts
@@ -84,7 +84,12 @@ export function createSlackThreadReadTool(
   return zodTool({
     description:
       "Read a Slack thread from a shared Slack message archive URL or explicit channel + timestamp. Use when the user shares a Slack message link (https://*.slack.com/archives/...) and you need the referenced message and its thread context. Only the current conversation and public channels Junior has seen in this workspace are readable.",
-    annotations: { readOnlyHint: true, destructiveHint: false },
+    annotations: {
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+      readOnlyHint: true,
+    },
     inputSchema: z.object({
       url: z
         .string()

--- a/packages/junior/src/chat/slack/tools/user-lookup.ts
+++ b/packages/junior/src/chat/slack/tools/user-lookup.ts
@@ -25,7 +25,12 @@ export function createSlackUserLookupTool() {
   return zodTool({
     description:
       "Look up Slack user profiles by user ID, email, or name search. Use when you need to identify a user, resolve cross-platform identity, or look up profile details like title or status. Returns profile fields including custom fields. For user ID lookup, pass a Slack user ID (e.g. U039RR91S). For search, pass a name query.",
-    annotations: { readOnlyHint: true, destructiveHint: false },
+    annotations: {
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+      readOnlyHint: true,
+    },
     inputSchema: z.object({
       user_id: slackUserIdParam(
         "Slack user ID to look up (e.g. U039RR91S). Mutually exclusive with email and query.",

--- a/packages/junior/src/chat/tool-support/action-review.ts
+++ b/packages/junior/src/chat/tool-support/action-review.ts
@@ -187,13 +187,13 @@ export class ToolActionReviewLimitError extends Error {
   }
 }
 
-/** Resolve omitted approval modes through the conservative auto policy. */
+/** Keep core tools outside action review unless they explicitly opt in. */
 function effectiveApprovalMode(
   tool: AnyToolDefinition,
   resolved: ToolApprovalResolution | undefined,
 ): "approve" | "review" {
-  const declared = tool.approvalMode ?? "auto";
-  if (declared === "approve") {
+  const declared = tool.approvalMode;
+  if (declared === undefined || declared === "approve") {
     return "approve";
   }
   if (declared === "review") {
@@ -417,7 +417,7 @@ async function prepareToolActionReview(
   context: ToolActionReviewContext,
   priorRejections: ToolActionPriorRejection[],
 ): Promise<ToolActionProposal | undefined> {
-  if (tool.approvalMode === "approve") {
+  if (tool.approvalMode === undefined || tool.approvalMode === "approve") {
     return;
   }
   const resolved = await tool.resolveApprovalMetadata?.(input);
@@ -531,14 +531,10 @@ export async function reviewToolAction(
   review: ToolActionReview | undefined,
   signal?: AbortSignal,
 ): Promise<ToolActionReviewDecision | undefined> {
-  if (tool.approvalMode === "approve") {
+  if (tool.approvalMode === undefined || tool.approvalMode === "approve") {
     return;
   }
   if (!review) {
-    const resolved = await tool.resolveApprovalMetadata?.(input);
-    if (effectiveApprovalMode(tool, resolved) === "approve") {
-      return;
-    }
     throw new ToolActionReviewUnavailableError();
   }
   return review.review(toolCallId, toolName, tool, input, signal);

--- a/packages/junior/src/chat/tool-support/action-review.ts
+++ b/packages/junior/src/chat/tool-support/action-review.ts
@@ -187,13 +187,13 @@ export class ToolActionReviewLimitError extends Error {
   }
 }
 
-/** Keep tools outside action review unless they explicitly opt in. */
+/** Resolve omitted approval modes through the conservative auto policy. */
 function effectiveApprovalMode(
   tool: AnyToolDefinition,
   resolved: ToolApprovalResolution | undefined,
 ): "approve" | "review" {
-  const declared = tool.approvalMode;
-  if (declared === undefined || declared === "approve") {
+  const declared = tool.approvalMode ?? "auto";
+  if (declared === "approve") {
     return "approve";
   }
   if (declared === "review") {
@@ -417,7 +417,7 @@ async function prepareToolActionReview(
   context: ToolActionReviewContext,
   priorRejections: ToolActionPriorRejection[],
 ): Promise<ToolActionProposal | undefined> {
-  if (tool.approvalMode === undefined || tool.approvalMode === "approve") {
+  if (tool.approvalMode === "approve") {
     return;
   }
   const resolved = await tool.resolveApprovalMetadata?.(input);
@@ -531,10 +531,14 @@ export async function reviewToolAction(
   review: ToolActionReview | undefined,
   signal?: AbortSignal,
 ): Promise<ToolActionReviewDecision | undefined> {
-  if (tool.approvalMode === undefined || tool.approvalMode === "approve") {
+  if (tool.approvalMode === "approve") {
     return;
   }
   if (!review) {
+    const resolved = await tool.resolveApprovalMetadata?.(input);
+    if (effectiveApprovalMode(tool, resolved) === "approve") {
+      return;
+    }
     throw new ToolActionReviewUnavailableError();
   }
   return review.review(toolCallId, toolName, tool, input, signal);

--- a/packages/junior/src/chat/tool-support/zod-tool.ts
+++ b/packages/junior/src/chat/tool-support/zod-tool.ts
@@ -233,7 +233,6 @@ export function zodTool<
   }
   return {
     ...toolDef,
-    approvalMode: toolDef.approvalMode ?? "auto",
     inputSchema: modelInputSchema,
     ...(modelOutputSchema ? { outputSchema: modelOutputSchema } : {}),
     prepareArguments(args) {

--- a/packages/junior/src/chat/tool-support/zod-tool.ts
+++ b/packages/junior/src/chat/tool-support/zod-tool.ts
@@ -233,6 +233,7 @@ export function zodTool<
   }
   return {
     ...toolDef,
+    approvalMode: toolDef.approvalMode ?? "auto",
     inputSchema: modelInputSchema,
     ...(modelOutputSchema ? { outputSchema: modelOutputSchema } : {}),
     prepareArguments(args) {

--- a/packages/junior/src/chat/tools/definition.ts
+++ b/packages/junior/src/chat/tools/definition.ts
@@ -154,8 +154,5 @@ export function isTypeBoxInputSchema(
 export function tool<TInputSchema extends TSchema>(
   definition: ToolDefinition<TInputSchema>,
 ): ToolDefinition<TInputSchema> {
-  return {
-    ...definition,
-    approvalMode: definition.approvalMode ?? "auto",
-  };
+  return definition;
 }

--- a/packages/junior/src/chat/tools/definition.ts
+++ b/packages/junior/src/chat/tools/definition.ts
@@ -154,5 +154,8 @@ export function isTypeBoxInputSchema(
 export function tool<TInputSchema extends TSchema>(
   definition: ToolDefinition<TInputSchema>,
 ): ToolDefinition<TInputSchema> {
-  return definition;
+  return {
+    ...definition,
+    approvalMode: definition.approvalMode ?? "auto",
+  };
 }

--- a/packages/junior/src/chat/tools/execute-tool.ts
+++ b/packages/junior/src/chat/tools/execute-tool.ts
@@ -8,6 +8,12 @@ export const EXECUTE_TOOL_NAME = "executeTool";
 /** Create the model-visible dispatcher schema for catalog tools. */
 export function createExecuteToolTool() {
   return zodTool({
+    annotations: {
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: true,
+      readOnlyHint: false,
+    },
     description:
       "Execute any catalog tool by exact tool_name from searchTools or a tool-result execution hint. Put tool-specific parameters inside arguments.",
     executionMode: "sequential",

--- a/packages/junior/src/chat/tools/handoff/tool.ts
+++ b/packages/junior/src/chat/tools/handoff/tool.ts
@@ -19,6 +19,12 @@ export function createHandoffTool(
     .map((profile) => `\`${profile}\``)
     .join(", ");
   return zodTool({
+    annotations: {
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+      readOnlyHint: false,
+    },
     description: `Switch to another execution profile and continue the same task. Profiles: ${profileNames}. Call this as the only tool.`,
     executionMode: "sequential",
     inputSchema: z

--- a/packages/junior/src/chat/tools/query-conversation-events.ts
+++ b/packages/junior/src/chat/tools/query-conversation-events.ts
@@ -95,7 +95,12 @@ export function createQueryConversationEventsTool(context: ToolRuntimeContext) {
       "Inspect Junior's stored turns, tool calls, handoffs, and compaction events when debugging its behavior. Returns events from the current conversation tree or another retained public conversation in the same Slack workspace, newest first by default.",
     exposure: "deferred",
     source: CONVERSATION_EVENTS_TOOL_SOURCE,
-    annotations: { readOnlyHint: true, destructiveHint: false },
+    annotations: {
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+      readOnlyHint: true,
+    },
     inputSchema: z
       .object({
         conversation_id: z

--- a/packages/junior/src/chat/tools/resource-events.ts
+++ b/packages/junior/src/chat/tools/resource-events.ts
@@ -106,6 +106,12 @@ function ttlMs(input: SubscribeInput): number {
 /** Create the tool that subscribes the current conversation to resource events. */
 function createSubscribeToResourceEventsTool(context: ToolRuntimeContext) {
   return zodTool({
+    annotations: {
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+      readOnlyHint: false,
+    },
     description:
       "Subscribe the current conversation to high-signal events for a resource returned by a subscribable tool result. Matching events are queued as normal conversation messages; they do not interrupt active work.",
     inputSchema: subscribeInputSchema,
@@ -156,6 +162,12 @@ function createSubscribeToResourceEventsTool(context: ToolRuntimeContext) {
 /** Create the tool that lists active resource subscriptions for this conversation. */
 function createListResourceEventSubscriptionsTool(context: ToolRuntimeContext) {
   return zodTool({
+    annotations: {
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+      readOnlyHint: true,
+    },
     description:
       "List active resource event subscriptions for the current conversation.",
     exposure: "deferred",
@@ -192,6 +204,12 @@ function createListResourceEventSubscriptionsTool(context: ToolRuntimeContext) {
 /** Create the tool that stops resource watches for this conversation. */
 function createStopWatchingResourcesTool(context: ToolRuntimeContext) {
   return zodTool({
+    annotations: {
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: false,
+      readOnlyHint: false,
+    },
     description:
       "Stop every resource watch for the current conversation. Infer the user's intent from context instead of requiring a special command, and call this tool before confirming that watching stopped.",
     exposure: "deferred",

--- a/packages/junior/src/chat/tools/runtime/report-progress.ts
+++ b/packages/junior/src/chat/tools/runtime/report-progress.ts
@@ -5,6 +5,12 @@ import { zodTool } from "@/chat/tool-support/zod-tool";
 /** Create the internal tool the model uses for sparse progress updates. */
 export function createReportProgressTool() {
   return zodTool({
+    annotations: {
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+      readOnlyHint: false,
+    },
     description:
       "Update the user-visible assistant loading message with a short progress phase. Use this only for work with multiple substantive phases or a materially long wait. Skip short lookups, routine commands, generic filler, and minor substeps. After an initial update, call it again only when the major phase meaningfully changes. Messages must be written in sentence case with a present-participle verb (e.g. 'Searching docs', 'Reviewing results', 'Running checks').",
     inputSchema: z.object({

--- a/packages/junior/src/chat/tools/sandbox/bash.ts
+++ b/packages/junior/src/chat/tools/sandbox/bash.ts
@@ -5,6 +5,12 @@ import { zodTool } from "@/chat/tool-support/zod-tool";
 /** Create the sandbox shell tool definition exposed to the agent. */
 export function createBashTool() {
   return zodTool({
+    annotations: {
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: false,
+      readOnlyHint: false,
+    },
     description:
       "Run a bash command inside the isolated sandbox workspace. Use this for repository inspection/execution tasks that need shell access. Do not use for network-sensitive or destructive actions unless explicitly required.",
     inputSchema: z.object({

--- a/packages/junior/src/chat/tools/sandbox/edit-file.ts
+++ b/packages/junior/src/chat/tools/sandbox/edit-file.ts
@@ -196,6 +196,12 @@ const editReplacementSchema = z.object({
 /** Create the sandbox edit tool definition exposed to the agent. */
 export function createEditFileTool() {
   return zodTool({
+    annotations: {
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: false,
+      readOnlyHint: false,
+    },
     description:
       "Edit one sandbox workspace file with exact text replacements. Use for precise changes to existing files; prefer this over writeFile for targeted changes. Each oldText must match exactly, be unique, and not overlap another edit. Returns a diff. Multiple changes to the same file: use one edits[] call.",
     prepareArguments: prepareEditFileArguments,

--- a/packages/junior/src/chat/tools/sandbox/find-files.ts
+++ b/packages/junior/src/chat/tools/sandbox/find-files.ts
@@ -259,7 +259,12 @@ export function createFindFilesTool() {
   return zodTool({
     description:
       "Find sandbox workspace files by glob pattern. Returns bounded paths relative to the search root and skips dependency/cache directories.",
-    annotations: { readOnlyHint: true, destructiveHint: false },
+    annotations: {
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+      readOnlyHint: true,
+    },
     inputSchema: z.object({
       pattern: z
         .string()

--- a/packages/junior/src/chat/tools/sandbox/grep.ts
+++ b/packages/junior/src/chat/tools/sandbox/grep.ts
@@ -494,7 +494,12 @@ export function createGrepTool() {
   return zodTool({
     description:
       "Search sandbox workspace file contents. Returns bounded matching lines with file paths and line numbers. Respects path/glob filters and includes truncation notices.",
-    annotations: { readOnlyHint: true, destructiveHint: false },
+    annotations: {
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+      readOnlyHint: true,
+    },
     inputSchema: z.object({
       pattern: z
         .string()

--- a/packages/junior/src/chat/tools/sandbox/list-dir.ts
+++ b/packages/junior/src/chat/tools/sandbox/list-dir.ts
@@ -130,7 +130,12 @@ export function createListDirTool() {
   return zodTool({
     description:
       "List a sandbox workspace directory. Returns sorted entries with '/' suffixes for directories and bounded truncation notices.",
-    annotations: { readOnlyHint: true, destructiveHint: false },
+    annotations: {
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+      readOnlyHint: true,
+    },
     inputSchema: z.object({
       path: z
         .string()

--- a/packages/junior/src/chat/tools/sandbox/read-file.ts
+++ b/packages/junior/src/chat/tools/sandbox/read-file.ts
@@ -11,7 +11,12 @@ export function createReadFileTool() {
   return zodTool({
     description:
       "Read a bounded line range from a file in the sandbox workspace. Use when you need exact file contents to verify facts or make edits safely. Prefer grep/findFiles/listDir for broad discovery.",
-    annotations: { readOnlyHint: true, destructiveHint: false },
+    annotations: {
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+      readOnlyHint: true,
+    },
     inputSchema: z.object({
       path: z
         .string()

--- a/packages/junior/src/chat/tools/sandbox/view-image.ts
+++ b/packages/junior/src/chat/tools/sandbox/view-image.ts
@@ -58,6 +58,12 @@ export function createViewImageTool(
   deps: ViewImageToolDeps = {},
 ) {
   return zodTool({
+    annotations: {
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+      readOnlyHint: true,
+    },
     description:
       "View an image file from the sandbox workspace when visual inspection is needed. Supports PNG, JPEG, GIF, and WebP images up to 5 MB.",
     exposure: "direct",

--- a/packages/junior/src/chat/tools/sandbox/write-file.ts
+++ b/packages/junior/src/chat/tools/sandbox/write-file.ts
@@ -5,6 +5,12 @@ import { zodTool } from "@/chat/tool-support/zod-tool";
 /** Create the sandbox full-file write tool definition exposed to the agent. */
 export function createWriteFileTool() {
   return zodTool({
+    annotations: {
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: false,
+      readOnlyHint: false,
+    },
     description:
       "Write UTF-8 content to a file in the sandbox workspace. Use for intentional file creation or deliberate full-file replacement after validation; use editFile instead for targeted changes to existing files. Do not use for exploratory analysis-only turns.",
     executionMode: "sequential",

--- a/packages/junior/src/chat/tools/search-tools.ts
+++ b/packages/junior/src/chat/tools/search-tools.ts
@@ -211,7 +211,12 @@ export function createSearchToolsTool(
   const knownSources = sourceSummaries(catalogTools);
   return zodTool({
     description: renderSearchToolsDescription(knownSources),
-    annotations: { readOnlyHint: true, destructiveHint: false },
+    annotations: {
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+      readOnlyHint: true,
+    },
     inputSchema: z
       .object({
         query: z

--- a/packages/junior/src/chat/tools/skill/call-mcp-tool.ts
+++ b/packages/junior/src/chat/tools/skill/call-mcp-tool.ts
@@ -56,6 +56,12 @@ function missingToolMessage(toolName: string, provider: string | undefined) {
 export function createCallMcpToolTool(mcpToolManager: CallMcpToolManager) {
   return zodTool({
     approvalMode: "auto",
+    annotations: {
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: true,
+      readOnlyHint: false,
+    },
     description:
       "Call an active MCP tool by exact tool_name. Use searchMcpTools to discover tool names and schemas; copy required provider fields into arguments. Do not call with only tool_name unless the discovered tool has no arguments. Authorization is handled by the runtime when required.",
     inputSchema: z

--- a/packages/junior/src/chat/tools/skill/load-skill.ts
+++ b/packages/junior/src/chat/tools/skill/load-skill.ts
@@ -109,6 +109,12 @@ export function createLoadSkillTool(
   },
 ) {
   return zodTool({
+    annotations: {
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+      readOnlyHint: false,
+    },
     description:
       "Load a skill by name for this turn. The result includes working_directory; resolve skill paths there and run skill-owned bash commands from there or with absolute paths. When the result includes mcp_provider, use searchMcpTools before callMcpTool. Use when a request clearly matches a known skill.",
     inputSchema: z.object({

--- a/packages/junior/src/chat/tools/skill/search-mcp-tools.ts
+++ b/packages/junior/src/chat/tools/skill/search-mcp-tools.ts
@@ -220,6 +220,12 @@ function searchProviderCatalog(
 /** Create the progressive MCP catalog search tool used before callMcpTool. */
 export function createSearchMcpToolsTool(mcpToolManager: SearchMcpToolManager) {
   return zodTool({
+    annotations: {
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+      readOnlyHint: true,
+    },
     description:
       "List or search MCP providers and active MCP tools. When provider is supplied and not yet active, Junior connects to it on demand and returns tool descriptors including schemas. Without provider, returns active tools plus matching configured providers without connecting. Use when choosing a provider tool or when callMcpTool arguments are unclear.",
     inputSchema: z

--- a/packages/junior/src/chat/tools/system-time.ts
+++ b/packages/junior/src/chat/tools/system-time.ts
@@ -13,7 +13,12 @@ export function createSystemTimeTool() {
   return zodTool({
     description:
       "Return current system time in UTC and local ISO formats. Use when the user asks for current time/date context. Do not use as a substitute for historical or timezone-conversion research.",
-    annotations: { readOnlyHint: true, destructiveHint: false },
+    annotations: {
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+      readOnlyHint: true,
+    },
     inputSchema: z.object({}),
     outputSchema: systemTimeOutputSchema,
     privateTraceResult: (result) => ({

--- a/packages/junior/src/chat/tools/web/fetch-tool.ts
+++ b/packages/junior/src/chat/tools/web/fetch-tool.ts
@@ -48,9 +48,10 @@ export function createWebFetchTool(
     description:
       "Fetch and extract readable content from a specific URL. Use when you need details from a known page or document. Do not use for discovery when search is the first step.",
     annotations: {
-      readOnlyHint: true,
       destructiveHint: false,
+      idempotentHint: true,
       openWorldHint: true,
+      readOnlyHint: true,
     },
     inputSchema: z.object({
       url: z.string().min(1).describe("HTTP(S) URL to fetch."),

--- a/packages/junior/src/chat/tools/web/image-generate.ts
+++ b/packages/junior/src/chat/tools/web/image-generate.ts
@@ -92,6 +92,12 @@ export function createImageGenerateTool(
   deps: ImageGenerateToolDeps = {},
 ) {
   return zodTool({
+    annotations: {
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+      readOnlyHint: false,
+    },
     description:
       "Generate images from a prompt. Use when the user wants to visually show or represent something — feelings, concepts, art, humor, or any visual idea. Also use for explicit image creation requests.",
     inputSchema: z.object({

--- a/packages/junior/src/chat/tools/web/search.ts
+++ b/packages/junior/src/chat/tools/web/search.ts
@@ -81,9 +81,10 @@ export function createWebSearchTool(
     description:
       "Search public web sources and return top snippets/URLs. Use when you need discovery or source candidates. Do not use when the user already provided a specific URL to inspect.",
     annotations: {
-      readOnlyHint: true,
       destructiveHint: false,
+      idempotentHint: true,
       openWorldHint: true,
+      readOnlyHint: true,
     },
     inputSchema: z.object({
       query: z.string().min(1).max(500).describe("Search query."),

--- a/packages/junior/tests/integration/sandbox-egress-proxy.test.ts
+++ b/packages/junior/tests/integration/sandbox-egress-proxy.test.ts
@@ -693,6 +693,13 @@ describe("sandbox egress proxy integration", () => {
       tools(ctx) {
         return {
           managedEgressRead: definePluginTool({
+            approvalMode: "approve",
+            annotations: {
+              destructiveHint: false,
+              idempotentHint: true,
+              openWorldHint: true,
+              readOnlyHint: true,
+            },
             description: "Read managed provider data through host egress",
             inputSchema: z.object({}),
             outputSchema: managedEgressReadResultSchema,

--- a/packages/junior/tests/integration/tool-support/pi-tool-adapter.test.ts
+++ b/packages/junior/tests/integration/tool-support/pi-tool-adapter.test.ts
@@ -55,6 +55,15 @@ function agentTool(tools: ReturnType<typeof createPiAgentTools>, name: string) {
 describe("Pi tool adapter integration", () => {
   it("discovers and executes plugin tools through catalog tool primitives", async () => {
     const onToolCall = vi.fn();
+    const actionReview = {
+      projectToolResult: <T>(_: string, result: T) => result,
+      review: vi.fn(async () => ({
+        decision: "allow" as const,
+        reason: "Read-only lookup requested by the user.",
+        riskLevel: "low" as const,
+        userAuthorization: "high" as const,
+      })),
+    };
     const previousPlugins = setPlugins([
       defineJuniorPlugin({
         manifest: {
@@ -66,6 +75,12 @@ describe("Pi tool adapter integration", () => {
           tools() {
             return {
               lookupCustomer: zodTool({
+                annotations: {
+                  destructiveHint: false,
+                  idempotentHint: true,
+                  openWorldHint: true,
+                  readOnlyHint: true,
+                },
                 description: "Lookup customer health for account review.",
                 inputSchema: z.object({
                   customerId: z
@@ -114,6 +129,8 @@ describe("Pi tool adapter integration", () => {
         onToolCall,
         undefined,
         "private",
+        undefined,
+        actionReview,
       );
 
       expect(registry.agentDemo_lookupCustomer?.exposure).toBe("deferred");
@@ -183,6 +200,13 @@ describe("Pi tool adapter integration", () => {
         {
           customerId: "C123",
         },
+      );
+      expect(actionReview.review).toHaveBeenCalledWith(
+        "tool-execute",
+        "agentDemo_lookupCustomer",
+        registry.agentDemo_lookupCustomer,
+        { customerId: "C123" },
+        undefined,
       );
     } finally {
       setPlugins(previousPlugins);

--- a/packages/junior/tests/unit/mcp/tool-manager-telemetry.test.ts
+++ b/packages/junior/tests/unit/mcp/tool-manager-telemetry.test.ts
@@ -1,16 +1,20 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { PluginDefinition } from "@/chat/plugins/types";
 
-const { endAttributes, resultMock, startAttributes } = vi.hoisted(() => ({
-  endAttributes: { value: {} as Record<string, unknown> },
-  resultMock: vi.fn(),
-  startAttributes: { value: {} as Record<string, unknown> },
-}));
+const { endAttributes, logWarnMock, resultMock, startAttributes } = vi.hoisted(
+  () => ({
+    endAttributes: { value: {} as Record<string, unknown> },
+    logWarnMock: vi.fn(),
+    resultMock: vi.fn(),
+    startAttributes: { value: {} as Record<string, unknown> },
+  }),
+);
 
 vi.mock("@/chat/logging", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/chat/logging")>();
   return {
     ...actual,
+    logWarn: logWarnMock,
     setSpanAttributes: vi.fn((attributes: Record<string, unknown>) => {
       Object.assign(endAttributes.value, attributes);
     }),
@@ -74,9 +78,23 @@ describe("McpToolManager telemetry", () => {
     startAttributes.value = {};
     endAttributes.value = {};
     resultMock.mockReset();
+    logWarnMock.mockReset();
     resultMock.mockResolvedValue({
       content: [{ type: "text", text: "private result" }],
       isError: false,
+    });
+  });
+
+  it("warns when an MCP tool omits behavioral annotations", async () => {
+    const manager = new McpToolManager([buildPlugin()]);
+
+    await manager.activateProvider("demo");
+
+    expect(logWarnMock).toHaveBeenCalledWith("mcp.tool_annotations.missing", {
+      "app.plugin.name": "demo",
+      "gen_ai.tool.name": "inspect",
+      "app.tool.missing_annotations":
+        "destructiveHint,idempotentHint,openWorldHint,readOnlyHint",
     });
   });
 

--- a/packages/junior/tests/unit/plugins/agent-hooks.test.ts
+++ b/packages/junior/tests/unit/plugins/agent-hooks.test.ts
@@ -8,7 +8,19 @@ import {
   type ToolRegistrationHookContext,
 } from "@sentry/junior-plugin-api";
 import { z } from "zod";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { logWarnMock } = vi.hoisted(() => ({
+  logWarnMock: vi.fn(),
+}));
+
+vi.mock("@/chat/logging", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/chat/logging")>();
+  return {
+    ...actual,
+    logWarn: logWarnMock,
+  };
+});
 import {
   createPluginHookRunner,
   getPluginApiRoutes,
@@ -35,6 +47,12 @@ function demoPluginTool(
 ) {
   return definePluginTool({
     approvalMode,
+    annotations: {
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+      readOnlyHint: true,
+    },
     describeProposal: () => `${description} proposal`,
     description,
     inputSchema: z.object({}),
@@ -76,6 +94,12 @@ const SLACK_SOURCE = createSlackSource({
 });
 
 class PrototypeTool {
+  annotations = {
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+    readOnlyHint: true,
+  };
   description = "Prototype tool";
   inputSchema = z.toJSONSchema(z.object({}));
   outputSchema = z.toJSONSchema(demoToolResultSchema);
@@ -144,6 +168,10 @@ function fakeSandbox(
 }
 
 describe("agent plugin hooks", () => {
+  beforeEach(() => {
+    logWarnMock.mockReset();
+  });
+
   it("accepts Slack source visibility from the runtime boundary", () => {
     expect(
       createSlackSource({
@@ -512,6 +540,51 @@ describe("agent plugin hooks", () => {
     }
   });
 
+  it("warns when a plugin tool omits behavioral annotations", () => {
+    const previous = setPlugins([
+      defineJuniorPlugin({
+        manifest: {
+          name: "agent-demo",
+          displayName: "Agent Demo",
+          description: "Agent demo",
+        },
+        hooks: {
+          tools() {
+            return {
+              demoTool: definePluginTool({
+                description: "Demo tool",
+                inputSchema: z.object({}),
+                outputSchema: demoToolResultSchema,
+                execute: () => ({ ok: true, status: "success" }) as const,
+              }),
+            };
+          },
+        },
+      }),
+    ]);
+    try {
+      getPluginTools({
+        destination: SLACK_DESTINATION,
+        actor: TEST_ACTOR,
+        egress: TEST_EGRESS,
+        source: SLACK_SOURCE,
+        workspace: {} as any,
+      });
+
+      expect(logWarnMock).toHaveBeenCalledWith(
+        "plugin.tool_annotations.missing",
+        {
+          "app.plugin.name": "agent-demo",
+          "gen_ai.tool.name": "demoTool",
+          "app.tool.missing_annotations":
+            "destructiveHint,idempotentHint,openWorldHint,readOnlyHint",
+        },
+      );
+    } finally {
+      setPlugins(previous);
+    }
+  });
+
   it("preserves plugin tool instances while adding internal identity", () => {
     const prototypeTool = new PrototypeTool();
     const previous = setPlugins([
@@ -540,6 +613,7 @@ describe("agent plugin hooks", () => {
 
       expect(tools.agentDemo_prototypeTool).toBe(prototypeTool);
       expect(tools.prototypeTool).toBeUndefined();
+      expect(tools.agentDemo_prototypeTool?.approvalMode).toBe("auto");
       expect(tools.agentDemo_prototypeTool?.identity).toEqual({
         id: "agent-demo.prototypeTool",
         name: "prototypeTool",

--- a/packages/junior/tests/unit/plugins/define-plugin-tool.test.ts
+++ b/packages/junior/tests/unit/plugins/define-plugin-tool.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   definePluginTool,
+  missingToolAnnotationKeys,
   PluginToolInputError,
   pluginToolResultSchema,
   toolApprovalModeSchema,
@@ -21,6 +22,7 @@ describe("definePluginTool", () => {
       approvalMode: "review",
       annotations: {
         destructiveHint: false,
+        idempotentHint: true,
         openWorldHint: true,
         readOnlyHint: true,
       },
@@ -40,12 +42,22 @@ describe("definePluginTool", () => {
     expect(tool.approvalMode).toBe("review");
     expect(tool.annotations).toEqual({
       destructiveHint: false,
+      idempotentHint: true,
       openWorldHint: true,
       readOnlyHint: true,
     });
     const input = tool.prepareArguments?.({ query: "errors" });
     expect(tool.describeProposal?.(input!)).toBe("Search for errors.");
     expect(toolApprovalModeSchema.safeParse("unexpected").success).toBe(false);
+  });
+
+  it("reports missing behavioral annotations", () => {
+    expect(
+      missingToolAnnotationKeys({
+        destructiveHint: false,
+        readOnlyHint: true,
+      }),
+    ).toEqual(["idempotentHint", "openWorldHint"]);
   });
 
   it("projects Zod input schemas to JSON Schema and parses tool arguments", async () => {
@@ -67,6 +79,7 @@ describe("definePluginTool", () => {
       execute,
     });
 
+    expect(tool.approvalMode).toBe("auto");
     expect(tool.inputSchema).toMatchObject({
       properties: {
         count: { type: "integer" },

--- a/packages/junior/tests/unit/tool-support/action-review.test.ts
+++ b/packages/junior/tests/unit/tool-support/action-review.test.ts
@@ -77,7 +77,7 @@ function definition(
 }
 
 describe("tool action review", () => {
-  it("uses auto policy when approval mode is omitted", async () => {
+  it("preserves execution behavior for unclassified core tools", async () => {
     const reviewer = { review: vi.fn() };
     const resolveApprovalMetadata = vi.fn();
 
@@ -90,10 +90,10 @@ describe("tool action review", () => {
     );
 
     expect(reviewer.review).not.toHaveBeenCalled();
-    expect(resolveApprovalMetadata).toHaveBeenCalledTimes(1);
+    expect(resolveApprovalMetadata).not.toHaveBeenCalled();
   });
 
-  it("reviews plugin actions with omitted approval mode", async () => {
+  it("reviews auto plugin actions with exact input and safe context", async () => {
     const review = vi.fn<ToolActionReviewer["review"]>(async () => ({
       decision: "allow",
       reason: "Matches the scheduled request.",
@@ -101,6 +101,7 @@ describe("tool action review", () => {
       userAuthorization: "high",
     }));
     const tool = definition({
+      approvalMode: "auto",
       annotations: {
         destructiveHint: false,
         idempotentHint: true,

--- a/packages/junior/tests/unit/tool-support/action-review.test.ts
+++ b/packages/junior/tests/unit/tool-support/action-review.test.ts
@@ -77,7 +77,7 @@ function definition(
 }
 
 describe("tool action review", () => {
-  it("preserves execution behavior for unclassified tools", async () => {
+  it("uses auto policy when approval mode is omitted", async () => {
     const reviewer = { review: vi.fn() };
     const resolveApprovalMetadata = vi.fn();
 
@@ -90,10 +90,10 @@ describe("tool action review", () => {
     );
 
     expect(reviewer.review).not.toHaveBeenCalled();
-    expect(resolveApprovalMetadata).not.toHaveBeenCalled();
+    expect(resolveApprovalMetadata).toHaveBeenCalledTimes(1);
   });
 
-  it("reviews auto plugin actions with exact input and safe credential context", async () => {
+  it("reviews plugin actions with omitted approval mode", async () => {
     const review = vi.fn<ToolActionReviewer["review"]>(async () => ({
       decision: "allow",
       reason: "Matches the scheduled request.",
@@ -101,9 +101,9 @@ describe("tool action review", () => {
       userAuthorization: "high",
     }));
     const tool = definition({
-      approvalMode: "auto",
       annotations: {
         destructiveHint: false,
+        idempotentHint: true,
         openWorldHint: true,
         readOnlyHint: true,
       },

--- a/packages/junior/tests/unit/tool-support/zod-tool.test.ts
+++ b/packages/junior/tests/unit/tool-support/zod-tool.test.ts
@@ -44,6 +44,7 @@ describe("zodTool", () => {
       },
     });
 
+    expect(tool.approvalMode).toBe("auto");
     expect(tool.inputSchema).toMatchObject({
       properties: {
         count: { type: "integer" },

--- a/packages/junior/tests/unit/tool-support/zod-tool.test.ts
+++ b/packages/junior/tests/unit/tool-support/zod-tool.test.ts
@@ -44,7 +44,7 @@ describe("zodTool", () => {
       },
     });
 
-    expect(tool.approvalMode).toBe("auto");
+    expect(tool.approvalMode).toBeUndefined();
     expect(tool.inputSchema).toMatchObject({
       properties: {
         count: { type: "integer" },


### PR DESCRIPTION
Plugin tools could bypass Guardian when `approvalMode` was omitted, even when they performed an external write. Plugin tool helpers and registration now normalize an omitted mode to `auto`, so plugin identity, provider source, and behavioral annotations participate in action review by default. Core tools retain explicit approval-mode opt-in.

All repo-owned tools now declare `readOnlyHint`, `destructiveHint`, `openWorldHint`, and `idempotentHint`. A new lint check rejects missing, non-boolean, or contradictory hints before merge. External plugin and MCP tools remain loadable, but emit a warning when their metadata is incomplete and are handled conservatively.

This closes the gap where GitHub and other plugin writes could execute without producing a Guardian review event, without forcing unrelated internal control tools through Guardian.

Validation includes the repo-wide lint policy gate, tool annotation checker, typechecks, 64 focused unit tests, and all 78 tests from the previously failing component and integration files.

Fixes #1149.