### PR TITLE
ref(plugin-api)!: standardize source visibility

### DIFF
--- a/packages/junior-evals/evals/memory/helpers.ts
+++ b/packages/junior-evals/evals/memory/helpers.ts
@@ -43,7 +43,7 @@ export async function seedMemory(args: {
       messageTs: args.thread.thread_ts,
       teamId: memoryTeamId,
       threadTs: args.thread.thread_ts,
-      type: args.thread.channel_type === "channel" ? "pub" : "priv",
+      visibility: args.thread.channel_type === "channel" ? "public" : "private",
     }),
   });
   const input = {

--- a/packages/junior-evals/evals/memory/personal.eval.ts
+++ b/packages/junior-evals/evals/memory/personal.eval.ts
@@ -196,7 +196,7 @@ describeEval("Personal Memory", slackEvals, (it) => {
         teamId: memoryTeamId,
         threadTs: "17000000.000003",
 
-        type: "priv",
+        visibility: "private",
       }),
     };
 

--- a/packages/junior-github/tests/github-plugin.test.ts
+++ b/packages/junior-github/tests/github-plugin.test.ts
@@ -324,7 +324,7 @@ function githubToolsContext(input?: {
     destination: { platform: "local" as const, conversationId },
     source: {
       platform: "local" as const,
-      type: "priv" as const,
+      visibility: "private" as const,
       conversationId,
     },
     embedder: {},

--- a/packages/junior-memory/src/personal.ts
+++ b/packages/junior-memory/src/personal.ts
@@ -57,7 +57,7 @@ function runtimeContext(actor: PluginUserPageActor): MemoryRuntimeContext {
       actor,
       source: {
         platform: "slack",
-        type: "priv",
+        visibility: "private",
         teamId: actor.teamId,
         channelId: "DDASHBOARD",
       },
@@ -67,7 +67,7 @@ function runtimeContext(actor: PluginUserPageActor): MemoryRuntimeContext {
     actor,
     source: {
       platform: "local",
-      type: "priv",
+      visibility: "private",
       conversationId: "local:dashboard:memories",
     },
   };
@@ -75,7 +75,10 @@ function runtimeContext(actor: PluginUserPageActor): MemoryRuntimeContext {
 
 function decodeCursor(
   value: string | undefined,
-  input: Pick<ViewerMemoryPageInput, "kind" | "origin" | "query" | "visibility">,
+  input: Pick<
+    ViewerMemoryPageInput,
+    "kind" | "origin" | "query" | "visibility"
+  >,
 ) {
   if (!value) return undefined;
   try {
@@ -98,7 +101,10 @@ function decodeCursor(
 
 function encodeCursor(
   cursor: { createdAtMs: number; id: string },
-  input: Pick<ViewerMemoryPageInput, "kind" | "origin" | "query" | "visibility">,
+  input: Pick<
+    ViewerMemoryPageInput,
+    "kind" | "origin" | "query" | "visibility"
+  >,
 ): string {
   return Buffer.from(
     JSON.stringify({

--- a/packages/junior-memory/tests/retrieval-quality.test.ts
+++ b/packages/junior-memory/tests/retrieval-quality.test.ts
@@ -74,7 +74,7 @@ function runtimeContext() {
       messageTs: threadTs,
       teamId,
       threadTs,
-      type: "pub",
+      visibility: "public",
     }),
   };
 }

--- a/packages/junior-memory/tests/storage.test.ts
+++ b/packages/junior-memory/tests/storage.test.ts
@@ -371,7 +371,7 @@ function slackContext(
       channelId,
       // The Slack boundary supplies normalized public visibility for these
       // C-prefixed test channels unless a test overrides the channel id.
-      type: channelId.startsWith("C") ? "pub" : "priv",
+      visibility: channelId.startsWith("C") ? "public" : "private",
       messageTs: threadTs,
       threadTs,
     }),
@@ -1602,7 +1602,7 @@ describe("memory plugin storage", () => {
                   teamId: runtime.source.teamId,
                   channelId: runtime.source.channelId,
 
-                  type: "priv",
+                  visibility: "private",
                 }),
               });
             },
@@ -3532,7 +3532,7 @@ WHERE id = '${superseded.memory.id}'
           },
           source: {
             platform: "slack",
-            type: "pub",
+            visibility: "public",
             teamId: "T123",
             channelId: "C123",
             messageTs: "1718800000.000000",

--- a/packages/junior-plugin-api/src/context.ts
+++ b/packages/junior-plugin-api/src/context.ts
@@ -19,7 +19,7 @@ export type SystemActor = z.output<typeof systemActorSchema>;
 export type Source = z.output<typeof sourceSchema>;
 export type SlackSource = Extract<Source, { platform: "slack" }>;
 export type LocalSource = Extract<Source, { platform: "local" }>;
-export type SourceType = Source["type"];
+export type SourceVisibility = Source["visibility"];
 
 export type Destination = z.output<typeof destinationSchema>;
 
@@ -103,11 +103,11 @@ export function createSlackSource(input: {
   teamId: string;
   threadTs?: string;
   /** Runtime-normalized source visibility. */
-  type: SourceType;
+  visibility: SourceVisibility;
 }): SlackSource {
   return {
     platform: "slack",
-    type: input.type,
+    visibility: input.visibility,
     teamId: input.teamId,
     channelId: input.channelId,
     ...(input.messageTs ? { messageTs: input.messageTs } : {}),
@@ -119,14 +119,14 @@ export function createSlackSource(input: {
 export function createLocalSource(conversationId: string): LocalSource {
   return {
     platform: "local",
-    type: "priv",
+    visibility: "private",
     conversationId,
   };
 }
 
 /** Return whether a source is private to a person or restricted group. */
 export function isPrivateSource(source: Source): boolean {
-  return source.type === "priv";
+  return source.visibility === "private";
 }
 
 /** Return the stable source identity used for idempotency and attribution. */

--- a/packages/junior-plugin-api/src/schemas.ts
+++ b/packages/junior-plugin-api/src/schemas.ts
@@ -23,7 +23,7 @@ const exactNonBlankStringSchema = nonBlankStringSchema.refine(
 export const platformSchema = z.enum(["slack", "local"]);
 
 /** Runtime source visibility visible to plugins. */
-export const sourceTypeSchema = z.enum(["pub", "priv"]);
+export const sourceVisibilitySchema = z.enum(["public", "private"]);
 
 /** Provider-neutral visibility of a routed destination. */
 export const destinationVisibilitySchema = z.enum(["public", "private"]);
@@ -56,7 +56,7 @@ export const destinationSchema = z.discriminatedUnion("platform", [
 /** Runtime-owned Slack coordinates for the inbound invocation. */
 export const slackSourceSchema = slackAddressSchema
   .extend({
-    type: sourceTypeSchema,
+    visibility: sourceVisibilitySchema,
     messageTs: nonBlankStringSchema.optional(),
     threadTs: nonBlankStringSchema.optional(),
   })
@@ -66,7 +66,7 @@ export const slackSourceSchema = slackAddressSchema
 export const localSourceSchema = z
   .object({
     platform: z.literal("local"),
-    type: z.literal("priv"),
+    visibility: z.literal("private"),
     conversationId: localConversationIdSchema,
   })
   .strict();

--- a/packages/junior-scheduler/src/plugin.ts
+++ b/packages/junior-scheduler/src/plugin.ts
@@ -81,7 +81,8 @@ function scheduledTaskDispatchSource(task: ScheduledTask): Source {
   return createSlackSource({
     teamId: task.destination.teamId,
     channelId: task.destination.channelId,
-    type: task.conversationAccess?.visibility === "public" ? "pub" : "priv",
+    visibility:
+      task.conversationAccess?.visibility === "public" ? "public" : "private",
   });
 }
 

--- a/packages/junior-scheduler/src/tool-support.ts
+++ b/packages/junior-scheduler/src/tool-support.ts
@@ -164,7 +164,7 @@ export function getConversationAccess(
   }
   return {
     audience: "channel",
-    visibility: source?.type === "pub" ? "public" : "private",
+    visibility: source?.visibility === "public" ? "public" : "private",
   };
 }
 

--- a/packages/junior/migrations/0014_source_visibility.sql
+++ b/packages/junior/migrations/0014_source_visibility.sql
@@ -1,0 +1,8 @@
+UPDATE "junior_conversations"
+SET "source_json" = ("source_json" - 'type') || jsonb_build_object(
+  'visibility', CASE "source_json" ->> 'type'
+    WHEN 'pub' THEN 'public'
+    WHEN 'priv' THEN 'private'
+  END
+)
+WHERE "source_json" ->> 'type' IN ('pub', 'priv');

--- a/packages/junior/migrations/meta/0014_snapshot.json
+++ b/packages/junior/migrations/meta/0014_snapshot.json
@@ -1,0 +1,1201 @@
+{
+  "id": "7ee48964-32cb-4444-913d-33cc5680a64e",
+  "prevId": "5d0244f5-7ca6-4a03-ad59-4699ba6bf0e1",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.junior_api_tokens": {
+      "name": "junior_api_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_email_normalized": {
+          "name": "owner_email_normalized",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_suffix": {
+          "name": "token_suffix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "junior_api_tokens_token_hash_uidx": {
+          "name": "junior_api_tokens_token_hash_uidx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "junior_api_tokens_owner_email_idx": {
+          "name": "junior_api_tokens_owner_email_idx",
+          "columns": [
+            {
+              "expression": "owner_email_normalized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_conversation_annotations": {
+      "name": "junior_conversation_annotations",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plugin": {
+          "name": "plugin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "annotation_json": {
+          "name": "annotation_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "junior_conversation_annotations_conversation_id_fk": {
+          "name": "junior_conversation_annotations_conversation_id_fk",
+          "tableFrom": "junior_conversation_annotations",
+          "columnsFrom": ["conversation_id"],
+          "tableTo": "junior_conversations",
+          "columnsTo": ["conversation_id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "junior_conversation_annotations_pk": {
+          "name": "junior_conversation_annotations_pk",
+          "columns": ["conversation_id", "plugin", "kind", "key"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_conversation_events": {
+      "name": "junior_conversation_events",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "history_version": {
+          "name": "history_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "junior_conversation_events_history_version_idx": {
+          "name": "junior_conversation_events_history_version_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "history_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "junior_conversation_events_type_idx": {
+          "name": "junior_conversation_events_type_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "junior_conversation_events_message_search_idx": {
+          "name": "junior_conversation_events_message_search_idx",
+          "columns": [
+            {
+              "expression": "to_tsvector('english', \"payload\"->>'text')",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gin",
+          "where": "\"junior_conversation_events\".\"type\" = 'message'",
+          "concurrently": false
+        },
+        "junior_conversation_events_idempotency_idx": {
+          "name": "junior_conversation_events_idempotency_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "junior_conversation_events_conversation_id_junior_conversations_conversation_id_fk": {
+          "name": "junior_conversation_events_conversation_id_junior_conversations_conversation_id_fk",
+          "tableFrom": "junior_conversation_events",
+          "columnsFrom": ["conversation_id"],
+          "tableTo": "junior_conversations",
+          "columnsTo": ["conversation_id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "junior_conversation_events_conversation_id_seq_pk": {
+          "name": "junior_conversation_events_conversation_id_seq_pk",
+          "columns": ["conversation_id", "seq"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_conversations": {
+      "name": "junior_conversations",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_json": {
+          "name": "source_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin_type": {
+          "name": "origin_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin_id": {
+          "name": "origin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin_run_id": {
+          "name": "origin_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destination_id": {
+          "name": "destination_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destination_json": {
+          "name": "destination_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_identity_id": {
+          "name": "actor_identity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_identity_id": {
+          "name": "creator_identity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_subject_identity_id": {
+          "name": "credential_subject_identity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_json": {
+          "name": "actor_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_name": {
+          "name": "channel_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "execution_updated_at": {
+          "name": "execution_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_status": {
+          "name": "execution_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_checkpoint_at": {
+          "name": "last_checkpoint_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_enqueued_at": {
+          "name": "last_enqueued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_conversation_id": {
+          "name": "parent_conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_conversation_id": {
+          "name": "root_conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcript_purged_at": {
+          "name": "transcript_purged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "usage_json": {
+          "name": "usage_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_duration_ms": {
+          "name": "execution_duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "execution_usage_json": {
+          "name": "execution_usage_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metric_run_id": {
+          "name": "metric_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "junior_conversations_last_activity_idx": {
+          "name": "junior_conversations_last_activity_idx",
+          "columns": [
+            {
+              "expression": "last_activity_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "junior_conversations_active_idx": {
+          "name": "junior_conversations_active_idx",
+          "columns": [
+            {
+              "expression": "coalesce(\"execution_updated_at\", \"updated_at\")",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"junior_conversations\".\"execution_status\" <> 'idle'",
+          "concurrently": false
+        },
+        "junior_conversations_destination_activity_idx": {
+          "name": "junior_conversations_destination_activity_idx",
+          "columns": [
+            {
+              "expression": "destination_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_activity_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "junior_conversations_actor_activity_idx": {
+          "name": "junior_conversations_actor_activity_idx",
+          "columns": [
+            {
+              "expression": "actor_identity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_activity_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "junior_conversations_origin_idx": {
+          "name": "junior_conversations_origin_idx",
+          "columns": [
+            {
+              "expression": "origin_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "origin_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_activity_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "junior_conversations_parent_idx": {
+          "name": "junior_conversations_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "junior_conversations_root_idx": {
+          "name": "junior_conversations_root_idx",
+          "columns": [
+            {
+              "expression": "root_conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "junior_conversations_destination_id_junior_destinations_id_fk": {
+          "name": "junior_conversations_destination_id_junior_destinations_id_fk",
+          "tableFrom": "junior_conversations",
+          "columnsFrom": ["destination_id"],
+          "tableTo": "junior_destinations",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "junior_conversations_actor_identity_id_junior_identities_id_fk": {
+          "name": "junior_conversations_actor_identity_id_junior_identities_id_fk",
+          "tableFrom": "junior_conversations",
+          "columnsFrom": ["actor_identity_id"],
+          "tableTo": "junior_identities",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "junior_conversations_creator_identity_id_junior_identities_id_fk": {
+          "name": "junior_conversations_creator_identity_id_junior_identities_id_fk",
+          "tableFrom": "junior_conversations",
+          "columnsFrom": ["creator_identity_id"],
+          "tableTo": "junior_identities",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "junior_conversations_credential_subject_identity_id_junior_identities_id_fk": {
+          "name": "junior_conversations_credential_subject_identity_id_junior_identities_id_fk",
+          "tableFrom": "junior_conversations",
+          "columnsFrom": ["credential_subject_identity_id"],
+          "tableTo": "junior_identities",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "junior_conversations_parent_conversation_id_junior_conversations_conversation_id_fk": {
+          "name": "junior_conversations_parent_conversation_id_junior_conversations_conversation_id_fk",
+          "tableFrom": "junior_conversations",
+          "columnsFrom": ["parent_conversation_id"],
+          "tableTo": "junior_conversations",
+          "columnsTo": ["conversation_id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "junior_conversations_root_conversation_id_junior_conversations_conversation_id_fk": {
+          "name": "junior_conversations_root_conversation_id_junior_conversations_conversation_id_fk",
+          "tableFrom": "junior_conversations",
+          "columnsFrom": ["root_conversation_id"],
+          "tableTo": "junior_conversations",
+          "columnsTo": ["conversation_id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_destinations": {
+      "name": "junior_destinations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_tenant_id": {
+          "name": "provider_tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "provider_destination_id": {
+          "name": "provider_destination_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_destination_id": {
+          "name": "parent_destination_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "junior_destinations_provider_destination_uidx": {
+          "name": "junior_destinations_provider_destination_uidx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_destination_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "junior_destinations_provider_kind_idx": {
+          "name": "junior_destinations_provider_kind_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_identities": {
+      "name": "junior_identities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_tenant_id": {
+          "name": "provider_tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "provider_subject_id": {
+          "name": "provider_subject_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_normalized": {
+          "name": "email_normalized",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "junior_identities_provider_subject_uidx": {
+          "name": "junior_identities_provider_subject_uidx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "junior_identities_user_idx": {
+          "name": "junior_identities_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "junior_identities_verified_email_idx": {
+          "name": "junior_identities_verified_email_idx",
+          "columns": [
+            {
+              "expression": "email_normalized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"junior_identities\".\"email_verified\" = true AND \"junior_identities\".\"email_normalized\" IS NOT NULL",
+          "concurrently": false
+        },
+        "junior_identities_kind_provider_idx": {
+          "name": "junior_identities_kind_provider_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "junior_identities_user_id_junior_users_id_fk": {
+          "name": "junior_identities_user_id_junior_users_id_fk",
+          "tableFrom": "junior_identities",
+          "columnsFrom": ["user_id"],
+          "tableTo": "junior_users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_stats": {
+      "name": "junior_stats",
+      "schema": "",
+      "columns": {
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metric": {
+          "name": "metric",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "junior_stats_date_namespace_metric_name_pk": {
+          "name": "junior_stats_date_namespace_metric_name_pk",
+          "columns": ["date", "namespace", "metric", "name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_users": {
+      "name": "junior_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "primary_email": {
+          "name": "primary_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "primary_email_normalized": {
+          "name": "primary_email_normalized",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "junior_users_primary_email_normalized_uidx": {
+          "name": "junior_users_primary_email_normalized_uidx",
+          "columns": [
+            {
+              "expression": "primary_email_normalized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "views": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/junior/migrations/meta/_journal.json
+++ b/packages/junior/migrations/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1785516038862,
       "tag": "0013_conversation_session_source",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1785625416358,
+      "tag": "0014_source_visibility",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/junior/src/chat/runtime/reply-executor.ts
+++ b/packages/junior/src/chat/runtime/reply-executor.ts
@@ -501,7 +501,7 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
         messageTs,
         teamId,
         threadTs,
-        type: destinationVisibility === "public" ? "pub" : "priv",
+        visibility: destinationVisibility ?? "private",
       });
     const slackActionToken = readSlackActionToken(message);
     const runId = options.execution?.dispatch?.id ?? getRunId(thread, message);

--- a/packages/junior/src/chat/source.ts
+++ b/packages/junior/src/chat/source.ts
@@ -20,7 +20,7 @@ export function normalizeSessionSource(
   if (value.platform === "local") {
     return {
       platform: "local",
-      type: "priv",
+      visibility: "private",
       conversationId: value.conversationId,
     };
   }
@@ -30,7 +30,7 @@ export function normalizeSessionSource(
   }
   return {
     platform: "slack",
-    type: value.type,
+    visibility: value.visibility,
     teamId: value.teamId,
     channelId: value.channelId,
     threadTs,

--- a/packages/junior/src/chat/tools/index.ts
+++ b/packages/junior/src/chat/tools/index.ts
@@ -165,7 +165,7 @@ export function createTools(
     tools.slackCanvasEdit = createSlackCanvasEditTool(state);
     tools.slackCanvasWrite = createSlackCanvasWriteTool(state);
     tools.slackThreadRead = createSlackThreadReadTool(slackContext);
-    if (context.conversationId && slackContext.source.type === "pub") {
+    if (context.conversationId && slackContext.source.visibility === "public") {
       tools.searchConversationHistory = createSlackConversationSearchTool(
         {
           kind: "public_provider_tenant",

--- a/packages/junior/tests/component/agent-dispatch-worker.test.ts
+++ b/packages/junior/tests/component/agent-dispatch-worker.test.ts
@@ -37,7 +37,7 @@ async function createDispatch(idempotencyKey: string) {
         input: "Post the scheduled digest.",
         source: createSlackSource({
           ...destination,
-          type: "priv",
+          visibility: "private",
         }),
       },
       plugin: "scheduler",

--- a/packages/junior/tests/component/conversation-sql-store.test.ts
+++ b/packages/junior/tests/component/conversation-sql-store.test.ts
@@ -484,7 +484,7 @@ describe("conversation SQL store", () => {
         source: "slack",
         sessionSource: {
           platform: "slack",
-          type: "pub",
+          visibility: "public",
           teamId: "T123",
           channelId: "C123",
           threadTs: "1700000000.000100",
@@ -497,7 +497,7 @@ describe("conversation SQL store", () => {
       ).resolves.toMatchObject({
         sessionSource: {
           platform: "slack",
-          type: "pub",
+          visibility: "public",
           teamId: "T123",
           channelId: "C123",
           threadTs: "1700000000.000100",
@@ -510,7 +510,7 @@ describe("conversation SQL store", () => {
         destination,
         sessionSource: {
           platform: "slack",
-          type: "priv",
+          visibility: "private",
           teamId: "T123",
           channelId: "C123",
           threadTs: "1700000000.999999",
@@ -522,7 +522,7 @@ describe("conversation SQL store", () => {
       ).resolves.toMatchObject({
         sessionSource: {
           platform: "slack",
-          type: "pub",
+          visibility: "public",
           teamId: "T123",
           channelId: "C123",
           threadTs: "1700000000.000100",

--- a/packages/junior/tests/component/memory-plugin-storage.test.ts
+++ b/packages/junior/tests/component/memory-plugin-storage.test.ts
@@ -285,7 +285,7 @@ WHERE table_name = 'junior_memory_memories'
         messageTs: "1718800000.000000",
         threadTs: "1718800000.000000",
 
-        type: "priv",
+        visibility: "private",
       });
       const store = createMemoryStore(fixture.sql.db() as unknown as MemoryDb, {
         conversationId,

--- a/packages/junior/tests/component/plugins/plugin-tasks.test.ts
+++ b/packages/junior/tests/component/plugins/plugin-tasks.test.ts
@@ -412,7 +412,7 @@ describe("plugin background tasks", () => {
     const source = createSlackSource({
       teamId,
       channelId,
-      type: "pub",
+      visibility: "public",
       messageTs: "1700000000.000100",
       threadTs: "1700000000.000000",
     });
@@ -524,7 +524,7 @@ describe("plugin background tasks", () => {
     const source = createSlackSource({
       teamId,
       channelId,
-      type: "pub",
+      visibility: "public",
       messageTs: "1700000000.950000",
       threadTs: "1700000000.000200",
     });
@@ -707,7 +707,7 @@ describe("plugin background tasks", () => {
     const source = createSlackSource({
       teamId,
       channelId,
-      type: "priv",
+      visibility: "private",
       messageTs: "1700000000.000100",
       threadTs: "1700000000.000000",
     });

--- a/packages/junior/tests/component/runtime/agent-continue-runner.test.ts
+++ b/packages/junior/tests/component/runtime/agent-continue-runner.test.ts
@@ -13,7 +13,7 @@ const SLACK_SOURCE = createSlackSource({
   teamId: SLACK_DESTINATION.teamId,
   channelId: SLACK_DESTINATION.channelId,
   threadTs: "1712345.0005",
-  type: "priv",
+  visibility: "private",
 });
 
 const ORIGINAL_ENV = vi.hoisted(() => {

--- a/packages/junior/tests/component/runtime/agent-run-agent-continue.test.ts
+++ b/packages/junior/tests/component/runtime/agent-run-agent-continue.test.ts
@@ -293,7 +293,7 @@ const TEST_SOURCE = createSlackSource({
   teamId: TEST_DESTINATION.teamId,
   channelId: TEST_DESTINATION.channelId,
   threadTs: "1712345.0001",
-  type: "priv",
+  visibility: "private",
 });
 
 const TEST_ACTOR = {

--- a/packages/junior/tests/component/runtime/agent-run-mcp-progressive-loading.test.ts
+++ b/packages/junior/tests/component/runtime/agent-run-mcp-progressive-loading.test.ts
@@ -690,7 +690,7 @@ function makeAgentRunRequest(
         channelId: destination.channelId,
         threadTs: args.threadTs,
 
-        type: "priv",
+        visibility: "private",
       }),
       actor: TEST_ACTOR,
       ...(overrides.routing ?? {}),

--- a/packages/junior/tests/component/runtime/agent-run-provider-retry.test.ts
+++ b/packages/junior/tests/component/runtime/agent-run-provider-retry.test.ts
@@ -616,7 +616,7 @@ const TEST_SOURCE = createSlackSource({
   teamId: TEST_DESTINATION.teamId,
   channelId: TEST_DESTINATION.channelId,
   threadTs: "1712345.0001",
-  type: "priv",
+  visibility: "private",
 });
 const TEST_USAGE = {
   input: 1,

--- a/packages/junior/tests/component/services/turn-session-record.test.ts
+++ b/packages/junior/tests/component/services/turn-session-record.test.ts
@@ -18,7 +18,7 @@ const SLACK_SOURCE = createSlackSource({
   teamId: "T123",
   channelId: "C123",
   threadTs: "1700000000.001",
-  type: "priv",
+  visibility: "private",
 }) satisfies Source;
 
 function userMessage(text: string): PiMessage {

--- a/packages/junior/tests/component/tool-support/pi-tool-adapter.test.ts
+++ b/packages/junior/tests/component/tool-support/pi-tool-adapter.test.ts
@@ -49,7 +49,7 @@ function actionReview(
       },
       source: {
         platform: "local",
-        type: "priv",
+        visibility: "private",
         conversationId: "local:tool-review",
       },
       userIntent: () => userIntent,

--- a/packages/junior/tests/integration/agent-continue-slack.test.ts
+++ b/packages/junior/tests/integration/agent-continue-slack.test.ts
@@ -41,7 +41,7 @@ function slackSource(threadTs: string) {
     channelId: SLACK_DESTINATION.channelId,
     threadTs,
 
-    type: "priv",
+    visibility: "private",
   });
 }
 
@@ -205,7 +205,7 @@ describe("agent continuation Slack integration", () => {
       messageTs: "1712345.continue-source",
       threadTs: "1712345.0001",
 
-      type: "priv",
+      visibility: "private",
     });
     const sessionRecord =
       await turnSessionStoreModule.upsertAgentTurnSessionRecord({

--- a/packages/junior/tests/integration/agent-dispatch-handler.test.ts
+++ b/packages/junior/tests/integration/agent-dispatch-handler.test.ts
@@ -39,7 +39,7 @@ describe("legacy agent dispatch callback", () => {
         source: createSlackSource({
           teamId: "T123",
           channelId: "C123",
-          type: "priv",
+          visibility: "private",
         }),
       },
       plugin: "scheduler",
@@ -91,7 +91,7 @@ describe("legacy agent dispatch callback", () => {
         source: createSlackSource({
           teamId: "T123",
           channelId: "C123",
-          type: "priv",
+          visibility: "private",
         }),
       },
       plugin: "scheduler",

--- a/packages/junior/tests/integration/agent-dispatch-work.test.ts
+++ b/packages/junior/tests/integration/agent-dispatch-work.test.ts
@@ -96,7 +96,7 @@ async function createDispatch(
           source ??
           createSlackSource({
             ...destination,
-            type: "priv",
+            visibility: "private",
           }),
       },
       plugin: "scheduler",

--- a/packages/junior/tests/integration/api/conversations/list.test.ts
+++ b/packages/junior/tests/integration/api/conversations/list.test.ts
@@ -56,7 +56,7 @@ describe("conversation list API", () => {
         nowMs: 1_000,
         sessionSource: {
           platform: "slack",
-          type: "pub",
+          visibility: "public",
           teamId: "T123",
           channelId: "C123",
           threadTs: "1700000000.000100",
@@ -84,7 +84,7 @@ describe("conversation list API", () => {
         nowMs: 2_000,
         sessionSource: {
           platform: "slack",
-          type: "priv",
+          visibility: "private",
           teamId: "T123",
           channelId: "D123",
           threadTs: "1700000000.000200",

--- a/packages/junior/tests/integration/conversation-sql.test.ts
+++ b/packages/junior/tests/integration/conversation-sql.test.ts
@@ -50,6 +50,14 @@ describe("conversation SQL local mode", () => {
     if (!sourceMigration) {
       throw new Error("Conversation session source migration not found");
     }
+    const visibilityMigration = coreMigrations[sourceMigrationIndex + 1];
+    if (
+      !visibilityMigration?.sql.some((statement) =>
+        statement.includes("jsonb_build_object(\n  'visibility'"),
+      )
+    ) {
+      throw new Error("Conversation source visibility migration not found");
+    }
 
     try {
       for (const migration of coreMigrations.slice(0, sourceMigrationIndex)) {
@@ -92,6 +100,9 @@ INSERT INTO junior_conversations (
       for (const statement of sourceMigration.sql) {
         await fixture.sql.execute(statement);
       }
+      for (const statement of visibilityMigration.sql) {
+        await fixture.sql.execute(statement);
+      }
 
       const rows = await fixture.sql.query<{
         conversationId: string;
@@ -110,12 +121,12 @@ ORDER BY conversation_id
       ).toEqual({
         "local:test:session": {
           platform: "local",
-          type: "priv",
+          visibility: "private",
           conversationId: "local:test:session",
         },
         "slack:C123:1700000000.001": {
           platform: "slack",
-          type: "pub",
+          visibility: "public",
           teamId: "T123",
           channelId: "C123",
           threadTs: "1700000000.001",
@@ -124,7 +135,7 @@ ORDER BY conversation_id
         "slack:C999:1700000000.004": null,
         "slack:G123:1700000000.003": {
           platform: "slack",
-          type: "priv",
+          visibility: "private",
           teamId: "T123",
           channelId: "G123",
           threadTs: "1700000000.003",

--- a/packages/junior/tests/integration/heartbeat.test.ts
+++ b/packages/junior/tests/integration/heartbeat.test.ts
@@ -44,7 +44,7 @@ const SLACK_DESTINATION = {
 } satisfies Destination;
 const SLACK_SOURCE = createSlackSource({
   ...SLACK_DESTINATION,
-  type: "priv",
+  visibility: "private",
 }) satisfies Source;
 
 function slackDmSource(channelId = "D123"): Source {
@@ -52,7 +52,7 @@ function slackDmSource(channelId = "D123"): Source {
     teamId: "T123",
     channelId,
 
-    type: "priv",
+    visibility: "private",
   });
 }
 
@@ -693,7 +693,7 @@ describe("plugin heartbeat", () => {
       createSlackSource({
         teamId: "T123",
         channelId: "C123",
-        type: "pub",
+        visibility: "public",
       }),
     );
     expect(dispatchRecord?.metadata).toMatchObject({

--- a/packages/junior/tests/integration/local-agent-runner.test.ts
+++ b/packages/junior/tests/integration/local-agent-runner.test.ts
@@ -891,7 +891,7 @@ describe("local agent runner", () => {
         ],
         source: {
           platform: "local",
-          type: "priv",
+          visibility: "private",
           conversationId,
         },
       }),

--- a/packages/junior/tests/integration/mcp-oauth-callback.test.ts
+++ b/packages/junior/tests/integration/mcp-oauth-callback.test.ts
@@ -63,7 +63,7 @@ function slackSource(threadTs: string) {
     channelId: SLACK_DESTINATION.channelId,
     threadTs,
 
-    type: "priv",
+    visibility: "private",
   });
 }
 
@@ -322,7 +322,7 @@ describe("mcp oauth callback integration", () => {
       messageTs: "1700000000.mcp-source",
       threadTs: "1700000000.001",
 
-      type: "priv",
+      visibility: "private",
     });
 
     await stateAdapterModule.getStateAdapter().set(`thread-state:${threadId}`, {

--- a/packages/junior/tests/integration/oauth-callback.test.ts
+++ b/packages/junior/tests/integration/oauth-callback.test.ts
@@ -67,7 +67,7 @@ function slackSource(threadTs: string) {
     channelId: SLACK_DESTINATION.channelId,
     threadTs,
 
-    type: "priv",
+    visibility: "private",
   });
 }
 
@@ -312,7 +312,7 @@ describe("oauth callback integration", () => {
       messageTs: "1700000000.session-source",
       threadTs: "1700000000.009",
 
-      type: "priv",
+      visibility: "private",
     });
 
     await turnSessionStoreModule.upsertAgentTurnSessionRecord({

--- a/packages/junior/tests/integration/oauth-resume-slack.test.ts
+++ b/packages/junior/tests/integration/oauth-resume-slack.test.ts
@@ -37,7 +37,7 @@ function testSlackSource(threadTs: string) {
     channelId: TEST_SLACK_DESTINATION.channelId,
     threadTs,
 
-    type: "priv",
+    visibility: "private",
   });
 }
 

--- a/packages/junior/tests/integration/query-conversation-events.test.ts
+++ b/packages/junior/tests/integration/query-conversation-events.test.ts
@@ -29,7 +29,7 @@ function context(): SlackToolRuntimeContext {
       teamId: "T123",
       channelId: "C123",
       threadTs: "1700000000.100000",
-      type: "pub",
+      visibility: "public",
     }),
     egress: {
       async fetch() {

--- a/packages/junior/tests/integration/slack-channel-tools.test.ts
+++ b/packages/junior/tests/integration/slack-channel-tools.test.ts
@@ -114,7 +114,7 @@ function createContext(
       channelId: sourceChannelId,
       messageTs,
 
-      type: "priv",
+      visibility: "private",
     }),
     destinationChannelId,
     messageTs,

--- a/packages/junior/tests/integration/slack-schedule-tools.test.ts
+++ b/packages/junior/tests/integration/slack-schedule-tools.test.ts
@@ -73,7 +73,7 @@ function createContext(
       teamId,
       channelId,
 
-      type: channelId.startsWith("C") ? "pub" : "priv",
+      visibility: channelId.startsWith("C") ? "public" : "private",
     }),
     actor: {
       platform: "slack",
@@ -425,7 +425,7 @@ describe("Slack schedule tools", () => {
           channelId: "C123",
           threadTs: "1700000000.000",
 
-          type: "priv",
+          visibility: "private",
         }),
       }),
     );
@@ -1105,7 +1105,7 @@ describe("Slack schedule tools", () => {
               teamId: TEST_TEAM_ID,
               channelId: "D123",
 
-              type: "priv",
+              visibility: "private",
             }),
             teamId: TEST_TEAM_ID,
             channelId: "slack:D123:1700000000.000",
@@ -1438,7 +1438,7 @@ describe("Slack schedule tool wiring via getPluginTools", () => {
           teamId: TEAM_ID,
           channelId: "DDM",
 
-          type: "priv",
+          visibility: "private",
         }),
         destination: {
           platform: "slack",

--- a/packages/junior/tests/integration/slack-thread-read.test.ts
+++ b/packages/junior/tests/integration/slack-thread-read.test.ts
@@ -63,7 +63,7 @@ function createContext(overrides: ContextOverrides = {}): SlackToolContext {
         teamId,
         channelId: sourceChannelId,
 
-        type: "priv",
+        visibility: "private",
       }),
     destinationChannelId,
     sourceChannelId,

--- a/packages/junior/tests/integration/slack-user-lookup.test.ts
+++ b/packages/junior/tests/integration/slack-user-lookup.test.ts
@@ -347,7 +347,7 @@ describe("slackUserLookup", () => {
             teamId: "T0TEST",
             channelId: "C0TEST",
 
-            type: "priv",
+            visibility: "private",
           }),
           destination: {
             platform: "slack",

--- a/packages/junior/tests/integration/slack/bot-handlers.test.ts
+++ b/packages/junior/tests/integration/slack/bot-handlers.test.ts
@@ -134,7 +134,7 @@ function createSlackSourceForTest(channelId: string) {
     channelId,
     threadTs: "1700000000.000",
 
-    type: "priv",
+    visibility: "private",
   });
 }
 

--- a/packages/junior/tests/integration/tool-idempotency.test.ts
+++ b/packages/junior/tests/integration/tool-idempotency.test.ts
@@ -81,7 +81,7 @@ function slackContext(channelId: string): SlackToolContext {
       teamId,
       channelId: parsedChannelId,
 
-      type: "priv",
+      visibility: "private",
     }),
     destinationChannelId: parsedChannelId,
     sourceChannelId: parsedChannelId,

--- a/packages/junior/tests/unit/handlers/oauth-callback.test.ts
+++ b/packages/junior/tests/unit/handlers/oauth-callback.test.ts
@@ -107,9 +107,7 @@ vi.mock("@/chat/plugins/credential-hooks", () => ({
 }));
 
 vi.mock("@/chat/conversations/projection", async (importOriginal) => ({
-  ...(await importOriginal<
-    typeof import("@/chat/conversations/projection")
-  >()),
+  ...(await importOriginal<typeof import("@/chat/conversations/projection")>()),
   recordAuthenticationLinked: vi.fn(async () => undefined),
 }));
 
@@ -728,7 +726,7 @@ describe("oauth callback handler", () => {
         channelId: "C123",
         threadTs: "123.789",
 
-        type: "priv",
+        visibility: "private",
       }),
       threadTs: "123.789",
       resumeConversationId: "slack:C123:123.789",

--- a/packages/junior/tests/unit/handlers/oauth-resume.test.ts
+++ b/packages/junior/tests/unit/handlers/oauth-resume.test.ts
@@ -84,7 +84,7 @@ function testSlackSource(threadTs: string) {
     channelId: TEST_SLACK_DESTINATION.channelId,
     threadTs,
 
-    type: "priv",
+    visibility: "private",
   });
 }
 

--- a/packages/junior/tests/unit/plugin-api-source.test.ts
+++ b/packages/junior/tests/unit/plugin-api-source.test.ts
@@ -7,17 +7,17 @@ describe("plugin source helpers", () => {
       createSlackSource({
         teamId: "T123",
         channelId: "C123",
-        type: "pub",
+        visibility: "public",
       }),
-    ).toMatchObject({ type: "pub" });
+    ).toMatchObject({ visibility: "public" });
     // Modern Slack private channels also use C-prefixed ids.
     expect(
       createSlackSource({
         teamId: "T123",
         channelId: "C123",
-        type: "priv",
+        visibility: "private",
       }),
-    ).toMatchObject({ type: "priv" });
+    ).toMatchObject({ visibility: "private" });
   });
 
   it("constructs private Slack sources from caller-provided visibility", () => {
@@ -25,22 +25,22 @@ describe("plugin source helpers", () => {
       createSlackSource({
         teamId: "T123",
         channelId: "C123",
-        type: "priv",
+        visibility: "private",
       }),
-    ).toMatchObject({ type: "priv" });
+    ).toMatchObject({ visibility: "private" });
     expect(
       createSlackSource({
         teamId: "T123",
         channelId: "G123",
-        type: "priv",
+        visibility: "private",
       }),
-    ).toMatchObject({ type: "priv" });
+    ).toMatchObject({ visibility: "private" });
     expect(
       createSlackSource({
         teamId: "T123",
         channelId: "D123",
-        type: "priv",
+        visibility: "private",
       }),
-    ).toMatchObject({ type: "priv" });
+    ).toMatchObject({ visibility: "private" });
   });
 });

--- a/packages/junior/tests/unit/plugins/agent-hooks.test.ts
+++ b/packages/junior/tests/unit/plugins/agent-hooks.test.ts
@@ -90,7 +90,7 @@ const SLACK_DESTINATION = {
 const SLACK_SOURCE = createSlackSource({
   teamId: SLACK_DESTINATION.teamId,
   channelId: SLACK_DESTINATION.channelId,
-  type: "priv",
+  visibility: "private",
 });
 
 class PrototypeTool {
@@ -117,7 +117,7 @@ function slackSource(channelId: string) {
     teamId: "T123",
     channelId,
 
-    type: "priv",
+    visibility: "private",
   });
 }
 
@@ -177,10 +177,10 @@ describe("agent plugin hooks", () => {
       createSlackSource({
         teamId: "T123",
         channelId: "C123",
-        type: "pub",
+        visibility: "public",
         threadTs: "1718800000.000000",
-      }).type,
-    ).toBe("pub");
+      }).visibility,
+    ).toBe("public");
     // Without a signal, C-prefixed channels fail closed to private.
     expect(
       createSlackSource({
@@ -188,27 +188,27 @@ describe("agent plugin hooks", () => {
         channelId: "C123",
         threadTs: "1718800000.000000",
 
-        type: "priv",
-      }).type,
-    ).toBe("priv");
+        visibility: "private",
+      }).visibility,
+    ).toBe("private");
     expect(
       createSlackSource({
         teamId: "T123",
         channelId: "D123",
         threadTs: "1718800000.000000",
 
-        type: "priv",
-      }).type,
-    ).toBe("priv");
+        visibility: "private",
+      }).visibility,
+    ).toBe("private");
     expect(
       createSlackSource({
         teamId: "T123",
         channelId: "G123",
         threadTs: "1718800000.000000",
 
-        type: "priv",
-      }).type,
-    ).toBe("priv");
+        visibility: "private",
+      }).visibility,
+    ).toBe("private");
   });
 
   it("collects system prompt contributions from configured plugins", async () => {

--- a/packages/junior/tests/unit/prompt.test.ts
+++ b/packages/junior/tests/unit/prompt.test.ts
@@ -46,7 +46,7 @@ describe("prompt builders", () => {
           teamId: "T123",
           channelId: "C123",
 
-          type: "priv",
+          visibility: "private",
         }),
         destination: {
           platform: "slack",

--- a/packages/junior/tests/unit/runtime/agent-dispatch-validation.test.ts
+++ b/packages/junior/tests/unit/runtime/agent-dispatch-validation.test.ts
@@ -24,7 +24,7 @@ const validOptions = {
     teamId: "T123",
     channelId: "C123",
 
-    type: "priv",
+    visibility: "private",
   }),
 };
 

--- a/packages/junior/tests/unit/runtime/source.test.ts
+++ b/packages/junior/tests/unit/runtime/source.test.ts
@@ -6,14 +6,14 @@ describe("session source", () => {
     expect(
       parseSessionSource({
         platform: "slack",
-        type: "pub",
+        visibility: "public",
         teamId: "T123",
         channelId: "C123",
         threadTs: "1700000000.000100",
       }),
     ).toEqual({
       platform: "slack",
-      type: "pub",
+      visibility: "public",
       teamId: "T123",
       channelId: "C123",
       threadTs: "1700000000.000100",
@@ -24,7 +24,7 @@ describe("session source", () => {
     expect(
       normalizeSessionSource({
         platform: "slack",
-        type: "priv",
+        visibility: "private",
         teamId: "T123",
         channelId: "C123",
         threadTs: "1700000000.000100",
@@ -32,7 +32,7 @@ describe("session source", () => {
       }),
     ).toEqual({
       platform: "slack",
-      type: "priv",
+      visibility: "private",
       teamId: "T123",
       channelId: "C123",
       threadTs: "1700000000.000100",
@@ -43,7 +43,7 @@ describe("session source", () => {
     expect(
       normalizeSessionSource({
         platform: "slack",
-        type: "pub",
+        visibility: "public",
         teamId: "T123",
         channelId: "C123",
         messageTs: "1700000000.000200",
@@ -52,7 +52,7 @@ describe("session source", () => {
     expect(
       parseSessionSource({
         platform: "slack",
-        type: "pub",
+        visibility: "public",
         teamId: "T123",
         channelId: "C123",
         messageTs: "1700000000.000200",
@@ -64,12 +64,12 @@ describe("session source", () => {
     expect(
       normalizeSessionSource({
         platform: "local",
-        type: "priv",
+        visibility: "private",
         conversationId: "local:abc123:demo",
       }),
     ).toEqual({
       platform: "local",
-      type: "priv",
+      visibility: "private",
       conversationId: "local:abc123:demo",
     });
   });

--- a/packages/junior/tests/unit/services/guardian-action-review.test.ts
+++ b/packages/junior/tests/unit/services/guardian-action-review.test.ts
@@ -24,7 +24,7 @@ const proposal: ToolActionProposal = {
     },
     source: {
       platform: "local",
-      type: "priv",
+      visibility: "private",
       conversationId: "local:guardian-test",
     },
     userIntent: "Create a weekly report.",

--- a/packages/junior/tests/unit/services/mcp-auth-orchestration.test.ts
+++ b/packages/junior/tests/unit/services/mcp-auth-orchestration.test.ts
@@ -62,7 +62,7 @@ const slackSource = createSlackSource({
   channelId: "C123",
   messageTs: "1700000000.source",
   threadTs: "1700000000.000000",
-  type: "priv",
+  visibility: "private",
 });
 
 describe("createMcpAuthOrchestration", () => {

--- a/packages/junior/tests/unit/services/plugin-auth-orchestration.test.ts
+++ b/packages/junior/tests/unit/services/plugin-auth-orchestration.test.ts
@@ -69,7 +69,7 @@ const slackSource = createSlackSource({
   channelId: "C123",
   messageTs: "1700000000.source",
   threadTs: "1700000000.000000",
-  type: "priv",
+  visibility: "private",
 });
 
 describe("createPluginAuthOrchestration", () => {

--- a/packages/junior/tests/unit/slack/slack-message-add-reaction-tool.test.ts
+++ b/packages/junior/tests/unit/slack/slack-message-add-reaction-tool.test.ts
@@ -36,7 +36,7 @@ const TEST_SLACK_CONTEXT: SlackToolContext = {
     channelId: TEST_CHANNEL_ID,
     messageTs: TEST_MESSAGE_TS,
 
-    type: "priv",
+    visibility: "private",
   }),
   destinationChannelId: TEST_CHANNEL_ID,
   messageTs: TEST_MESSAGE_TS,

--- a/packages/junior/tests/unit/slack/tool-registration.test.ts
+++ b/packages/junior/tests/unit/slack/tool-registration.test.ts
@@ -24,11 +24,11 @@ const noopEgress = {
 function ctx(): Extract<ToolRuntimeContext, { source: { platform: "local" } }>;
 function ctx(
   channelId: string,
-  sourceType?: "priv" | "pub",
+  sourceVisibility?: "private" | "public",
 ): Extract<ToolRuntimeContext, { source: { platform: "slack" } }>;
 function ctx(
   channelId?: string,
-  sourceType?: "priv" | "pub",
+  sourceVisibility?: "private" | "public",
 ): ToolRuntimeContext {
   if (!channelId) {
     return {
@@ -53,7 +53,8 @@ function ctx(
     source: createSlackSource({
       teamId: "T123",
       channelId,
-      type: sourceType ?? (channelId.startsWith("C") ? "pub" : "priv"),
+      visibility:
+        sourceVisibility ?? (channelId.startsWith("C") ? "public" : "private"),
     }),
     egress: noopEgress,
     workspace: noopSandbox,
@@ -136,7 +137,7 @@ describe("Slack tool registration", () => {
   });
 
   it("does not register conversation search for a source-confirmed private C channel", () => {
-    const tools = createTools([], {}, ctx("C12345", "priv"));
+    const tools = createTools([], {}, ctx("C12345", "private"));
 
     expect(tools).not.toHaveProperty("searchConversationHistory");
   });

--- a/packages/junior/tests/unit/tool-support/action-review.test.ts
+++ b/packages/junior/tests/unit/tool-support/action-review.test.ts
@@ -11,7 +11,7 @@ import {
 
 const LOCAL_SOURCE = {
   platform: "local",
-  type: "priv",
+  visibility: "private",
   conversationId: "local:approval-test",
 } as const;
 const LOCAL_DESTINATION = {

--- a/packages/junior/tests/unit/tools/resource-events.test.ts
+++ b/packages/junior/tests/unit/tools/resource-events.test.ts
@@ -29,7 +29,7 @@ const context: ToolRuntimeContext = {
     teamId: "T123",
     channelId: "C123",
     threadTs: "1712345.0001",
-    type: "pub",
+    visibility: "public",
   }),
   egress: {
     async fetch() {


### PR DESCRIPTION
## Summary

- replace `Source.type: "pub" | "priv"` with `Source.visibility: "public" | "private"`
- hard-cut runtime, plugin, scheduler, memory, test, and eval consumers to the canonical vocabulary
- migrate persisted conversation `source_json` records to the new field and values

This PR is stacked on #1182 and should be retargeted to `main` after that PR merges.

## Breaking change

Plugin authors must update source construction and reads from `type`/`pub`/`priv` to `visibility`/`public`/`private`. There is no compatibility reader; durable conversation records are upgraded by the included SQL migration.

## Testing

- `pnpm typecheck`
- `pnpm --filter @sentry/junior exec vitest run tests/unit/plugin-api-source.test.ts tests/unit/runtime/source.test.ts tests/unit/plugins/agent-hooks.test.ts tests/integration/heartbeat.test.ts tests/integration/slack-schedule-tools.test.ts tests/integration/conversation-sql.test.ts` (118 tests)
- `pnpm --filter @sentry/junior-memory test` (89 tests)
- `pnpm --filter @sentry/junior-github exec vitest run tests/github-plugin.test.ts` (73 tests)
- `pnpm --filter @sentry/junior-plugin-api build`
- `pnpm --filter @sentry/junior-scheduler build`
- `pnpm lint` passed all source and architecture checks; the final `publint` packaging step failed locally because it could not find pnpm's tarball despite `pnpm pack` exiting successfully
