### PR TITLE
feat(memory): track automatic recall cost

### DIFF
--- a/packages/junior-memory/README.md
+++ b/packages/junior-memory/README.md
@@ -68,6 +68,10 @@ exported types, tools, and tests are authoritative.
 - Automatic recall retrieves a broad candidate window, then uses the
   memory-owned relevance model to admit at most five directly useful memories.
   An empty result contributes no filler prompt text.
+- Every completed automatic recall attempt emits an invisible, namespaced
+  `memory/memories_recalled` conversation event with the admitted memory IDs
+  and best-effort embedding and relevance-model cost, including retrievals that
+  find no candidates and decisions that admit no memories.
 - Automatic recall degrades to no prompt contribution when relevance selection
   fails. Review, extraction, and write failures still fail their owning
   hook/task without corrupting existing memory state.

--- a/packages/junior-memory/src/agent.ts
+++ b/packages/junior-memory/src/agent.ts
@@ -205,11 +205,17 @@ export type MemoryExtractionResult = {
   memories: ExtractedMemory[];
 };
 
+/** Memories admitted by automatic recall and the model cost of that decision. */
+export type MemoryRecallResult = {
+  costUsd?: number;
+  relevantIds: string[];
+};
+
 export interface MemoryAgent {
   /** Select candidate memories that directly help with the current request. */
   selectRelevantMemories(
     request: MemoryRecallInput,
-  ): Promise<string[]> | string[];
+  ): Promise<MemoryRecallResult> | MemoryRecallResult;
   /** Classify a new preference against related active preferences. */
   adjudicateSupersession(
     request: MemorySupersessionInput,
@@ -546,9 +552,12 @@ export function createMemoryAgent(model: PluginModel): MemoryAgent {
       });
       const decision = memoryRecallDecisionSchema.parse(result.object);
       const candidateIds = new Set(request.candidates.map(({ id }) => id));
-      return [...new Set(decision.relevantIds)].filter((id) =>
-        candidateIds.has(id),
-      );
+      return {
+        relevantIds: [...new Set(decision.relevantIds)].filter((id) =>
+          candidateIds.has(id),
+        ),
+        ...(result.costUsd !== undefined ? { costUsd: result.costUsd } : {}),
+      };
     },
     async adjudicateSupersession(rawRequest) {
       const request = memorySupersessionInputSchema.parse(rawRequest);

--- a/packages/junior-memory/src/events.ts
+++ b/packages/junior-memory/src/events.ts
@@ -28,6 +28,13 @@ const capturedMemoriesSchema = z
   })
   .strict();
 
