### PR TITLE
feat(scheduler): label scheduled task replies

### DIFF
--- a/packages/junior-plugin-api/README.md
+++ b/packages/junior-plugin-api/README.md
@@ -89,6 +89,9 @@ routing, response validation, rendering, confirmation, and query state.
   owns browser rendering.
 - `ctx.agent.dispatch` creates durable agent work with an explicit actor,
   destination, source, metadata, and idempotency identity.
+- Dispatches may include compact `replyAttribution` for destination-visible
+  context about what produced the reply. Core owns platform rendering; opaque
+  dispatch metadata remains internal.
 - Delegated credential subjects declare the narrow action that authorized them.
   Core owns runtime bindings; scheduler task subjects are accepted only from the
   scheduler plugin and are bound to the exact task id.

--- a/packages/junior-plugin-api/src/dispatch.ts
+++ b/packages/junior-plugin-api/src/dispatch.ts
@@ -2,12 +2,15 @@ import { z } from "zod";
 import {
   destinationVisibilitySchema,
   dispatchOptionsSchema,
+  replyAttributionSchema,
 } from "./schemas";
 
 export type DestinationVisibility = z.output<
   typeof destinationVisibilitySchema
 >;
 export type DispatchOptions = z.output<typeof dispatchOptionsSchema>;
+/** Compact destination-visible context explaining what produced a reply. */
+export type ReplyAttribution = z.output<typeof replyAttributionSchema>;
 
 export interface DispatchResult {
   id: string;

--- a/packages/junior-plugin-api/src/schemas.ts
+++ b/packages/junior-plugin-api/src/schemas.ts
@@ -187,6 +187,19 @@ const dispatchMetadataSchema = z
     }
   });
 
+/** Compact destination-visible context explaining what produced a reply. */
+export const replyAttributionSchema = z
+  .object({
+    label: exactNonBlankStringSchema
+      .pipe(z.string().max(48))
+      .refine((value) => !/[\r\n]/.test(value)),
+    detail: exactNonBlankStringSchema
+      .pipe(z.string().max(128))
+      .refine((value) => !/[\r\n]/.test(value))
+      .optional(),
+  })
+  .strict();
+
 /** Plugin dispatch request accepted by Junior core. */
 export const dispatchOptionsSchema = z
   .object({
@@ -196,6 +209,7 @@ export const dispatchOptionsSchema = z
     destinationVisibility: destinationVisibilitySchema,
     input: nonBlankStringSchema.pipe(z.string().max(32_000)),
     metadata: dispatchMetadataSchema.optional(),
+    replyAttribution: replyAttributionSchema.optional(),
     source: sourceSchema,
   })
   .strict();

--- a/packages/junior-scheduler/README.md
+++ b/packages/junior-scheduler/README.md
@@ -28,6 +28,8 @@ Junior's durable agent runtime.
 - Claiming and completion transitions are atomic and safe to retry.
 - Each run dispatches with explicit source, destination, creator attribution,
   execution actor, metadata, and idempotency identity.
+- Scheduled dispatch replies carry compact destination-visible attribution;
+  core owns platform footer rendering.
 - A deleted, paused, or rescheduled task is skipped when its claimed run no
   longer matches current task state.
 - Dispatch completion, failure, or blocking updates both the run and the task's

--- a/packages/junior-scheduler/src/plugin.ts
+++ b/packages/junior-scheduler/src/plugin.ts
@@ -6,6 +6,7 @@ import {
   type PluginOperationalReportContent,
   type PluginReadState,
   type PluginState,
+  type ReplyAttribution,
   type SlackDestination,
   type Source,
   type ToolRegistrationHookContext,
@@ -39,6 +40,13 @@ import { createSchedulerUserPage } from "./user-pages";
 
 const SCHEDULER_HEARTBEAT_LIMIT = 10;
 const DASHBOARD_TABLE_LIMIT = 5;
+
+const SCHEDULE_FREQUENCY_COPY = {
+  daily: { label: "Daily", unit: "day" },
+  weekly: { label: "Weekly", unit: "week" },
+  monthly: { label: "Monthly", unit: "month" },
+  yearly: { label: "Yearly", unit: "year" },
+} as const;
 
 function singleLineMetadataValue(value: string): string {
   return value
@@ -74,6 +82,30 @@ function buildScheduledTaskDispatchMetadata(args: {
           recurrenceStartDate: task.schedule.recurrence.startDate,
         }
       : {}),
+  };
+}
+
+/** Describe scheduled execution compactly for the reply footer. */
+function buildScheduledTaskReplyAttribution(
+  task: ScheduledTask,
+): ReplyAttribution {
+  if (task.schedule.kind === "one_off") {
+    return { label: "Scheduled task", detail: "One-time" };
+  }
+  const recurrence = task.schedule.recurrence;
+  if (!recurrence) {
+    return { label: "Scheduled task", detail: "Recurring" };
+  }
+  const frequency = SCHEDULE_FREQUENCY_COPY[recurrence.frequency];
+  if (recurrence.interval === 1) {
+    return {
+      label: "Scheduled task",
+      detail: frequency.label,
+    };
+  }
+  return {
+    label: "Scheduled task",
+    detail: `Every ${recurrence.interval} ${frequency.unit}s`,
   };
 }
 
