### PR TITLE
feat(conversations): show auxiliary cost breakdown

### DIFF
--- a/packages/junior-dashboard/src/client/components/ConversationRowStats.tsx
+++ b/packages/junior-dashboard/src/client/components/ConversationRowStats.tsx
@@ -1,5 +1,5 @@
 import {
-  formatCostTotal,
+  formatConversationCostTotal,
   formatRuntime,
   formatUsageTotal,
   slackLocationLabel,
@@ -12,7 +12,10 @@ export function ConversationRowStats(props: {
   timeLabel: string;
 }) {
   const tokens = formatUsageTotal(props.conversation.cumulativeUsage);
-  const cost = formatCostTotal(props.conversation.cumulativeUsage);
+  const cost = formatConversationCostTotal(
+    props.conversation.cumulativeUsage,
+    props.conversation.auxiliaryCosts,
+  );
   const runtime = formatRuntime(props.conversation.cumulativeDurationMs);
   const primaryStats = [
     tokens,

--- a/packages/junior-dashboard/src/client/components/Metric.tsx
+++ b/packages/junior-dashboard/src/client/components/Metric.tsx
@@ -33,10 +33,12 @@ function clamp(value: number, min: number, max: number): number {
 function tooltipPosition(
   trigger: HTMLElement,
   align: "left" | "right" | undefined,
+  wide: boolean,
 ): TooltipPosition {
   const margin = 16;
   const viewportWidth = window.innerWidth;
-  const width = Math.min(320, Math.max(256, viewportWidth - margin * 2));
+  const maxWidth = wide ? 520 : 320;
+  const width = Math.min(maxWidth, Math.max(256, viewportWidth - margin * 2));
   const rect = trigger.getBoundingClientRect();
   const preferredLeft = align === "right" ? rect.right - width : rect.left;
   return {
@@ -48,24 +50,77 @@ function tooltipPosition(
   };
 }
 
+function TooltipLines(props: { lines: MetricTooltipLine[] }) {
+  return (
+    <span className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] gap-x-3 gap-y-1.5">
+      {props.lines.map((line, index) => (
+        <span
+          className={
+            line.label
+              ? "contents"
+              : cn(
+                  "col-span-2 block min-w-0 break-words text-dashboard-text",
+                  line.valueStyle === "heading" &&
+                    "font-mono font-semibold text-dashboard-text",
+                  line.valueStyle === "heading" &&
+                    index > 0 &&
+                    "mt-1 border-t border-white/10 pt-2",
+                )
+          }
+          key={`${index}-${line.label ?? ""}-${line.value}`}
+        >
+          {line.label ? (
+            <span
+              className={cn(
+                "min-w-0 break-words font-medium text-dashboard-text-muted",
+                line.labelStyle === "code" &&
+                  "break-all font-mono text-[0.74rem] text-dashboard-text",
+              )}
+            >
+              {line.label}
+            </span>
+          ) : null}
+          {line.label ? (
+            <span className="whitespace-nowrap text-right text-dashboard-text">
+              {line.value}
+            </span>
+          ) : (
+            line.value
+          )}
+        </span>
+      ))}
+    </span>
+  );
+}
+
 /** Render compact metadata text with an optional styled hover/focus tooltip. */
 export function MetricValue(props: {
   align?: "left" | "right";
   children: ReactNode;
   className?: string;
   tooltip?: MetricTooltipLine[];
+  tooltipColumns?: MetricTooltipLine[][];
 }) {
   const tooltipId = useId();
   const triggerRef = useRef<HTMLSpanElement>(null);
   const [position, setPosition] = useState<TooltipPosition | null>(null);
   const tooltip = props.tooltip?.filter((line) => line.value.trim());
-  if (!tooltip?.length) {
+  const tooltipColumns = props.tooltipColumns
+    ?.map((column) => column.filter((line) => line.value.trim()))
+    .filter((column) => column.length);
+  if (!tooltip?.length && !tooltipColumns?.length) {
     return <span className={props.className}>{props.children}</span>;
   }
 
   const showTooltip = () => {
     if (!triggerRef.current) return;
-    setPosition(tooltipPosition(triggerRef.current, props.align));
+    setPosition(
+      tooltipPosition(
+        triggerRef.current,
+        props.align,
+        Boolean(tooltipColumns?.length),
+      ),
+    );
   };
   const hideTooltip = () => setPosition(null);
   const tooltipStyle: CSSProperties | undefined = position
@@ -97,44 +152,17 @@ export function MetricValue(props: {
           role="tooltip"
           style={tooltipStyle}
         >
-          <span className="grid max-h-72 grid-cols-[minmax(0,1fr)_auto] gap-x-3 gap-y-1.5 overflow-y-auto">
-            {tooltip.map((line, index) => (
-              <span
-                className={
-                  line.label
-                    ? "contents"
-                    : cn(
-                        "col-span-2 block min-w-0 break-words text-dashboard-text",
-                        line.valueStyle === "heading" &&
-                          "font-mono font-semibold text-dashboard-text",
-                        line.valueStyle === "heading" &&
-                          index > 0 &&
-                          "mt-1 border-t border-white/10 pt-2",
-                      )
-                }
-                key={`${index}-${line.label ?? ""}-${line.value}`}
-              >
-                {line.label ? (
-                  <span
-                    className={cn(
-                      "min-w-0 break-words font-medium text-dashboard-text-muted",
-                      line.labelStyle === "code" &&
-                        "break-all font-mono text-[0.74rem] text-dashboard-text",
-                    )}
-                  >
-                    {line.label}
-                  </span>
-                ) : null}
-                {line.label ? (
-                  <span className="whitespace-nowrap text-right text-dashboard-text">
-                    {line.value}
-                  </span>
-                ) : (
-                  line.value
-                )}
-              </span>
-            ))}
-          </span>
+          {tooltipColumns?.length ? (
+            <span className="grid max-h-72 grid-cols-1 gap-4 overflow-y-auto sm:grid-cols-2 sm:gap-6">
+              {tooltipColumns.map((column, index) => (
+                <TooltipLines key={index} lines={column} />
+              ))}
+            </span>
+          ) : tooltip ? (
+            <span className="block max-h-72 overflow-y-auto">
+              <TooltipLines lines={tooltip} />
+            </span>
+          ) : null}
         </span>
       ) : null}
     </span>

--- a/packages/junior-dashboard/src/client/conversations/ConversationPage.tsx
+++ b/packages/junior-dashboard/src/client/conversations/ConversationPage.tsx
@@ -432,10 +432,16 @@ function ConversationStats(props: {
           key: "tokens",
         }
       : undefined,
-    costSummary
+    costSummary ||
+    props.detail?.auxiliaryCosts ||
+    props.conversation.auxiliaryCosts
       ? {
           content: (
             <CostMetric
+              auxiliaryCosts={
+                props.detail?.auxiliaryCosts ??
+                props.conversation.auxiliaryCosts
+              }
               modelUsage={props.detail?.modelUsage}
               summary={costSummary}
             />

--- a/packages/junior-dashboard/src/client/conversations/ConversationTranscript.tsx
+++ b/packages/junior-dashboard/src/client/conversations/ConversationTranscript.tsx
@@ -693,10 +693,11 @@ function transcriptMeta(
           key: "tokens",
         }
       : undefined,
-    costSummary
+    costSummary || conversation.auxiliaryCosts
       ? {
           content: (
             <CostMetric
+              auxiliaryCosts={conversation.auxiliaryCosts}
               modelUsage={conversation.modelUsage}
               summary={costSummary}
             />

--- a/packages/junior-dashboard/src/client/conversations/TelemetryMetrics.tsx
+++ b/packages/junior-dashboard/src/client/conversations/TelemetryMetrics.tsx
@@ -1,11 +1,16 @@
-import type { ConversationModelUsage } from "@sentry/junior/api/schema";
+import type {
+  ConversationAuxiliaryCosts,
+  ConversationModelUsage,
+} from "@sentry/junior/api/schema";
 import {
+  formatCostBreakdown,
   formatCostSummary,
   formatCompactNumber,
   formatTime,
   formatTokenSummary,
   summarizeCost,
   summarizeUsage,
+  totalConversationCost,
   type CostUsageSummary,
   type MessageSummary,
   type TokenUsageSummary,
@@ -92,26 +97,29 @@ function tokenTooltip(
 
 function costTooltipLines(summary: CostUsageSummary): MetricTooltipLine[] {
   const lines: Array<MetricTooltipLine | undefined> = [
-    { label: "total", value: formatCostSummary(summary) },
+    { label: "total", value: formatCostBreakdown(summary) },
     summary.input !== undefined
-      ? { label: "input", value: formatCostSummary({ total: summary.input }) }
+      ? {
+          label: "input",
+          value: formatCostBreakdown({ total: summary.input }),
+        }
       : undefined,
     summary.output !== undefined
       ? {
           label: "output",
-          value: formatCostSummary({ total: summary.output }),
+          value: formatCostBreakdown({ total: summary.output }),
         }
       : undefined,
     summary.cacheRead !== undefined
       ? {
           label: "cache read",
-          value: formatCostSummary({ total: summary.cacheRead }),
+          value: formatCostBreakdown({ total: summary.cacheRead }),
         }
       : undefined,
     summary.cacheWrite !== undefined
       ? {
           label: "cache write",
-          value: formatCostSummary({ total: summary.cacheWrite }),
+          value: formatCostBreakdown({ total: summary.cacheWrite }),
         }
       : undefined,
   ];
@@ -119,41 +127,110 @@ function costTooltipLines(summary: CostUsageSummary): MetricTooltipLine[] {
 }
 
 function costTooltip(
-  summary: CostUsageSummary,
+  summary: CostUsageSummary | undefined,
   modelUsage: ConversationModelUsage[] | undefined,
-): MetricTooltipLine[] {
+  auxiliaryCosts: ConversationAuxiliaryCosts | undefined,
+): {
+  tooltip?: MetricTooltipLine[];
+  tooltipColumns?: MetricTooltipLine[][];
+} {
+  const total = totalConversationCost(summary, auxiliaryCosts);
+  if (!total) return {};
   const modelSummaries = (modelUsage ?? []).flatMap((item) => {
     const modelSummary = summarizeCost(item.usage);
     return modelSummary
       ? [{ modelId: item.modelId, summary: modelSummary }]
       : [];
   });
-  if (!modelSummaries.length) {
-    return costTooltipLines(summary);
+  if (!auxiliaryCosts) {
+    if (!summary) return {};
+    if (!modelSummaries.length) {
+      return { tooltip: costTooltipLines(summary) };
+    }
+    return {
+      tooltip: modelSummaries.flatMap((item) => [
+        { value: modelLabel(item.modelId), valueStyle: "heading" },
+        ...costTooltipLines(item.summary).map((line) => ({
+          ...line,
+          label: `• ${line.label}`,
+        })),
+      ]),
+    };
   }
 
-  return modelSummaries.flatMap((item) => [
-    { value: modelLabel(item.modelId), valueStyle: "heading" },
-    ...costTooltipLines(item.summary).map((line) => ({
-      ...line,
-      label: `• ${line.label}`,
-    })),
-  ]);
+  const conversationLines: MetricTooltipLine[] = [
+    { value: "Conversation", valueStyle: "heading" },
+    { label: "total", value: formatCostBreakdown(total) },
+  ];
+  if (summary) {
+    conversationLines.push({
+      label: "agent",
+      value: formatCostBreakdown(summary),
+    });
+    if (!modelSummaries.length) {
+      conversationLines.push(
+        ...costTooltipLines(summary)
+          .filter((line) => line.label !== "total")
+          .map((line) => ({ ...line, label: `• ${line.label}` })),
+      );
+    } else {
+      for (const item of modelSummaries) {
+        conversationLines.push(
+          { value: modelLabel(item.modelId), valueStyle: "heading" },
+          ...costTooltipLines(item.summary).map((line) => ({
+            ...line,
+            label: `• ${line.label}`,
+          })),
+        );
+      }
+    }
+  }
+  const auxiliaryLines: MetricTooltipLine[] = [
+    { value: "Auxiliary", valueStyle: "heading" },
+    {
+      label: "total",
+      value: formatCostBreakdown({ total: auxiliaryCosts.costUsd }),
+    },
+  ];
+  for (const operation of auxiliaryCosts.operations) {
+    auxiliaryLines.push({
+      label: `${auxiliaryOperationLabel(operation)} (${formatCompactNumber(operation.events)})`,
+      value: formatCostBreakdown({ total: operation.costUsd }),
+    });
+  }
+  return { tooltipColumns: [conversationLines, auxiliaryLines] };
+}
+
+function auxiliaryOperationLabel(
+  operation: ConversationAuxiliaryCosts["operations"][number],
+): string {
+  const knownLabels: Readonly<Record<string, string>> = {
+    "junior/guardian_action_reviewed": "Guardian",
+    "memory/memories_captured": "Memory extraction",
+    "memory/memories_recalled": "Memory recall",
+  };
+  const key = `${operation.namespace}/${operation.name}`;
+  return (
+    knownLabels[key] ??
+    `${operation.namespace} · ${operation.name.replaceAll("_", " ")}`
+  );
 }
 
 /** Render estimated model cost with a hoverable USD breakdown. */
 export function CostMetric(props: {
   align?: "left" | "right";
+  auxiliaryCosts?: ConversationAuxiliaryCosts;
   modelUsage?: ConversationModelUsage[];
   summary: CostUsageSummary | undefined;
 }) {
-  if (!props.summary) return null;
+  const total = totalConversationCost(props.summary, props.auxiliaryCosts);
+  if (!total) return null;
   return (
     <MetricValue
       align={props.align}
-      tooltip={costTooltip(props.summary, props.modelUsage)}
+      {...costTooltip(props.summary, props.modelUsage, props.auxiliaryCosts)}
     >
-      {formatCostSummary(props.summary)}
+      {formatCostSummary(total)}
     </MetricValue>
   );
 }

--- a/packages/junior-dashboard/src/client/format.ts
+++ b/packages/junior-dashboard/src/client/format.ts
@@ -1,6 +1,7 @@
 import { bundledLanguages, type BundledLanguage } from "shiki/bundle/web";
 import type {
   ActorIdentity,
+  ConversationAuxiliaryCosts,
   ConversationSummaryReport,
   ConversationUsage,
 } from "@sentry/junior/api/schema";
@@ -471,9 +472,44 @@ export function formatCostSummary(
   }).format(summary.total);
 }
 
+/** Format tooltip cost detail without hiding sub-cent contributions. */
+export function formatCostBreakdown(
+  summary: CostUsageSummary | undefined,
+): string {
+  if (!summary) return "";
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 4,
+  }).format(summary.total);
+}
+
 /** Format persisted cumulative estimated model cost for a conversation. */
 export function formatCostTotal(usage: ConversationUsage | undefined): string {
   return formatCostSummary(summarizeCost(usage));
+}
+
+/** Combine agent model cost with additive auxiliary operation cost. */
+export function totalConversationCost(
+  summary: CostUsageSummary | undefined,
+  auxiliaryCosts: ConversationAuxiliaryCosts | undefined,
+): CostUsageSummary | undefined {
+  if (!summary && !auxiliaryCosts) return undefined;
+  return {
+    ...(summary ?? {}),
+    total: addCost(summary?.total ?? 0, auxiliaryCosts?.costUsd ?? 0),
+  };
+}
+
+/** Format the inclusive cost of agent and auxiliary conversation work. */
+export function formatConversationCostTotal(
+  usage: ConversationUsage | undefined,
+  auxiliaryCosts: ConversationAuxiliaryCosts | undefined,
+): string {
+  return formatCostSummary(
+    totalConversationCost(summarizeCost(usage), auxiliaryCosts),
+  );
 }
 
 /** Format the execution time accumulated across a conversation's runs. */
@@ -786,6 +822,7 @@ export function buildConversations(
   return summaries
     .map((summary) => ({
       archivedAt: summary.archivedAt,
+      auxiliaryCosts: summary.auxiliaryCosts,
       channel: summary.channel,
       channelName: summary.channelName,
       channelNameRedacted: summary.channelNameRedacted,

--- a/packages/junior-dashboard/src/client/markdownExport.ts
+++ b/packages/junior-dashboard/src/client/markdownExport.ts
@@ -1,6 +1,6 @@
 import {
   conversationDisplayTitle,
-  formatCostTotal,
+  formatConversationCostTotal,
   formatElapsedDuration,
   formatMs,
   formatUsageTotal,
@@ -47,7 +47,10 @@ export function buildConversationMarkdown(
     "Usage",
     [
       formatUsageTotal(detail.cumulativeUsage),
-      formatCostTotal(detail.cumulativeUsage),
+      formatConversationCostTotal(
+        detail.cumulativeUsage,
+        detail.auxiliaryCosts,
+      ),
     ]
       .filter(Boolean)
       .join(" · "),

--- a/packages/junior-dashboard/src/client/types.ts
+++ b/packages/junior-dashboard/src/client/types.ts
@@ -116,6 +116,7 @@ export type ConversationTranscript = ConversationDetailReport;
 
 export type Conversation = {
   archivedAt?: string;
+  auxiliaryCosts?: ConversationSummaryReport["auxiliaryCosts"];
   channel?: string;
   channelName?: string;
   channelNameRedacted?: boolean;

--- a/packages/junior-dashboard/src/mock-reporting/fixtures.ts
+++ b/packages/junior-dashboard/src/mock-reporting/fixtures.ts
@@ -120,6 +120,29 @@ function activeConversation(nowMs: number): ConversationDetailReport {
     channel: "CQA123",
     channelName: "proj-checkout",
     actorIdentity: actor("morgan@sentry.io", "Morgan Lee", "morgan"),
+    auxiliaryCosts: {
+      costUsd: 0.0018,
+      operations: [
+        {
+          costUsd: 0.0012,
+          events: 3,
+          name: "guardian_action_reviewed",
+          namespace: "junior",
+        },
+        {
+          costUsd: 0.0002,
+          events: 2,
+          name: "memories_captured",
+          namespace: "memory",
+        },
+        {
+          costUsd: 0.0004,
+          events: 6,
+          name: "memories_recalled",
+          namespace: "memory",
+        },
+      ],
+    },
     cumulativeDurationMs: 31_000,
     cumulativeUsage: usage(0.041),
     sentryConversationUrl: sentryConversationUrl(ACTIVE_CONVERSATION_ID),

--- a/packages/junior-dashboard/tests/telemetry-metrics.test.tsx
+++ b/packages/junior-dashboard/tests/telemetry-metrics.test.tsx
@@ -6,14 +6,17 @@ vi.mock("../src/client/components/Metric", () => ({
   MetricValue: (props: {
     children: ReactNode;
     tooltip?: Array<{ label?: string; value: string }>;
+    tooltipColumns?: Array<Array<{ label?: string; value: string }>>;
   }) => (
     <span>
       {props.children}
-      {props.tooltip?.map((line) => (
-        <span key={`${line.label}-${line.value}`}>
-          {line.label}: {line.value}
-        </span>
-      ))}
+      {[...(props.tooltip ?? []), ...(props.tooltipColumns?.flat() ?? [])].map(
+        (line) => (
+          <span key={`${line.label}-${line.value}`}>
+            {line.label}: {line.value}
+          </span>
+        ),
+      )}
     </span>
   ),
 }));
@@ -47,5 +50,44 @@ describe("CostMetric", () => {
 
     expect(html).toContain("gpt-5");
     for (const line of expected) expect(html).toContain(line);
+  });
+
+  it("includes auxiliary operations in the total and tooltip", () => {
+    const html = renderToStaticMarkup(
+      <CostMetric
+        auxiliaryCosts={{
+          costUsd: 0.0018,
+          operations: [
+            {
+              costUsd: 0.0004,
+              events: 2,
+              name: "memories_recalled",
+              namespace: "memory",
+            },
+            {
+              costUsd: 0.0014,
+              events: 1,
+              name: "guardian_action_reviewed",
+              namespace: "junior",
+            },
+          ],
+        }}
+        modelUsage={[
+          {
+            modelId: "openai/gpt-5",
+            usage: { cost: { total: 0.041 } },
+          },
+        ]}
+        summary={{ total: 0.041 }}
+      />,
+    );
+
+    expect(html).toContain("$0.04");
+    expect(html).toContain("total: $0.0428");
+    expect(html).toContain("agent: $0.041");
+    expect(html).toContain("Auxiliary");
+    expect(html).toContain("total: $0.0018");
+    expect(html).toContain("Memory recall (2): $0.0004");
+    expect(html).toContain("Guardian (1): $0.0014");
   });
 });

--- a/packages/junior-plugin-api/README.md
+++ b/packages/junior-plugin-api/README.md
@@ -53,6 +53,8 @@ reports, and other typed hook surfaces exported by this package.
 - Operational report and authenticated API hooks may aggregate `costUsd` from
   their own registered conversation events through `ctx.eventStats`. Core
   binds the plugin namespace and owns access to the conversation event log.
+  Event `costUsd` is additive operation cost and must not duplicate cost
+  already recorded in the conversation's agent model usage.
 - Authenticated API route apps receive one verified viewer in their request
   context. The registration hook exposes actor resolution for plugins whose
   viewer-owned data spans platform identities.

--- a/packages/junior/src/api/conversations/auxiliary-costs.ts
+++ b/packages/junior/src/api/conversations/auxiliary-costs.ts
@@ -1,0 +1,97 @@
+import { and, eq, inArray, or, sql, type SQL } from "drizzle-orm";
+import type { JuniorDatabase } from "@/db/db";
+import { juniorConversationEvents, juniorConversations } from "@/db/schema";
+import type { ConversationAuxiliaryCosts } from "../schema/conversation";
+
+function eventCost(): SQL<number | null> {
+  return sql<number | null>`CASE
+    WHEN ${juniorConversationEvents.type} = 'structured_event'
+      AND jsonb_typeof(${juniorConversationEvents.payload}->'content'->'costUsd') = 'number'
+      THEN (${juniorConversationEvents.payload}->'content'->>'costUsd')::numeric
+    WHEN ${juniorConversationEvents.type} = 'guardian_action_reviewed'
+      AND jsonb_typeof(${juniorConversationEvents.payload}->'costUsd') = 'number'
+      THEN (${juniorConversationEvents.payload}->>'costUsd')::numeric
+    ELSE NULL
+  END`;
+}
+
+/** Aggregate additive event costs by namespaced operation for conversations. */
+export async function readConversationAuxiliaryCostsFromSql(
+  db: JuniorDatabase,
+  conversationIds: readonly string[],
+  options: { includeDescendants: boolean },
+): Promise<Map<string, ConversationAuxiliaryCosts>> {
+  if (conversationIds.length === 0) return new Map();
+
+  const selectedIds = [...conversationIds];
+  const conversationId = options.includeDescendants
+    ? sql<string>`coalesce(
+        ${juniorConversations.rootConversationId},
+        ${juniorConversations.conversationId}
+      )`
+    : sql<string>`${juniorConversations.conversationId}`;
+  const namespace = sql<string>`CASE
+    WHEN ${juniorConversationEvents.type} = 'structured_event'
+      THEN ${juniorConversationEvents.payload}->>'namespace'
+    ELSE 'junior'
+  END`;
+  const name = sql<string>`CASE
+    WHEN ${juniorConversationEvents.type} = 'structured_event'
+      THEN ${juniorConversationEvents.payload}->>'name'
+    ELSE ${juniorConversationEvents.type}
+  END`;
+  const cost = eventCost();
+  const selectedConversation = options.includeDescendants
+    ? or(
+        inArray(juniorConversations.rootConversationId, selectedIds),
+        inArray(juniorConversations.conversationId, selectedIds),
+      )
+    : inArray(juniorConversations.conversationId, selectedIds);
+  const rows = await db
+    .select({
+      conversationId,
+      costUsd: sql<number>`round(sum(${cost}), 12)::double precision`.mapWith(
+        Number,
+      ),
+      events: sql<number>`count(*)::integer`.mapWith(Number),
+      name,
+      namespace,
+    })
+    .from(juniorConversationEvents)
+    .innerJoin(
+      juniorConversations,
+      eq(
+        juniorConversations.conversationId,
+        juniorConversationEvents.conversationId,
+      ),
+    )
+    .where(
+      and(
+        selectedConversation,
+        or(
+          eq(juniorConversationEvents.type, "structured_event"),
+          eq(juniorConversationEvents.type, "guardian_action_reviewed"),
+        ),
+        sql`${cost} >= 0`,
+      ),
+    )
+    .groupBy(conversationId, namespace, name)
+    .orderBy(conversationId, namespace, name);
+
+  const result = new Map<string, ConversationAuxiliaryCosts>();
+  for (const row of rows) {
+    const current = result.get(row.conversationId) ?? {
+      costUsd: 0,
+      operations: [],
+    };
+    current.costUsd = Math.round((current.costUsd + row.costUsd) * 1e12) / 1e12;
+    current.operations.push({
+      costUsd: row.costUsd,
+      events: row.events,
+      name: row.name,
+      namespace: row.namespace,
+    });
+    result.set(row.conversationId, current);
+  }
+  return result;
+}

--- a/packages/junior/src/api/conversations/auxiliary-costs.ts
+++ b/packages/junior/src/api/conversations/auxiliary-costs.ts
@@ -1,7 +1,22 @@
-import { and, eq, inArray, or, sql, type SQL } from "drizzle-orm";
+import {
+  and,
+  eq,
+  inArray,
+  isNotNull,
+  isNull,
+  or,
+  sql,
+  type SQL,
+} from "drizzle-orm";
+import { alias } from "drizzle-orm/pg-core";
 import type { JuniorDatabase } from "@/db/db";
 import { juniorConversationEvents, juniorConversations } from "@/db/schema";
 import type { ConversationAuxiliaryCosts } from "../schema/conversation";
+
+const auxiliaryRootConversation = alias(
+  juniorConversations,
+  "auxiliary_root_conversation",
+);
 
 function eventCost(): SQL<number | null> {
   return sql<number | null>`CASE
@@ -26,7 +41,7 @@ export async function readConversationAuxiliaryCostsFromSql(
   const selectedIds = [...conversationIds];
   const conversationId = options.includeDescendants
     ? sql<string>`coalesce(
-        ${juniorConversations.rootConversationId},
+        ${auxiliaryRootConversation.conversationId},
         ${juniorConversations.conversationId}
       )`
     : sql<string>`${juniorConversations.conversationId}`;
@@ -43,7 +58,10 @@ export async function readConversationAuxiliaryCostsFromSql(
   const cost = eventCost();
   const selectedConversation = options.includeDescendants
     ? or(
-        inArray(juniorConversations.rootConversationId, selectedIds),
+        and(
+          inArray(juniorConversations.rootConversationId, selectedIds),
+          isNotNull(auxiliaryRootConversation.conversationId),
+        ),
         inArray(juniorConversations.conversationId, selectedIds),
       )
     : inArray(juniorConversations.conversationId, selectedIds);
@@ -63,6 +81,20 @@ export async function readConversationAuxiliaryCostsFromSql(
       eq(
         juniorConversations.conversationId,
         juniorConversationEvents.conversationId,
+      ),
+    )
+    .leftJoin(
+      auxiliaryRootConversation,
+      and(
+        eq(
+          auxiliaryRootConversation.conversationId,
+          juniorConversations.rootConversationId,
+        ),
+        isNull(auxiliaryRootConversation.parentConversationId),
+        eq(
+          auxiliaryRootConversation.rootConversationId,
+          auxiliaryRootConversation.conversationId,
+        ),
       ),
     )
     .where(

--- a/packages/junior/src/api/conversations/detail.ts
+++ b/packages/junior/src/api/conversations/detail.ts
@@ -14,6 +14,7 @@ import {
   type ConversationAccess,
 } from "./access";
 import { readRootConversationMetricsFromSql } from "./usage";
+import { readConversationAuxiliaryCostsFromSql } from "./auxiliary-costs";
 import {
   conversationDetailQuerySchema,
   conversationDetailReportSchema,
@@ -27,6 +28,7 @@ import { listConversationAnnotations } from "@/chat/plugins/annotations";
 /** Project stored metadata and a bounded event page into a signed history cursor. */
 function projectConversationDetail(args: {
   access?: ConversationAccess;
+  auxiliaryCosts?: ConversationDetailReport["auxiliaryCosts"];
   conversation: Conversation;
   durationMs: number;
   annotations: NonNullable<ConversationDetailReport["annotations"]>;
@@ -46,6 +48,7 @@ function projectConversationDetail(args: {
   return {
     ...conversationSummaryFromStoredConversation({
       access: args.access,
+      auxiliaryCosts: args.auxiliaryCosts,
       conversation,
       durationMs: args.durationMs,
       ...(args.locationId ? { locationId: args.locationId } : {}),
@@ -83,25 +86,33 @@ async function readConversationDetailFromSql(
 
   const executor = getSqlExecutor();
   const includeDescendantMetrics = record.rootConversationId === conversationId;
-  const [accessByConversation, annotations, modelUsage, metricsByRoot] =
-    await Promise.all([
-      readConversationAccessFromSql(
-        getDb(),
-        [conversationId],
-        options.verifiedViewerEmail,
-      ),
-      listConversationAnnotations(getDb(), conversationId),
-      record.conversation.transcriptPurgedAtMs === undefined
-        ? readConversationModelUsageFromSql(executor, {
-            conversationId,
-            includeDescendants: includeDescendantMetrics,
-          })
-        : Promise.resolve([]),
-      readRootConversationMetricsFromSql(
-        getDb(),
-        includeDescendantMetrics ? [conversationId] : [],
-      ),
-    ]);
+  const [
+    accessByConversation,
+    annotations,
+    auxiliaryCostsByConversation,
+    modelUsage,
+    metricsByRoot,
+  ] = await Promise.all([
+    readConversationAccessFromSql(
+      getDb(),
+      [conversationId],
+      options.verifiedViewerEmail,
+    ),
+    listConversationAnnotations(getDb(), conversationId),
+    readConversationAuxiliaryCostsFromSql(getDb(), [conversationId], {
+      includeDescendants: includeDescendantMetrics,
+    }),
+    record.conversation.transcriptPurgedAtMs === undefined
+      ? readConversationModelUsageFromSql(executor, {
+          conversationId,
+          includeDescendants: includeDescendantMetrics,
+        })
+      : Promise.resolve([]),
+    readRootConversationMetricsFromSql(
+      getDb(),
+      includeDescendantMetrics ? [conversationId] : [],
+    ),
+  ]);
   const access = accessByConversation.get(conversationId);
   const page =
     record.conversation.transcriptPurgedAtMs === undefined
@@ -116,6 +127,7 @@ async function readConversationDetailFromSql(
     ...record,
     access,
     annotations,
+    auxiliaryCosts: auxiliaryCostsByConversation.get(conversationId),
     durationMs: metrics?.durationMs ?? record.durationMs,
     events: page.events,
     modelUsage,

--- a/packages/junior/src/api/conversations/list.ts
+++ b/packages/junior/src/api/conversations/list.ts
@@ -14,6 +14,7 @@ import { readConversationAccessFromSql } from "./access";
 import { conversationFeedSchema } from "../schema/conversation";
 import type { ConversationFeed } from "../schema/conversation";
 import { readRootConversationMetricsFromSql } from "./usage";
+import { readConversationAuxiliaryCostsFromSql } from "./auxiliary-costs";
 import { defineApiRoute } from "../route";
 import { parseQuery } from "../http";
 import { conversationFeedQuerySchema } from "../schema/conversation";
@@ -192,20 +193,27 @@ export async function readConversationFeedFromSql(
     options.actorEmail,
   );
   const conversationIds = rows.map((row) => row.conversation.conversationId);
-  const [accessByConversation, metricsByRoot] = await Promise.all([
-    readConversationAccessFromSql(
-      db,
-      conversationIds,
-      options.verifiedViewerEmail,
-    ),
-    readRootConversationMetricsFromSql(db, conversationIds),
-  ]);
+  const [accessByConversation, auxiliaryCostsByRoot, metricsByRoot] =
+    await Promise.all([
+      readConversationAccessFromSql(
+        db,
+        conversationIds,
+        options.verifiedViewerEmail,
+      ),
+      readConversationAuxiliaryCostsFromSql(db, conversationIds, {
+        includeDescendants: true,
+      }),
+      readRootConversationMetricsFromSql(db, conversationIds),
+    ]);
   return {
     conversations: rows.map((row) => {
       const metrics = metricsByRoot.get(row.conversation.conversationId);
       return conversationSummaryFromStoredConversation({
         conversation: conversationFromRow(row),
         access: accessByConversation.get(row.conversation.conversationId),
+        auxiliaryCosts: auxiliaryCostsByRoot.get(
+          row.conversation.conversationId,
+        ),
         durationMs: metrics?.durationMs ?? row.conversation.durationMs,
         ...(row.destinationVisibility === "public" && row.destinationId
           ? { locationId: row.destinationId }

--- a/packages/junior/src/api/conversations/projection.ts
+++ b/packages/junior/src/api/conversations/projection.ts
@@ -186,6 +186,7 @@ export function conversationEventHistory(args: {
 /** Project one durable conversation and its SQL metrics into the REST summary. */
 export function conversationSummaryFromStoredConversation(args: {
   access?: ConversationAccess;
+  auxiliaryCosts?: ConversationSummaryReport["auxiliaryCosts"];
   conversation: ConversationProjectionSource;
   durationMs: number;
   locationId?: string;
@@ -227,6 +228,7 @@ export function conversationSummaryFromStoredConversation(args: {
     startedAt: new Date(conversation.createdAtMs).toISOString(),
     status: statusFromConversation(conversation),
     surface,
+    ...(args.auxiliaryCosts ? { auxiliaryCosts: args.auxiliaryCosts } : {}),
     ...(usage ? { cumulativeUsage: usage } : {}),
     ...(actorIdentity ? { actorIdentity } : {}),
     ...(sourceUrl ? { sourceUrl } : {}),

--- a/packages/junior/src/api/schema.ts
+++ b/packages/junior/src/api/schema.ts
@@ -3,6 +3,7 @@ export type { DailyConversationActivity } from "./activity";
 export {
   archiveConversationBodySchema,
   archiveConversationResponseSchema,
+  conversationAuxiliaryCostsSchema,
   conversationDetailQuerySchema,
   conversationDetailReportSchema,
   conversationEventPageSchema,
@@ -20,6 +21,7 @@ export type {
   ArchiveConversationBody,
   ArchiveConversationResponse,
   ActorIdentity,
+  ConversationAuxiliaryCosts,
   ConversationCost,
   ConversationDetailReport,
   ConversationEventPage,

--- a/packages/junior/src/api/schema/conversation.ts
+++ b/packages/junior/src/api/schema/conversation.ts
@@ -67,11 +67,30 @@ export const actorIdentitySchema = z
   })
   .strict();
 
+export const conversationAuxiliaryCostsSchema = z
+  .object({
+    costUsd: z.number().finite().nonnegative(),
+    operations: z
+      .array(
+        z
+          .object({
+            costUsd: z.number().finite().nonnegative(),
+            events: z.number().int().positive(),
+            name: z.string().min(1),
+            namespace: z.string().min(1),
+          })
+          .strict(),
+      )
+      .min(1),
+  })
+  .strict();
+
 export const conversationSummaryReportSchema = z
   .object({
     displayTitle: z.string(),
     cumulativeDurationMs: z.number(),
     cumulativeUsage: conversationUsageSchema.optional(),
+    auxiliaryCosts: conversationAuxiliaryCostsSchema.optional(),
     conversationId: z.string(),
     isParticipant: z.boolean(),
     status: conversationReportStatusSchema,
@@ -597,6 +616,9 @@ export type ConversationReportStatus = z.infer<
 export type ConversationSurface = z.infer<typeof conversationSurfaceSchema>;
 export type ConversationCost = z.infer<typeof conversationCostSchema>;
 export type ConversationUsage = z.infer<typeof conversationUsageSchema>;
+export type ConversationAuxiliaryCosts = z.infer<
+  typeof conversationAuxiliaryCostsSchema
+>;
 export type ActorIdentity = z.infer<typeof actorIdentitySchema>;
 export type ConversationSummaryReport = z.infer<
   typeof conversationSummaryReportSchema

--- a/packages/junior/tests/integration/api/conversations/detail.test.ts
+++ b/packages/junior/tests/integration/api/conversations/detail.test.ts
@@ -43,6 +43,16 @@ describe("conversation detail API", () => {
           type: "message",
         },
       },
+      {
+        createdAtMs: 3,
+        data: {
+          content: { costUsd: 0.0004, memories: [] },
+          name: "memories_recalled",
+          namespace: "memory",
+          type: "structured_event",
+          version: 1,
+        },
+      },
     ]);
     const refreshedResponse = await app.request(
       `http://localhost/api/conversations/${conversationId}`,
@@ -51,6 +61,17 @@ describe("conversation detail API", () => {
       await refreshedResponse.json(),
     );
     expect(refreshed.events.map((event) => event.seq)).toEqual([0]);
+    expect(refreshed.auxiliaryCosts).toEqual({
+      costUsd: 0.0004,
+      operations: [
+        {
+          costUsd: 0.0004,
+          events: 1,
+          name: "memories_recalled",
+          namespace: "memory",
+        },
+      ],
+    });
   });
 
   it("only returns annotations to viewers with private-content access", async () => {

--- a/packages/junior/tests/integration/api/conversations/list.test.ts
+++ b/packages/junior/tests/integration/api/conversations/list.test.ts
@@ -9,6 +9,7 @@ import { apiErrorSchema, conversationFeedSchema } from "@/api/schema";
 import { migrateSchema } from "@/chat/conversations/sql/migrations";
 import { createSqlStore } from "@/chat/conversations/sql/store";
 import {
+  juniorConversationEvents,
   juniorConversations,
   juniorIdentities,
   juniorUsers,
@@ -306,6 +307,32 @@ describe("conversation list API", () => {
           executionStatus: "idle",
           usage: { outputTokens: 5 },
         });
+      await fixture.sql
+        .db()
+        .insert(juniorConversationEvents)
+        .values([
+          {
+            conversationId: "slack:C1:root",
+            createdAt: new Date(3_000),
+            historyVersion: 1,
+            payload: {
+              content: { costUsd: 0.0002, memories: [] },
+              name: "memories_recalled",
+              namespace: "memory",
+              version: 1,
+            },
+            seq: 0,
+            type: "structured_event",
+          },
+          {
+            conversationId: "advisor:child",
+            createdAt: new Date(4_000),
+            historyVersion: 1,
+            payload: { costUsd: 0.0003 },
+            seq: 0,
+            type: "guardian_action_reviewed",
+          },
+        ]);
 
       const feed = await readConversationFeedFromSql();
 
@@ -315,6 +342,23 @@ describe("conversation list API", () => {
       expect(feed.conversations[0]?.cumulativeUsage).toEqual({
         inputTokens: 10,
         outputTokens: 5,
+      });
+      expect(feed.conversations[0]?.auxiliaryCosts).toEqual({
+        costUsd: 0.0005,
+        operations: [
+          {
+            costUsd: 0.0003,
+            events: 1,
+            name: "guardian_action_reviewed",
+            namespace: "junior",
+          },
+          {
+            costUsd: 0.0002,
+            events: 1,
+            name: "memories_recalled",
+            namespace: "memory",
+          },
+        ],
       });
     } finally {
       await fixture.close();

--- a/packages/junior/tests/integration/api/conversations/list.test.ts
+++ b/packages/junior/tests/integration/api/conversations/list.test.ts
@@ -399,6 +399,32 @@ describe("conversation list API", () => {
           durationMs: 500,
           usage: { outputTokens: 50 },
         });
+      await fixture.sql
+        .db()
+        .insert(juniorConversationEvents)
+        .values([
+          {
+            conversationId: "slack:C1:invalid-root",
+            createdAt: new Date(3_000),
+            historyVersion: 1,
+            payload: {
+              content: { costUsd: 0.0002, memories: [] },
+              name: "memories_recalled",
+              namespace: "memory",
+              version: 1,
+            },
+            seq: 0,
+            type: "structured_event",
+          },
+          {
+            conversationId: "advisor:invalid-root-child",
+            createdAt: new Date(4_000),
+            historyVersion: 1,
+            payload: { costUsd: 0.0003 },
+            seq: 0,
+            type: "guardian_action_reviewed",
+          },
+        ]);
 
       const feed = await readConversationFeedFromSql();
 
@@ -407,6 +433,17 @@ describe("conversation list API", () => {
           conversationId: "slack:C1:invalid-root",
           cumulativeDurationMs: 100,
           cumulativeUsage: { inputTokens: 10 },
+          auxiliaryCosts: {
+            costUsd: 0.0002,
+            operations: [
+              {
+                costUsd: 0.0002,
+                events: 1,
+                name: "memories_recalled",
+                namespace: "memory",
+              },
+            ],
+          },
         }),
       );
     } finally {


### PR DESCRIPTION
Conversation reporting now aggregates additive `costUsd` values from plugin events into a namespaced auxiliary-cost breakdown, including child conversations, and exposes it separately from agent model usage. Auxiliary work such as Guardian and memory extraction or recall now contributes to the displayed conversation total without changing model-usage semantics.

The dashboard presents precise conversation, agent, and auxiliary totals with per-operation event counts in a responsive two-column tooltip that stacks on mobile. Existing non-cost metric tooltips retain their current layout, and the API aggregation and dashboard formatting are covered across the relevant integration and UI tests.