+const recalledMemoriesSchema = z
+  .object({
+    memories: z.array(z.string().min(1)).max(5),
+    costUsd: z.number().finite().nonnegative().optional(),
+  })
+  .strict();
+
 function renderCapturedMemories(
   event: z.output<typeof capturedMemoriesSchema>,
 ) {
@@ -65,6 +72,16 @@ export const memoriesCapturedEvent = defineConversationEvent({
   version: 2,
   schema: capturedMemoriesSchema,
   renderEvent: renderCapturedMemories,
+});
+
+/** Durable outcome emitted after one completed automatic recall attempt. */
+export const memoriesRecalledEvent = defineConversationEvent({
+  name: "memories_recalled",
+  version: 1,
+  schema: recalledMemoriesSchema,
+  renderEvent() {
+    return undefined;
+  },
 });
 
 /** Select the stable, safe memory fields retained in conversation history. */

--- a/packages/junior-memory/src/plugin.ts
+++ b/packages/junior-memory/src/plugin.ts
@@ -14,7 +14,11 @@ import {
 import { processMemorySession } from "./process-session";
 import { createMemoryPromptContributions } from "./recall";
 import { buildMemoryOperationalReport } from "./operational-report";
-import { memoriesCapturedEvent, memoriesCapturedEventV1 } from "./events";
+import {
+  memoriesCapturedEvent,
+  memoriesCapturedEventV1,
+  memoriesRecalledEvent,
+} from "./events";
 import type { MemoryDb } from "./store";
 import { createMemoryUserPage } from "./user-pages";
 
@@ -101,7 +105,11 @@ export function memoryPlugin(options: MemoryPluginOptions = {}) {
       ? { structuredModelId: modelId }
       : { structuredModel: "default" },
     packageName: "@sentry/junior-memory",
-    conversationEvents: [memoriesCapturedEventV1, memoriesCapturedEvent],
+    conversationEvents: [
+      memoriesCapturedEventV1,
+      memoriesCapturedEvent,
+      memoriesRecalledEvent,
+    ],
     cli: {
       commands: [createMemoryCliCommand()],
     },
@@ -162,6 +170,7 @@ export function memoryPlugin(options: MemoryPluginOptions = {}) {
           ...(ctx.actor ? { actor: ctx.actor } : {}),
           db: ctx.db as MemoryDb,
           embedder: ctx.embedder,
+          events: ctx.events,
           log: ctx.log,
           maxVectorDistance: recallMaxVectorDistance(options),
           source: ctx.source,

--- a/packages/junior-memory/src/recall.ts
+++ b/packages/junior-memory/src/recall.ts
@@ -2,11 +2,13 @@ import {
   definePromptContext,
   type UserPromptContribution,
   type Actor,
+  type PluginConversationEvents,
   type PluginLogger,
   type Source,
 } from "@sentry/junior-plugin-api";
 import { z } from "zod";
-import type { MemoryAgent } from "./agent";
+import type { MemoryAgent, MemoryRecallResult } from "./agent";
+import { memoriesRecalledEvent } from "./events";
 import {
   createMemoryStore,
   type MemoryDb,
@@ -25,6 +27,7 @@ export interface MemoryRecallContext {
   conversationId?: string;
   db: MemoryDb;
   embedder?: MemoryEmbeddingProvider;
+  events?: PluginConversationEvents;
   log: PluginLogger;
   /** Maximum cosine distance for vector recall. Passed through to the memory store. */
   maxVectorDistance?: number;
@@ -101,6 +104,28 @@ function renderMemoryPrompt(memories: RecalledMemory[]): string {
   ].join("\n");
 }
 
+function addUsd(
+  left: number | undefined,
+  right: number | undefined,
+): number | undefined {
+  if (left === undefined) return right;
+  if (right === undefined) return left;
+  return Math.round((left + right) * 1e12) / 1e12;
+}
+
+async function emitRecallOutcome(args: {
+  costUsd?: number;
+  events?: PluginConversationEvents;
+  memories: string[];
+}): Promise<void> {
+  await args.events?.emit(
+    memoriesRecalledEvent({
+      memories: args.memories,
+      ...(args.costUsd !== undefined ? { costUsd: args.costUsd } : {}),
+    }),
+  );
+}
+
 const memoryRecallContext = definePromptContext({
   kind: "recall",
   version: 1,
@@ -122,8 +147,19 @@ export async function createMemoryPromptContributions(
     ...(context.actor ? { actor: context.actor } : {}),
     source: context.source,
   });
+  let embeddingCostUsd: number | undefined;
+  const sourceEmbedder = context.embedder;
+  const embedder = sourceEmbedder
+    ? {
+        async embedTexts(input: { texts: string[] }) {
+          const result = await sourceEmbedder.embedTexts(input);
+          embeddingCostUsd = addUsd(embeddingCostUsd, result.costUsd);
+          return result;
+        },
+      }
+    : undefined;
   const candidates = await createMemoryStore(context.db, runtimeContext, {
-    ...(context.embedder ? { embedder: context.embedder } : {}),
+    ...(embedder ? { embedder } : {}),
     ...(context.maxVectorDistance !== undefined
       ? { maxVectorDistance: context.maxVectorDistance }
       : {}),
@@ -132,11 +168,16 @@ export async function createMemoryPromptContributions(
     limit: RECALL_CANDIDATE_LIMIT,
   });
   if (candidates.length === 0) {
+    await emitRecallOutcome({
+      ...(embeddingCostUsd !== undefined ? { costUsd: embeddingCostUsd } : {}),
+      events: context.events,
+      memories: [],
+    });
     return undefined;
   }
-  let relevantIds: string[];
+  let recall: MemoryRecallResult;
   try {
-    relevantIds = await context.agent.selectRelevantMemories({
+    recall = await context.agent.selectRelevantMemories({
       candidates: candidates.map(({ content, id }) => ({ content, id })),
       userRequest: context.text,
     });
@@ -149,11 +190,17 @@ export async function createMemoryPromptContributions(
   const candidatesById = new Map(
     candidates.map((memory) => [memory.id, memory]),
   );
-  const relevant = relevantIds
+  const relevant = recall.relevantIds
     .map((id) => candidatesById.get(id))
     .filter((memory): memory is MemoryRecord => memory !== undefined)
     .slice(0, DEFAULT_RECALL_LIMIT);
   const selected = selectPromptMemories(relevant);
+  const costUsd = addUsd(embeddingCostUsd, recall.costUsd);
+  await emitRecallOutcome({
+    ...(costUsd !== undefined ? { costUsd } : {}),
+    events: context.events,
+    memories: selected.map(({ id }) => id),
+  });
   if (selected.length === 0) {
     return undefined;
   }

--- a/packages/junior-memory/src/store.ts
+++ b/packages/junior-memory/src/store.ts
@@ -180,6 +180,7 @@ const embeddingVectorSchema = z
   .length(MEMORY_EMBEDDING_DIMENSIONS);
 const embeddingResultSchema = z
   .object({
+    costUsd: z.number().finite().nonnegative().optional(),
     dimensions: z.literal(MEMORY_EMBEDDING_DIMENSIONS),
     model: nonEmptyStringSchema,
     provider: nonEmptyStringSchema,
@@ -272,6 +273,7 @@ export interface ArchiveExpiredMemoriesResult {
 export interface MemoryEmbeddingProvider {
   /** Embed normalized memory text for derived vector retrieval. */
   embedTexts(input: { texts: string[] }): Promise<{
+    costUsd?: number;
     dimensions: number;
     model: string;
     provider: string;

--- a/packages/junior-memory/tests/events.test.ts
+++ b/packages/junior-memory/tests/events.test.ts
@@ -1,10 +1,19 @@
 import { describe, expect, it } from "vitest";
-import { memoriesCapturedEvent } from "../src/events";
+import { memoriesCapturedEvent, memoriesRecalledEvent } from "../src/events";
 
 describe("memory conversation events", () => {
   it("omits empty extraction results from transcript presentation", () => {
     expect(
       memoriesCapturedEvent.renderEvent({
+        costUsd: 0.0042,
+        memories: [],
+      }),
+    ).toBeUndefined();
+  });
+
+  it("keeps automatic recall outcomes out of transcript presentation", () => {
+    expect(
+      memoriesRecalledEvent.renderEvent({
         costUsd: 0.0042,
         memories: [],
       }),

--- a/packages/junior-memory/tests/storage.test.ts
+++ b/packages/junior-memory/tests/storage.test.ts
@@ -12,6 +12,7 @@ import {
   pluginApiRouteRequestContextSchema,
   pluginUserPageContentSchema,
   PluginToolInputError,
+  type PluginConversationEventValue,
   type PluginLogger,
   type PluginModel,
   type PluginRunTranscriptEntry,
@@ -208,7 +209,12 @@ function cosineEmbedding(cosine: number): number[] {
 
 function createTestEmbedder(
   vectors: Record<string, number[]> = {},
-  overrides: { dimensions?: number; model?: string; provider?: string } = {},
+  overrides: {
+    costUsd?: number;
+    dimensions?: number;
+    model?: string;
+    provider?: string;
+  } = {},
 ) {
   const calls: string[][] = [];
   return {
@@ -216,6 +222,9 @@ function createTestEmbedder(
     async embedTexts(input: { texts: string[] }) {
       calls.push(input.texts);
       return {
+        ...(overrides.costUsd !== undefined
+          ? { costUsd: overrides.costUsd }
+          : {}),
         dimensions: overrides.dimensions ?? TEST_EMBEDDING_DIMENSIONS,
         model: overrides.model ?? "test-embedding-model",
         provider: overrides.provider ?? "test-embedding-provider",
@@ -225,7 +234,10 @@ function createTestEmbedder(
   };
 }
 
-function recallModel(select: (candidates: string[]) => string[]): PluginModel {
+function recallModel(
+  select: (candidates: string[]) => string[],
+  costUsd?: number,
+): PluginModel {
   return {
     async completeObject(input) {
       const encoded =
@@ -242,6 +254,7 @@ function recallModel(select: (candidates: string[]) => string[]): PluginModel {
         id: string;
       }>;
       return {
+        ...(costUsd !== undefined ? { costUsd } : {}),
         object: {
           relevantIds: select(candidates.map(({ content }) => content)).map(
             (content) =>
@@ -523,6 +536,7 @@ describe("memory plugin storage", () => {
       async completeObject(input) {
         calls.push(input);
         return {
+          costUsd: 0.0042,
           object: {
             relevantIds: ["memory-2", "unknown", "memory-2", "memory-1"],
           },
@@ -542,7 +556,10 @@ describe("memory plugin storage", () => {
         ],
         userRequest: "How does CI work in getsentry/junior?",
       }),
-    ).resolves.toEqual(["memory-2", "memory-1"]);
+    ).resolves.toEqual({
+      costUsd: 0.0042,
+      relevantIds: ["memory-2", "memory-1"],
+    });
     expect(calls[0]?.system).toContain(
       "Reject memories that merely share a company",
     );
@@ -3759,14 +3776,20 @@ WHERE id = '${superseded.memory.id}'
         idempotencyKey: "memory-test:recall-other-user",
       });
 
+      const emitted: PluginConversationEventValue[] = [];
       const plugin = memoryPlugin();
       const result = await plugin.hooks?.userPrompt?.({
         ...context,
         destination: slackDestination(context),
         db: memoryDb(fixture),
-        embedder: createTestEmbedder(),
+        embedder: createTestEmbedder({}, { costUsd: 0.0003 }),
+        events: {
+          async emit(event) {
+            emitted.push(event);
+          },
+        },
         log: noopLogger,
-        model: selectAllRecallModel,
+        model: recallModel((candidates) => candidates, 0.0042),
         plugin: { name: "memory" },
         state: memoryState,
         text: "Draft a PR summary and mention release notes.",
@@ -3806,6 +3829,18 @@ WHERE id = '${superseded.memory.id}'
       expect(text).not.toContain(conversation.memory.id);
       expect(text).not.toContain("obsolete wording");
       expect(text).not.toContain("unrelated owner");
+      expect(emitted).toEqual([
+        expect.objectContaining({
+          data: {
+            costUsd: 0.0045,
+            memories: [conversation.memory.id, personal.memory.id],
+          },
+          definition: expect.objectContaining({
+            eventName: "memories_recalled",
+            version: 1,
+          }),
+        }),
+      ]);
     } finally {
       await fixture.close();
     }
@@ -3938,20 +3973,78 @@ WHERE id = '${superseded.memory.id}'
         idempotencyKey: "memory-test:recall-gate-empty",
       });
 
+      const emitted: PluginConversationEventValue[] = [];
       const plugin = memoryPlugin();
       await expect(
         plugin.hooks?.userPrompt?.({
           ...context,
           destination: slackDestination(context),
           db: memoryDb(fixture),
-          embedder: createTestEmbedder(),
+          embedder: createTestEmbedder({}, { costUsd: 0.0002 }),
+          events: {
+            async emit(event) {
+              emitted.push(event);
+            },
+          },
           log: noopLogger,
-          model: recallModel(() => []),
+          model: recallModel(() => [], 0.0017),
           plugin: { name: "memory" },
           state: memoryState,
-          text: "How does CI work in getsentry/junior?",
+          text: "How do autofix PR tests use the dashboard workflow?",
         }),
       ).resolves.toBeUndefined();
+      expect(emitted).toEqual([
+        expect.objectContaining({
+          data: { costUsd: 0.0019, memories: [] },
+          definition: expect.objectContaining({
+            eventName: "memories_recalled",
+            version: 1,
+          }),
+        }),
+      ]);
+    } finally {
+      await fixture.close();
+    }
+  }, 15_000);
+
+  it("records embedding cost when retrieval finds no recall candidates", async () => {
+    const fixture = await createMemoryFixture();
+    const emitted: PluginConversationEventValue[] = [];
+
+    try {
+      const context = slackContext();
+      const plugin = memoryPlugin();
+      await expect(
+        plugin.hooks?.userPrompt?.({
+          ...context,
+          destination: slackDestination(context),
+          db: memoryDb(fixture),
+          embedder: createTestEmbedder({}, { costUsd: 0.0002 }),
+          events: {
+            async emit(event) {
+              emitted.push(event);
+            },
+          },
+          log: noopLogger,
+          model: {
+            async completeObject() {
+              throw new Error("Recall model should not run without candidates");
+            },
+          },
+          plugin: { name: "memory" },
+          state: memoryState,
+          text: "Where do release notes live?",
+        }),
+      ).resolves.toBeUndefined();
+      expect(emitted).toEqual([
+        expect.objectContaining({
+          data: { costUsd: 0.0002, memories: [] },
+          definition: expect.objectContaining({
+            eventName: "memories_recalled",
+            version: 1,
+          }),
+        }),
+      ]);
     } finally {
       await fixture.close();
     }

--- a/packages/junior-plugin-api/README.md
+++ b/packages/junior-plugin-api/README.md
@@ -44,10 +44,12 @@ reports, and other typed hook surfaces exported by this package.
   database, logging, and only the host capabilities required by that hook.
 - Prompt hooks return bounded structured prompt messages rather than mutate the
   core prompt.
+- User prompt hooks for durable turns may emit registered structured events
+  through `ctx.events` for auxiliary work completed while building context.
 - Tool hooks return model-visible schemas aligned with their executor inputs.
 - Host-owned structured model and embedding calls do not expose provider
-  credentials to plugins. Structured calls return a best-effort provider cost
-  estimate when one is available.
+  credentials to plugins. Both return a best-effort provider cost estimate when
+  one is available.
 - Operational report and authenticated API hooks may aggregate `costUsd` from
   their own registered conversation events through `ctx.eventStats`. Core
   binds the plugin namespace and owns access to the conversation event log.
@@ -99,7 +101,7 @@ projection. A renderer may return `undefined` when an event should remain
 durable without producing a transcript row. The active plugin context supplies
 the namespace, so plugins cannot emit native events or impersonate another
 plugin. The `junior` plugin name is reserved for host-owned native events.
-Versions of the same event name share one task-operation idempotency identity,
+Versions of the same event name share one operation idempotency identity,
 so keep previous definitions registered when evolving an event. Stored events
 remain durable when a plugin is removed, but normal transcript projection skips
 definitions that are not currently registered.

--- a/packages/junior-plugin-api/src/context.ts
+++ b/packages/junior-plugin-api/src/context.ts
@@ -54,6 +54,8 @@ export interface PluginModel {
 export interface PluginEmbedder {
   /** Embed plugin-owned text for derived retrieval without exposing provider credentials. */
   embedTexts(input: { texts: string[] }): Promise<{
+    /** Best-effort estimated provider cost for this embedding call. */
+    costUsd?: number;
     dimensions: number;
     model: string;
     provider: string;

--- a/packages/junior-plugin-api/src/prompt.ts
+++ b/packages/junior-plugin-api/src/prompt.ts
@@ -9,6 +9,7 @@ import type {
   Source,
 } from "./context";
 import type { PluginState } from "./state";
+import type { PluginConversationEvents } from "./conversation-events";
 
 const promptContextKindSchema = z
   .string()
@@ -80,6 +81,8 @@ export type UserPromptContext = Pick<PluginContext, "db" | "log" | "plugin"> & {
   conversationId?: string;
   destination: Destination;
   embedder: PluginEmbedder;
+  /** Conversation-bound event writer when the prompt belongs to a durable turn. */
+  events?: PluginConversationEvents;
   model: PluginModel;
   actor?: Actor;
   source: Source;

--- a/packages/junior/src/chat/README.md
+++ b/packages/junior/src/chat/README.md
@@ -85,7 +85,7 @@ delegation without becoming the execution actor or a general task owner.
 - Tool failures remain internal agent-loop data unless the final result exposes
   an appropriate diagnostic.
 - Durable state is committed before acknowledging queue work or yielding.
-- Conversation events emitted by plugin background tasks preserve conversation
+- Conversation events emitted by plugin operations preserve conversation
   activity, archive, and transcript-retention state.
 - Model input stays below the configured bot context cap and the active model's
   advertised window. The agent checks before its first provider request and

--- a/packages/junior/src/chat/agent/index.ts
+++ b/packages/junior/src/chat/agent/index.ts
@@ -816,6 +816,7 @@ async function executeAgentRunInPrivacyContext(
       resumedFromSessionRecord,
       routing,
       spanContext,
+      turnId,
       toolGuidance: wiring.toolGuidance,
       toolRuntimeContext: wiring.toolRuntimeContext,
       userContentParts,

--- a/packages/junior/src/chat/agent/prompt.ts
+++ b/packages/junior/src/chat/agent/prompt.ts
@@ -425,6 +425,7 @@ export async function assemblePrompt(args: {
   resumedFromSessionRecord: boolean;
   routing: AgentRunRouting;
   spanContext: LogContext;
+  turnId: string;
   toolGuidance: Array<{
     name: string;
     promptGuidelines: AnyToolDefinition["promptGuidelines"];
@@ -485,6 +486,7 @@ export async function assemblePrompt(args: {
       ? []
       : await getPluginUserPromptContributions({
           context: args.toolRuntimeContext,
+          turnId: args.turnId,
         });
   const turnContextPrompt =
     needsBootstrapContextForPrompt || pluginUserPromptContributions.length > 0

--- a/packages/junior/src/chat/pi/client.ts
+++ b/packages/junior/src/chat/pi/client.ts
@@ -60,8 +60,34 @@ export const GEN_AI_SERVER_ADDRESS = "ai-gateway.vercel.sh";
 export const GEN_AI_SERVER_PORT = 443;
 const GEN_AI_OPERATION_CHAT = "chat" as const;
 const GEN_AI_OPERATION_EMBEDDINGS = "embeddings" as const;
+// AI Gateway input rates in USD per million tokens. Keep estimates
+// model-specific so unlisted configured models remain explicitly unknown.
+const EMBEDDING_INPUT_COST_USD_PER_MILLION_TOKENS: Readonly<
+  Record<string, number>
+> = {
+  "cohere/embed-v4.0": 0.12,
+  "google/gemini-embedding-001": 0.15,
+  "google/text-embedding-005": 0.025,
+  "mistral/mistral-embed": 0.1,
+  "openai/text-embedding-3-large": 0.13,
+  "openai/text-embedding-3-small": 0.02,
+  "openai/text-embedding-ada-002": 0.1,
+  "voyage/voyage-3.5": 0.06,
+  "voyage/voyage-3.5-lite": 0.02,
+};
 export const MISSING_GATEWAY_CREDENTIALS_ERROR =
   "Missing AI gateway credentials (AI_GATEWAY_API_KEY or VERCEL_OIDC_TOKEN)";
+
+function embeddingCostUsd(
+  modelId: string,
+  inputTokens: number,
+): number | undefined {
+  const costPerMillionTokens =
+    EMBEDDING_INPUT_COST_USD_PER_MILLION_TOKENS[modelId];
+  return costPerMillionTokens === undefined
+    ? undefined
+    : (inputTokens * costPerMillionTokens) / 1_000_000;
+}
 
 /**
  * Resolve the documented AI Gateway env credentials for the paths that need
@@ -436,6 +462,7 @@ export async function embedTexts(params: {
   signal?: AbortSignal;
   metadata?: Record<string, unknown>;
 }): Promise<{
+  costUsd?: number;
   dimensions: number;
   model: string;
   provider: string;
@@ -476,11 +503,17 @@ export async function embedTexts(params: {
             },
           );
         }
+        const costUsd = embeddingCostUsd(params.modelId, result.usage.tokens);
         setSpanAttributes({
           "gen_ai.embeddings.dimension.count": dimensions,
-          ...extractGenAiUsageAttributes(result.usage),
+          ...extractGenAiUsageAttributes({
+            inputTokens: result.usage.tokens,
+            ...(costUsd !== undefined
+              ? { cost: { input: costUsd, total: costUsd } }
+              : {}),
+          }),
         });
-        return { dimensions, result };
+        return { costUsd, dimensions, result };
       },
       {
         "gen_ai.provider.name": GEN_AI_PROVIDER_NAME,
@@ -491,6 +524,7 @@ export async function embedTexts(params: {
       },
     );
     return {
+      ...(result.costUsd !== undefined ? { costUsd: result.costUsd } : {}),
       dimensions: result.dimensions,
       model: params.modelId,
       provider: GEN_AI_PROVIDER_NAME,

--- a/packages/junior/src/chat/plugins/agent-hooks.ts
+++ b/packages/junior/src/chat/plugins/agent-hooks.ts
@@ -23,6 +23,7 @@ import type {
 } from "@sentry/junior-plugin-api";
 import { getDb } from "@/chat/db";
 import { createPluginAnnotations } from "@/chat/plugins/annotations";
+import { createPluginConversationEvents } from "@/chat/plugins/conversation-events";
 import { createPluginConversationEventStats } from "@/chat/plugins/conversation-event-stats";
 import { logInfo, logWarn } from "@/chat/logging";
 import { createPluginLogger } from "@/chat/plugins/logging";
@@ -148,12 +149,23 @@ function invocationPluginContext(
     ToolRuntimeContext,
     "conversationId" | "destination" | "actor" | "source" | "userText"
   >,
+  turnId?: string,
 ): UserPromptContext {
   const base = basePluginContext(plugin);
   const common = {
     ...base,
     conversationId: context.conversationId,
     embedder: createPluginEmbedder(plugin.manifest.name),
+    ...(context.conversationId && turnId
+      ? {
+          events: createPluginConversationEvents({
+            conversationId: context.conversationId,
+            operationId: `user-prompt:${turnId}`,
+            plugin,
+            turnId,
+          }),
+        }
+      : {}),
     model: createPluginModel(plugin.manifest.name, plugin.model),
     source: context.source,
     text: context.userText ?? "",
@@ -410,6 +422,7 @@ export async function getPluginUserPromptContributions(args: {
     ToolRuntimeContext,
     "conversationId" | "destination" | "actor" | "source" | "userText"
   >;
+  turnId?: string;
 }): Promise<PluginPromptContributionContext[]> {
   const contributions: PluginPromptContributionContext[] = [];
   let totalChars = 0;
@@ -422,7 +435,7 @@ export async function getPluginUserPromptContributions(args: {
     }
     try {
       const rawResult = await hook({
-        ...invocationPluginContext(plugin, args.context),
+        ...invocationPluginContext(plugin, args.context, args.turnId),
       });
       if (rawResult === undefined) {
         continue;

--- a/packages/junior/src/chat/plugins/conversation-events.ts
+++ b/packages/junior/src/chat/plugins/conversation-events.ts
@@ -31,7 +31,7 @@ function eventIdentityVersion(
   return version;
 }
 
-/** Create a conversation-bound writer for one plugin task operation. */
+/** Create a conversation-bound writer for one plugin operation. */
 export function createPluginConversationEvents(args: {
   conversationId: string;
   operationId: string;

--- a/packages/junior/tests/component/plugins/plugin-conversation-events.test.ts
+++ b/packages/junior/tests/component/plugins/plugin-conversation-events.test.ts
@@ -92,6 +92,76 @@ afterEach(async () => {
 });
 
 describe("plugin conversation events", () => {
+  it("binds user prompt events to the current turn and deduplicates retries", async () => {
+    const runId = randomUUID();
+    const conversationId = `local:test:prompt-event-${runId}`;
+    const sessionId = `prompt-event-session:${runId}`;
+    const recallEvent = defineConversationEvent({
+      name: "memories_recalled",
+      version: 1,
+      schema: z
+        .object({
+          costUsd: z.number(),
+          memories: z.array(z.string()),
+        })
+        .strict(),
+      renderEvent() {
+        return undefined;
+      },
+    });
+    const plugin = defineJuniorPlugin({
+      manifest: {
+        name: "prompt-event-demo",
+        displayName: "Prompt Event Demo",
+        description: "Prompt event demo",
+      },
+      conversationEvents: [recallEvent],
+      hooks: {
+        async userPrompt(ctx) {
+          if (!ctx.events) {
+            throw new Error("User prompt event writer is missing");
+          }
+          await ctx.events.emit(recallEvent({ costUsd: 0.0042, memories: [] }));
+          return undefined;
+        },
+      },
+    });
+    const { getPluginUserPromptContributions, setPlugins } =
+      await import("@/chat/plugins/agent-hooks");
+    const { getConversationEventStore } = await import("@/chat/db");
+    setPlugins([plugin]);
+    await recordCompletedSession({ conversationId, sessionId });
+    const request = {
+      context: {
+        conversationId,
+        destination: { platform: "local" as const, conversationId },
+        source: createLocalSource(conversationId),
+        userText: "Recall relevant memory.",
+      },
+      turnId: sessionId,
+    };
+
+    await getPluginUserPromptContributions(request);
+    await getPluginUserPromptContributions(request);
+
+    const events =
+      await getConversationEventStore().loadHistory(conversationId);
+    expect(
+      events.filter((event) => event.data.type === "structured_event"),
+    ).toEqual([
+      expect.objectContaining({
+        data: {
+          type: "structured_event",
+          namespace: "prompt-event-demo",
+          name: "memories_recalled",
+          version: 1,
+          turnId: sessionId,
+          content: { costUsd: 0.0042, memories: [] },
+        },
+      }),
+    ]);
+  });
+
   it("aggregates event cost inside the owning plugin namespace", async () => {
     const runId = randomUUID();
     const conversationId = `local:test:event-cost-${runId}`;

--- a/packages/junior/tests/unit/pi/client.test.ts
+++ b/packages/junior/tests/unit/pi/client.test.ts
@@ -359,7 +359,7 @@ describe("completeText", () => {
         [0.1, 0.2, 0.3],
         [0.4, 0.5, 0.6],
       ],
-      usage: { inputTokens: 8 },
+      usage: { tokens: 8 },
     });
 
     const { embedTexts } = await import("@/chat/pi/client");
@@ -369,12 +369,34 @@ describe("completeText", () => {
     });
 
     expect(result.dimensions).toBe(3);
+    expect(result.costUsd).toBe(0.00000016);
     const startAttributes = mocks.withSpan.mock.calls[0]?.[4] as Record<
       string,
       unknown
     >;
     expect(startAttributes["gen_ai.operation.name"]).toBe("embeddings");
     expect(startAttributes["gen_ai.output.type"]).toBeUndefined();
+    expect(mocks.setSpanAttributes).toHaveBeenCalledWith({
+      "app.cost.input_usd": 0.00000016,
+      "app.cost.total_usd": 0.00000016,
+      "gen_ai.embeddings.dimension.count": 3,
+      "gen_ai.usage.input_tokens": 8,
+    });
+  });
+
+  it("leaves embedding cost unknown for models without a verified rate", async () => {
+    mocks.embedMany.mockResolvedValue({
+      embeddings: [[0.1, 0.2, 0.3]],
+      usage: { tokens: 8 },
+    });
+
+    const { embedTexts } = await import("@/chat/pi/client");
+    const result = await embedTexts({
+      modelId: "example/unpriced-embedding-model",
+      texts: ["one"],
+    });
+
+    expect(result).not.toHaveProperty("costUsd");
     expect(mocks.setSpanAttributes).toHaveBeenCalledWith({
       "gen_ai.embeddings.dimension.count": 3,
       "gen_ai.usage.input_tokens": 8,
@@ -384,7 +406,7 @@ describe("completeText", () => {
   it("validates embedding output before the embedding span ends", async () => {
     mocks.embedMany.mockResolvedValue({
       embeddings: [[0.1], [0.2, 0.3]],
-      usage: { inputTokens: 8 },
+      usage: { tokens: 8 },
     });
 
     const { embedTexts } = await import("@/chat/pi/client");


### PR DESCRIPTION
Automatic memory recall now emits a transcript-invisible `memory/memories_recalled@1` event for every completed attempt, including attempts where retrieval or relevance selection returns no memories. The event records admitted memory IDs and a best-effort `costUsd` combining the structured relevance decision with query embedding cost, making recall spend available to plugin reporting without duplicating recalled content in the event log.

Durable user-prompt hooks receive the existing namespace-bound event writer keyed to the current turn, so retries remain idempotent and plugins cannot emit unregistered events or spoof another namespace. Embedding estimates use exact reported token usage and an explicit AI Gateway rate table; models without a verified rate remain unpriced. Regression coverage exercises event persistence, retry idempotency, empty recall outcomes, combined costs, and unknown embedding rates.
