### PR TITLE
feat(memory): track passive extraction cost

### DIFF
--- a/packages/junior-memory/README.md
+++ b/packages/junior-memory/README.md
@@ -55,6 +55,10 @@ exported types, tools, and tests are authoritative.
   learning.
 - Passive extraction creates only durable, reusable facts—not transient tasks,
   conversation summaries, secrets, or speculative interpretation.
+- Every completed passive extraction emits the namespaced
+  `memory/memories_captured` conversation event with its best-effort model cost.
+  Empty extraction outcomes remain durable for reporting but do not produce a
+  transcript row.
 - Candidate review resolves duplicates and supersession before activation.
 - Search combines independently ranked vector and PostgreSQL full-text matches
   with reciprocal rank fusion; provider-specific raw scores are never added

--- a/packages/junior-memory/src/agent.ts
+++ b/packages/junior-memory/src/agent.ts
@@ -199,6 +199,12 @@ export type ExtractSessionRequest = z.output<
 >;
 export type ExtractedMemory = z.output<typeof extractedMemoryResultSchema>;
 
+/** Memories proposed by passive extraction and the model cost of that pass. */
+export type MemoryExtractionResult = {
+  costUsd?: number;
+  memories: ExtractedMemory[];
+};
+
 export interface MemoryAgent {
   /** Select candidate memories that directly help with the current request. */
   selectRelevantMemories(
@@ -210,7 +216,7 @@ export interface MemoryAgent {
   ): Promise<MemorySupersessionDecision> | MemorySupersessionDecision;
   extractSessionMemories(
     request: ExtractSessionRequest,
-  ): Promise<ExtractedMemory[]> | ExtractedMemory[];
+  ): Promise<MemoryExtractionResult> | MemoryExtractionResult;
   reviewCreateRequest(
     request: CreateMemoryRequest,
   ): Promise<MemoryReview> | MemoryReview;
@@ -562,9 +568,12 @@ export function createMemoryAgent(model: PluginModel): MemoryAgent {
         prompt: sessionExtractionPrompt(request),
         maxTokens: 1_000,
       });
