### PR TITLE
fix(dashboard): add conversations navigation link

### DIFF
--- a/packages/junior-dashboard/e2e/conversations.spec.ts
+++ b/packages/junior-dashboard/e2e/conversations.spec.ts
@@ -52,9 +52,9 @@ test("opens a conversation in the built dashboard", async ({ page }) => {
   expect(headerBounds).toEqual({ left: 160, width: 1280 });
   expect(await containerBounds()).toEqual(headerBounds);
 
-  await expect(page.getByRole("link", { name: "Conversations" })).toHaveCount(
-    0,
-  );
+  await expect(
+    page.getByRole("link", { name: "Conversations" }),
+  ).toHaveAttribute("aria-current", "page");
   await expect(page.getByRole("link", { name: "Plugins" })).toHaveCount(0);
   expect(await containerBounds()).toEqual(headerBounds);
   expect(browserErrors).toEqual([]);

--- a/packages/junior-dashboard/src/client/App.tsx
+++ b/packages/junior-dashboard/src/client/App.tsx
@@ -109,9 +109,13 @@ export function DashboardShell() {
             <JuniorLogo />
           </Link>
           <nav className="col-span-2 row-start-2 flex min-w-0 items-center gap-6 overflow-x-auto md:col-span-1 md:col-start-2 md:row-start-1 md:justify-self-start md:overflow-visible">
-            <NavLink className={navLinkClass} end to="/">
+            <Link
+              aria-current={workspace ? "page" : undefined}
+              className={navLinkClass({ isActive: workspace })}
+              to="/"
+            >
               Conversations
-            </NavLink>
+            </Link>
             <NavLink className={navLinkClass} to="/locations">
               Locations
             </NavLink>

--- a/packages/junior-dashboard/src/client/App.tsx
+++ b/packages/junior-dashboard/src/client/App.tsx
@@ -109,6 +109,9 @@ export function DashboardShell() {
             <JuniorLogo />
           </Link>
           <nav className="col-span-2 row-start-2 flex min-w-0 items-center gap-6 overflow-x-auto md:col-span-1 md:col-start-2 md:row-start-1 md:justify-self-start md:overflow-visible">
+            <NavLink className={navLinkClass} end to="/">
+              Conversations
+            </NavLink>
             <NavLink className={navLinkClass} to="/locations">
               Locations
             </NavLink>


### PR DESCRIPTION
Adds a visible Conversations link to the dashboard navigation immediately before Locations. The link returns users to the conversations homepage instead of requiring them to use the logo icon.