### PR TITLE
fix(dashboard): correct metric tooltip layout

### DIFF
--- a/packages/junior-dashboard/e2e/conversations.spec.ts
+++ b/packages/junior-dashboard/e2e/conversations.spec.ts
@@ -83,6 +83,72 @@ test("opens a conversation in the built dashboard", async ({ page }) => {
   expect(browserErrors).toEqual([]);
 });
 
+test("positions a long cost tooltip clear of its metric", async ({ page }) => {
+  const conversationId = "slack:CQA123:1770003600.000200";
+  await page.setViewportSize({ height: 900, width: 1600 });
+  await page.route(
+    `**/api/conversations/${encodeURIComponent(conversationId)}`,
+    async (route) => {
+      const response = await route.fetch();
+      const detail = (await response.json()) as ConversationDetailReport;
+      await route.fulfill({
+        response,
+        json: {
+          ...detail,
+          modelUsage: [
+            {
+              modelId: "openai/gpt-5.6-sol",
+              usage: {
+                cost: {
+                  cacheRead: 0.004,
+                  cacheWrite: 0.005,
+                  input: 0.01,
+                  output: 0.021,
+                  total: 0.04,
+                },
+              },
+            },
+            {
+              modelId: "xai/grok-4.5",
+              usage: { cost: { input: 0.0004, output: 0.0006, total: 0.001 } },
+            },
+          ],
+        },
+      });
+    },
+  );
+  await page.goto(
+    `${server.baseURL}/conversations/${encodeURIComponent(conversationId)}`,
+  );
+
+  const cost = page.getByText("$0.04", { exact: true }).first();
+  await cost.hover();
+  const tooltip = page.getByRole("tooltip");
+  await expect(tooltip).toBeVisible();
+
+  const costBounds = await cost.boundingBox();
+  const tooltipBounds = await tooltip.boundingBox();
+  expect(costBounds).not.toBeNull();
+  expect(tooltipBounds).not.toBeNull();
+  const tooltipIsAbove =
+    tooltipBounds!.y + tooltipBounds!.height < costBounds!.y;
+  const tooltipIsBelow = tooltipBounds!.y > costBounds!.y + costBounds!.height;
+  expect(tooltipIsAbove || tooltipIsBelow).toBe(true);
+
+  const columns = tooltip.locator(":scope > span > span");
+  await expect(columns).toHaveCount(2);
+  const auxiliary = columns.nth(1);
+  const headingBounds = await auxiliary
+    .getByText("Auxiliary", { exact: true })
+    .boundingBox();
+  const totalBounds = await auxiliary
+    .getByText("total", { exact: true })
+    .boundingBox();
+  expect(headingBounds).not.toBeNull();
+  expect(totalBounds).not.toBeNull();
+  expect(totalBounds!.y - headingBounds!.y).toBeLessThan(40);
+});
+
 test("opens and closes a conversation in the mobile workspace", async ({
   page,
 }) => {

--- a/packages/junior-dashboard/src/client/components/Metric.tsx
+++ b/packages/junior-dashboard/src/client/components/Metric.tsx
@@ -1,12 +1,7 @@
-import {
-  useId,
-  useRef,
-  useState,
-  type CSSProperties,
-  type ReactNode,
-} from "react";
+import type { ReactNode } from "react";
 
 import { cn } from "../styles";
+import { Tooltip } from "./Tooltip";
 
 export type MetricTooltipLine = {
   label?: string;
@@ -20,40 +15,9 @@ export type MetricListItem = {
   key: string;
 };
 
-type TooltipPosition = {
-  left: number;
-  top: number;
-  width: number;
-};
-
-function clamp(value: number, min: number, max: number): number {
-  return Math.min(Math.max(value, min), max);
-}
-
-function tooltipPosition(
-  trigger: HTMLElement,
-  align: "left" | "right" | undefined,
-  topAligned: boolean,
-  wide: boolean,
-): TooltipPosition {
-  const margin = 16;
-  const viewportWidth = window.innerWidth;
-  const maxWidth = wide ? 520 : 320;
-  const width = Math.min(maxWidth, Math.max(256, viewportWidth - margin * 2));
-  const rect = trigger.getBoundingClientRect();
-  const preferredLeft = align === "right" ? rect.right - width : rect.left;
-  return {
-    left: Math.round(
-      clamp(preferredLeft, margin, viewportWidth - width - margin),
-    ),
-    top: Math.round(topAligned ? rect.top : rect.bottom + 8),
-    width,
-  };
-}
-
 function TooltipLines(props: { lines: MetricTooltipLine[] }) {
   return (
-    <span className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] gap-x-3 gap-y-1.5">
+    <span className="grid min-w-0 self-start grid-cols-[minmax(0,1fr)_auto] content-start gap-x-3 gap-y-1.5">
       {props.lines.map((line, index) => (
         <span
           className={
@@ -101,74 +65,50 @@ export function MetricValue(props: {
   className?: string;
   tooltip?: MetricTooltipLine[];
   tooltipColumns?: MetricTooltipLine[][];
-  tooltipTopAligned?: boolean;
+  tooltipPlacement?: "above" | "below";
 }) {
-  const tooltipId = useId();
-  const triggerRef = useRef<HTMLSpanElement>(null);
-  const [position, setPosition] = useState<TooltipPosition | null>(null);
   const tooltip = props.tooltip?.filter((line) => line.value.trim());
   const tooltipColumns = props.tooltipColumns
     ?.map((column) => column.filter((line) => line.value.trim()))
     .filter((column) => column.length);
+  const wide = Boolean(tooltipColumns?.length);
+
   if (!tooltip?.length && !tooltipColumns?.length) {
     return <span className={props.className}>{props.children}</span>;
   }
 
-  const showTooltip = () => {
-    if (!triggerRef.current) return;
-    setPosition(
-      tooltipPosition(
-        triggerRef.current,
-        props.align,
-        Boolean(props.tooltipTopAligned),
-        Boolean(tooltipColumns?.length),
-      ),
-    );
-  };
-  const hideTooltip = () => setPosition(null);
-  const tooltipStyle: CSSProperties | undefined = position
-    ? {
-        left: position.left,
-        top: position.top,
-        width: position.width,
-      }
-    : undefined;
-
   return (
-    <span className={cn("relative inline-flex", props.className)}>
+    <Tooltip
+      align={props.align}
+      className={cn(
+        "w-[calc(100vw-2rem)] rounded-lg border border-white/15 bg-[#050505] px-3 py-2 text-left text-[0.76rem] font-normal leading-relaxed text-dashboard-text-muted shadow-xl shadow-black/35",
+        wide ? "max-w-[32.5rem]" : "max-w-80",
+      )}
+      content={
+        tooltipColumns?.length ? (
+          <span className="grid max-h-72 grid-cols-1 items-start gap-4 overflow-y-auto sm:grid-cols-2 sm:gap-6">
+            {tooltipColumns.map((column, index) => (
+              <TooltipLines key={index} lines={column} />
+            ))}
+          </span>
+        ) : tooltip ? (
+          <span className="block max-h-72 overflow-y-auto">
+            <TooltipLines lines={tooltip} />
+          </span>
+        ) : null
+      }
+      placement={props.tooltipPlacement ?? "below"}
+    >
       <span
-        aria-describedby={position ? tooltipId : undefined}
-        className="border-b border-dotted border-white/20 outline-none transition-colors hover:border-white/45 focus-visible:border-white/45"
-        onBlur={hideTooltip}
-        onFocus={showTooltip}
-        onMouseEnter={showTooltip}
-        onMouseLeave={hideTooltip}
-        ref={triggerRef}
+        className={cn(
+          "inline-flex border-b border-dotted border-white/20 outline-none transition-colors hover:border-white/45 focus-visible:border-white/45",
+          props.className,
+        )}
         tabIndex={0}
       >
         {props.children}
       </span>
-      {position ? (
-        <span
-          className="pointer-events-none fixed z-30 rounded-lg border border-white/15 bg-[#050505] px-3 py-2 text-left text-[0.76rem] font-normal leading-relaxed text-dashboard-text-muted shadow-xl shadow-black/35"
-          id={tooltipId}
-          role="tooltip"
-          style={tooltipStyle}
-        >
-          {tooltipColumns?.length ? (
-            <span className="grid max-h-72 grid-cols-1 gap-4 overflow-y-auto sm:grid-cols-2 sm:gap-6">
-              {tooltipColumns.map((column, index) => (
-                <TooltipLines key={index} lines={column} />
-              ))}
-            </span>
-          ) : tooltip ? (
-            <span className="block max-h-72 overflow-y-auto">
-              <TooltipLines lines={tooltip} />
-            </span>
-          ) : null}
-        </span>
-      ) : null}
-    </span>
+    </Tooltip>
   );
 }
 

--- a/packages/junior-dashboard/src/client/components/Tooltip.tsx
+++ b/packages/junior-dashboard/src/client/components/Tooltip.tsx
@@ -12,10 +12,15 @@ import {
 } from "react";
 import { createPortal } from "react-dom";
 
+import { cn } from "../styles";
+
 type TooltipProps = {
+  align?: "center" | "left" | "right";
   children: ReactElement;
+  className?: string;
   content: ReactNode;
   label?: ReactNode;
+  placement?: "above" | "below";
 };
 
 type Position = {
@@ -27,7 +32,14 @@ const VIEWPORT_GAP = 8;
 const ANCHOR_GAP = 10;
 
 /** Show dashboard details beside an element while keeping the surface on-screen. */
-export function Tooltip({ children, content, label }: TooltipProps) {
+export function Tooltip({
+  align = "center",
+  children,
+  className,
+  content,
+  label,
+  placement = "above",
+}: TooltipProps) {
   const anchorRef = useRef<Element | null>(null);
   const tooltipRef = useRef<HTMLDivElement | null>(null);
   const tooltipId = useId();
@@ -41,28 +53,41 @@ export function Tooltip({ children, content, label }: TooltipProps) {
 
     const anchorRect = anchor.getBoundingClientRect();
     const tooltipRect = tooltip.getBoundingClientRect();
-    const centeredLeft =
-      anchorRect.left + anchorRect.width / 2 - tooltipRect.width / 2;
+    const preferredLeft =
+      align === "left"
+        ? anchorRect.left
+        : align === "right"
+          ? anchorRect.right - tooltipRect.width
+          : anchorRect.left + anchorRect.width / 2 - tooltipRect.width / 2;
     const left = Math.max(
       VIEWPORT_GAP,
       Math.min(
         window.innerWidth - tooltipRect.width - VIEWPORT_GAP,
-        centeredLeft,
+        preferredLeft,
       ),
     );
     const above = anchorRect.top - tooltipRect.height - ANCHOR_GAP;
-    const top =
-      above >= VIEWPORT_GAP
-        ? above
-        : Math.max(
-            VIEWPORT_GAP,
-            Math.min(
-              window.innerHeight - tooltipRect.height - VIEWPORT_GAP,
-              anchorRect.bottom + ANCHOR_GAP,
-            ),
-          );
+    const below = anchorRect.bottom + ANCHOR_GAP;
+    const fitsAbove = above >= VIEWPORT_GAP;
+    const fitsBelow =
+      below + tooltipRect.height <= window.innerHeight - VIEWPORT_GAP;
+    const preferredTop =
+      placement === "above"
+        ? fitsAbove || !fitsBelow
+          ? above
+          : below
+        : fitsBelow || !fitsAbove
+          ? below
+          : above;
+    const top = Math.max(
+      VIEWPORT_GAP,
+      Math.min(
+        window.innerHeight - tooltipRect.height - VIEWPORT_GAP,
+        preferredTop,
+      ),
+    );
     setPosition({ left, top });
-  }, []);
+  }, [align, placement]);
 
   useLayoutEffect(() => {
     if (!open) {
@@ -121,7 +146,11 @@ export function Tooltip({ children, content, label }: TooltipProps) {
       {open && typeof document !== "undefined"
         ? createPortal(
             <div
-              className="pointer-events-none fixed z-50 min-w-36 max-w-64 rounded-md border border-white/15 bg-dashboard-surface-raised px-3 py-2 font-mono text-[0.68rem] leading-relaxed text-dashboard-text-muted shadow-2xl shadow-black/70"
+              className={cn(
+                "pointer-events-none fixed z-50",
+                className ??
+                  "min-w-36 max-w-64 rounded-md border border-white/15 bg-dashboard-surface-raised px-3 py-2 font-mono text-[0.68rem] leading-relaxed text-dashboard-text-muted shadow-2xl shadow-black/70",
+              )}
               id={tooltipId}
               ref={tooltipRef}
               role="tooltip"

--- a/packages/junior-dashboard/src/client/conversations/TelemetryMetrics.tsx
+++ b/packages/junior-dashboard/src/client/conversations/TelemetryMetrics.tsx
@@ -228,7 +228,7 @@ export function CostMetric(props: {
   return (
     <MetricValue
       align={props.align}
-      tooltipTopAligned
+      tooltipPlacement="above"
       {...costTooltip(props.summary, props.modelUsage, props.auxiliaryCosts)}
     >
       {formatCostSummary(total)}

--- a/packages/junior-dashboard/tests/telemetry-metrics.test.tsx
+++ b/packages/junior-dashboard/tests/telemetry-metrics.test.tsx
@@ -7,9 +7,9 @@ vi.mock("../src/client/components/Metric", () => ({
     children: ReactNode;
     tooltip?: Array<{ label?: string; value: string }>;
     tooltipColumns?: Array<Array<{ label?: string; value: string }>>;
-    tooltipTopAligned?: boolean;
+    tooltipPlacement?: "above" | "below";
   }) => (
-    <span data-tooltip-top-aligned={props.tooltipTopAligned || undefined}>
+    <span data-tooltip-placement={props.tooltipPlacement}>
       {props.children}
       {[...(props.tooltip ?? []), ...(props.tooltipColumns?.flat() ?? [])].map(
         (line) => (
@@ -90,6 +90,6 @@ describe("CostMetric", () => {
     expect(html).toContain("total: $0.0018");
     expect(html).toContain("Memory recall (2): $0.0004");
     expect(html).toContain("Guardian (1): $0.0014");
-    expect(html).toContain('data-tooltip-top-aligned="true"');
+    expect(html).toContain('data-tooltip-placement="above"');
   });
 });


### PR DESCRIPTION
Metric breakdowns now use the dashboard’s shared portal-based tooltip, keeping the surface separated from its trigger and flipping above or below when viewport space requires it. Multi-column cost details align their rows to the top, so a short Auxiliary column no longer stretches its text to match a taller Conversation column.

The shared tooltip now supports caller-selected placement, alignment, and surface styling while preserving viewport collision handling and repositioning on scroll or resize. A Chromium regression covers both trigger separation and compact Auxiliary row spacing.
