### PR TITLE
feat(memory): chart passive extraction cost

### DIFF
--- a/packages/junior-dashboard/e2e/harness.ts
+++ b/packages/junior-dashboard/e2e/harness.ts
@@ -210,12 +210,18 @@ export async function mockDashboardApis(page: Page) {
       return {
         date: date.toISOString().slice(0, 10),
         personal: index % 9 === 0 ? 2 : index % 5 === 0 ? 1 : 0,
-        public: index % 13 === 0 ? 3 : index % 4 === 0 ? 2 : index % 3 === 0 ? 1 : 0,
+        public:
+          index % 13 === 0 ? 3 : index % 4 === 0 ? 2 : index % 3 === 0 ? 1 : 0,
       };
     });
     await route.fulfill({
       json: {
         days,
+        extractionDays: days.map((day, index) => ({
+          costUsd: index % 6 === 0 ? 0.08 : index % 4 === 0 ? 0.03 : 0,
+          date: day.date,
+          events: index % 3 === 0 ? 2 : 1,
+        })),
         generatedAt: "2026-07-30T12:00:00.000Z",
         stats: {
           active: 210,

--- a/packages/junior-dashboard/e2e/user-pages.spec.ts
+++ b/packages/junior-dashboard/e2e/user-pages.spec.ts
@@ -46,12 +46,14 @@ test("opens a registered plugin page from primary navigation", async ({
   await expect(
     page.getByRole("heading", { name: "Activity over time" }),
   ).toBeVisible();
+  await expect(page.getByRole("heading", { name: /^\$/ })).toBeVisible();
   await expect(
     page.getByRole("heading", { name: "What Junior remembers" }),
   ).toBeVisible();
-  const sevenDays = page.getByRole("button", { name: "7d" });
-  const thirtyDays = page.getByRole("button", { name: "30d" });
-  const ninetyDays = page.getByRole("button", { name: "90d" });
+  const activityRange = page.getByLabel("Memory timeline range");
+  const sevenDays = activityRange.getByRole("button", { name: "7d" });
+  const thirtyDays = activityRange.getByRole("button", { name: "30d" });
+  const ninetyDays = activityRange.getByRole("button", { name: "90d" });
   await expect(thirtyDays).toHaveAttribute("aria-pressed", "true");
   await sevenDays.click();
   await expect(sevenDays).toHaveAttribute("aria-pressed", "true");

--- a/packages/junior-dashboard/src/client/format.ts
+++ b/packages/junior-dashboard/src/client/format.ts
@@ -461,11 +461,13 @@ export function formatCostSummary(
   summary: CostUsageSummary | undefined,
 ): string {
   if (!summary) return "";
+  const maximumFractionDigits =
+    summary.total > 0 && summary.total < 0.01 ? 4 : 2;
   return new Intl.NumberFormat("en-US", {
     style: "currency",
     currency: "USD",
     minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
+    maximumFractionDigits,
   }).format(summary.total);
 }
 

--- a/packages/junior-dashboard/src/client/pages/memory/MemoryExtractionCost.tsx
+++ b/packages/junior-dashboard/src/client/pages/memory/MemoryExtractionCost.tsx
@@ -1,0 +1,163 @@
+import { useState } from "react";
+
+import { Card } from "../../components/layout/Card";
+import { formatCostSummary } from "../../format";
+import { cn } from "../../styles";
+import type { MemoryExtractionDay } from "./memoryDashboard";
+
+type MemoryRange = 7 | 30 | 90;
+
+/** Render passive memory extraction cost from durable plugin events. */
+export function MemoryExtractionCost(props: { days: MemoryExtractionDay[] }) {
+  const [range, setRange] = useState<MemoryRange>(30);
+  const days = props.days.slice(-range);
+  const total = days.reduce((sum, day) => sum + day.costUsd, 0);
+  const runs = days.reduce((sum, day) => sum + day.events, 0);
+  const maximum = Math.max(0.01, ...days.map((day) => day.costUsd));
+  const width = 720;
+  const height = 200;
+  const left = 48;
+  const right = 12;
+  const top = 14;
+  const bottom = 34;
+  const plotHeight = height - top - bottom;
+  const step = (width - left - right) / days.length;
+  const barWidth = Math.max(2, Math.min(13, step * 0.68));
+
+  return (
+    <Card className="min-h-[17rem] p-4 sm:p-5">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <div className="font-mono text-[0.6rem] uppercase tracking-[0.16em] text-cyan-200/65">
+            Extraction cost
+          </div>
+          <h2 className="mt-1 mb-0 font-display text-xl font-medium text-dashboard-text">
+            {formatCostSummary({ total })}
+          </h2>
+          <p className="mt-1 mb-0 font-mono text-[0.64rem] leading-relaxed text-dashboard-text-muted">
+            System-wide estimate across {runs.toLocaleString()} passive runs.
+          </p>
+        </div>
+        <div
+          aria-label="Memory extraction cost range"
+          className="inline-flex rounded border border-white/[0.08] bg-black/20 p-0.5"
+        >
+          {([7, 30, 90] as const).map((days) => (
+            <button
+              aria-pressed={range === days}
+              className={cn(
+                "cursor-pointer rounded-sm border-0 px-2.5 py-1.5 font-mono text-[0.58rem] uppercase tracking-[0.1em] transition-colors",
+                range === days
+                  ? "bg-cyan-300/10 text-cyan-100"
+                  : "bg-transparent text-dashboard-text-muted hover:text-dashboard-text",
+              )}
+              key={days}
+              onClick={() => setRange(days)}
+              type="button"
+            >
+              {days}d
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="relative mt-4 overflow-hidden">
+        <svg
+          aria-label={`Memory extraction cost during the last ${range} days`}
+          className="block h-auto min-h-40 w-full"
+          role="img"
+          viewBox={`0 0 ${width} ${height}`}
+        >
+          {[maximum, maximum / 2, 0].map((value, index) => {
+            const y = top + index * (plotHeight / 2);
+            return (
+              <g key={index}>
+                <line
+                  stroke="rgba(255,255,255,0.07)"
+                  strokeDasharray="3 5"
+                  x1={left}
+                  x2={width - right}
+                  y1={y}
+                  y2={y}
+                />
+                <text
+                  fill="rgba(255,255,255,0.34)"
+                  fontFamily="ui-monospace, monospace"
+                  fontSize="9"
+                  textAnchor="end"
+                  x={left - 7}
+                  y={y + 3}
+                >
+                  {formatCostSummary({ total: value })}
+                </text>
+              </g>
+            );
+          })}
+          {days.map((day, index) => {
+            const height = (day.costUsd / maximum) * plotHeight;
+            const x = left + index * step + (step - barWidth) / 2;
+            return (
+              <rect
+                aria-label={`${formatDate(day.date)}: ${formatCostSummary({ total: day.costUsd })}, ${day.events} runs`}
+                fill="#67e8f9"
+                height={height}
+                key={day.date}
+                opacity={day.costUsd > 0 ? 0.82 : 0.1}
+                rx="1"
+                width={barWidth}
+                x={x}
+                y={top + plotHeight - height}
+              >
+                <title>{`${formatDate(day.date)}: ${formatCostSummary({ total: day.costUsd })}, ${day.events} runs`}</title>
+              </rect>
+            );
+          })}
+          {[0, Math.floor((days.length - 1) / 2), days.length - 1].map(
+            (index) => {
+              const day = days[index];
+              if (!day) return null;
+              return (
+                <text
+                  fill="rgba(255,255,255,0.34)"
+                  fontFamily="ui-monospace, monospace"
+                  fontSize="9"
+                  key={day.date}
+                  textAnchor={
+                    index === 0
+                      ? "start"
+                      : index === days.length - 1
+                        ? "end"
+                        : "middle"
+                  }
+                  x={
+                    index === 0
+                      ? left
+                      : index === days.length - 1
+                        ? width - right
+                        : left + index * step + step / 2
+                  }
+                  y={height - 9}
+                >
+                  {formatDate(day.date)}
+                </text>
+              );
+            },
+          )}
+        </svg>
+        {runs === 0 ? (
+          <div className="pointer-events-none absolute inset-0 grid place-items-center pt-12 font-mono text-[0.68rem] text-dashboard-text-muted">
+            No passive extractions ran in this period.
+          </div>
+        ) : null}
+      </div>
+    </Card>
+  );
+}
+
+function formatDate(date: string): string {
+  return new Intl.DateTimeFormat("en-US", {
+    day: "numeric",
+    month: "short",
+    timeZone: "UTC",
+  }).format(new Date(`${date}T00:00:00.000Z`));
+}

--- a/packages/junior-dashboard/src/client/pages/memory/MemoryPage.tsx
+++ b/packages/junior-dashboard/src/client/pages/memory/MemoryPage.tsx
@@ -35,6 +35,7 @@ import {
   useMemoryDashboardData,
 } from "./memoryDashboard";
 import { MemoryTimeline } from "./MemoryTimeline";
+import { MemoryExtractionCost } from "./MemoryExtractionCost";
 
 /** Render the temporary first-class dashboard experience for memory. */
 export function MemoryPage(props: { page: PluginUserPageLink }) {
@@ -105,7 +106,10 @@ function MemoryOverview() {
   }
   return (
     <>
-      <MemoryTimeline days={dashboardQuery.data.days} />
+      <section className="grid gap-4 xl:grid-cols-2">
+        <MemoryTimeline days={dashboardQuery.data.days} />
+        <MemoryExtractionCost days={dashboardQuery.data.extractionDays} />
+      </section>
       <MemorySummary data={dashboardQuery.data} />
       <section className="grid gap-4 md:grid-cols-2">
         <MemoryKindPanel data={dashboardQuery.data} />

--- a/packages/junior-dashboard/src/client/pages/memory/memoryDashboard.ts
+++ b/packages/junior-dashboard/src/client/pages/memory/memoryDashboard.ts
@@ -11,9 +11,18 @@ const memoryDaySchema = z
   })
   .strict();
 
+const memoryExtractionDaySchema = z
+  .object({
+    costUsd: z.number().finite().min(0),
+    date: z.iso.date(),
+    events: z.number().int().min(0),
+  })
+  .strict();
+
 export const memoryDashboardSchema = z
   .object({
     days: z.array(memoryDaySchema).length(90),
+    extractionDays: z.array(memoryExtractionDaySchema).length(90),
     generatedAt: z.iso.datetime(),
     stats: z
       .object({
@@ -34,6 +43,7 @@ export const memoryDashboardSchema = z
 
 export type MemoryDashboardData = z.output<typeof memoryDashboardSchema>;
 export type MemoryDay = MemoryDashboardData["days"][number];
+export type MemoryExtractionDay = MemoryDashboardData["extractionDays"][number];
 
 /** Load the viewer-scoped Memory dashboard summary. */
 export function useMemoryDashboardData() {

--- a/packages/junior-dashboard/src/client/pages/system/PluginBarChart.tsx
+++ b/packages/junior-dashboard/src/client/pages/system/PluginBarChart.tsx
@@ -2,6 +2,7 @@ import type { PluginOperationalReport } from "@sentry/junior/api/schema";
 
 import type { TimeRangeDays } from "../../components/controls/TimeRangeSelector";
 import { Tooltip } from "../../components/Tooltip";
+import { formatCostSummary } from "../../format";
 
 type Widget = NonNullable<PluginOperationalReport["widgets"]>[number];
 
@@ -105,7 +106,7 @@ export function PluginBarChart(props: {
                   x={left - 6}
                   y={y + 3}
                 >
-                  {formatChartNumber(tickValue)}
+                  {formatChartValue(tickValue, commonSeriesFormat(widget))}
                 </text>
               </g>
             );
@@ -117,7 +118,7 @@ export function PluginBarChart(props: {
                 value ? 2 : 0,
                 (Math.abs(value) / span) * plotHeight,
               );
-              const formatted = formatChartNumber(value);
+              const formatted = formatChartValue(value, series.format);
               return (
                 <Tooltip
                   content={`${series.label}: ${formatted}`}
@@ -194,4 +195,15 @@ function formatCategoryLabel(label: string): string {
 
 function formatChartNumber(value: number): string {
   return String(Number(value.toPrecision(12)));
+}
+
+function commonSeriesFormat(widget: Widget): "usd" | undefined {
+  const formats = new Set(widget.series.map((series) => series.format));
+  return formats.size === 1 ? widget.series[0]?.format : undefined;
+}
+
+function formatChartValue(value: number, format: "usd" | undefined): string {
+  return format === "usd"
+    ? formatCostSummary({ total: value })
+    : formatChartNumber(value);
 }

--- a/packages/junior-dashboard/src/client/pages/system/PluginBarChart.tsx
+++ b/packages/junior-dashboard/src/client/pages/system/PluginBarChart.tsx
@@ -23,9 +23,10 @@ export function PluginBarChart(props: {
   const categories = widget.timeRangeDays
     ? widget.categories.slice(-supportedRange(widget, props.range))
     : widget.categories;
+  const seriesFormat = commonSeriesFormat(widget);
   const width = 520;
   const height = 250;
-  const left = 42;
+  const left = seriesFormat === "usd" ? 56 : 42;
   const top = 16;
   const bottom = 36;
   const plotHeight = height - top - bottom;
@@ -106,7 +107,7 @@ export function PluginBarChart(props: {
                   x={left - 6}
                   y={y + 3}
                 >
-                  {formatChartValue(tickValue, commonSeriesFormat(widget))}
+                  {formatChartValue(tickValue, seriesFormat)}
                 </text>
               </g>
             );

--- a/packages/junior-dashboard/tests/format.test.ts
+++ b/packages/junior-dashboard/tests/format.test.ts
@@ -83,6 +83,7 @@ describe("dashboard conversation formatting", () => {
       }),
     ).toBe("80 tokens");
     expect(formatCostTotal({ cost: { total: 1.999 } })).toBe("$2.00");
+    expect(formatCostTotal({ cost: { total: 0.0042 } })).toBe("$0.0042");
   });
 
   it("formats human-readable durations at increasing scales", () => {

--- a/packages/junior-dashboard/tests/telemetry-components.test.tsx
+++ b/packages/junior-dashboard/tests/telemetry-components.test.tsx
@@ -1434,7 +1434,7 @@ describe("dashboard canonical-event components", () => {
                   {
                     id: "2026-07-31",
                     label: "2026-07-31",
-                    values: { costUsd: 1.25 },
+                    values: { costUsd: 0.0042 },
                   },
                 ],
                 id: "extraction-cost",
@@ -1453,8 +1453,8 @@ describe("dashboard canonical-event components", () => {
         ]}
       />,
     );
-    expect(html).toContain('aria-label="2026-07-31, Cost: $1.25"');
-    expect(html).toContain(">$1.25</text>");
+    expect(html).toContain('aria-label="2026-07-31, Cost: $0.0042"');
+    expect(html).toContain(">$0.0042</text>");
   });
 
   it("renders daily chart ranges from the shared page selection", () => {

--- a/packages/junior-dashboard/tests/telemetry-components.test.tsx
+++ b/packages/junior-dashboard/tests/telemetry-components.test.tsx
@@ -1455,6 +1455,7 @@ describe("dashboard canonical-event components", () => {
     );
     expect(html).toContain('aria-label="2026-07-31, Cost: $0.0042"');
     expect(html).toContain(">$0.0042</text>");
+    expect(html).toContain('x1="56"');
   });
 
   it("renders daily chart ranges from the shared page selection", () => {

--- a/packages/junior-dashboard/tests/telemetry-components.test.tsx
+++ b/packages/junior-dashboard/tests/telemetry-components.test.tsx
@@ -1422,6 +1422,41 @@ describe("dashboard canonical-event components", () => {
     expect(html).not.toContain('aria-label="Chart legend"');
   });
 
+  it("formats plugin cost charts as USD", () => {
+    const html = renderToStaticMarkup(
+      <PluginReports
+        reports={[
+          {
+            pluginName: "memory",
+            widgets: [
+              {
+                categories: [
+                  {
+                    id: "2026-07-31",
+                    label: "2026-07-31",
+                    values: { costUsd: 1.25 },
+                  },
+                ],
+                id: "extraction-cost",
+                series: [
+                  {
+                    format: "usd",
+                    key: "costUsd",
+                    label: "Cost",
+                  },
+                ],
+                title: "Extraction cost",
+                type: "bar_chart",
+              },
+            ],
+          },
+        ]}
+      />,
+    );
+    expect(html).toContain('aria-label="2026-07-31, Cost: $1.25"');
+    expect(html).toContain(">$1.25</text>");
+  });
+
   it("renders daily chart ranges from the shared page selection", () => {
     const categories = Array.from({ length: 90 }, (_, index) => {
       const date = new Date("2026-05-03T00:00:00.000Z");

--- a/packages/junior-memory/README.md
+++ b/packages/junior-memory/README.md
@@ -15,7 +15,9 @@ exported types, tools, and tests are authoritative.
   inspection.
 - The dashboard exposes a searchable, paginated **Memories** user page for
   personal memories owned by actors linked to the signed-in viewer. Its
-  **Forget** action archives the selected memory.
+  **Forget** action archives the selected memory. The overview charts global
+  passive-extraction cost from the durable `memory/memories_captured` events;
+  the System plugin report uses the same event-cost feed.
 - Authenticated REST clients can list and search personal memories through
   `GET /api/plugins/memory/memories`, read one through
   `GET /api/plugins/memory/memories/:id`, and archive one through

--- a/packages/junior-memory/src/api.ts
+++ b/packages/junior-memory/src/api.ts
@@ -8,6 +8,7 @@
 import { z } from "zod";
 import {
   pluginApiRouteRequestContextSchema,
+  type PluginConversationEventStats,
   type PluginApiRouteRequestContext,
   type PluginRouteApp,
   type PluginUserPageActor,
@@ -47,9 +48,18 @@ const memoryDashboardDaySchema = z
   })
   .strict();
 
+const memoryExtractionDaySchema = z
+  .object({
+    costUsd: z.number().finite().nonnegative(),
+    date: z.iso.date(),
+    events: z.number().int().min(0),
+  })
+  .strict();
+
 export const memoryDashboardResponseSchema = z
   .object({
     days: z.array(memoryDashboardDaySchema).length(90),
+    extractionDays: z.array(memoryExtractionDaySchema).length(90),
     generatedAt: z.iso.datetime(),
     stats: z
       .object({
@@ -85,6 +95,7 @@ const memoryListQuerySchema = z
 interface MemoryApiOptions {
   actors(email: string): Promise<PluginUserPageActor[]>;
   db: MemoryDb;
+  eventStats: PluginConversationEventStats;
 }
 
 function json(body: unknown, status = 200): Response {
@@ -94,7 +105,9 @@ function json(body: unknown, status = 200): Response {
   });
 }
 
-function apiMemory(memory: PersonalMemoryRecord): z.output<typeof memoryApiSchema> {
+function apiMemory(
+  memory: PersonalMemoryRecord,
+): z.output<typeof memoryApiSchema> {
   return {
     content: memory.content,
     createdAt: new Date(memory.createdAtMs).toISOString(),
@@ -142,12 +155,17 @@ export function createMemoryApi(options: MemoryApiOptions): PluginRouteApp {
           isDashboard &&
           (request.method === "GET" || request.method === "HEAD")
         ) {
-          const [stats, days] = await Promise.all([
+          const [stats, days, extractionDays] = await Promise.all([
             memories.stats(),
             memories.timeline({ days: 90 }),
+            options.eventStats.costsByDay({
+              days: 90,
+              eventName: "memories_captured",
+            }),
           ]);
           const body = memoryDashboardResponseSchema.parse({
             days,
+            extractionDays,
             generatedAt: new Date().toISOString(),
             stats,
           });

--- a/packages/junior-memory/src/operational-report.ts
+++ b/packages/junior-memory/src/operational-report.ts
@@ -1,4 +1,7 @@
-import type { PluginOperationalReportContent } from "@sentry/junior-plugin-api";
+import type {
+  PluginConversationEventCostDay,
+  PluginOperationalReportContent,
+} from "@sentry/junior-plugin-api";
 import { and, eq, gt, isNull, or, sql } from "drizzle-orm";
 import { z } from "zod";
 import { juniorMemoryEmbeddings, juniorMemoryMemories } from "./db/schema";
@@ -87,9 +90,19 @@ function formatPercent(value: number): string {
   }).format(value);
 }
 
+function formatUsd(value: number): string {
+  return new Intl.NumberFormat("en-US", {
+    currency: "USD",
+    maximumFractionDigits: 2,
+    minimumFractionDigits: 2,
+    style: "currency",
+  }).format(value);
+}
+
 /** Build aggregate memory storage and indexing diagnostics for the System page. */
 export async function buildMemoryOperationalReport(args: {
   db: MemoryDb;
+  extractionDays: PluginConversationEventCostDay[];
   nowMs: number;
 }): Promise<PluginOperationalReportContent> {
   const active = and(
@@ -133,6 +146,11 @@ export async function buildMemoryOperationalReport(args: {
   const activeCount = counts?.active ?? 0;
   const embeddedCount = counts?.embedded ?? 0;
   const embeddingCoverage = activeCount === 0 ? 0 : embeddedCount / activeCount;
+  const extractionThirtyDays = args.extractionDays.slice(-30);
+  const extractionCostThirtyDays = extractionThirtyDays.reduce(
+    (total, day) => total + day.costUsd,
+    0,
+  );
 
   return {
     generatedAt: new Date(args.nowMs).toISOString(),
@@ -142,6 +160,10 @@ export async function buildMemoryOperationalReport(args: {
         label: "active memories",
         tone: activeCount > 0 ? "good" : "neutral",
         value: formatCount(activeCount),
+      },
+      {
+        label: "extraction cost · 30d",
+        value: formatUsd(extractionCostThirtyDays),
       },
       {
         label: "created · 30d",
@@ -167,6 +189,19 @@ export async function buildMemoryOperationalReport(args: {
       },
     ],
     widgets: [
+      {
+        categories: args.extractionDays.map((day) => ({
+          id: day.date,
+          label: day.date,
+          values: { costUsd: day.costUsd },
+        })),
+        description: "Estimated model cost of passive memory extraction",
+        id: "extraction-cost",
+        series: [{ format: "usd", key: "costUsd", label: "Cost" }],
+        timeRangeDays: [...WINDOWS],
+        title: "Extraction cost",
+        type: "bar_chart",
+      },
       {
         categories: memoryDays.map((day) => ({
           id: day.date,

--- a/packages/junior-memory/src/operational-report.ts
+++ b/packages/junior-memory/src/operational-report.ts
@@ -91,9 +91,10 @@ function formatPercent(value: number): string {
 }
 
 function formatUsd(value: number): string {
+  const maximumFractionDigits = value > 0 && value < 0.01 ? 4 : 2;
   return new Intl.NumberFormat("en-US", {
     currency: "USD",
-    maximumFractionDigits: 2,
+    maximumFractionDigits,
     minimumFractionDigits: 2,
     style: "currency",
   }).format(value);

--- a/packages/junior-memory/src/plugin.ts
+++ b/packages/junior-memory/src/plugin.ts
@@ -115,8 +115,13 @@ export function memoryPlugin(options: MemoryPluginOptions = {}) {
     userPages: [createMemoryUserPage()],
     hooks: {
       async operationalReport(ctx) {
+        const extractionDays = await ctx.eventStats.costsByDay({
+          days: 90,
+          eventName: "memories_captured",
+        });
         return await buildMemoryOperationalReport({
           db: ctx.db as MemoryDb,
+          extractionDays,
           nowMs: ctx.nowMs,
         });
       },
@@ -124,6 +129,7 @@ export function memoryPlugin(options: MemoryPluginOptions = {}) {
         return createMemoryApi({
           actors: ctx.viewer.actors,
           db: ctx.db as MemoryDb,
+          eventStats: ctx.eventStats,
         });
       },
       tools(ctx) {

--- a/packages/junior-memory/tests/operational-report.test.ts
+++ b/packages/junior-memory/tests/operational-report.test.ts
@@ -16,6 +16,17 @@ import { createMemoryStore, type MemoryDb } from "../src/store";
 const TEST_NOW_MS = Date.parse("2026-07-28T12:00:00.000Z");
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
+function emptyExtractionDays() {
+  const start = Date.parse("2026-04-30T00:00:00.000Z");
+  return Array.from({ length: 90 }, (_, index) => ({
+    costUsd: 0,
+    date: new Date(start + index * 24 * 60 * 60 * 1_000)
+      .toISOString()
+      .slice(0, 10),
+    events: 0,
+  }));
+}
+
 type MemoryFixture = LocalPgliteFixture<MemoryDb>;
 
 async function createMemoryFixture(): Promise<MemoryFixture> {
@@ -81,11 +92,12 @@ describe("memory operational report", () => {
 
       const report = await buildMemoryOperationalReport({
         db: fixture.db(),
+        extractionDays: emptyExtractionDays(),
         nowMs: TEST_NOW_MS,
       });
 
-      expect(report.widgets?.[0]?.categories).toHaveLength(90);
-      expect(report.widgets?.[0]?.categories.at(-1)).toEqual({
+      expect(report.widgets?.[1]?.categories).toHaveLength(90);
+      expect(report.widgets?.[1]?.categories.at(-1)).toEqual({
         id: "2026-07-28",
         label: "2026-07-28",
         values: {
@@ -103,6 +115,7 @@ describe("memory operational report", () => {
     try {
       const report = await buildMemoryOperationalReport({
         db: fixture.db(),
+        extractionDays: emptyExtractionDays(),
         nowMs: TEST_NOW_MS,
       });
       expect(report).toMatchObject({
@@ -114,6 +127,7 @@ describe("memory operational report", () => {
             tone: "neutral",
             value: "0",
           },
+          { label: "extraction cost · 30d", value: "$0.00" },
           { label: "created · 30d", value: "0" },
           { label: "personal", value: "0" },
           { label: "conversation", value: "0" },
@@ -125,6 +139,13 @@ describe("memory operational report", () => {
         ],
       });
       expect(report.widgets).toEqual([
+        expect.objectContaining({
+          id: "extraction-cost",
+          series: [{ format: "usd", key: "costUsd", label: "Cost" }],
+          timeRangeDays: [7, 30, 90],
+          title: "Extraction cost",
+          type: "bar_chart",
+        }),
         expect.objectContaining({
           id: "memories-created",
           series: [
@@ -138,7 +159,7 @@ describe("memory operational report", () => {
       ]);
       expect(report.widgets?.[0]?.categories).toHaveLength(90);
       expect(
-        report.widgets?.[0]?.categories.every((day) => {
+        report.widgets?.[1]?.categories.every((day) => {
           return day.values.personal === 0 && day.values.conversation === 0;
         }),
       ).toBe(true);
@@ -179,26 +200,39 @@ describe("memory operational report", () => {
         subjectKey: "report-user",
         subjectType: "user",
       });
+      const extractionDays = emptyExtractionDays();
+      extractionDays[89] = {
+        costUsd: 0.125,
+        date: "2026-07-28",
+        events: 4,
+      };
 
       const report = await buildMemoryOperationalReport({
         db,
+        extractionDays,
         nowMs: TEST_NOW_MS,
       });
 
       expect(report.metrics).toEqual([
         { label: "active memories", tone: "good", value: "2" },
+        { label: "extraction cost · 30d", value: "$0.13" },
         { label: "created · 30d", value: "3" },
         { label: "personal", value: "1" },
         { label: "conversation", value: "1" },
         { label: "embedding coverage", tone: "good", value: "100%" },
       ]);
-      expect(report.widgets?.[0]?.categories.at(-1)).toEqual({
+      expect(report.widgets?.[1]?.categories.at(-1)).toEqual({
         id: "2026-07-28",
         label: "2026-07-28",
         values: {
           conversation: 1,
           personal: 2,
         },
+      });
+      expect(report.widgets?.[0]?.categories.at(-1)).toEqual({
+        id: "2026-07-28",
+        label: "2026-07-28",
+        values: { costUsd: 0.125 },
       });
       expect(JSON.stringify(report)).not.toContain("checkout");
       expect(JSON.stringify(report)).not.toContain("report-user");

--- a/packages/junior-memory/tests/operational-report.test.ts
+++ b/packages/junior-memory/tests/operational-report.test.ts
@@ -202,7 +202,7 @@ describe("memory operational report", () => {
       });
       const extractionDays = emptyExtractionDays();
       extractionDays[89] = {
-        costUsd: 0.125,
+        costUsd: 0.0042,
         date: "2026-07-28",
         events: 4,
       };
@@ -215,7 +215,7 @@ describe("memory operational report", () => {
 
       expect(report.metrics).toEqual([
         { label: "active memories", tone: "good", value: "2" },
-        { label: "extraction cost · 30d", value: "$0.13" },
+        { label: "extraction cost · 30d", value: "$0.0042" },
         { label: "created · 30d", value: "3" },
         { label: "personal", value: "1" },
         { label: "conversation", value: "1" },
@@ -232,7 +232,7 @@ describe("memory operational report", () => {
       expect(report.widgets?.[0]?.categories.at(-1)).toEqual({
         id: "2026-07-28",
         label: "2026-07-28",
-        values: { costUsd: 0.125 },
+        values: { costUsd: 0.0042 },
       });
       expect(JSON.stringify(report)).not.toContain("checkout");
       expect(JSON.stringify(report)).not.toContain("report-user");

--- a/packages/junior-memory/tests/storage.test.ts
+++ b/packages/junior-memory/tests/storage.test.ts
@@ -2336,6 +2336,18 @@ ORDER BY created_at_ms ASC
       const api = createMemoryApi({
         actors: async () => actors,
         db: memoryDb(fixture),
+        eventStats: {
+          async costsByDay({ days }) {
+            const start = Date.parse("2026-04-30T00:00:00.000Z");
+            return Array.from({ length: days }, (_, index) => ({
+              costUsd: index === days - 1 ? 0.0042 : 0,
+              date: new Date(start + index * 24 * 60 * 60 * 1_000)
+                .toISOString()
+                .slice(0, 10),
+              events: index === days - 1 ? 1 : 0,
+            }));
+          },
+        },
       });
       const requestContext = pluginApiRouteRequestContextSchema.parse({
         auth: {
@@ -2456,6 +2468,11 @@ ORDER BY created_at_ms ASC
         public: 1,
       });
       expect(dashboard.days).toHaveLength(90);
+      expect(dashboard.extractionDays.at(-1)).toEqual({
+        costUsd: 0.0042,
+        date: "2026-07-28",
+        events: 1,
+      });
       expect(dashboard.days.find((day) => day.date === "2026-06-19")).toEqual({
         date: "2026-06-19",
         personal: 2,

--- a/packages/junior-plugin-api/README.md
+++ b/packages/junior-plugin-api/README.md
@@ -48,6 +48,9 @@ reports, and other typed hook surfaces exported by this package.
 - Host-owned structured model and embedding calls do not expose provider
   credentials to plugins. Structured calls return a best-effort provider cost
   estimate when one is available.
+- Operational report and authenticated API hooks may aggregate `costUsd` from
+  their own registered conversation events through `ctx.eventStats`. Core
+  binds the plugin namespace and owns access to the conversation event log.
 - Authenticated API route apps receive one verified viewer in their request
   context. The registration hook exposes actor resolution for plugins whose
   viewer-owned data spans platform identities.

--- a/packages/junior-plugin-api/src/conversation-events.ts
+++ b/packages/junior-plugin-api/src/conversation-events.ts
@@ -111,3 +111,17 @@ export function defineConversationEvent<
 export interface PluginConversationEvents {
   emit(event: PluginConversationEventValue): Promise<void>;
 }
+
+export interface PluginConversationEventCostDay {
+  costUsd: number;
+  date: string;
+  events: number;
+}
+
+/** Read aggregate costs for events owned by the current plugin namespace. */
+export interface PluginConversationEventStats {
+  costsByDay(input: {
+    days: 7 | 30 | 90;
+    eventName: string;
+  }): Promise<PluginConversationEventCostDay[]>;
+}

--- a/packages/junior-plugin-api/src/operations.ts
+++ b/packages/junior-plugin-api/src/operations.ts
@@ -5,6 +5,7 @@ import { nonBlankStringSchema } from "./schemas";
 import type { PluginReadState, PluginState } from "./state";
 import type { ResourceEventPublisher } from "./resource-events";
 import type { PluginConversationAnnotations } from "./annotations";
+import type { PluginConversationEventStats } from "./conversation-events";
 
 export interface HeartbeatHookContext extends PluginContext {
   agent: {
@@ -46,6 +47,7 @@ export interface PluginOperationalRecordSet {
 }
 
 export interface PluginOperationalChartSeries {
+  format?: "usd";
   key: string;
   label: string;
   tone?: PluginOperationalTone;
@@ -81,6 +83,7 @@ export interface PluginOperationalReport extends PluginOperationalReportContent 
 }
 
 export interface OperationalReportHookContext extends PluginContext {
+  eventStats: PluginConversationEventStats;
   nowMs: number;
   state: PluginReadState;
 }
@@ -120,6 +123,7 @@ export interface RouteRegistrationHookContext extends PluginContext {
 }
 
 export interface ApiRouteRegistrationHookContext extends PluginContext {
+  eventStats: PluginConversationEventStats;
   viewer: {
     /** Resolve every runtime actor linked to one authenticated viewer email. */
     actors(email: string): Promise<Array<LocalActor | SlackActor>>;

--- a/packages/junior/src/chat/plugins/agent-hooks.ts
+++ b/packages/junior/src/chat/plugins/agent-hooks.ts
@@ -23,6 +23,7 @@ import type {
 } from "@sentry/junior-plugin-api";
 import { getDb } from "@/chat/db";
 import { createPluginAnnotations } from "@/chat/plugins/annotations";
+import { createPluginConversationEventStats } from "@/chat/plugins/conversation-event-stats";
 import { logInfo, logWarn } from "@/chat/logging";
 import { createPluginLogger } from "@/chat/plugins/logging";
 import { createPluginEmbedder, createPluginModel } from "@/chat/plugins/model";
@@ -741,6 +742,7 @@ export function getPluginApiRoutes(): PluginApiRouteRegistration[] {
     }
     const app = hook({
       ...basePluginContext(plugin),
+      eventStats: createPluginConversationEventStats(plugin),
       viewer: {
         actors: readViewerActors,
       },
@@ -976,6 +978,9 @@ function sanitizeOperationalReport(args: {
           const sanitizedSeries: NonNullable<
             PluginOperationalReport["widgets"]
           >[number]["series"][number] = { key, label };
+          if (item.format === "usd") {
+            sanitizedSeries.format = "usd";
+          }
           const tone = operationalReportTone(item.tone);
           if (tone) {
             sanitizedSeries.tone = tone;
@@ -1104,6 +1109,7 @@ export async function getPluginOperationalReports(
       const state = createPluginState(pluginName);
       const report = await hook({
         ...basePluginContext(plugin),
+        eventStats: createPluginConversationEventStats(plugin, () => nowMs),
         nowMs,
         state: pluginReadState(state),
       });

--- a/packages/junior/src/chat/plugins/conversation-event-stats.ts
+++ b/packages/junior/src/chat/plugins/conversation-event-stats.ts
@@ -1,0 +1,100 @@
+import type {
+  PluginConversationEventCostDay,
+  PluginConversationEventStats,
+  PluginRegistration,
+} from "@sentry/junior-plugin-api";
+import { and, eq, gte, lt, sql } from "drizzle-orm";
+import { z } from "zod";
+import { getDb } from "@/chat/db";
+import { juniorConversationEvents } from "@/db/schema";
+
+const DAY_MS = 24 * 60 * 60 * 1_000;
+
+const costRowSchema = z
+  .object({
+    costUsd: z.number().finite().nonnegative(),
+    date: z.string().date(),
+    events: z.number().int().nonnegative(),
+  })
+  .strict();
+
+function startOfUtcDay(value: number): Date {
+  const date = new Date(value);
+  date.setUTCHours(0, 0, 0, 0);
+  return date;
+}
+
+function registeredEventName(
+  plugin: PluginRegistration,
+  eventName: string,
+): string {
+  if (
+    !plugin.conversationEvents?.some(
+      (definition) => definition.eventName === eventName,
+    )
+  ) {
+    throw new TypeError(
+      `Plugin "${plugin.manifest.name}" did not register event "${eventName}"`,
+    );
+  }
+  return eventName;
+}
+
+/** Create aggregate event-cost reads bound to one plugin's registered namespace. */
+export function createPluginConversationEventStats(
+  plugin: PluginRegistration,
+  now: () => number = Date.now,
+): PluginConversationEventStats {
+  return {
+    async costsByDay(input) {
+      const eventName = registeredEventName(plugin, input.eventName);
+      const end = startOfUtcDay(now());
+      const start = new Date(end.getTime() - (input.days - 1) * DAY_MS);
+      const endExclusive = new Date(end.getTime() + DAY_MS);
+      const date = sql<string>`TO_CHAR(
+        ${juniorConversationEvents.createdAt} AT TIME ZONE 'UTC',
+        'YYYY-MM-DD'
+      )`;
+      const cost = sql<number>`CASE
+        WHEN jsonb_typeof(${juniorConversationEvents.payload}->'content'->'costUsd') = 'number'
+          THEN (${juniorConversationEvents.payload}->'content'->>'costUsd')::double precision
+        ELSE 0
+      END`;
+      const rows = await getDb()
+        .select({
+          costUsd: sql<number>`SUM(${cost})::double precision`.mapWith(Number),
+          date,
+          events: sql<number>`COUNT(*)::integer`.mapWith(Number),
+        })
+        .from(juniorConversationEvents)
+        .where(
+          and(
+            eq(juniorConversationEvents.type, "structured_event"),
+            sql`${juniorConversationEvents.payload}->>'namespace' = ${plugin.manifest.name}`,
+            sql`${juniorConversationEvents.payload}->>'name' = ${eventName}`,
+            gte(juniorConversationEvents.createdAt, start),
+            lt(juniorConversationEvents.createdAt, endExclusive),
+          ),
+        )
+        .groupBy(date);
+      const byDate = new Map(
+        z
+          .array(costRowSchema)
+          .parse(rows)
+          .map((row) => [row.date, row]),
+      );
+      return Array.from({ length: input.days }, (_, index) => {
+        const day = new Date(start.getTime() + index * DAY_MS);
+        const date = day.toISOString().slice(0, 10);
+        return (
+          byDate.get(date) ??
+          ({
+            costUsd: 0,
+            date,
+            events: 0,
+          } satisfies PluginConversationEventCostDay)
+        );
+      });
+    },
+  };
+}

--- a/packages/junior/src/reporting-schema.ts
+++ b/packages/junior/src/reporting-schema.ts
@@ -115,6 +115,7 @@ const pluginOperationalBarChartWidgetSchema = z
       .array(
         z
           .object({
+            format: z.literal("usd").optional(),
             key: z.string().min(1),
             label: z.string().min(1),
             tone: pluginOperationalToneSchema.optional(),

--- a/packages/junior/tests/component/plugins/plugin-conversation-events.test.ts
+++ b/packages/junior/tests/component/plugins/plugin-conversation-events.test.ts
@@ -92,6 +92,66 @@ afterEach(async () => {
 });
 
 describe("plugin conversation events", () => {
+  it("aggregates event cost inside the owning plugin namespace", async () => {
+    const runId = randomUUID();
+    const conversationId = `local:test:event-cost-${runId}`;
+    const sessionId = `event-cost-session:${runId}`;
+    const completedEvent = defineConversationEvent({
+      name: "session_processed",
+      version: 1,
+      schema: z.object({ costUsd: z.number() }).strict(),
+      renderEvent() {
+        return undefined;
+      },
+    });
+    let observedDays:
+      | Array<{ costUsd: number; date: string; events: number }>
+      | undefined;
+    const plugin = defineJuniorPlugin({
+      manifest: {
+        name: "event-cost-demo",
+        displayName: "Event Cost Demo",
+        description: "Event cost demo",
+      },
+      conversationEvents: [completedEvent],
+      hooks: {
+        async operationalReport(ctx) {
+          observedDays = await ctx.eventStats.costsByDay({
+            days: 7,
+            eventName: "session_processed",
+          });
+          return { title: "Event cost demo" };
+        },
+      },
+      tasks: {
+        processSession: {
+          async run(ctx) {
+            await ctx.events.emit(completedEvent({ costUsd: 0.0042 }));
+          },
+        },
+      },
+    });
+    const { getPluginOperationalReports, setPlugins } =
+      await import("@/chat/plugins/agent-hooks");
+    const { processPluginTask } = await import("@/chat/plugins/task-runner");
+    setPlugins([plugin]);
+    await recordCompletedSession({ conversationId, sessionId });
+    await processPluginTask({
+      name: "processSession",
+      params: { conversationId, sessionId },
+      plugin: "event-cost-demo",
+    });
+
+    await getPluginOperationalReports(Date.now());
+
+    expect(observedDays).toHaveLength(7);
+    expect(observedDays?.at(-1)).toEqual({
+      costUsd: 0.0042,
+      date: new Date().toISOString().slice(0, 10),
+      events: 1,
+    });
+  });
+
   it("deduplicates task events across schema versions without refreshing activity", async () => {
     const runId = randomUUID();
     const conversationId = `local:test:structured-events-${runId}`;

--- a/packages/junior/tests/component/scheduler-sql-plugin.test.ts
+++ b/packages/junior/tests/component/scheduler-sql-plugin.test.ts
@@ -449,6 +449,11 @@ INSERT INTO junior_scheduler_tasks (
 
       const api = schedulerPlugin().hooks?.apiRoutes?.({
         db,
+        eventStats: {
+          async costsByDay() {
+            throw new Error("Scheduler API test does not read event stats");
+          },
+        },
         log: noopLogger,
         plugin: { name: "scheduler" },
         viewer: { actors: async () => context.viewer.actors },


### PR DESCRIPTION
Memory now shows system-wide passive extraction spend beside memory activity, with 7/30/90-day range controls and responsive desktop/mobile layouts. The Memory System panel also surfaces 30-day extraction cost and a USD-formatted trend, while existing viewer-scoped memory counts remain unchanged.

Core supplies operational-report and authenticated API hooks with a namespace-bound aggregation of `costUsd` from registered structured events. Memory reads `memory/memories_captured` through that capability for both dashboard surfaces, keeping plugins away from core event tables and making the same reporting path reusable for future auxiliary model operations.
