### PR TITLE
feat(dashboard): add all plugins system view

### DIFF
--- a/packages/junior-dashboard/e2e/system.spec.ts
+++ b/packages/junior-dashboard/e2e/system.spec.ts
@@ -26,10 +26,8 @@ test("shows system usage and plugin details", async ({ page }) => {
   await page.goto(`${server.baseURL}/system`);
 
   await expect(page.getByText("Usage over time")).toBeVisible();
-  await expect(
-    page.getByRole("heading", { name: "Plugins", exact: true }),
-  ).toBeVisible();
   await expect(page.getByText("Model spend")).toBeVisible();
+  await expect(page.getByRole("region", { name: "Plugins" })).toHaveCount(0);
 
   const headerBounds = await page
     .locator("main > header > div")
@@ -40,12 +38,21 @@ test("shows system usage and plugin details", async ({ page }) => {
   expect(headerBounds).toEqual({ left: 160, width: 1280 });
 
   const systemNavigation = page.getByLabel("System navigation");
+  const allPluginsLink = systemNavigation.getByRole("link", {
+    name: "All Plugins",
+    exact: true,
+  });
+  await expect(allPluginsLink).toBeVisible();
   await expect(
     systemNavigation.getByRole("link", { name: "GitHub", exact: true }),
   ).toHaveCount(0);
   await expect(
     systemNavigation.getByRole("link", { name: "Scheduler", exact: true }),
   ).toHaveCount(0);
+
+  await allPluginsLink.click();
+  await expect(page).toHaveURL(`${server.baseURL}/system/plugins`);
+  await expect(page.getByLabel("Reporting period")).toHaveCount(0);
 
   const pluginPanels = page.getByRole("region", { name: "Plugins" });
   const githubPanel = pluginPanels.getByRole("link", {
@@ -145,8 +152,14 @@ test("navigates plugin information and activity on mobile", async ({
   ).toBeLessThanOrEqual(390);
   await expect(page.getByLabel("System view").locator("option")).toHaveText([
     "Overview",
+    "All Plugins",
     "Scheduler",
   ]);
+  await page.getByLabel("System view").selectOption("/system/plugins");
+  await expect(page).toHaveURL(`${server.baseURL}/system/plugins`);
+  await expect(
+    page.getByLabel("System view").locator("option:checked"),
+  ).toHaveText("All Plugins");
   await page
     .getByRole("region", { name: "Plugins" })
     .getByRole("link", { name: /GitHub/ })

--- a/packages/junior-dashboard/src/client/pages/system/PluginPanels.tsx
+++ b/packages/junior-dashboard/src/client/pages/system/PluginPanels.tsx
@@ -5,7 +5,7 @@ import { Card } from "../../components/layout/Card";
 import { SectionIntro } from "../../components/layout/SectionIntro";
 import { systemPluginPath, type SystemPlugin } from "./SystemPlugins";
 
-/** Render loaded plugins as useful System overview launch panels. */
+/** Render the loaded plugin inventory as launch panels. */
 export function PluginPanels(props: { plugins: SystemPlugin[] }) {
   return (
     <section aria-labelledby="system-plugins-heading" className="grid gap-3">

--- a/packages/junior-dashboard/src/client/pages/system/SystemNavigation.tsx
+++ b/packages/junior-dashboard/src/client/pages/system/SystemNavigation.tsx
@@ -5,6 +5,7 @@ import { cn, dashboardInteractiveTextClass } from "../../styles";
 import {
   normalizeSystemPath,
   systemPluginPath,
+  systemPluginsPath,
   type SystemPlugin,
 } from "./SystemPlugins";
 
@@ -44,6 +45,7 @@ export function SystemNavigation(props: {
             value={systemNavigationValue(location.pathname, props.plugins)}
           >
             <option value="/system">Overview</option>
+            <option value={systemPluginsPath}>All Plugins</option>
             {props.reportingPlugins.map((plugin) => (
               <option key={plugin.name} value={systemPluginPath(plugin.name)}>
                 {plugin.displayName}
@@ -71,11 +73,15 @@ export function SystemNavigation(props: {
             <Gauge aria-hidden="true" size={15} strokeWidth={1.8} />
             Overview
           </NavLink>
+          <div className="px-3 pt-4 pb-1.5 font-mono text-[0.56rem] font-medium uppercase tracking-[0.16em] text-dashboard-text-muted">
+            Plugins
+          </div>
+          <NavLink className={linkClass} end to={systemPluginsPath}>
+            <Boxes aria-hidden="true" size={15} strokeWidth={1.8} />
+            All Plugins
+          </NavLink>
           {props.reportingPlugins.length ? (
-            <>
-              <div className="px-3 pt-4 pb-1.5 font-mono text-[0.56rem] font-medium uppercase tracking-[0.16em] text-dashboard-text-muted">
-                Plugins
-              </div>
+            <div className="mt-3 grid min-w-0 gap-1">
               {props.reportingPlugins.map((plugin) => (
                 <NavLink
                   className={linkClass}
@@ -86,7 +92,7 @@ export function SystemNavigation(props: {
                   <span className="truncate">{plugin.displayName}</span>
                 </NavLink>
               ))}
-            </>
+            </div>
           ) : null}
         </nav>
       </aside>
@@ -99,7 +105,10 @@ function systemNavigationValue(
   plugins: SystemPlugin[],
 ): string {
   const plugin = findSystemPlugin(pathname, plugins);
-  return plugin ? systemPluginPath(plugin.name) : "/system";
+  if (plugin) return systemPluginPath(plugin.name);
+  return normalizeSystemPath(pathname) === systemPluginsPath
+    ? systemPluginsPath
+    : "/system";
 }
 
 function findSystemPlugin(

--- a/packages/junior-dashboard/src/client/pages/system/SystemPage.tsx
+++ b/packages/junior-dashboard/src/client/pages/system/SystemPage.tsx
@@ -21,6 +21,7 @@ import {
   buildSystemPlugins,
   normalizeSystemPath,
   systemPluginPath,
+  systemPluginsPath,
   type SystemPlugin,
 } from "./SystemPlugins";
 
@@ -44,12 +45,14 @@ export function SystemPage(props: { data: SystemData }) {
   const plugin = plugins.find(
     (candidate) => systemPluginPath(candidate.name) === pathname,
   );
-  const pluginPath = pathname !== "/system";
+  const allPlugins = pathname === systemPluginsPath;
+  const pluginPath = pathname !== "/system" && !allPlugins;
   const rangeRelevant =
-    !plugin ||
-    plugin.reports.some((report) =>
+    pathname === "/system" ||
+    (plugin?.reports.some((report) =>
       report.widgets?.some((widget) => widget.timeRangeDays?.length),
-    );
+    ) ??
+      false);
 
   if (pluginPath && !plugin) {
     return <Navigate replace to="/system" />;
@@ -74,7 +77,9 @@ export function SystemPage(props: { data: SystemData }) {
           reportingPlugins={reportingPlugins}
         />
         <div className="grid min-w-0 gap-4 sm:gap-6">
-          {plugin ? (
+          {allPlugins ? (
+            <PluginPanels plugins={plugins} />
+          ) : plugin ? (
             <PluginSystemPage data={props.data} plugin={plugin} range={range} />
           ) : (
             <>
@@ -87,7 +92,6 @@ export function SystemPage(props: { data: SystemData }) {
               {props.data.pluginReportsError ? (
                 <PluginReportError showingReports={false} />
               ) : null}
-              <PluginPanels plugins={plugins} />
               {props.data.skills.length ? (
                 <SkillInventory skills={props.data.skills} />
               ) : null}

--- a/packages/junior-dashboard/src/client/pages/system/SystemPage.tsx
+++ b/packages/junior-dashboard/src/client/pages/system/SystemPage.tsx
@@ -78,7 +78,16 @@ export function SystemPage(props: { data: SystemData }) {
         />
         <div className="grid min-w-0 gap-4 sm:gap-6">
           {allPlugins ? (
-            <PluginPanels plugins={plugins} />
+            <>
+              {props.data.pluginReportsError ? (
+                <PluginReportError
+                  showingReports={plugins.some(
+                    (candidate) => candidate.reports.length,
+                  )}
+                />
+              ) : null}
+              <PluginPanels plugins={plugins} />
+            </>
           ) : plugin ? (
             <PluginSystemPage data={props.data} plugin={plugin} range={range} />
           ) : (
@@ -89,9 +98,6 @@ export function SystemPage(props: { data: SystemData }) {
                 loading={props.data.conversationStatsLoading}
                 stats={props.data.conversationStats}
               />
-              {props.data.pluginReportsError ? (
-                <PluginReportError showingReports={false} />
-              ) : null}
               {props.data.skills.length ? (
                 <SkillInventory skills={props.data.skills} />
               ) : null}

--- a/packages/junior-dashboard/src/client/pages/system/SystemPlugins.ts
+++ b/packages/junior-dashboard/src/client/pages/system/SystemPlugins.ts
@@ -9,6 +9,9 @@ export type SystemPlugin = Plugin & {
   skills: SkillReport[];
 };
 
+/** Canonical System route for the complete plugin inventory. */
+export const systemPluginsPath = "/system/plugins";
+
 /** Combine plugin inventory, skills, and operational reports for System UI. */
 export function buildSystemPlugins(input: {
   plugins: Plugin[];
@@ -49,7 +52,7 @@ export function buildSystemPlugins(input: {
 
 /** Build the canonical System route for a plugin name. */
 export function systemPluginPath(name: string): string {
-  return `/system/plugins/${encodeURIComponent(name)}`;
+  return `${systemPluginsPath}/${encodeURIComponent(name)}`;
 }
 
 /** Treat trailing slashes as equivalent on System routes. */

--- a/packages/junior-dashboard/tests/telemetry-components.test.tsx
+++ b/packages/junior-dashboard/tests/telemetry-components.test.tsx
@@ -1279,14 +1279,25 @@ describe("dashboard canonical-event components", () => {
       systemHtml.match(/aria-label="Reporting period"/g) ?? [],
     ).toHaveLength(1);
     expect(systemHtml).toContain(">Plugins<");
+    expect(systemHtml).toContain(">All Plugins<");
     expect(systemHtml).toContain(">Skills<");
-    expect(systemHtml).toContain(">GitHub<");
+    expect(systemHtml).not.toContain(">GitHub<");
     expect(systemHtml).not.toContain(">loaded<");
     expect(systemHtml).not.toContain(">quiet<");
     expect(systemHtml).not.toContain(">metrics<");
     expect(systemHtml).not.toContain(">datasets<");
     expect(systemHtml).not.toContain(">1 loaded<");
     expect(systemHtml).toContain(">triage<");
+
+    const pluginsHtml = renderToStaticMarkup(
+      <MemoryRouter initialEntries={["/system/plugins"]}>
+        <SystemPage data={data} />
+      </MemoryRouter>,
+    );
+    expect(pluginsHtml).toContain(">All Plugins<");
+    expect(pluginsHtml).toContain(">GitHub<");
+    expect(pluginsHtml).not.toContain("Usage over time");
+    expect(pluginsHtml).not.toContain('aria-label="Reporting period"');
 
     const skillsHtml = renderToStaticMarkup(
       <SkillInventory skills={data.skills} />,

--- a/packages/junior-dashboard/tests/telemetry-components.test.tsx
+++ b/packages/junior-dashboard/tests/telemetry-components.test.tsx
@@ -1250,10 +1250,15 @@ describe("dashboard canonical-event components", () => {
         <SystemPage data={stale} />
       </MemoryRouter>,
     );
-    expect(overviewHtml).toContain(
-      "Plugin details and capabilities are still available.",
+    expect(overviewHtml).not.toContain("Plugin stats failed to load.");
+
+    const inventoryHtml = renderToStaticMarkup(
+      <MemoryRouter initialEntries={["/system/plugins"]}>
+        <SystemPage data={stale} />
+      </MemoryRouter>,
     );
-    expect(overviewHtml).not.toContain(
+    expect(inventoryHtml).toContain("Plugin stats failed to load.");
+    expect(inventoryHtml).toContain(
       "Showing the last operational reports Junior received.",
     );
   });


### PR DESCRIPTION
Moves the loaded plugin inventory out of the System overview and onto a dedicated `/system/plugins` view. The Plugins navigation now starts with an “All Plugins” item on desktop and mobile, with spacing before plugin-specific reporting links, leaving the overview focused on runtime activity and skills.

The inventory route reuses the existing plugin panels and omits the reporting-period control because that control does not filter the inventory. Component coverage now verifies the overview/inventory split and route-specific controls; the flow was also exercised against the local example dashboard with its configured plugins.