-      return extractedMemoriesFromResponse(
-        extractMemoriesResponseSchema.parse(result.object),
-      );
+      return {
+        memories: extractedMemoriesFromResponse(
+          extractMemoriesResponseSchema.parse(result.object),
+        ),
+        ...(result.costUsd !== undefined ? { costUsd: result.costUsd } : {}),
+      };
     },
     async reviewCreateRequest(rawRequest) {
       const request = parseCreateMemoryRequest(rawRequest);

--- a/packages/junior-memory/src/events.ts
+++ b/packages/junior-memory/src/events.ts
@@ -21,8 +21,34 @@ function eventPreview(content: string): string {
   return `${trimmed.slice(0, MAX_EVENT_PREVIEW_CHARS - 3).trimEnd()}...`;
 }
 
-/** Durable transcript event emitted after background memory capture. */
-export const memoriesCapturedEvent = defineConversationEvent({
+const capturedMemoriesSchema = z
+  .object({
+    memories: z.array(capturedMemorySchema).max(100),
+    costUsd: z.number().finite().nonnegative().optional(),
+  })
+  .strict();
+
+function renderCapturedMemories(
+  event: z.output<typeof capturedMemoriesSchema>,
+) {
+  const count = event.memories.length;
+  if (count === 0) return undefined;
+  return {
+    icon: "brain" as const,
+    title: count === 1 ? "Memory captured" : "Memories captured",
+    preview:
+      count === 1
+        ? eventPreview(event.memories[0]!.content)
+        : `${count} memories`,
+    details: event.memories.map((memory) => ({
+      title: memory.content,
+      metadata: [memory.kind, memory.scope],
+    })),
+  };
+}
+
+/** Previous stored memory-capture event shape retained for transcript rendering. */
+export const memoriesCapturedEventV1 = defineConversationEvent({
   name: "memories_captured",
   version: 1,
   schema: z
@@ -30,21 +56,15 @@ export const memoriesCapturedEvent = defineConversationEvent({
       memories: z.array(capturedMemorySchema).min(1).max(100),
     })
     .strict(),
-  renderEvent(event) {
-    const count = event.memories.length;
-    return {
-      icon: "brain",
-      title: count === 1 ? "Memory captured" : "Memories captured",
-      preview:
-        count === 1
-          ? eventPreview(event.memories[0]!.content)
-          : `${count} memories`,
-      details: event.memories.map((memory) => ({
-        title: memory.content,
-        metadata: [memory.kind, memory.scope],
-      })),
-    };
-  },
+  renderEvent: renderCapturedMemories,
+});
+
+/** Durable outcome emitted after every completed passive memory extraction. */
+export const memoriesCapturedEvent = defineConversationEvent({
+  name: "memories_captured",
+  version: 2,
+  schema: capturedMemoriesSchema,
+  renderEvent: renderCapturedMemories,
 });
 
 /** Select the stable, safe memory fields retained in conversation history. */

--- a/packages/junior-memory/src/plugin.ts
+++ b/packages/junior-memory/src/plugin.ts
@@ -14,7 +14,7 @@ import {
 import { processMemorySession } from "./process-session";
 import { createMemoryPromptContributions } from "./recall";
 import { buildMemoryOperationalReport } from "./operational-report";
-import { memoriesCapturedEvent } from "./events";
+import { memoriesCapturedEvent, memoriesCapturedEventV1 } from "./events";
 import type { MemoryDb } from "./store";
 import { createMemoryUserPage } from "./user-pages";
 
@@ -101,7 +101,7 @@ export function memoryPlugin(options: MemoryPluginOptions = {}) {
       ? { structuredModelId: modelId }
       : { structuredModel: "default" },
     packageName: "@sentry/junior-memory",
-    conversationEvents: [memoriesCapturedEvent],
+    conversationEvents: [memoriesCapturedEventV1, memoriesCapturedEvent],
     cli: {
       commands: [createMemoryCliCommand()],
     },

--- a/packages/junior-memory/src/process-session.ts
+++ b/packages/junior-memory/src/process-session.ts
@@ -17,6 +17,7 @@ import {
   createMemoryAgent,
   parseExtractedMemory,
   type ExtractedMemory,
+  type MemoryExtractionResult,
 } from "./agent";
 import { MEMORY_KINDS, memoryRuntimeContextSchema } from "./types";
 import { capturedMemory, memoriesCapturedEvent } from "./events";
@@ -28,20 +29,30 @@ const MEMORY_TOOL_NAMES = new Set([
   "searchMemories",
 ]);
 const MEMORY_TASK_STATE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
-const extractedMemoryCacheSchema = z.array(
+const extractedMemorySchema = z
+  .object({
+    content: z.string().min(1),
+    expiresAtMs: z.number().finite().nullable(),
+    kind: z.enum(MEMORY_KINDS),
+    evidenceMessageIndices: z
+      .array(z.number().int().nonnegative())
+      .min(1)
+      .max(10),
+  })
+  .strict()
+  .transform(parseExtractedMemory);
+const extractedMemoryCacheSchema = z.union([
   z
     .object({
-      content: z.string().min(1),
-      expiresAtMs: z.number().finite().nullable(),
-      kind: z.enum(MEMORY_KINDS),
-      evidenceMessageIndices: z
-        .array(z.number().int().nonnegative())
-        .min(1)
-        .max(10),
+      costUsd: z.number().finite().nonnegative().optional(),
+      memories: z.array(extractedMemorySchema).max(5),
     })
-    .strict()
-    .transform(parseExtractedMemory),
-);
+    .strict(),
+  z
+    .array(extractedMemorySchema)
+    .max(5)
+    .transform((memories) => ({ memories })),
+]);
 
 /** Where a passively extracted memory may be stored, or dropped when unproven. */
 type MemoryRouteTarget = "drop" | "personal" | "conversation";
@@ -178,10 +189,10 @@ function passiveInput(
   };
 }
 
-async function getTaskMemories(
+async function getTaskExtraction(
   context: PluginTaskContext,
-  extract: () => Promise<ExtractedMemory[]>,
-): Promise<ExtractedMemory[]> {
+  extract: () => Promise<MemoryExtractionResult>,
+): Promise<MemoryExtractionResult> {
   const cacheKey = `memory-extraction:${context.id}`;
   const cached = await context.state.get(cacheKey);
   if (cached !== undefined) {
@@ -191,11 +202,9 @@ async function getTaskMemories(
     }
     await context.state.delete(cacheKey);
   }
-  const memories = await extract();
-  if (memories.length > 0) {
-    await context.state.set(cacheKey, memories, MEMORY_TASK_STATE_TTL_MS);
-  }
-  return memories;
+  const extraction = await extract();
+  await context.state.set(cacheKey, extraction, MEMORY_TASK_STATE_TTL_MS);
+  return extraction;
 }
 
 /**
@@ -251,7 +260,7 @@ export async function processMemorySession(
     supersessionDecider: agent,
   });
   await store.archiveExpiredMemories();
-  const memories = await getTaskMemories(context, async () => {
+  const extraction = await getTaskExtraction(context, async () => {
     const existingMemories = await store.searchMemories({
       limit: 10,
       query: evidenceText,
@@ -265,14 +274,11 @@ export async function processMemorySession(
       runtimeContext,
     });
   });
-  if (memories.length === 0) {
-    return;
-  }
 
   const captured: ReturnType<typeof capturedMemory>[] = [];
-  for (const memory of memories) {
+  for (const memory of extraction.memories) {
     // The routing gate stays even though extraction is also actor-gated:
-    // getTaskMemories caches extraction output for 7 days, so a retry can replay
+    // getTaskExtraction caches extraction output for 7 days, so a retry can replay
     // preference proposals cached before this gate existed.
     const target = routeExtractedMemory(memory, transcript, run);
     if (target === "drop") {
@@ -287,7 +293,12 @@ export async function processMemorySession(
     const result = await store.createMemory(input);
     recordCapturedMemory(captured, result);
   }
-  if (captured.length > 0) {
-    await context.events.emit(memoriesCapturedEvent({ memories: captured }));
-  }
+  await context.events.emit(
+    memoriesCapturedEvent({
+      memories: captured,
+      ...(extraction.costUsd !== undefined
+        ? { costUsd: extraction.costUsd }
+        : {}),
+    }),
+  );
 }

--- a/packages/junior-memory/tests/events.test.ts
+++ b/packages/junior-memory/tests/events.test.ts
@@ -2,6 +2,15 @@ import { describe, expect, it } from "vitest";
 import { memoriesCapturedEvent } from "../src/events";
 
 describe("memory conversation events", () => {
+  it("omits empty extraction results from transcript presentation", () => {
+    expect(
+      memoriesCapturedEvent.renderEvent({
+        costUsd: 0.0042,
+        memories: [],
+      }),
+    ).toBeUndefined();
+  });
+
   it("bounds a single-memory preview to the presentation contract", () => {
     const content = `Long memory ${"x".repeat(1_000)}`;
 
@@ -17,8 +26,8 @@ describe("memory conversation events", () => {
       ],
     });
 
-    expect(presentation.preview).toHaveLength(500);
-    expect(presentation.preview).toMatch(/\.\.\.$/);
-    expect(presentation.details?.[0]?.title).toBe(content);
+    expect(presentation?.preview).toHaveLength(500);
+    expect(presentation?.preview).toMatch(/\.\.\.$/);
+    expect(presentation?.details?.[0]?.title).toBe(content);
   });
 });

--- a/packages/junior-memory/tests/storage.test.ts
+++ b/packages/junior-memory/tests/storage.test.ts
@@ -262,6 +262,7 @@ function extractionModel(
     kind: "preference" | "procedure" | "knowledge";
     evidenceMessageIndices?: number[];
   }>,
+  costUsd?: number,
 ) {
   const calls: Parameters<PluginModel["completeObject"]>[0][] = [];
   const model: PluginModel = {
@@ -274,6 +275,7 @@ function extractionModel(
         evidenceMessageIndices: memory.evidenceMessageIndices ?? [0],
       });
       return {
+        ...(costUsd !== undefined ? { costUsd } : {}),
         object: {
           memories: memories.map(toResponseMemory),
         },
@@ -612,14 +614,16 @@ describe("memory plugin storage", () => {
         actors: [localContext().actor],
         runtimeContext: localContext(),
       }),
-    ).resolves.toEqual([
-      {
-        content: "Prefers causes before mitigations in incident writeups.",
-        expiresAtMs: null,
-        kind: "preference",
-        evidenceMessageIndices: [0],
-      },
-    ]);
+    ).resolves.toEqual({
+      memories: [
+        {
+          content: "Prefers causes before mitigations in incident writeups.",
+          expiresAtMs: null,
+          kind: "preference",
+          evidenceMessageIndices: [0],
+        },
+      ],
+    });
   });
 
   it("accepts up to five passive extraction memories", async () => {
@@ -665,19 +669,19 @@ describe("memory plugin storage", () => {
     };
     const agent = createMemoryAgent(model);
 
-    await expect(
-      agent.extractSessionMemories({
-        transcript: [
-          {
-            type: "message",
-            role: "user",
-            text: "Store several durable facts.",
-          },
-        ],
-        actors: [localContext().actor],
-        runtimeContext: localContext(),
-      }),
-    ).resolves.toHaveLength(5);
+    const result = await agent.extractSessionMemories({
+      transcript: [
+        {
+          type: "message",
+          role: "user",
+          text: "Store several durable facts.",
+        },
+      ],
+      actors: [localContext().actor],
+      runtimeContext: localContext(),
+    });
+
+    expect(result.memories).toHaveLength(5);
   });
 
   it("rejects passive extraction responses with more than five memories", async () => {
@@ -759,16 +763,19 @@ describe("memory plugin storage", () => {
 
     try {
       const emitted: Parameters<MemoryTaskContext["events"]["emit"]>[0][] = [];
-      const { model } = extractionModel([
-        {
-          kind: "preference",
-          content: "Prefers QA notes that mention database row checks.",
-        },
-        {
-          content: "Deploy runbooks live in Notion.",
-          kind: "knowledge",
-        },
-      ]);
+      const { model } = extractionModel(
+        [
+          {
+            kind: "preference",
+            content: "Prefers QA notes that mention database row checks.",
+          },
+          {
+            content: "Deploy runbooks live in Notion.",
+            kind: "knowledge",
+          },
+        ],
+        0.0042,
+      );
       const embedder = createTestEmbedder();
 
       await processMemorySession(
@@ -825,6 +832,7 @@ describe("memory plugin storage", () => {
       expect(rows).toHaveLength(2);
       expect(emitted).toHaveLength(1);
       expect(emitted[0]?.data).toEqual({
+        costUsd: 0.0042,
         memories: expect.arrayContaining([
           expect.objectContaining({
             content: "Prefers QA notes that mention database row checks.",
@@ -860,6 +868,33 @@ describe("memory plugin storage", () => {
       await fixture.close();
     }
   }, 15_000);
+
+  it("records empty extraction cost without capturing memories", async () => {
+    const fixture = await createMemoryFixture();
+
+    try {
+      const emitted: Parameters<MemoryTaskContext["events"]["emit"]>[0][] = [];
+      await processMemorySession(
+        processSessionContext({
+          db: memoryDb(fixture),
+          events: {
+            async emit(event) {
+              emitted.push(event);
+            },
+          },
+          model: extractionModel([], 0.0017).model,
+        }),
+      );
+
+      expect(emitted).toHaveLength(1);
+      expect(emitted[0]?.data).toEqual({ costUsd: 0.0017, memories: [] });
+      await expect(
+        memoryDb(fixture).select().from(memorySqlSchema.juniorMemoryMemories),
+      ).resolves.toEqual([]);
+    } finally {
+      await fixture.close();
+    }
+  });
 
   it("supersedes old preferences from passive completed-session extraction", async () => {
     const fixture = await createMemoryFixture();
@@ -1033,12 +1068,16 @@ describe("memory plugin storage", () => {
 
     try {
       const state = createMemoryState();
-      const { model } = extractionModel([
-        {
-          content: "Prefers retry-safe memory extraction.",
-          kind: "preference",
-        },
-      ]);
+      const emitted: Parameters<MemoryTaskContext["events"]["emit"]>[0][] = [];
+      const { model } = extractionModel(
+        [
+          {
+            content: "Prefers retry-safe memory extraction.",
+            kind: "preference",
+          },
+        ],
+        0.0023,
+      );
       const run = {
         async load() {
           return completedRun({
@@ -1052,6 +1091,11 @@ describe("memory plugin storage", () => {
       await processMemorySession(
         processSessionContext({
           db: memoryDb(fixture),
+          events: {
+            async emit(event) {
+              emitted.push(event);
+            },
+          },
           model,
           run,
           state,
@@ -1060,6 +1104,11 @@ describe("memory plugin storage", () => {
       await processMemorySession(
         processSessionContext({
           db: memoryDb(fixture),
+          events: {
+            async emit(event) {
+              emitted.push(event);
+            },
+          },
           model: {
             async completeObject() {
               throw new Error("model should not run on cached retry");
@@ -1079,6 +1128,9 @@ describe("memory plugin storage", () => {
           kind: "preference",
         }),
       ]);
+      expect(emitted).toHaveLength(2);
+      expect(emitted[1]?.data).toEqual(emitted[0]?.data);
+      expect(emitted[0]?.data).toMatchObject({ costUsd: 0.0023 });
     } finally {
       await fixture.close();
     }

--- a/packages/junior-plugin-api/README.md
+++ b/packages/junior-plugin-api/README.md
@@ -46,7 +46,8 @@ reports, and other typed hook surfaces exported by this package.
   core prompt.
 - Tool hooks return model-visible schemas aligned with their executor inputs.
 - Host-owned structured model and embedding calls do not expose provider
-  credentials to plugins.
+  credentials to plugins. Structured calls return a best-effort provider cost
+  estimate when one is available.
 - Authenticated API route apps receive one verified viewer in their request
   context. The registration hook exposes actor resolution for plugins whose
   viewer-owned data spans platform identities.
@@ -90,11 +91,12 @@ routing, response validation, rendering, confirmation, and query state.
 
 Register plugin-owned event definitions through `conversationEvents`. A
 definition owns one local name, version, content schema, and `renderEvent()`
-projection. The active plugin context supplies the namespace, so plugins cannot
-emit native events or impersonate another plugin. The `junior` plugin name is
-reserved for host-owned native events. Stored events remain durable when a
-plugin is removed, but normal transcript projection skips definitions that are
-not currently registered.
+projection. A renderer may return `undefined` when an event should remain
+durable without producing a transcript row. The active plugin context supplies
+the namespace, so plugins cannot emit native events or impersonate another
+plugin. The `junior` plugin name is reserved for host-owned native events.
+Stored events remain durable when a plugin is removed, but normal transcript
+projection skips definitions that are not currently registered.
 
 ## Database
 

--- a/packages/junior-plugin-api/README.md
+++ b/packages/junior-plugin-api/README.md
@@ -77,8 +77,9 @@ routing, response validation, rendering, confirmation, and query state.
 - Conversation-bound background tasks may emit registered structured events
   through `ctx.events`. Define each version with `defineConversationEvent()`;
   the host supplies the plugin namespace, conversation, turn, ordering, and
-  timestamps. Event definitions return bounded transcript presentation data,
-  while Junior owns browser rendering.
+  timestamps without treating background work as new conversation activity.
+  Event definitions return bounded transcript presentation data, while Junior
+  owns browser rendering.
 - `ctx.agent.dispatch` creates durable agent work with an explicit actor,
   destination, source, metadata, and idempotency identity.
 - Delegated credential subjects declare the narrow action that authorized them.

--- a/packages/junior-plugin-api/README.md
+++ b/packages/junior-plugin-api/README.md
@@ -96,8 +96,10 @@ projection. A renderer may return `undefined` when an event should remain
 durable without producing a transcript row. The active plugin context supplies
 the namespace, so plugins cannot emit native events or impersonate another
 plugin. The `junior` plugin name is reserved for host-owned native events.
-Stored events remain durable when a plugin is removed, but normal transcript
-projection skips definitions that are not currently registered.
+Versions of the same event name share one task-operation idempotency identity,
+so keep previous definitions registered when evolving an event. Stored events
+remain durable when a plugin is removed, but normal transcript projection skips
+definitions that are not currently registered.
 
 ## Database
 

--- a/packages/junior-plugin-api/src/context.ts
+++ b/packages/junior-plugin-api/src/context.ts
@@ -44,7 +44,11 @@ export interface PluginModel {
     prompt: string;
     schema: TSchema;
     system?: string;
-  }): Promise<{ object: z.infer<TSchema> }>;
+  }): Promise<{
+    /** Best-effort estimated provider cost for this completion. */
+    costUsd?: number;
+    object: z.infer<TSchema>;
+  }>;
 }
 
 export interface PluginEmbedder {

--- a/packages/junior-plugin-api/src/conversation-events.ts
+++ b/packages/junior-plugin-api/src/conversation-events.ts
@@ -48,12 +48,14 @@ export interface PluginConversationEventValue {
   readonly definition: PluginConversationEventDefinition;
 }
 
-/** Registered schema and transcript presentation for one plugin event version. */
+/** Registered schema and optional transcript presentation for one event version. */
 export interface PluginConversationEventDefinition {
   readonly eventName: string;
   readonly version: number;
   parse(data: unknown): Record<string, unknown>;
-  renderEvent(data: Record<string, unknown>): ConversationEventPresentation;
+  renderEvent(
+    data: Record<string, unknown>,
+  ): ConversationEventPresentation | undefined;
 }
 
 /** Typed factory returned while authoring one plugin conversation event. */
@@ -72,7 +74,7 @@ export function defineConversationEvent<
   schema: TSchema;
   renderEvent(
     event: z.output<TSchema>,
-  ): z.input<typeof conversationEventPresentationSchema>;
+  ): z.input<typeof conversationEventPresentationSchema> | undefined;
 }): DefinedConversationEvent<z.input<TSchema>> {
   const identity = z
     .object({
@@ -96,9 +98,10 @@ export function defineConversationEvent<
     },
     renderEvent(data: Record<string, unknown>) {
       const parsed = definition.schema.parse(data);
-      return conversationEventPresentationSchema.parse(
-        definition.renderEvent(parsed),
-      );
+      const presentation = definition.renderEvent(parsed);
+      return presentation === undefined
+        ? undefined
+        : conversationEventPresentationSchema.parse(presentation);
     },
   });
   return eventDefinition;

--- a/packages/junior/src/chat/README.md
+++ b/packages/junior/src/chat/README.md
@@ -85,6 +85,8 @@ delegation without becoming the execution actor or a general task owner.
 - Tool failures remain internal agent-loop data unless the final result exposes
   an appropriate diagnostic.
 - Durable state is committed before acknowledging queue work or yielding.
+- Conversation events emitted by plugin background tasks preserve conversation
+  activity, archive, and transcript-retention state.
 - Model input stays below the configured bot context cap and the active model's
   advertised window. The agent checks before its first provider request and
   after each tool batch; an in-turn compaction commits its history replacement

--- a/packages/junior/src/chat/conversations/history.ts
+++ b/packages/junior/src/chat/conversations/history.ts
@@ -526,8 +526,12 @@ export interface ConversationEventPage {
 
 /** Persist and read the canonical per-conversation event log. */
 export interface ConversationEventStore {
-  /** Append events atomically, assigning `seq = max+1` under the lease. */
-  append(conversationId: string, events: NewConversationEvent[]): Promise<void>;
+  /** Append events atomically, optionally preserving conversation activity. */
+  append(
+    conversationId: string,
+    events: NewConversationEvent[],
+    options?: { activity?: "preserve" },
+  ): Promise<void>;
   /** Replace active model history with a compaction or handoff event. */
   replaceHistory(
     conversationId: string,

--- a/packages/junior/src/chat/conversations/sql/conversation-row.ts
+++ b/packages/junior/src/chat/conversations/sql/conversation-row.ts
@@ -9,33 +9,38 @@ import { juniorConversations } from "@/db/schema";
  *
  * First contact creates the row; every later content write advances the
  * activity clock so retention mirrors append-refresh semantics (each content
- * append refreshes the retention window). The timestamp is content-intrinsic
- * (the first item's `createdAtMs`), and `greatest(...)` guarantees a backfilled
- * or imported historical write — which carries an old timestamp — can never
+ * append refreshes the retention window). Background observations may opt out
+ * and leave an existing row unchanged. The timestamp is content-intrinsic (the
+ * first item's `createdAtMs`), and `greatest(...)` guarantees a backfilled or
+ * imported historical write — which carries an old timestamp — can never
  * regress `last_activity_at`.
  */
 export async function ensureConversationRow(
   executor: JuniorSqlDatabase,
   conversationId: string,
   atMs: number,
+  options: { activity?: "preserve" } = {},
 ): Promise<void> {
   const at = new Date(atMs);
-  await executor
-    .db()
-    .insert(juniorConversations)
-    .values({
-      conversationId,
-      createdAt: at,
-      lastActivityAt: at,
-      updatedAt: at,
-      executionStatus: "idle",
-    })
-    .onConflictDoUpdate({
+  const insert = executor.db().insert(juniorConversations).values({
+    conversationId,
+    createdAt: at,
+    lastActivityAt: at,
+    updatedAt: at,
+    executionStatus: "idle",
+  });
+  if (options.activity === "preserve") {
+    await insert.onConflictDoNothing({
       target: juniorConversations.conversationId,
-      set: {
-        lastActivityAt: sql`greatest(${juniorConversations.lastActivityAt}, excluded.last_activity_at)`,
-        updatedAt: sql`greatest(${juniorConversations.updatedAt}, excluded.updated_at)`,
-        transcriptPurgedAt: null,
-      },
     });
+    return;
+  }
+  await insert.onConflictDoUpdate({
+    target: juniorConversations.conversationId,
+    set: {
+      lastActivityAt: sql`greatest(${juniorConversations.lastActivityAt}, excluded.last_activity_at)`,
+      updatedAt: sql`greatest(${juniorConversations.updatedAt}, excluded.updated_at)`,
+      transcriptPurgedAt: null,
+    },
+  });
 }

--- a/packages/junior/src/chat/conversations/sql/history.ts
+++ b/packages/junior/src/chat/conversations/sql/history.ts
@@ -98,6 +98,7 @@ class SqlConversationEventStore implements ConversationEventStore {
   async append(
     conversationId: string,
     events: NewConversationEvent[],
+    options: { activity?: "preserve" } = {},
   ): Promise<void> {
     const parsed = events.map((event) =>
       newConversationEventSchema.parse(event),
@@ -149,17 +150,20 @@ class SqlConversationEventStore implements ConversationEventStore {
         this.executor,
         conversationId,
         newestCreatedAtMs,
+        options,
       );
-      await this.executor
-        .db()
-        .update(juniorConversations)
-        .set({ archivedAt: null })
-        .where(
-          and(
-            eq(juniorConversations.conversationId, conversationId),
-            isNotNull(juniorConversations.archivedAt),
-          ),
-        );
+      if (options.activity !== "preserve") {
+        await this.executor
+          .db()
+          .update(juniorConversations)
+          .set({ archivedAt: null })
+          .where(
+            and(
+              eq(juniorConversations.conversationId, conversationId),
+              isNotNull(juniorConversations.archivedAt),
+            ),
+          );
+      }
       const cursor = await this.readCursor(conversationId);
       const historyVersion = cursor.maxHistoryVersion ?? 0;
       let seq = cursor.nextSeq;

--- a/packages/junior/src/chat/conversations/structured-events.ts
+++ b/packages/junior/src/chat/conversations/structured-events.ts
@@ -72,8 +72,10 @@ export const authenticationUnlinkedEvent = defineConversationEvent({
   },
 });
 
-const NATIVE_EVENT_DEFINITIONS: readonly PluginConversationEventDefinition[] =
-  [authenticationLinkedEvent, authenticationUnlinkedEvent];
+const NATIVE_EVENT_DEFINITIONS: readonly PluginConversationEventDefinition[] = [
+  authenticationLinkedEvent,
+  authenticationUnlinkedEvent,
+];
 
 /** Resolve a registered Junior-native conversation event definition. */
 export function getJuniorNativeEventDefinition(args: {
@@ -96,7 +98,8 @@ export function renderJuniorNativeConversationEvent(args: {
   if (args.namespace !== JUNIOR_NATIVE_EVENT_NAMESPACE) return undefined;
   const definition = getJuniorNativeEventDefinition(args);
   if (!definition) return undefined;
-  return conversationEventPresentationSchema.parse(
-    definition.renderEvent(definition.parse(args.content)),
-  );
+  const presentation = definition.renderEvent(definition.parse(args.content));
+  return presentation === undefined
+    ? undefined
+    : conversationEventPresentationSchema.parse(presentation);
 }

--- a/packages/junior/src/chat/plugins/conversation-events.ts
+++ b/packages/junior/src/chat/plugins/conversation-events.ts
@@ -17,6 +17,20 @@ function registeredDefinition(
   );
 }
 
+/** Keep operation idempotency stable when a registered event schema advances. */
+function eventIdentityVersion(
+  plugin: PluginRegistration,
+  definition: PluginConversationEventDefinition,
+): number {
+  let version = definition.version;
+  for (const candidate of plugin.conversationEvents ?? []) {
+    if (candidate.eventName === definition.eventName) {
+      version = Math.min(version, candidate.version);
+    }
+  }
+  return version;
+}
+
 /** Create a conversation-bound writer for one plugin task operation. */
 export function createPluginConversationEvents(args: {
   conversationId: string;
@@ -33,6 +47,7 @@ export function createPluginConversationEvents(args: {
         );
       }
       const content = definition.parse(value.data);
+      const identityVersion = eventIdentityVersion(args.plugin, definition);
       await getConversationEventStore().append(
         args.conversationId,
         [
@@ -40,7 +55,7 @@ export function createPluginConversationEvents(args: {
             createdAtMs: Date.now(),
             idempotencyKey:
               `plugin:${args.plugin.manifest.name}:operation:${args.operationId}:` +
-              `event:${definition.eventName}@${definition.version}`,
+              `event:${definition.eventName}@${identityVersion}`,
             data: {
               type: "structured_event",
               namespace: args.plugin.manifest.name,

--- a/packages/junior/src/chat/plugins/conversation-events.ts
+++ b/packages/junior/src/chat/plugins/conversation-events.ts
@@ -33,22 +33,26 @@ export function createPluginConversationEvents(args: {
         );
       }
       const content = definition.parse(value.data);
-      await getConversationEventStore().append(args.conversationId, [
-        {
-          createdAtMs: Date.now(),
-          idempotencyKey:
-            `plugin:${args.plugin.manifest.name}:operation:${args.operationId}:` +
-            `event:${definition.eventName}@${definition.version}`,
-          data: {
-            type: "structured_event",
-            namespace: args.plugin.manifest.name,
-            name: definition.eventName,
-            version: definition.version,
-            turnId: args.turnId,
-            content,
+      await getConversationEventStore().append(
+        args.conversationId,
+        [
+          {
+            createdAtMs: Date.now(),
+            idempotencyKey:
+              `plugin:${args.plugin.manifest.name}:operation:${args.operationId}:` +
+              `event:${definition.eventName}@${definition.version}`,
+            data: {
+              type: "structured_event",
+              namespace: args.plugin.manifest.name,
+              name: definition.eventName,
+              version: definition.version,
+              turnId: args.turnId,
+              content,
+            },
           },
-        },
-      ]);
+        ],
+        { activity: "preserve" },
+      );
     },
   };
 }

--- a/packages/junior/src/chat/plugins/model.ts
+++ b/packages/junior/src/chat/plugins/model.ts
@@ -34,7 +34,10 @@ export function createPluginModel(
           pluginModelRole: "structured",
         },
       });
-      return { object: result.object };
+      return {
+        object: result.object,
+        ...(result.costUsd !== undefined ? { costUsd: result.costUsd } : {}),
+      };
     },
   };
 }

--- a/packages/junior/tests/component/plugins/plugin-conversation-events.test.ts
+++ b/packages/junior/tests/component/plugins/plugin-conversation-events.test.ts
@@ -3,6 +3,7 @@ import {
   createLocalSource,
   defineConversationEvent,
   defineJuniorPlugin,
+  type PluginConversationEventDefinition,
 } from "@sentry/junior-plugin-api";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
@@ -91,11 +92,11 @@ afterEach(async () => {
 });
 
 describe("plugin conversation events", () => {
-  it("binds and deduplicates task events without refreshing conversation activity", async () => {
+  it("deduplicates task events across schema versions without refreshing activity", async () => {
     const runId = randomUUID();
     const conversationId = `local:test:structured-events-${runId}`;
     const sessionId = `structured-event-session:${runId}`;
-    const completedEvent = defineConversationEvent({
+    const completedEventV1 = defineConversationEvent({
       name: "session_processed",
       version: 1,
       schema: z.object({ summary: z.string() }).strict(),
@@ -103,28 +104,44 @@ describe("plugin conversation events", () => {
         return { title: "Session processed", preview: event.summary };
       },
     });
-    const { setPlugins } = await import("@/chat/plugins/agent-hooks");
-    const { getConversationEventStore, getDb } = await import("@/chat/db");
-    const { processPluginTask } = await import("@/chat/plugins/task-runner");
-    setPlugins([
+    const completedEventV2 = defineConversationEvent({
+      name: "session_processed",
+      version: 2,
+      schema: z.object({ costUsd: z.number(), summary: z.string() }).strict(),
+      renderEvent(event) {
+        return { title: "Session processed", preview: event.summary };
+      },
+    });
+    let emittedVersion: 1 | 2 = 1;
+    const plugin = (conversationEvents: PluginConversationEventDefinition[]) =>
       defineJuniorPlugin({
         manifest: {
           name: "task-event-demo",
           displayName: "Task Event Demo",
           description: "Task event demo",
         },
-        conversationEvents: [completedEvent],
+        conversationEvents,
         tasks: {
           processSession: {
             async run(ctx) {
               await ctx.events.emit(
-                completedEvent({ summary: "Background task finished." }),
+                emittedVersion === 1
+                  ? completedEventV1({
+                      summary: "Background task finished.",
+                    })
+                  : completedEventV2({
+                      costUsd: 0.0042,
+                      summary: "Background task finished.",
+                    }),
               );
             },
           },
         },
-      }),
-    ]);
+      });
+    const { setPlugins } = await import("@/chat/plugins/agent-hooks");
+    const { getConversationEventStore, getDb } = await import("@/chat/db");
+    const { processPluginTask } = await import("@/chat/plugins/task-runner");
+    setPlugins([plugin([completedEventV1])]);
     await recordCompletedSession({ conversationId, sessionId });
     const db = getDb();
     await db
@@ -156,6 +173,8 @@ describe("plugin conversation events", () => {
     };
 
     await processPluginTask(message);
+    emittedVersion = 2;
+    setPlugins([plugin([completedEventV1, completedEventV2])]);
     await processPluginTask(message);
 
     expect(await readConversationState()).toEqual(conversationState);

--- a/packages/junior/tests/component/plugins/plugin-conversation-events.test.ts
+++ b/packages/junior/tests/component/plugins/plugin-conversation-events.test.ts
@@ -4,9 +4,11 @@ import {
   defineConversationEvent,
   defineJuniorPlugin,
 } from "@sentry/junior-plugin-api";
+import { eq } from "drizzle-orm";
 import { z } from "zod";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { PiMessage } from "@/chat/pi/messages";
+import { juniorConversations } from "@/db/schema";
 
 const ORIGINAL_ENV = { ...process.env };
 
@@ -89,7 +91,7 @@ afterEach(async () => {
 });
 
 describe("plugin conversation events", () => {
-  it("binds task events to the plugin and deduplicates task redelivery", async () => {
+  it("binds and deduplicates task events without refreshing conversation activity", async () => {
     const runId = randomUUID();
     const conversationId = `local:test:structured-events-${runId}`;
     const sessionId = `structured-event-session:${runId}`;
@@ -102,7 +104,7 @@ describe("plugin conversation events", () => {
       },
     });
     const { setPlugins } = await import("@/chat/plugins/agent-hooks");
-    const { getConversationEventStore } = await import("@/chat/db");
+    const { getConversationEventStore, getDb } = await import("@/chat/db");
     const { processPluginTask } = await import("@/chat/plugins/task-runner");
     setPlugins([
       defineJuniorPlugin({
@@ -124,6 +126,29 @@ describe("plugin conversation events", () => {
       }),
     ]);
     await recordCompletedSession({ conversationId, sessionId });
+    const db = getDb();
+    await db
+      .update(juniorConversations)
+      .set({
+        archivedAt: new Date(3_000),
+        lastActivityAt: new Date(2_000),
+        transcriptPurgedAt: new Date(2_500),
+        updatedAt: new Date(2_000),
+      })
+      .where(eq(juniorConversations.conversationId, conversationId));
+    const readConversationState = async () => {
+      const [row] = await db
+        .select({
+          archivedAt: juniorConversations.archivedAt,
+          lastActivityAt: juniorConversations.lastActivityAt,
+          transcriptPurgedAt: juniorConversations.transcriptPurgedAt,
+          updatedAt: juniorConversations.updatedAt,
+        })
+        .from(juniorConversations)
+        .where(eq(juniorConversations.conversationId, conversationId));
+      return row;
+    };
+    const conversationState = await readConversationState();
     const message = {
       name: "processSession",
       params: { conversationId, sessionId },
@@ -133,6 +158,7 @@ describe("plugin conversation events", () => {
     await processPluginTask(message);
     await processPluginTask(message);
 
+    expect(await readConversationState()).toEqual(conversationState);
     const events =
       await getConversationEventStore().loadHistory(conversationId);
     expect(

--- a/packages/junior/tests/unit/api/conversation-events.test.ts
+++ b/packages/junior/tests/unit/api/conversation-events.test.ts
@@ -116,6 +116,46 @@ describe("conversation report event projection", () => {
     }
   });
 
+  it("omits registered plugin events without a presentation", async () => {
+    const background = defineConversationEvent({
+      name: "background_completed",
+      version: 1,
+      schema: z.object({ count: z.number().int().nonnegative() }).strict(),
+      renderEvent(value) {
+        return value.count === 0 ? undefined : { title: "Background work" };
+      },
+    });
+    const { setPlugins } = await import("@/chat/plugins/agent-hooks");
+    const previous = setPlugins([
+      defineJuniorPlugin({
+        manifest: {
+          name: "background",
+          displayName: "Background",
+          description: "Background event test plugin",
+        },
+        conversationEvents: [background],
+      }),
+    ]);
+    try {
+      expect(
+        projectConversationReportEventPage({
+          canExposePayload: true,
+          events: [
+            event(1, {
+              type: "structured_event",
+              namespace: "background",
+              name: "background_completed",
+              version: 1,
+              content: { count: 0 },
+            }),
+          ],
+        }),
+      ).toEqual([]);
+    } finally {
+      setPlugins(previous);
+    }
+  });
+
   it("ignores unsupported stored events", () => {
     const unsupported = decodeStoredConversationEvent({
       schemaVersion: 3,

--- a/packages/junior/tests/unit/plugins/plugin-model.test.ts
+++ b/packages/junior/tests/unit/plugins/plugin-model.test.ts
@@ -1,6 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const completeObject = vi.fn(async () => ({ object: { ok: true } }));
+const completeObject = vi.fn(async () => ({
+  costUsd: 0.0042,
+  object: { ok: true },
+}));
 const embedTexts = vi.fn(async () => ({
   dimensions: 1,
   model: "test-embedding-model",
@@ -32,7 +35,7 @@ describe("createPluginModel", () => {
   it("uses the fast model for structured plugin calls by default", async () => {
     const { createPluginModel } = await import("@/chat/plugins/model");
 
-    await createPluginModel("test-plugin").completeObject({
+    const result = await createPluginModel("test-plugin").completeObject({
       prompt: "classify",
       schema: {} as never,
     });
@@ -42,6 +45,7 @@ describe("createPluginModel", () => {
         modelId: "openai/gpt-5.4-mini",
       }),
     );
+    expect(result).toEqual({ costUsd: 0.0042, object: { ok: true } });
   });
 
   it("uses the host default model when requested", async () => {


### PR DESCRIPTION
Passive memory extraction now records its best-effort structured model cost on the namespaced `memory/memories_captured` event for every completed extraction, including outcomes that capture no memories. Empty outcomes remain durable for reporting while the event renderer omits them from conversation transcripts.

`PluginModel.completeObject` now exposes the optional cost estimate, and Memory caches that estimate with the extraction result so retries neither rerun the model nor lose cost attribution. The event advances to version 2 for the new shape while the version 1 definition remains registered for stored-event rendering and the original operation idempotency identity, preventing cross-deploy retries from duplicating an event.

Plugin task events are stored as background observations: they preserve conversation activity, archive state, and transcript-retention state instead of reopening or extending a conversation when asynchronous work finishes.

Refs #1170