@@ -558,6 +590,7 @@ export function schedulerPlugin() {
                   : "private",
               input: task.task.text,
               metadata: dispatchMetadata,
+              replyAttribution: buildScheduledTaskReplyAttribution(task),
               source: scheduledTaskDispatchSource(task),
             });
           } catch (error) {

--- a/packages/junior/src/chat/agent-dispatch/store.ts
+++ b/packages/junior/src/chat/agent-dispatch/store.ts
@@ -4,6 +4,7 @@ import {
   destinationSchema,
   destinationVisibilitySchema,
   isSlackDestination,
+  replyAttributionSchema,
   sourceSchema,
 } from "@sentry/junior-plugin-api";
 import { z } from "zod";
@@ -59,6 +60,7 @@ const dispatchRecordSchema = z
     input: z.string().min(1),
     metadata: z.record(z.string(), z.string()).optional(),
     plugin: nonEmptyExactStringSchema,
+    replyAttribution: replyAttributionSchema.optional(),
     resultMessageTs: z.string().optional(),
     source: sourceSchema,
     status: dispatchStatusSchema,
@@ -368,6 +370,9 @@ export async function createOrGetDispatch(args: {
       input: args.options.input,
       ...(metadata ? { metadata } : {}),
       plugin: args.plugin,
+      ...(args.options.replyAttribution
+        ? { replyAttribution: args.options.replyAttribution }
+        : {}),
       status: "pending",
       source: args.options.source,
       updatedAtMs: args.nowMs,

--- a/packages/junior/src/chat/agent-dispatch/types.ts
+++ b/packages/junior/src/chat/agent-dispatch/types.ts
@@ -1,6 +1,7 @@
 import type {
   DispatchOptions,
   DestinationVisibility,
+  ReplyAttribution,
   Source,
   SlackDestination,
 } from "@sentry/junior-plugin-api";
@@ -44,6 +45,7 @@ export interface DispatchRecord {
   input: string;
   metadata?: Record<string, string>;
   plugin: string;
+  replyAttribution?: ReplyAttribution;
   resultMessageTs?: string;
   source: Source;
   status: DispatchStatus;

--- a/packages/junior/src/chat/agent-dispatch/validation.ts
+++ b/packages/junior/src/chat/agent-dispatch/validation.ts
@@ -128,6 +128,9 @@ function dispatchOptionsErrorMessage(
   if (hasIssueUnderPath(issues, ["metadata"])) {
     return "Dispatch metadata values must be strings";
   }
+  if (hasIssueUnderPath(issues, ["replyAttribution"])) {
+    return "Dispatch reply attribution is invalid";
+  }
   return "Dispatch options are invalid";
 }
 

--- a/packages/junior/src/chat/agent-dispatch/work.ts
+++ b/packages/junior/src/chat/agent-dispatch/work.ts
@@ -87,6 +87,7 @@ export function buildDispatchRoutingContext(
       id: dispatch.id,
       metadata: dispatch.metadata,
       plugin: dispatch.plugin,
+      replyAttribution: dispatch.replyAttribution,
     },
     surface: "api",
   };

--- a/packages/junior/src/chat/agent/request.ts
+++ b/packages/junior/src/chat/agent/request.ts
@@ -9,6 +9,7 @@
  */
 import type {
   Destination,
+  ReplyAttribution,
   Source,
   SystemActor,
 } from "@sentry/junior-plugin-api";
@@ -95,6 +96,7 @@ export interface AgentRunRouting {
     id: string;
     metadata?: Record<string, string>;
     plugin?: string;
+    replyAttribution?: ReplyAttribution;
   };
   toolChannelId?: string;
 }

--- a/packages/junior/src/chat/runtime/reply-executor.ts
+++ b/packages/junior/src/chat/runtime/reply-executor.ts
@@ -617,6 +617,7 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
               await sendSlackReply({
                 channelId,
                 conversationId,
+                replyAttribution: options.execution?.dispatch?.replyAttribution,
                 text,
                 threadTs,
               });
@@ -1073,6 +1074,7 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
               slackTs = await sendSlackReply({
                 channelId,
                 conversationId,
+                replyAttribution: options.execution?.dispatch?.replyAttribution,
                 text,
                 ...(threadTs ? { threadTs } : {}),
               });

--- a/packages/junior/src/chat/runtime/slack-resume.ts
+++ b/packages/junior/src/chat/runtime/slack-resume.ts
@@ -5,6 +5,7 @@
  * Status notices are best effort. Completed assistant replies and auth-pause
  * notices use `sendSlackReply` so footer attachment stays consistent.
  */
+import type { ReplyAttribution } from "@sentry/junior-plugin-api";
 import { botConfig } from "@/chat/config";
 import { standardModelId } from "@/chat/model-profile";
 import type { ChannelConfigurationService } from "@/chat/configuration/types";
@@ -95,12 +96,14 @@ async function postSlackMessageBestEffort(
   threadTs: string | undefined,
   text: string,
   conversationId?: string,
+  replyAttribution?: ReplyAttribution,
 ): Promise<void> {
   try {
     if (conversationId) {
       await sendSlackReply({
         channelId,
         conversationId,
+        replyAttribution,
         text,
         threadTs,
       });
@@ -562,6 +565,8 @@ async function resumeSlackTurnInContext(
         messageTs = await sendSlackReply({
           channelId: runArgs.channelId,
           conversationId: runArgs.conversationId,
+          replyAttribution:
+            runArgs.replyContext?.routing.dispatch?.replyAttribution,
           text,
           threadTs: runArgs.threadTs,
         });
@@ -867,6 +872,7 @@ async function resumeSlackTurnInContext(
             deferredAuthInfo.requestText,
           ),
           runArgs.conversationId,
+          runArgs.replyContext?.routing.dispatch?.replyAttribution,
         );
       }
       return true;

--- a/packages/junior/src/chat/slack/footer.ts
+++ b/packages/junior/src/chat/slack/footer.ts
@@ -1,3 +1,4 @@
+import type { ReplyAttribution } from "@sentry/junior-plugin-api";
 import { buildSentryConversationUrl } from "@/chat/sentry-links";
 import { getPluginSlackConversationLink } from "@/chat/plugins/agent-hooks";
 import { getDashboardConversationLink } from "@/chat/slack/dashboard-link";
@@ -6,6 +7,11 @@ import { escapeSlackMrkdwnText, formatSlackLink } from "@/chat/slack/mrkdwn";
 interface SlackMrkdwnTextObject {
   text: string;
   type: "mrkdwn";
+}
+
+interface SlackPlainTextObject {
+  text: string;
+  type: "plain_text";
 }
 
 /** Slack-flavored Markdown block — accepts a standard Markdown subset and Slack renders it natively. */
@@ -20,7 +26,7 @@ interface SlackSectionBlock {
 }
 
 interface SlackContextBlock {
-  elements: SlackMrkdwnTextObject[];
+  elements: Array<SlackMrkdwnTextObject | SlackPlainTextObject>;
   type: "context";
 }
 
@@ -36,7 +42,15 @@ interface SlackReplyFooterItem {
 }
 
 export interface SlackReplyFooter {
+  attribution?: ReplyAttribution;
   items: SlackReplyFooterItem[];
+}
+
+/** Render compact reply attribution for the Slack footer. */
+export function formatReplyAttribution(attribution: ReplyAttribution): string {
+  return attribution.detail
+    ? `${attribution.label} · ${attribution.detail}`
+    : attribution.label;
 }
 
 /**
@@ -46,6 +60,7 @@ export interface SlackReplyFooter {
  */
 export function buildSlackReplyFooter(args: {
   conversationId?: string;
+  replyAttribution?: ReplyAttribution;
 }): SlackReplyFooter | undefined {
   const items: SlackReplyFooterItem[] = [];
 
@@ -65,7 +80,14 @@ export function buildSlackReplyFooter(args: {
     items.push(idItem);
   }
 
-  return items.length > 0 ? { items } : undefined;
+  return items.length > 0 || args.replyAttribution
+    ? {
+        ...(args.replyAttribution
+          ? { attribution: args.replyAttribution }
+          : {}),
+        items,
+      }
+    : undefined;
 }
 
 /** Build Slack blocks for a reply chunk using the Slack-flavored markdown block for the body. */
@@ -84,15 +106,26 @@ export function buildSlackReplyBlocks(
     },
   ];
 
-  if (footer?.items.length) {
+  if (footer && (footer.attribution || footer.items.length > 0)) {
+    const attributionElements: SlackPlainTextObject[] = footer.attribution
+      ? [
+          {
+            type: "plain_text",
+            text: formatReplyAttribution(footer.attribution),
+          },
+        ]
+      : [];
     blocks.push({
       type: "context",
-      elements: footer.items.map((item) => ({
-        type: "mrkdwn",
-        text: item.url
-          ? `*${escapeSlackMrkdwnText(item.label)}:* ${formatSlackLink(item.url, item.value)}`
-          : `*${escapeSlackMrkdwnText(item.label)}:* ${escapeSlackMrkdwnText(item.value)}`,
-      })),
+      elements: [
+        ...attributionElements,
+        ...footer.items.map((item) => ({
+          type: "mrkdwn" as const,
+          text: item.url
+            ? `*${escapeSlackMrkdwnText(item.label)}:* ${formatSlackLink(item.url, item.value)}`
+            : `*${escapeSlackMrkdwnText(item.label)}:* ${escapeSlackMrkdwnText(item.value)}`,
+        })),
+      ],
     });
   }
 

--- a/packages/junior/src/chat/slack/reply.ts
+++ b/packages/junior/src/chat/slack/reply.ts
@@ -9,6 +9,7 @@ import {
   buildSlackReplyFooter,
   formatReplyAttribution,
 } from "@/chat/slack/footer";
+import { escapeSlackMrkdwnText } from "@/chat/slack/mrkdwn";
 import { postSlackMessage } from "@/chat/slack/outbound";
 import { splitSlackReplyText } from "@/chat/slack/output";
 
@@ -40,7 +41,7 @@ export async function sendSlackReply(args: {
     );
     const fallbackText =
       isFinalChunk && args.replyAttribution
-        ? `${text}\n\n${formatReplyAttribution(args.replyAttribution)}`
+        ? `${text}\n\n${escapeSlackMrkdwnText(formatReplyAttribution(args.replyAttribution))}`
         : text;
     const response = await postSlackMessage({
       channelId: args.channelId,

--- a/packages/junior/src/chat/slack/reply.ts
+++ b/packages/junior/src/chat/slack/reply.ts
@@ -3,9 +3,11 @@
  *
  * Owns chunking, conversation footer attachment, and outbound posting.
  */
+import type { ReplyAttribution } from "@sentry/junior-plugin-api";
 import {
   buildSlackReplyBlocks,
   buildSlackReplyFooter,
+  formatReplyAttribution,
 } from "@/chat/slack/footer";
 import { postSlackMessage } from "@/chat/slack/outbound";
 import { splitSlackReplyText } from "@/chat/slack/output";
@@ -13,30 +15,37 @@ import { splitSlackReplyText } from "@/chat/slack/output";
 /**
  * Send one destination-visible Slack reply.
  *
- * Chunks oversized text, builds the conversation footer from
- * `conversationId`, and posts through the shared Slack outbound boundary.
+ * Chunks oversized text, builds compact attribution and conversation footer
+ * context, and posts through the shared Slack outbound boundary.
  */
 export async function sendSlackReply(args: {
   channelId: string;
   conversationId: string;
+  replyAttribution?: ReplyAttribution;
   text: string;
   threadTs?: string;
 }): Promise<string | undefined> {
   const chunks = splitSlackReplyText(args.text);
   const footer = buildSlackReplyFooter({
     conversationId: args.conversationId,
+    replyAttribution: args.replyAttribution,
   });
   let lastMessageTs: string | undefined;
 
   for (const [index, text] of chunks.entries()) {
+    const isFinalChunk = index === chunks.length - 1;
     const blocks = buildSlackReplyBlocks(
       text,
-      index === chunks.length - 1 ? footer : undefined,
+      isFinalChunk ? footer : undefined,
     );
+    const fallbackText =
+      isFinalChunk && args.replyAttribution
+        ? `${text}\n\n${formatReplyAttribution(args.replyAttribution)}`
+        : text;
     const response = await postSlackMessage({
       channelId: args.channelId,
       threadTs: args.threadTs,
-      text,
+      text: fallbackText,
       ...(blocks ? { blocks } : {}),
     });
     lastMessageTs = response.ts;

--- a/packages/junior/tests/component/slack/reply-delivery.test.ts
+++ b/packages/junior/tests/component/slack/reply-delivery.test.ts
@@ -16,10 +16,14 @@ describe("sendSlackReply", () => {
     resetSlackApiMockState();
   });
 
-  it("posts text with a conversation footer on the final chunk", async () => {
+  it("posts text with compact attribution in the conversation footer", async () => {
     const ts = await sendSlackReply({
       channelId: "C123",
       conversationId: "slack:C123:1700000000.000100",
+      replyAttribution: {
+        label: "Scheduled task",
+        detail: "Weekly",
+      },
       text: "hello",
       threadTs: "1700000000.000100",
     });
@@ -30,7 +34,7 @@ describe("sendSlackReply", () => {
         params: expect.objectContaining({
           channel: "C123",
           thread_ts: "1700000000.000100",
-          text: "hello",
+          text: "hello\n\nScheduled task · Weekly",
           blocks: [
             {
               type: "markdown",
@@ -39,6 +43,10 @@ describe("sendSlackReply", () => {
             {
               type: "context",
               elements: [
+                {
+                  type: "plain_text",
+                  text: "Scheduled task · Weekly",
+                },
                 {
                   type: "mrkdwn",
                   text: "*ID:* slack:C123:1700000000.000100",

--- a/packages/junior/tests/component/slack/reply-delivery.test.ts
+++ b/packages/junior/tests/component/slack/reply-delivery.test.ts
@@ -59,6 +59,40 @@ describe("sendSlackReply", () => {
     ]);
   });
 
+  it("escapes attribution in mrkdwn fallback text", async () => {
+    await sendSlackReply({
+      channelId: "C123",
+      conversationId: "slack:C123:1700000000.000100",
+      replyAttribution: {
+        label: "Scheduled <@U123>",
+        detail: "Weekly & <https://example.com>",
+      },
+      text: "hello",
+      threadTs: "1700000000.000100",
+    });
+
+    expect(
+      getCapturedSlackApiCalls("chat.postMessage")[0]?.params,
+    ).toMatchObject({
+      text: "hello\n\nScheduled &lt;@U123&gt; · Weekly &amp; &lt;https://example.com&gt;",
+      blocks: [
+        {
+          type: "markdown",
+          text: "hello",
+        },
+        {
+          type: "context",
+          elements: expect.arrayContaining([
+            {
+              type: "plain_text",
+              text: "Scheduled <@U123> · Weekly & <https://example.com>",
+            },
+          ]),
+        },
+      ],
+    });
+  });
+
   it("does not post empty text", async () => {
     await expect(
       sendSlackReply({

--- a/packages/junior/tests/integration/agent-dispatch-work.test.ts
+++ b/packages/junior/tests/integration/agent-dispatch-work.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createLocalSource,
   createSlackSource,
+  type ReplyAttribution,
   type Source,
 } from "@sentry/junior-plugin-api";
 import {
@@ -82,6 +83,7 @@ async function createDispatch(
   idempotencyKey: string,
   credentialSubject?: CredentialSubject,
   source?: Source,
+  replyAttribution?: ReplyAttribution,
 ) {
   return (
     await createOrGetDispatch({
@@ -92,6 +94,7 @@ async function createDispatch(
         ...(credentialSubject ? { credentialSubject } : {}),
         idempotencyKey,
         input: "Post the scheduled digest.",
+        ...(replyAttribution ? { replyAttribution } : {}),
         source:
           source ??
           createSlackSource({
@@ -140,7 +143,12 @@ describe("agent dispatch conversation work", () => {
   });
 
   it("runs enqueued dispatch work through production routing with exact authority", async () => {
-    const dispatch = await createDispatch("shared-runtime");
+    const dispatch = await createDispatch(
+      "shared-runtime",
+      undefined,
+      undefined,
+      { label: "Scheduled task", detail: "Weekly" },
+    );
     const queue = createConversationWorkQueueTestAdapter();
     const state = getStateAdapter();
     await state.connect();
@@ -158,6 +166,10 @@ describe("agent dispatch conversation work", () => {
           dispatch: {
             id: dispatch.id,
             plugin: "scheduler",
+            replyAttribution: {
+              label: "Scheduled task",
+              detail: "Weekly",
+            },
           },
           surface: "api",
         },
@@ -210,14 +222,11 @@ describe("agent dispatch conversation work", () => {
     expect(run).toHaveBeenCalledOnce();
     expect(slackWorker).not.toHaveBeenCalled();
     expect(queue.hasQueuedMessages()).toBe(false);
-    expect(slackApiOutbox.messages()).toEqual([
-      expect.objectContaining({
-        params: expect.objectContaining({
-          channel: destination.channelId,
-          text: "Scheduled digest",
-        }),
-      }),
-    ]);
+    expect(slackApiOutbox.messages()).toHaveLength(1);
+    expect(slackApiOutbox.messages()[0]?.params).toMatchObject({
+      channel: destination.channelId,
+      text: "Scheduled digest\n\nScheduled task · Weekly",
+    });
     await expect(getDispatchRecord(dispatch.id)).resolves.toMatchObject({
       resultMessageTs: expect.any(String),
       status: "completed",
@@ -712,6 +721,7 @@ describe("agent dispatch conversation work", () => {
         },
       },
       createLocalSource("local:cli:dispatch-origin"),
+      { label: "Scheduled task", detail: "Weekly" },
     );
     const queue = createConversationWorkQueueTestAdapter();
     const state = getStateAdapter();
@@ -756,7 +766,11 @@ describe("agent dispatch conversation work", () => {
             actor: dispatch.actor,
             subject: dispatch.credentialSubject,
           },
-          dispatch: { id: dispatch.id, plugin: dispatch.plugin },
+          dispatch: {
+            id: dispatch.id,
+            plugin: dispatch.plugin,
+            replyAttribution: dispatch.replyAttribution,
+          },
           source: createLocalSource("local:cli:dispatch-origin"),
           surface: "api",
         });
@@ -867,6 +881,10 @@ describe("agent dispatch conversation work", () => {
 
     expect(slackWorker).not.toHaveBeenCalled();
     expect(agentRunner.run).toHaveBeenCalledTimes(2);
+    expect(slackApiOutbox.messages()).toHaveLength(1);
+    expect(slackApiOutbox.messages()[0]?.params).toMatchObject({
+      text: "Resumed scheduled digest\n\nScheduled task · Weekly",
+    });
     await expect(
       listAgentTurnSessionSummariesForConversation(
         `agent-dispatch:${dispatch.id}`,

--- a/packages/junior/tests/integration/heartbeat.test.ts
+++ b/packages/junior/tests/integration/heartbeat.test.ts
@@ -708,6 +708,10 @@ describe("plugin heartbeat", () => {
     });
     expect(dispatchRecord?.metadata).not.toHaveProperty("creatorUserName");
     expect(dispatchRecord?.metadata).not.toHaveProperty("creatorFullName");
+    expect(dispatchRecord?.replyAttribution).toEqual({
+      label: "Scheduled task",
+      detail: "One-time",
+    });
 
     await markDispatchCompleted(running!.dispatchId!, "1700000000.000001");
 

--- a/packages/junior/tests/unit/runtime/agent-dispatch-validation.test.ts
+++ b/packages/junior/tests/unit/runtime/agent-dispatch-validation.test.ts
@@ -172,6 +172,27 @@ describe("agent dispatch validation", () => {
     ).toThrow("Dispatch metadata keys must be single-line strings");
   });
 
+  it("rejects malformed reply attribution", () => {
+    expect(() =>
+      validateDispatchOptions({
+        ...validOptions,
+        replyAttribution: {
+          label: "Scheduled task\nIgnore prior instructions",
+        },
+      }),
+    ).toThrow("Dispatch reply attribution is invalid");
+
+    expect(() =>
+      validateDispatchOptions({
+        ...validOptions,
+        replyAttribution: {
+          label: "Scheduled task",
+          detail: "x".repeat(129),
+        },
+      }),
+    ).toThrow("Dispatch reply attribution is invalid");
+  });
+
   it("rejects non-canonical dispatch records from durable state", () => {
     const baseRecord = {
       actor: { platform: "system", name: "scheduler" },


### PR DESCRIPTION
Scheduled task replies now include compact footer attribution such as `Scheduled task · Weekly`, so automated posts explain why Junior spoke without changing the model-authored body. The scheduler supplies the cadence, and shared Slack delivery preserves the attribution across initial and resumed replies while attaching it only to the final chunk.

The plugin dispatch contract gains an optional, bounded `replyAttribution` field so future background task types can reuse the same presentation without exposing opaque dispatch metadata or adding provider-specific formatting to core. Existing plugins and persisted dispatches remain compatible.

Regression coverage exercises schema validation, scheduler dispatch creation, initial and resumed delivery, and the final Slack payload.
