### PR TITLE
fix(dashboard): remove conversation list from location details

### DIFF
--- a/packages/junior-dashboard/src/client/pages/locations/LocationDetailPage.tsx
+++ b/packages/junior-dashboard/src/client/pages/locations/LocationDetailPage.tsx
@@ -1,27 +1,17 @@
 import { Duration } from "../../components/Duration";
 import { Clock3, Coins, MapPin, MessageSquare, Users } from "lucide-react";
-import { useState } from "react";
 import { Link, useParams } from "react-router";
 import type { LocationDetailReport } from "@sentry/junior/api/schema";
 
 import { useLocationDetailData } from "../../api";
-import { Button } from "../../components/Button";
-import { ConversationList } from "../../components/ConversationList";
-import { SearchInput } from "../../components/SearchInput";
 import { EmptyTelemetry } from "../../components/EmptyTelemetry";
 import { LoadingView } from "../../components/LoadingView";
-import { Section } from "../../components/Section";
-import { SectionHeader } from "../../components/SectionHeader";
-import { SectionTitle } from "../../components/SectionTitle";
 import { Card } from "../../components/layout/Card";
 import { PageHeader } from "../../components/layout/PageHeader";
 import { StatCard } from "../../components/metrics/StatCard";
 import {
-  buildConversations,
-  filterConversationList,
   formatCompactNumber,
   formatRelativeTime,
-  formatTime,
   peoplePath,
 } from "../../format";
 import { cn, dashboardContainerClass } from "../../styles";
@@ -65,9 +55,6 @@ export function LocationDetailPageContent(props: {
 
 function LocationDetail(props: { detail: LocationDetailReport }) {
   const detail = props.detail;
-  const [search, setSearch] = useState("");
-  const conversations = buildConversations(detail.recentConversations);
-  const visible = filterConversationList(conversations, { query: search });
   return (
     <>
       <PageHeader
@@ -165,38 +152,6 @@ function LocationDetail(props: { detail: LocationDetailReport }) {
           </div>
         )}
       </Card>
-
-      <Section className="mb-0">
-        <SectionHeader>
-          <div>
-            <SectionTitle>Recent conversations</SectionTitle>
-            <div className="mt-1 font-mono text-[0.67rem] text-dashboard-text-muted">
-              {visible.length} of {conversations.length} / generated{" "}
-              {formatTime(detail.generatedAt)}
-            </div>
-          </div>
-        </SectionHeader>
-        <div className="grid gap-2 border-b border-white/[0.06] bg-black/15 p-3 md:grid-cols-[minmax(12rem,36rem)_auto]">
-          <SearchInput
-            label="Search location conversations"
-            placeholder="Search title, person, or ID..."
-            value={search}
-            onChange={setSearch}
-          />
-          {search ? (
-            <Button
-              className="h-9 justify-center"
-              onClick={() => setSearch("")}
-            >
-              Clear
-            </Button>
-          ) : null}
-        </div>
-        <ConversationList
-          conversations={visible}
-          emptyLabel="No conversations match this search."
-        />
-      </Section>
     </>
   );
 }

--- a/packages/junior-dashboard/tests/telemetry-components.test.tsx
+++ b/packages/junior-dashboard/tests/telemetry-components.test.tsx
@@ -1109,7 +1109,7 @@ describe("dashboard canonical-event components", () => {
     expect(html).toContain("Public and private conversations per day");
   });
 
-  it("renders Location detail actors and recent conversations through stale data", () => {
+  it("renders Location detail actors without recent conversations through stale data", () => {
     const detail: LocationDetailReport = {
       active: 0,
       activityDays: [],
@@ -1161,8 +1161,9 @@ describe("dashboard canonical-event components", () => {
       </MemoryRouter>,
     );
     expect(html).toContain("Location telemetry refresh failed");
-    expect(html).toContain("Investigate checkout");
     expect(html).toContain("avery@example.com");
+    expect(html).not.toContain("Investigate checkout");
+    expect(html).not.toContain("Recent conversations");
   });
 
   it("keeps plugin loading, failure, and stale data states distinct", () => {


### PR DESCRIPTION
Location detail pages no longer render or search recent conversations. They still show summary stats, activity, and people, keeping conversation browsing in the dedicated conversation surfaces.

The existing component test now verifies that a conversation returned by the location report is not rendered.