### PR TITLE
ref(dashboard): group stats under System

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "test:ci": "pnpm --filter @sentry/junior build && pnpm --filter @sentry/junior-memory build && pnpm --filter @sentry/junior-github build && pnpm --filter @sentry/junior-linear build && pnpm --filter @sentry/junior-vercel build && pnpm --filter @sentry/junior-dashboard build && pnpm --filter @sentry/junior test:coverage && pnpm --filter @sentry/junior-memory test && pnpm --filter @sentry/junior-github test && pnpm --filter @sentry/junior-vercel test && pnpm --filter @sentry/junior-dashboard test:coverage"
   },
   "simple-git-hooks": {
-    "pre-commit": "pnpm lint-staged"
+    "pre-commit": "pnpm lint-staged",
+    "pre-push": "pnpm lint"
   },
   "lint-staged": {
     "packages/junior-dashboard/src/**/*.{ts,tsx}": "pnpm --filter @sentry/junior-dashboard lint",

--- a/packages/docs/src/content/docs/operate/dashboard.md
+++ b/packages/docs/src/content/docs/operate/dashboard.md
@@ -79,12 +79,13 @@ The dashboard package owns these routes:
 | `/`                             | Personal conversation workspace.        |
 | `/conversations`                | Redirect to the personal workspace.     |
 | `/conversations/:conversation`  | Workspace with a selected transcript.   |
-| `/locations`                    | Public location activity directory.     |
-| `/locations/:location`          | Public location activity detail.        |
-| `/people`                       | Actor directory.                        |
-| `/people/:email`                | Actor activity profile.                 |
 | `/plugins/:plugin/:page/*`      | Core-rendered signed-in plugin page.    |
-| `/system`                       | Aggregate metrics and loaded plugins.   |
+| `/system`                       | Aggregate runtime and model metrics.    |
+| `/system/people`                | Actor activity directory.               |
+| `/system/people/:email`         | Actor activity profile.                 |
+| `/system/locations`             | Public location activity directory.     |
+| `/system/locations/:location`   | Public location activity detail.        |
+| `/system/plugins`               | Loaded plugin and skill inventory.      |
 | `/system/plugins/:plugin`       | Plugin details and operational reports. |
 | `/_junior/dashboard/client.js`  | Authenticated dashboard browser bundle. |
 | `/_junior/dashboard/avatar.png` | Authenticated Junior header avatar.     |
@@ -93,6 +94,9 @@ The dashboard package owns these routes:
 
 When the GitHub plugin is enabled, open `/system/plugins/github` for its pull
 request and issue analytics.
+
+Existing `/people/*` and `/locations/*` links redirect to their corresponding
+System routes.
 
 `/health` remains the public minimal Junior runtime health response.
 
@@ -121,7 +125,7 @@ The current authenticated product API slices are:
 
 For a private conversation, the transcript is available only when the signed-in verified email matches the owning root conversation actor's persisted verified email. Conversation summary resources report that match through `isParticipant`; event-page resources apply the same authorization decision through their projected events and `eventHistory`. Other viewers receive redacted metadata. Top-level conversation resources and System, People, and Location statistics include descendant duration and usage even when child resources are loaded separately. A directly requested child reports only its own metrics.
 
-The dashboard UI is a React client using React Router for browser views and TanStack Query for authenticated product API state. `/` is a focused workspace listing the signed-in actor's conversations in a sidebar; `/conversations/:conversation` selects a transcript in that workspace. `/conversations` redirects to the personal workspace instead of exposing a global conversation index. `/locations` provides aggregate browsing for public destinations without exposing private destination identity, while `/system` shows 90-day aggregate conversation metrics and the loaded plugin inventory. Each `/system/plugins/:plugin` page shows that plugin's details and operational summaries. Plugins may also register signed-in pages in primary navigation or the profile menu; Junior owns their route, metrics, search, pagination, record inspection, and actions. System always remains the last primary navigation item. The dashboard does not wrap Slack webhooks, provider OAuth callbacks, sandbox egress, or `/api/internal/*`.
+The dashboard UI is a React client using React Router for browser views and TanStack Query for authenticated product API state. `/` is a focused workspace listing the signed-in actor's conversations in a sidebar; `/conversations/:conversation` selects a transcript in that workspace. `/conversations` redirects to the personal workspace instead of exposing a global conversation index. `/system` owns runtime metrics and the People, Locations, and Plugins reporting views. People and Locations remain separate pages under System so their directories and detail views stay focused. Each `/system/plugins/:plugin` page shows that plugin's details and operational summaries. Plugins may also register signed-in pages in primary navigation or the profile menu; Junior owns their route, metrics, search, pagination, record inspection, and actions. System always remains the last primary navigation item. The dashboard does not wrap Slack webhooks, provider OAuth callbacks, sandbox egress, or `/api/internal/*`.
 On desktop, the conversation sidebar and selected transcript scroll independently within the viewport. Mobile presents the list and selected conversation as separate navigable views.
 When dashboard auth is explicitly disabled for local or demo use, the workspace shows the global feed because there is no authenticated actor to filter by.
 The conversation feed and detail are backed by durable SQL conversation and event records. Retention and purge settings determine when transcript data is removed. Conversation detail returns the latest 500 reporting events by default and a `previousCursor` when earlier events remain. The `limit` query parameter can select between 1 and 1,000 events. Cursors are signed for one conversation; consumers should treat them as opaque.

--- a/packages/junior-dashboard/e2e/conversations.spec.ts
+++ b/packages/junior-dashboard/e2e/conversations.spec.ts
@@ -383,7 +383,7 @@ test("groups the signed-in profile and session actions in the header", async ({
   await expect(popover.getByText("morgan@sentry.io")).toBeVisible();
   await expect(
     popover.getByRole("link", { name: "My profile" }),
-  ).toHaveAttribute("href", "/people/morgan%40sentry.io");
+  ).toHaveAttribute("href", "/system/people/morgan%40sentry.io");
   await expect(popover.getByRole("button", { name: "Log out" })).toBeVisible();
 
   await page.keyboard.press("Escape");

--- a/packages/junior-dashboard/e2e/locations.spec.ts
+++ b/packages/junior-dashboard/e2e/locations.spec.ts
@@ -23,10 +23,16 @@ test.beforeEach(async ({ page }) => {
 test("explores location activity", async ({ page }) => {
   await page.setViewportSize({ height: 900, width: 1600 });
   const browserErrors = collectBrowserErrors(page);
-  await page.goto(`${server.baseURL}/locations`);
+  await page.goto(`${server.baseURL}/locations?q=proj`);
+
+  await expect(page).toHaveURL(`${server.baseURL}/system/locations?q=proj`);
+  await expect(
+    page.getByRole("searchbox", { name: "Search locations" }),
+  ).toHaveValue("proj");
+  await page.getByRole("searchbox", { name: "Search locations" }).fill("");
 
   await expect(
-    page.locator("main > div").getByText("Locations", { exact: true }),
+    page.getByRole("heading", { name: "Locations", exact: true }),
   ).toBeVisible();
   await expect(
     page.getByRole("img", { name: "Public and private conversations per day" }),
@@ -43,6 +49,11 @@ test("explores location activity", async ({ page }) => {
   await expect(
     page.getByRole("combobox", { name: "Sort locations" }),
   ).toHaveValue("conversations");
+  await expect(
+    page
+      .getByLabel("System navigation")
+      .getByRole("link", { name: "Locations" }),
+  ).toHaveAttribute("aria-current", "page");
 
   const headerBounds = await page
     .locator("main > header > div")

--- a/packages/junior-dashboard/e2e/people.spec.ts
+++ b/packages/junior-dashboard/e2e/people.spec.ts
@@ -23,6 +23,15 @@ test.beforeEach(async ({ page }) => {
 test("explores people activity", async ({ page }) => {
   await page.setViewportSize({ height: 900, width: 1600 });
   const browserErrors = collectBrowserErrors(page);
+  await page.route("**/api/plugin-reports", async (route) => {
+    await route.fulfill({
+      json: {
+        generatedAt: "2026-06-12T00:00:00.000Z",
+        reports: [{ pluginName: "scheduler", title: "Scheduler" }],
+        source: "plugins",
+      },
+    });
+  });
   await page.goto(`${server.baseURL}/system/people`);
 
   await expect(
@@ -41,6 +50,11 @@ test("explores people activity", async ({ page }) => {
   await expect(
     page.getByLabel("System navigation").getByRole("link", { name: "People" }),
   ).toHaveAttribute("aria-current", "page");
+  await expect(
+    page
+      .getByLabel("System navigation")
+      .getByRole("link", { name: "Scheduler" }),
+  ).toBeVisible();
   await page.getByRole("button", { name: "7d" }).click();
   await expect(page.getByRole("button", { name: "7d" })).toHaveAttribute(
     "aria-pressed",

--- a/packages/junior-dashboard/e2e/people.spec.ts
+++ b/packages/junior-dashboard/e2e/people.spec.ts
@@ -23,10 +23,10 @@ test.beforeEach(async ({ page }) => {
 test("explores people activity", async ({ page }) => {
   await page.setViewportSize({ height: 900, width: 1600 });
   const browserErrors = collectBrowserErrors(page);
-  await page.goto(`${server.baseURL}/people`);
+  await page.goto(`${server.baseURL}/system/people`);
 
   await expect(
-    page.locator("main > div").getByText("People", { exact: true }),
+    page.getByRole("heading", { name: "People", exact: true }),
   ).toBeVisible();
   await expect(
     page.getByRole("img", { name: "Active people per day" }),
@@ -38,6 +38,9 @@ test("explores people activity", async ({ page }) => {
   await expect(page.getByRole("combobox", { name: "Sort people" })).toHaveValue(
     "conversations",
   );
+  await expect(
+    page.getByLabel("System navigation").getByRole("link", { name: "People" }),
+  ).toHaveAttribute("aria-current", "page");
   await page.getByRole("button", { name: "7d" }).click();
   await expect(page.getByRole("button", { name: "7d" })).toHaveAttribute(
     "aria-pressed",

--- a/packages/junior-dashboard/e2e/system.spec.ts
+++ b/packages/junior-dashboard/e2e/system.spec.ts
@@ -49,14 +49,18 @@ test("shows system usage and plugin details", async ({ page }) => {
   });
   await expect(allPluginsLink).toBeVisible();
   await expect(
-    systemNavigation.getByRole("link", { name: "GitHub", exact: true }),
-  ).toHaveCount(0);
+    systemNavigation.getByRole("link", { name: "People", exact: true }),
+  ).toBeVisible();
   await expect(
-    systemNavigation.getByRole("link", { name: "Scheduler", exact: true }),
-  ).toHaveCount(0);
-
+    systemNavigation.getByRole("link", { name: "Locations", exact: true }),
+  ).toBeVisible();
   await allPluginsLink.click();
   await expect(page).toHaveURL(`${server.baseURL}/system/plugins`);
+  await expect(
+    page
+      .locator("main > div header")
+      .getByRole("heading", { name: "Plugins", exact: true }),
+  ).toBeVisible();
   await expect(page.getByLabel("Reporting period")).toHaveCount(0);
 
   const pluginPanels = page.getByRole("region", { name: "Plugins" });
@@ -86,7 +90,7 @@ test("shows system usage and plugin details", async ({ page }) => {
   await expect(page.getByText("github.organization")).toBeVisible();
   expect(
     await page
-      .getByRole("heading", { level: 2, name: "System", exact: true })
+      .getByRole("heading", { level: 2, name: "GitHub", exact: true })
       .evaluate((element) => element.getBoundingClientRect().top),
   ).toBeLessThan(180);
 
@@ -157,6 +161,8 @@ test("navigates plugin information and activity on mobile", async ({
   ).toBeLessThanOrEqual(390);
   await expect(page.getByLabel("System view").locator("option")).toHaveText([
     "Overview",
+    "People",
+    "Locations",
     "All Plugins",
     "Scheduler",
   ]);
@@ -167,25 +173,13 @@ test("navigates plugin information and activity on mobile", async ({
   ).toHaveText("All Plugins");
   await page
     .getByRole("region", { name: "Plugins" })
-    .getByRole("link", { name: /GitHub/ })
+    .getByRole("link", { name: /Scheduler/ })
     .click();
-  await expect(page.getByLabel("System view")).toHaveValue(
-    "/system/plugins/github",
-  );
-  await expect(
-    page.getByLabel("System view").locator("option:checked"),
-  ).toHaveText("GitHub");
-  await expect(
-    page
-      .getByLabel("System view")
-      .locator('option[value="/system/plugins/github"]'),
-  ).toHaveAttribute("disabled", "");
-  await page.getByLabel("System view").selectOption("/system");
-  await page
-    .getByLabel("System view")
-    .selectOption("/system/plugins/scheduler");
 
   await expect(page).toHaveURL(`${server.baseURL}/system/plugins/scheduler`);
+  await expect(page.getByLabel("System view")).toHaveValue(
+    "/system/plugins/scheduler",
+  );
   await page.reload();
   await expect(
     page.getByRole("heading", { level: 2, name: "Scheduler", exact: true }),

--- a/packages/junior-dashboard/src/client/App.tsx
+++ b/packages/junior-dashboard/src/client/App.tsx
@@ -139,12 +139,6 @@ export function DashboardShell() {
             >
               Conversations
             </Link>
-            <NavLink className={navLinkClass} to="/locations">
-              Locations
-            </NavLink>
-            <NavLink className={navLinkClass} to="/people">
-              People
-            </NavLink>
             {primaryUserPages.map((page) => (
               <NavLink
                 className={navLinkClass}
@@ -172,6 +166,14 @@ export function DashboardShell() {
 
       <Routes>
         <Route
+          element={<LegacySystemRedirect section="locations" />}
+          path="/locations"
+        />
+        <Route
+          element={<LegacySystemRedirect section="locations" />}
+          path="/locations/:locationId"
+        />
+        <Route
           element={
             loading ? (
               <LoadingView label="Loading locations" />
@@ -179,7 +181,7 @@ export function DashboardShell() {
               <LocationsPage />
             )
           }
-          path="/locations"
+          path="/system/locations"
         />
         <Route
           element={
@@ -189,7 +191,7 @@ export function DashboardShell() {
               <LocationDetailPage />
             )
           }
-          path="/locations/:locationId"
+          path="/system/locations/:locationId"
         />
         <Route
           element={
@@ -237,6 +239,30 @@ export function DashboardShell() {
           path="/dev/*"
         />
         <Route
+          element={<LegacySystemRedirect section="people" />}
+          path="/people"
+        />
+        <Route
+          element={<LegacySystemRedirect section="people" />}
+          path="/people/:email"
+        />
+        <Route
+          element={
+            loading ? <LoadingView label="Loading people" /> : <PeoplePage />
+          }
+          path="/system/people"
+        />
+        <Route
+          element={
+            loading ? (
+              <LoadingView label="Loading profile" />
+            ) : (
+              <PersonProfilePage />
+            )
+          }
+          path="/system/people/:email"
+        />
+        <Route
           element={
             loading ? (
               <LoadingView label="Loading system" />
@@ -249,22 +275,6 @@ export function DashboardShell() {
             )
           }
           path="/system/*"
-        />
-        <Route
-          element={
-            loading ? <LoadingView label="Loading people" /> : <PeoplePage />
-          }
-          path="/people"
-        />
-        <Route
-          element={
-            loading ? (
-              <LoadingView label="Loading profile" />
-            ) : (
-              <PersonProfilePage />
-            )
-          }
-          path="/people/:email"
         />
         <Route
           element={
@@ -298,6 +308,18 @@ export function DashboardShell() {
         style={dashboardNoise}
       />
     </main>
+  );
+}
+
+function LegacySystemRedirect(props: { section: "locations" | "people" }) {
+  const location = useLocation();
+  const legacyPrefix = `/${props.section}`;
+  const suffix = location.pathname.slice(legacyPrefix.length);
+  return (
+    <Navigate
+      replace
+      to={`/system/${props.section}${suffix}${location.search}${location.hash}`}
+    />
   );
 }
 

--- a/packages/junior-dashboard/src/client/api.ts
+++ b/packages/junior-dashboard/src/client/api.ts
@@ -137,6 +137,31 @@ export function useLocationDetailData(locationId: string | undefined) {
   });
 }
 
+/** Fetch discovered skills used by System navigation and capability views. */
+export function useSkillsData() {
+  return useQuery({
+    queryKey: ["dashboard", "skills"],
+    queryFn: ({ signal }) =>
+      fetchDashboardJson(skillReportsSchema, "/api/skills", signal),
+    retry: false,
+    staleTime: dashboardMetadataStaleTimeMs,
+  });
+}
+
+/** Fetch operational plugin reports used by System navigation and pages. */
+export function usePluginReportsData() {
+  return useQuery({
+    queryKey: ["dashboard", "plugin-reports"],
+    queryFn: ({ signal }) =>
+      fetchDashboardJson(
+        pluginOperationalReportFeedSchema,
+        "/api/plugin-reports",
+        signal,
+      ),
+    retry: false,
+  });
+}
+
 /** Fetch system metrics, plugin inventory, and operational reports. */
 export function useSystemData(coreData: DashboardCoreData) {
   const pluginsQuery = usePluginsData();
@@ -150,23 +175,8 @@ export function useSystemData(coreData: DashboardCoreData) {
       ),
     retry: false,
   });
-  const skillsQuery = useQuery({
-    queryKey: ["dashboard", "skills"],
-    queryFn: ({ signal }) =>
-      fetchDashboardJson(skillReportsSchema, "/api/skills", signal),
-    retry: false,
-    staleTime: dashboardMetadataStaleTimeMs,
-  });
-  const pluginReportsQuery = useQuery({
-    queryKey: ["dashboard", "plugin-reports"],
-    queryFn: ({ signal }) =>
-      fetchDashboardJson(
-        pluginOperationalReportFeedSchema,
-        "/api/plugin-reports",
-        signal,
-      ),
-    retry: false,
-  });
+  const skillsQuery = useSkillsData();
+  const pluginReportsQuery = usePluginReportsData();
   const dataReady = pluginsQuery.data && skillsQuery.data;
   return {
     data: dataReady

--- a/packages/junior-dashboard/src/client/format.ts
+++ b/packages/junior-dashboard/src/client/format.ts
@@ -657,12 +657,12 @@ export function conversationPath(conversationId: string): string {
 
 /** Build the canonical actor profile route for a trusted email address. */
 export function peoplePath(email: string): string {
-  return `/people/${encodeURIComponent(email)}`;
+  return `/system/people/${encodeURIComponent(email)}`;
 }
 
 /** Build the canonical detail route for a persisted public location. */
 export function locationPath(locationId: string): string {
-  return `/locations/${encodeURIComponent(locationId)}`;
+  return `/system/locations/${encodeURIComponent(locationId)}`;
 }
 
 function normalizeLanguage(language: string | undefined): BundledLanguage {

--- a/packages/junior-dashboard/src/client/pages/locations/LocationDetailPage.tsx
+++ b/packages/junior-dashboard/src/client/pages/locations/LocationDetailPage.tsx
@@ -8,13 +8,13 @@ import { EmptyTelemetry } from "../../components/EmptyTelemetry";
 import { LoadingView } from "../../components/LoadingView";
 import { Card } from "../../components/layout/Card";
 import { PageHeader } from "../../components/layout/PageHeader";
-import { PageLayout } from "../../components/layout/PageLayout";
 import { StatCard } from "../../components/metrics/StatCard";
 import {
   formatCompactNumber,
   formatRelativeTime,
   peoplePath,
 } from "../../format";
+import { SystemPageLayout } from "../system/SystemPageLayout";
 import { LocationActivityChart } from "./LocationActivityChart";
 
 /** Render operational activity for one persisted public location. */
@@ -33,7 +33,7 @@ export function LocationDetailPageContent(props: {
     return <LoadingView label="Loading location" />;
   }
   return (
-    <PageLayout>
+    <SystemPageLayout>
       {props.error ? (
         <Card padding="sm">
           <EmptyTelemetry>
@@ -44,7 +44,7 @@ export function LocationDetailPageContent(props: {
         </Card>
       ) : null}
       {props.data ? <LocationDetail detail={props.data} /> : null}
-    </PageLayout>
+    </SystemPageLayout>
   );
 }
 
@@ -54,7 +54,7 @@ function LocationDetail(props: { detail: LocationDetailReport }) {
     <>
       <PageHeader
         description={`${detail.provider} public ${detail.kind} / ${detail.providerDestinationId} / last active ${formatRelativeTime(detail.lastSeenAt)}`}
-        eyebrow="Locations / public channel"
+        eyebrow="System / locations"
         title={detail.label}
       />
 

--- a/packages/junior-dashboard/src/client/pages/locations/LocationDetailPage.tsx
+++ b/packages/junior-dashboard/src/client/pages/locations/LocationDetailPage.tsx
@@ -15,25 +15,37 @@ import {
   peoplePath,
 } from "../../format";
 import { SystemPageLayout } from "../system/SystemPageLayout";
+import {
+  type SystemNavigationData,
+  useSystemNavigationData,
+} from "../system/useSystemNavigationData";
 import { LocationActivityChart } from "./LocationActivityChart";
 
 /** Render operational activity for one persisted public location. */
 export function LocationDetailPage() {
   const params = useParams();
   const query = useLocationDetailData(params.locationId);
-  return <LocationDetailPageContent data={query.data} error={query.error} />;
+  const navigation = useSystemNavigationData();
+  return (
+    <LocationDetailPageContent
+      data={query.data}
+      error={query.error}
+      navigation={navigation}
+    />
+  );
 }
 
 /** Render loaded, stale, failed, and loading public-location detail states. */
 export function LocationDetailPageContent(props: {
   data: LocationDetailReport | undefined;
   error: unknown;
+  navigation: SystemNavigationData;
 }) {
   if (!props.data && !props.error) {
     return <LoadingView label="Loading location" />;
   }
   return (
-    <SystemPageLayout>
+    <SystemPageLayout navigation={props.navigation}>
       {props.error ? (
         <Card padding="sm">
           <EmptyTelemetry>

--- a/packages/junior-dashboard/src/client/pages/locations/LocationsPage.tsx
+++ b/packages/junior-dashboard/src/client/pages/locations/LocationsPage.tsx
@@ -16,7 +16,7 @@ import {
 } from "../../components/controls/TimeRangeSelector";
 import { Card } from "../../components/layout/Card";
 import { PageHeader } from "../../components/layout/PageHeader";
-import { agentNamePossessive, getDashboardAgentName } from "../../agentName";
+import { getDashboardAgentName } from "../../agentName";
 import { StatCard } from "../../components/metrics/StatCard";
 import { formatCompactNumber } from "../../format";
 import { SystemPageLayout } from "../system/SystemPageLayout";

--- a/packages/junior-dashboard/src/client/pages/locations/LocationsPage.tsx
+++ b/packages/junior-dashboard/src/client/pages/locations/LocationsPage.tsx
@@ -16,10 +16,10 @@ import {
 } from "../../components/controls/TimeRangeSelector";
 import { Card } from "../../components/layout/Card";
 import { PageHeader } from "../../components/layout/PageHeader";
-import { PageLayout } from "../../components/layout/PageLayout";
 import { agentNamePossessive, getDashboardAgentName } from "../../agentName";
 import { StatCard } from "../../components/metrics/StatCard";
 import { formatCompactNumber } from "../../format";
+import { SystemPageLayout } from "../system/SystemPageLayout";
 import { LocationDirectoryActivityChart } from "./LocationDirectoryActivityChart";
 import { LocationDirectory, type LocationSort } from "./LocationDirectory";
 import { PrivateActivityCard } from "./PrivateActivityCard";
@@ -69,7 +69,7 @@ export function LocationsPageContent(props: {
   }
 
   return (
-    <PageLayout>
+    <SystemPageLayout>
       <PageHeader
         actions={<TimeRangeSelector onChange={setRange} value={range} />}
         description={
@@ -77,7 +77,7 @@ export function LocationsPageContent(props: {
             ? "Locations failed to load."
             : `See the public channels where ${getDashboardAgentName()} has been working and how busy they've been.`
         }
-        eyebrow={`Where ${agentNamePossessive()} working`}
+        eyebrow="System / activity"
         title="Locations"
       />
       {props.error ? (
@@ -134,7 +134,7 @@ export function LocationsPageContent(props: {
           ) : null}
         </>
       ) : null}
-    </PageLayout>
+    </SystemPageLayout>
   );
 }
 

--- a/packages/junior-dashboard/src/client/pages/locations/LocationsPage.tsx
+++ b/packages/junior-dashboard/src/client/pages/locations/LocationsPage.tsx
@@ -20,6 +20,10 @@ import { getDashboardAgentName } from "../../agentName";
 import { StatCard } from "../../components/metrics/StatCard";
 import { formatCompactNumber } from "../../format";
 import { SystemPageLayout } from "../system/SystemPageLayout";
+import {
+  type SystemNavigationData,
+  useSystemNavigationData,
+} from "../system/useSystemNavigationData";
 import { LocationDirectoryActivityChart } from "./LocationDirectoryActivityChart";
 import { LocationDirectory, type LocationSort } from "./LocationDirectory";
 import { PrivateActivityCard } from "./PrivateActivityCard";
@@ -27,13 +31,21 @@ import { PrivateActivityCard } from "./PrivateActivityCard";
 /** Render the searchable directory of persisted public conversation locations. */
 export function LocationsPage() {
   const query = useLocationDirectoryData();
-  return <LocationsPageContent data={query.data} error={query.error} />;
+  const navigation = useSystemNavigationData();
+  return (
+    <LocationsPageContent
+      data={query.data}
+      error={query.error}
+      navigation={navigation}
+    />
+  );
 }
 
 /** Render loaded, failed, and empty public-location directory states. */
 export function LocationsPageContent(props: {
   data: LocationDirectoryReport | undefined;
   error: unknown;
+  navigation: SystemNavigationData;
 }) {
   const [params, setParams] = useSearchParams();
   const [range, setRange] = useState<TimeRangeDays>(90);
@@ -69,7 +81,7 @@ export function LocationsPageContent(props: {
   }
 
   return (
-    <SystemPageLayout>
+    <SystemPageLayout navigation={props.navigation}>
       <PageHeader
         actions={<TimeRangeSelector onChange={setRange} value={range} />}
         description={

--- a/packages/junior-dashboard/src/client/pages/people/PeoplePage.tsx
+++ b/packages/junior-dashboard/src/client/pages/people/PeoplePage.tsx
@@ -16,6 +16,10 @@ import { getDashboardAgentName } from "../../agentName";
 import { StatCard } from "../../components/metrics/StatCard";
 import { formatCompactNumber } from "../../format";
 import { SystemPageLayout } from "../system/SystemPageLayout";
+import {
+  type SystemNavigationData,
+  useSystemNavigationData,
+} from "../system/useSystemNavigationData";
 import { PeopleActivityChart } from "./PeopleActivityChart";
 import {
   filterPeople,
@@ -26,13 +30,21 @@ import {
 /** Render the actor directory returned by the REST API. */
 export function PeoplePage() {
   const query = useActorDirectoryData();
-  return <PeoplePageContent data={query.data} error={query.error} />;
+  const navigation = useSystemNavigationData();
+  return (
+    <PeoplePageContent
+      data={query.data}
+      error={query.error}
+      navigation={navigation}
+    />
+  );
 }
 
 /** Render People analytics, failure states, and the actor directory. */
 export function PeoplePageContent(props: {
   data: ActorDirectoryReport | undefined;
   error: unknown;
+  navigation: SystemNavigationData;
 }) {
   const [peopleSearch, setPeopleSearch] = useState("");
   const [range, setRange] = useState<TimeRangeDays>(90);
@@ -61,7 +73,7 @@ export function PeoplePageContent(props: {
   const peak = Math.max(0, ...visibleActivity.map((day) => day.activePeople));
 
   return (
-    <SystemPageLayout>
+    <SystemPageLayout navigation={props.navigation}>
       <PageHeader
         actions={<TimeRangeSelector onChange={setRange} value={range} />}
         description={

--- a/packages/junior-dashboard/src/client/pages/people/PeoplePage.tsx
+++ b/packages/junior-dashboard/src/client/pages/people/PeoplePage.tsx
@@ -12,10 +12,10 @@ import {
 } from "../../components/controls/TimeRangeSelector";
 import { Card } from "../../components/layout/Card";
 import { PageHeader } from "../../components/layout/PageHeader";
-import { PageLayout } from "../../components/layout/PageLayout";
 import { getDashboardAgentName } from "../../agentName";
 import { StatCard } from "../../components/metrics/StatCard";
 import { formatCompactNumber } from "../../format";
+import { SystemPageLayout } from "../system/SystemPageLayout";
 import { PeopleActivityChart } from "./PeopleActivityChart";
 import {
   filterPeople,
@@ -61,7 +61,7 @@ export function PeoplePageContent(props: {
   const peak = Math.max(0, ...visibleActivity.map((day) => day.activePeople));
 
   return (
-    <PageLayout>
+    <SystemPageLayout>
       <PageHeader
         actions={<TimeRangeSelector onChange={setRange} value={range} />}
         description={
@@ -69,7 +69,7 @@ export function PeoplePageContent(props: {
             ? "People failed to load."
             : `See who's been working with ${getDashboardAgentName()}, how often, and for how long.`
         }
-        eyebrow="Who's been around"
+        eyebrow="System / activity"
         title="People"
       />
       {props.error ? (
@@ -124,6 +124,6 @@ export function PeoplePageContent(props: {
           </EmptyTelemetry>
         </Card>
       )}
-    </PageLayout>
+    </SystemPageLayout>
   );
 }

--- a/packages/junior-dashboard/src/client/pages/people/PersonProfilePage.tsx
+++ b/packages/junior-dashboard/src/client/pages/people/PersonProfilePage.tsx
@@ -23,7 +23,7 @@ import { SectionIntro } from "../../components/layout/SectionIntro";
 import { SectionTitle } from "../../components/layout/SectionTitle";
 import { StatCard } from "../../components/metrics/StatCard";
 import { formatCompactNumber } from "../../format";
-import { cn, dashboardContainerClass } from "../../styles";
+import { SystemPageLayout } from "../system/SystemPageLayout";
 
 function runtimeLabel(durationMs: number, conversations: number): string {
   if (durationMs <= 0 && conversations > 0) return "unknown";
@@ -39,7 +39,7 @@ export function PersonProfilePage() {
     return <LoadingView label="Loading profile" />;
   }
   return (
-    <div className={cn(dashboardContainerClass, "px-4 py-4 sm:px-8 sm:py-8")}>
+    <SystemPageLayout>
       {query.data ? (
         <Profile profile={query.data} />
       ) : (
@@ -47,7 +47,7 @@ export function PersonProfilePage() {
           <EmptyTelemetry>Profile failed to load.</EmptyTelemetry>
         </Card>
       )}
-    </div>
+    </SystemPageLayout>
   );
 }
 
@@ -72,7 +72,7 @@ export function Profile(props: { profile: ActorProfileReport }) {
               : ""}
           </>
         }
-        eyebrow="People / profile"
+        eyebrow="System / people"
         title={displayName}
       />
 

--- a/packages/junior-dashboard/src/client/pages/people/PersonProfilePage.tsx
+++ b/packages/junior-dashboard/src/client/pages/people/PersonProfilePage.tsx
@@ -24,6 +24,7 @@ import { SectionTitle } from "../../components/layout/SectionTitle";
 import { StatCard } from "../../components/metrics/StatCard";
 import { formatCompactNumber } from "../../format";
 import { SystemPageLayout } from "../system/SystemPageLayout";
+import { useSystemNavigationData } from "../system/useSystemNavigationData";
 
 function runtimeLabel(durationMs: number, conversations: number): string {
   if (durationMs <= 0 && conversations > 0) return "unknown";
@@ -35,11 +36,12 @@ export function PersonProfilePage() {
   const params = useParams();
   const email = params.email ? decodeURIComponent(params.email) : undefined;
   const query = useActorProfileData(email);
+  const navigation = useSystemNavigationData();
   if (!query.data && !query.error) {
     return <LoadingView label="Loading profile" />;
   }
   return (
-    <SystemPageLayout>
+    <SystemPageLayout navigation={navigation}>
       {query.data ? (
         <Profile profile={query.data} />
       ) : (

--- a/packages/junior-dashboard/src/client/pages/system/PluginDetails.tsx
+++ b/packages/junior-dashboard/src/client/pages/system/PluginDetails.tsx
@@ -49,23 +49,6 @@ export function PluginDetails(props: { plugin: SystemPlugin }) {
   );
 }
 
-/** Render the plugin identity header shared by plugin System pages. */
-export function PluginHeader(props: { plugin: SystemPlugin }) {
-  return (
-    <header className="border-b border-white/[0.06] pb-4 sm:pb-5">
-      <div className="font-mono text-[0.62rem] uppercase tracking-[0.16em] text-cyan-200/65">
-        Plugin
-      </div>
-      <h2 className="mt-1 mb-0 font-display text-2xl font-medium tracking-[-0.02em] text-dashboard-text sm:text-3xl">
-        {props.plugin.displayName}
-      </h2>
-      <p className="mt-2 mb-0 max-w-2xl font-mono text-[0.7rem] leading-relaxed text-dashboard-text-muted">
-        {props.plugin.description}
-      </p>
-    </header>
-  );
-}
-
 function Detail(props: { icon: typeof Boxes; label: string; value: string }) {
   const Icon = props.icon;
   return (

--- a/packages/junior-dashboard/src/client/pages/system/PluginPanels.tsx
+++ b/packages/junior-dashboard/src/client/pages/system/PluginPanels.tsx
@@ -2,19 +2,12 @@ import { ArrowRight, Boxes, Sparkles } from "lucide-react";
 import { Link } from "react-router";
 
 import { Card } from "../../components/layout/Card";
-import { SectionIntro } from "../../components/layout/SectionIntro";
 import { systemPluginPath, type SystemPlugin } from "./SystemPlugins";
 
 /** Render the loaded plugin inventory as launch panels. */
 export function PluginPanels(props: { plugins: SystemPlugin[] }) {
   return (
-    <section aria-labelledby="system-plugins-heading" className="grid gap-3">
-      <SectionIntro
-        className="px-1"
-        eyebrow="Loaded plugins"
-        id="system-plugins-heading"
-        title="Plugins"
-      />
+    <section aria-label="Plugins" className="grid gap-3">
       {props.plugins.length ? (
         <div className="grid gap-3">
           {props.plugins.map((plugin) => (

--- a/packages/junior-dashboard/src/client/pages/system/SystemNavigation.tsx
+++ b/packages/junior-dashboard/src/client/pages/system/SystemNavigation.tsx
@@ -11,13 +11,13 @@ import {
 
 /** Render route-backed navigation for System activity and capabilities. */
 export function SystemNavigation(props: {
-  plugins?: SystemPlugin[];
-  reportingPlugins?: SystemPlugin[];
+  plugins: SystemPlugin[];
+  reportingPlugins: SystemPlugin[];
 }) {
   const location = useLocation();
   const navigate = useNavigate();
-  const plugins = props.plugins ?? [];
-  const reportingPlugins = props.reportingPlugins ?? [];
+  const plugins = props.plugins;
+  const reportingPlugins = props.reportingPlugins;
   const currentPlugin = findSystemPlugin(location.pathname, plugins);
   const currentPluginHasReporting = reportingPlugins.some(
     (plugin) => plugin.name === currentPlugin?.name,

--- a/packages/junior-dashboard/src/client/pages/system/SystemNavigation.tsx
+++ b/packages/junior-dashboard/src/client/pages/system/SystemNavigation.tsx
@@ -1,4 +1,4 @@
-import { Boxes, ChevronDown, Gauge } from "lucide-react";
+import { Boxes, ChevronDown, Gauge, MapPinned, Users } from "lucide-react";
 import { NavLink, useLocation, useNavigate } from "react-router";
 
 import { cn, dashboardInteractiveTextClass } from "../../styles";
@@ -9,15 +9,17 @@ import {
   type SystemPlugin,
 } from "./SystemPlugins";
 
-/** Render route-backed navigation for the System overview and loaded plugins. */
+/** Render route-backed navigation for System activity and capabilities. */
 export function SystemNavigation(props: {
-  plugins: SystemPlugin[];
-  reportingPlugins: SystemPlugin[];
+  plugins?: SystemPlugin[];
+  reportingPlugins?: SystemPlugin[];
 }) {
   const location = useLocation();
   const navigate = useNavigate();
-  const currentPlugin = findSystemPlugin(location.pathname, props.plugins);
-  const currentPluginHasReporting = props.reportingPlugins.some(
+  const plugins = props.plugins ?? [];
+  const reportingPlugins = props.reportingPlugins ?? [];
+  const currentPlugin = findSystemPlugin(location.pathname, plugins);
+  const currentPluginHasReporting = reportingPlugins.some(
     (plugin) => plugin.name === currentPlugin?.name,
   );
   const linkClass = ({ isActive }: { isActive: boolean }) =>
@@ -42,20 +44,26 @@ export function SystemNavigation(props: {
             aria-label="System view"
             className="w-full appearance-none rounded-md border border-white/[0.09] bg-[#0a0a0d] py-2.5 pr-10 pl-3 font-display text-sm font-medium text-dashboard-text outline-none focus:border-cyan-300/30"
             onChange={(event) => navigate(event.target.value)}
-            value={systemNavigationValue(location.pathname, props.plugins)}
+            value={systemNavigationValue(location.pathname, plugins)}
           >
             <option value="/system">Overview</option>
-            <option value={systemPluginsPath}>All Plugins</option>
-            {props.reportingPlugins.map((plugin) => (
-              <option key={plugin.name} value={systemPluginPath(plugin.name)}>
-                {plugin.displayName}
-              </option>
-            ))}
-            {currentPlugin && !currentPluginHasReporting ? (
-              <option disabled value={systemPluginPath(currentPlugin.name)}>
-                {currentPlugin.displayName}
-              </option>
-            ) : null}
+            <optgroup label="Activity">
+              <option value="/system/people">People</option>
+              <option value="/system/locations">Locations</option>
+            </optgroup>
+            <optgroup label="Capabilities">
+              <option value={systemPluginsPath}>All Plugins</option>
+              {reportingPlugins.map((plugin) => (
+                <option key={plugin.name} value={systemPluginPath(plugin.name)}>
+                  {plugin.displayName}
+                </option>
+              ))}
+              {currentPlugin && !currentPluginHasReporting ? (
+                <option disabled value={systemPluginPath(currentPlugin.name)}>
+                  {currentPlugin.displayName}
+                </option>
+              ) : null}
+            </optgroup>
           </select>
           <ChevronDown
             aria-hidden="true"
@@ -73,16 +81,23 @@ export function SystemNavigation(props: {
             <Gauge aria-hidden="true" size={15} strokeWidth={1.8} />
             Overview
           </NavLink>
-          <div className="px-3 pt-4 pb-1.5 font-mono text-[0.56rem] font-medium uppercase tracking-[0.16em] text-dashboard-text-muted">
-            Plugins
-          </div>
+          <NavigationGroup label="Activity" />
+          <NavLink className={linkClass} to="/system/people">
+            <Users aria-hidden="true" size={15} strokeWidth={1.8} />
+            People
+          </NavLink>
+          <NavLink className={linkClass} to="/system/locations">
+            <MapPinned aria-hidden="true" size={15} strokeWidth={1.8} />
+            Locations
+          </NavLink>
+          <NavigationGroup label="Capabilities" />
           <NavLink className={linkClass} end to={systemPluginsPath}>
             <Boxes aria-hidden="true" size={15} strokeWidth={1.8} />
             All Plugins
           </NavLink>
-          {props.reportingPlugins.length ? (
+          {reportingPlugins.length ? (
             <div className="mt-3 grid min-w-0 gap-1">
-              {props.reportingPlugins.map((plugin) => (
+              {reportingPlugins.map((plugin) => (
                 <NavLink
                   className={linkClass}
                   key={plugin.name}
@@ -100,15 +115,27 @@ export function SystemNavigation(props: {
   );
 }
 
+function NavigationGroup(props: { label: string }) {
+  return (
+    <div className="px-3 pt-4 pb-1.5 font-mono text-[0.56rem] font-medium uppercase tracking-[0.16em] text-dashboard-text-muted">
+      {props.label}
+    </div>
+  );
+}
+
 function systemNavigationValue(
   pathname: string,
   plugins: SystemPlugin[],
 ): string {
-  const plugin = findSystemPlugin(pathname, plugins);
+  const normalizedPath = normalizeSystemPath(pathname);
+  if (normalizedPath.startsWith("/system/people")) return "/system/people";
+  if (normalizedPath.startsWith("/system/locations")) {
+    return "/system/locations";
+  }
+  const plugin = findSystemPlugin(normalizedPath, plugins);
   if (plugin) return systemPluginPath(plugin.name);
-  return normalizeSystemPath(pathname) === systemPluginsPath
-    ? systemPluginsPath
-    : "/system";
+  if (normalizedPath.startsWith(systemPluginsPath)) return systemPluginsPath;
+  return "/system";
 }
 
 function findSystemPlugin(

--- a/packages/junior-dashboard/src/client/pages/system/SystemPage.tsx
+++ b/packages/junior-dashboard/src/client/pages/system/SystemPage.tsx
@@ -55,7 +55,7 @@ export function SystemPage(props: { data: SystemData }) {
   }
 
   return (
-    <SystemPageLayout plugins={plugins} reportingPlugins={reportingPlugins}>
+    <SystemPageLayout navigation={{ plugins, reportingPlugins }}>
       {plugin ? (
         <PluginSystemPage
           data={props.data}

--- a/packages/junior-dashboard/src/client/pages/system/SystemPage.tsx
+++ b/packages/junior-dashboard/src/client/pages/system/SystemPage.tsx
@@ -7,16 +7,15 @@ import {
   TimeRangeSelector,
   type TimeRangeDays,
 } from "../../components/controls/TimeRangeSelector";
-import { PluginReports } from "./PluginReports";
 import { Card } from "../../components/layout/Card";
 import { PageHeader } from "../../components/layout/PageHeader";
-import { PageLayout } from "../../components/layout/PageLayout";
 import type { SystemData } from "../../types";
-import { PluginDetails, PluginHeader } from "./PluginDetails";
+import { PluginDetails } from "./PluginDetails";
 import { PluginPanels } from "./PluginPanels";
+import { PluginReports } from "./PluginReports";
 import { SkillInventory } from "./SkillInventory";
 import { SystemActivity } from "./SystemActivity";
-import { SystemNavigation } from "./SystemNavigation";
+import { SystemPageLayout } from "./SystemPageLayout";
 import {
   buildSystemPlugins,
   normalizeSystemPath,
@@ -26,8 +25,8 @@ import {
 } from "./SystemPlugins";
 
 /**
- * Own `/system/*` route selection between the aggregate overview and loaded
- * plugin pages, redirecting paths that do not identify a loaded plugin.
+ * Own System overview, plugin inventory, and plugin detail route selection,
+ * redirecting paths that do not identify a loaded page.
  */
 export function SystemPage(props: { data: SystemData }) {
   const [range, setRange] = useState<TimeRangeDays>(30);
@@ -42,83 +41,119 @@ export function SystemPage(props: { data: SystemData }) {
     ? plugins
     : plugins.filter((plugin) => plugin.reports.length);
   const pathname = normalizeSystemPath(location.pathname);
+  const pluginsPath = pathname === systemPluginsPath;
   const plugin = plugins.find(
     (candidate) => systemPluginPath(candidate.name) === pathname,
   );
-  const allPlugins = pathname === systemPluginsPath;
-  const pluginPath = pathname !== "/system" && !allPlugins;
-  const rangeRelevant =
-    pathname === "/system" ||
-    (plugin?.reports.some((report) =>
-      report.widgets?.some((widget) => widget.timeRangeDays?.length),
-    ) ??
-      false);
+  const pluginPath = pathname.startsWith(`${systemPluginsPath}/`);
 
   if (pluginPath && !plugin) {
+    return <Navigate replace to={systemPluginsPath} />;
+  }
+  if (pathname !== "/system" && !pluginsPath && !plugin) {
     return <Navigate replace to="/system" />;
   }
 
   return (
-    <PageLayout>
+    <SystemPageLayout plugins={plugins} reportingPlugins={reportingPlugins}>
+      {plugin ? (
+        <PluginSystemPage
+          data={props.data}
+          onRangeChange={setRange}
+          plugin={plugin}
+          range={range}
+        />
+      ) : pluginsPath ? (
+        <PluginsSystemPage data={props.data} plugins={plugins} />
+      ) : (
+        <OverviewSystemPage
+          data={props.data}
+          range={range}
+          onRangeChange={setRange}
+        />
+      )}
+    </SystemPageLayout>
+  );
+}
+
+function OverviewSystemPage(props: {
+  data: SystemData;
+  onRangeChange(value: TimeRangeDays): void;
+  range: TimeRangeDays;
+}) {
+  return (
+    <>
       <PageHeader
         actions={
-          rangeRelevant ? (
-            <TimeRangeSelector onChange={setRange} value={range} />
-          ) : undefined
+          <TimeRangeSelector
+            onChange={props.onRangeChange}
+            value={props.range}
+          />
         }
-        description={`A live read on ${agentNamePossessive()} runtime, model usage, loaded capabilities, and the systems keeping work moving.`}
+        description={`A live read on ${agentNamePossessive()} runtime and model usage.`}
         eyebrow={`${agentNamePossessive()} engine room`}
         title="System"
       />
+      <SystemActivity
+        error={props.data.conversationStatsError}
+        range={props.range}
+        loading={props.data.conversationStatsLoading}
+        stats={props.data.conversationStats}
+      />
+    </>
+  );
+}
 
-      <div className="grid min-w-0 items-start gap-4 sm:gap-6 lg:grid-cols-[13rem_minmax(0,1fr)]">
-        <SystemNavigation
-          plugins={plugins}
-          reportingPlugins={reportingPlugins}
+function PluginsSystemPage(props: {
+  data: SystemData;
+  plugins: SystemPlugin[];
+}) {
+  return (
+    <>
+      <PageHeader
+        description={`Loaded capabilities and operational reports for ${getDashboardAgentName()}.`}
+        eyebrow="System / capabilities"
+        title="Plugins"
+      />
+      {props.data.pluginReportsError ? (
+        <PluginReportError
+          showingReports={props.plugins.some((plugin) => plugin.reports.length)}
         />
-        <div className="grid min-w-0 gap-4 sm:gap-6">
-          {allPlugins ? (
-            <>
-              {props.data.pluginReportsError ? (
-                <PluginReportError
-                  showingReports={plugins.some(
-                    (candidate) => candidate.reports.length,
-                  )}
-                />
-              ) : null}
-              <PluginPanels plugins={plugins} />
-            </>
-          ) : plugin ? (
-            <PluginSystemPage data={props.data} plugin={plugin} range={range} />
-          ) : (
-            <>
-              <SystemActivity
-                error={props.data.conversationStatsError}
-                range={range}
-                loading={props.data.conversationStatsLoading}
-                stats={props.data.conversationStats}
-              />
-              {props.data.skills.length ? (
-                <SkillInventory skills={props.data.skills} />
-              ) : null}
-            </>
-          )}
-        </div>
-      </div>
-    </PageLayout>
+      ) : null}
+      <PluginPanels plugins={props.plugins} />
+      {props.data.skills.length ? (
+        <SkillInventory skills={props.data.skills} />
+      ) : null}
+    </>
   );
 }
 
 function PluginSystemPage(props: {
   data: SystemData;
+  onRangeChange(value: TimeRangeDays): void;
   plugin: SystemPlugin;
   range: TimeRangeDays;
 }) {
   const reports = props.plugin.reports;
+  const rangeRelevant = reports.some((report) =>
+    report.widgets?.some((widget) => widget.timeRangeDays?.length),
+  );
 
   return (
     <>
-      <PluginHeader plugin={props.plugin} />
+      <PageHeader
+        actions={
+          rangeRelevant ? (
+            <TimeRangeSelector
+              onChange={props.onRangeChange}
+              value={props.range}
+            />
+          ) : undefined
+        }
+        description={props.plugin.description}
+        eyebrow="System / plugins"
+        title={props.plugin.displayName}
+      />
       {props.data.pluginReportsError ? (
         <PluginReportError showingReports={Boolean(reports.length)} />
       ) : null}

--- a/packages/junior-dashboard/src/client/pages/system/SystemPageLayout.tsx
+++ b/packages/junior-dashboard/src/client/pages/system/SystemPageLayout.tsx
@@ -1,0 +1,24 @@
+import type { ReactNode } from "react";
+
+import { PageLayout } from "../../components/layout/PageLayout";
+import { SystemNavigation } from "./SystemNavigation";
+import type { SystemPlugin } from "./SystemPlugins";
+
+/** Place one System page beside the shared route-backed navigation. */
+export function SystemPageLayout(props: {
+  children: ReactNode;
+  plugins?: SystemPlugin[];
+  reportingPlugins?: SystemPlugin[];
+}) {
+  return (
+    <PageLayout>
+      <div className="grid min-w-0 items-start gap-4 sm:gap-6 lg:grid-cols-[13rem_minmax(0,1fr)]">
+        <SystemNavigation
+          plugins={props.plugins}
+          reportingPlugins={props.reportingPlugins}
+        />
+        <div className="grid min-w-0 gap-4 sm:gap-6">{props.children}</div>
+      </div>
+    </PageLayout>
+  );
+}

--- a/packages/junior-dashboard/src/client/pages/system/SystemPageLayout.tsx
+++ b/packages/junior-dashboard/src/client/pages/system/SystemPageLayout.tsx
@@ -2,20 +2,19 @@ import type { ReactNode } from "react";
 
 import { PageLayout } from "../../components/layout/PageLayout";
 import { SystemNavigation } from "./SystemNavigation";
-import type { SystemPlugin } from "./SystemPlugins";
+import type { SystemNavigationData } from "./useSystemNavigationData";
 
 /** Place one System page beside the shared route-backed navigation. */
 export function SystemPageLayout(props: {
   children: ReactNode;
-  plugins?: SystemPlugin[];
-  reportingPlugins?: SystemPlugin[];
+  navigation: SystemNavigationData;
 }) {
   return (
     <PageLayout>
       <div className="grid min-w-0 items-start gap-4 sm:gap-6 lg:grid-cols-[13rem_minmax(0,1fr)]">
         <SystemNavigation
-          plugins={props.plugins}
-          reportingPlugins={props.reportingPlugins}
+          plugins={props.navigation.plugins}
+          reportingPlugins={props.navigation.reportingPlugins}
         />
         <div className="grid min-w-0 gap-4 sm:gap-6">{props.children}</div>
       </div>

--- a/packages/junior-dashboard/src/client/pages/system/useSystemNavigationData.ts
+++ b/packages/junior-dashboard/src/client/pages/system/useSystemNavigationData.ts
@@ -1,0 +1,34 @@
+import { usePluginReportsData, usePluginsData, useSkillsData } from "../../api";
+import { buildSystemPlugins, type SystemPlugin } from "./SystemPlugins";
+
+export type SystemNavigationData = {
+  plugins: SystemPlugin[];
+  reportingPlugins: SystemPlugin[];
+};
+
+export const emptySystemNavigationData: SystemNavigationData = {
+  plugins: [],
+  reportingPlugins: [],
+};
+
+/** Load the plugin data needed to keep System navigation consistent. */
+export function useSystemNavigationData(): SystemNavigationData {
+  const pluginsQuery = usePluginsData();
+  const skillsQuery = useSkillsData();
+  const pluginReportsQuery = usePluginReportsData();
+  if (!pluginsQuery.data || !skillsQuery.data) {
+    return emptySystemNavigationData;
+  }
+
+  const plugins = buildSystemPlugins({
+    plugins: pluginsQuery.data,
+    reports: pluginReportsQuery.data?.reports ?? [],
+    skills: skillsQuery.data,
+  });
+  return {
+    plugins,
+    reportingPlugins: pluginReportsQuery.isPending
+      ? plugins
+      : plugins.filter((plugin) => plugin.reports.length),
+  };
+}

--- a/packages/junior-dashboard/tests/dashboard-routes.test.ts
+++ b/packages/junior-dashboard/tests/dashboard-routes.test.ts
@@ -115,11 +115,6 @@ describe("dashboard routes", () => {
       "/locations",
       "/locations/destination-1",
       "/system",
-      "/system/locations",
-      "/system/locations/destination-1",
-      "/system/people",
-      "/system/people/person%40sentry.io",
-      "/system/plugins",
       "/system/plugins/github",
     ]) {
       const response = await app.fetch(new Request(`http://localhost${path}`));
@@ -452,11 +447,6 @@ describe("dashboard routes", () => {
       "/people",
       "/people/person%40sentry.io",
       "/system",
-      "/system/locations",
-      "/system/locations/destination-1",
-      "/system/people",
-      "/system/people/person%40sentry.io",
-      "/system/plugins",
       "/system/plugins/github",
       "/settings/api-tokens",
       "/plugins/memory/memories",

--- a/packages/junior-dashboard/tests/dashboard-routes.test.ts
+++ b/packages/junior-dashboard/tests/dashboard-routes.test.ts
@@ -115,6 +115,11 @@ describe("dashboard routes", () => {
       "/locations",
       "/locations/destination-1",
       "/system",
+      "/system/locations",
+      "/system/locations/destination-1",
+      "/system/people",
+      "/system/people/person%40sentry.io",
+      "/system/plugins",
       "/system/plugins/github",
     ]) {
       const response = await app.fetch(new Request(`http://localhost${path}`));
@@ -447,6 +452,11 @@ describe("dashboard routes", () => {
       "/people",
       "/people/person%40sentry.io",
       "/system",
+      "/system/locations",
+      "/system/locations/destination-1",
+      "/system/people",
+      "/system/people/person%40sentry.io",
+      "/system/plugins",
       "/system/plugins/github",
       "/settings/api-tokens",
       "/plugins/memory/memories",

--- a/packages/junior-dashboard/tests/telemetry-components.test.tsx
+++ b/packages/junior-dashboard/tests/telemetry-components.test.tsx
@@ -33,6 +33,7 @@ import { ContributionGrid } from "../src/client/pages/people/ContributionGrid";
 import { PluginReports } from "../src/client/pages/system/PluginReports";
 import { SkillInventory } from "../src/client/pages/system/SkillInventory";
 import { SystemPage } from "../src/client/pages/system/SystemPage";
+import { emptySystemNavigationData } from "../src/client/pages/system/useSystemNavigationData";
 import type { ConversationTranscript, SystemData } from "../src/client/types";
 
 const client = new QueryClient();
@@ -1140,7 +1141,11 @@ describe("dashboard canonical-event components", () => {
     };
     const html = renderToStaticMarkup(
       <MemoryRouter>
-        <LocationsPageContent data={data} error={new Error("refresh failed")} />
+        <LocationsPageContent
+          data={data}
+          error={new Error("refresh failed")}
+          navigation={emptySystemNavigationData}
+        />
       </MemoryRouter>,
     );
     expect(html).toContain("Location telemetry refresh failed");
@@ -1198,6 +1203,7 @@ describe("dashboard canonical-event components", () => {
         <LocationDetailPageContent
           data={detail}
           error={new Error("refresh failed")}
+          navigation={emptySystemNavigationData}
         />
       </MemoryRouter>,
     );

--- a/packages/junior-dashboard/tests/telemetry-components.test.tsx
+++ b/packages/junior-dashboard/tests/telemetry-components.test.tsx
@@ -1283,25 +1283,28 @@ describe("dashboard canonical-event components", () => {
     expect(
       systemHtml.match(/aria-label="Reporting period"/g) ?? [],
     ).toHaveLength(1);
-    expect(systemHtml).toContain(">Plugins<");
+    expect(systemHtml).toContain(">Capabilities<");
     expect(systemHtml).toContain(">All Plugins<");
-    expect(systemHtml).toContain(">Skills<");
+    expect(systemHtml).not.toContain(">Skills<");
     expect(systemHtml).not.toContain(">GitHub<");
     expect(systemHtml).not.toContain(">loaded<");
     expect(systemHtml).not.toContain(">quiet<");
     expect(systemHtml).not.toContain(">metrics<");
     expect(systemHtml).not.toContain(">datasets<");
     expect(systemHtml).not.toContain(">1 loaded<");
-    expect(systemHtml).toContain(">triage<");
+    expect(systemHtml).not.toContain(">triage<");
 
     const pluginsHtml = renderToStaticMarkup(
       <MemoryRouter initialEntries={["/system/plugins"]}>
         <SystemPage data={data} />
       </MemoryRouter>,
     );
-    expect(pluginsHtml).toContain(">All Plugins<");
+    expect(pluginsHtml).toContain(">Plugins<");
+    expect(pluginsHtml).toContain(">Skills<");
     expect(pluginsHtml).toContain(">GitHub<");
+    expect(pluginsHtml).toContain(">triage<");
     expect(pluginsHtml).not.toContain("Usage over time");
+    expect(pluginsHtml).toContain(">All Plugins<");
     expect(pluginsHtml).not.toContain('aria-label="Reporting period"');
 
     const skillsHtml = renderToStaticMarkup(
@@ -1336,6 +1339,7 @@ describe("dashboard canonical-event components", () => {
 
     expect(html).toContain('aria-label="System navigation"');
     expect(html).not.toContain('href="/system/plugins/github"');
+    expect(html).toContain('href="/system/plugins"');
     expect(html).toContain('href="/system/plugins/scheduler"');
     expect(html).toContain(">Scheduler<");
     expect(html).toContain(">active tasks<");


### PR DESCRIPTION
Moves People and Locations out of the global header and into System navigation alongside Overview and Plugins. The complete plugin inventory has its own page, while reporting plugins remain directly accessible and detail pages keep their parent navigation selected across desktop and mobile.

Canonical dashboard routes now live under `/system/people` and `/system/locations`; existing top-level links redirect without losing query parameters. The route helpers, browser coverage, component coverage, and dashboard documentation follow the new structure.

The workspace now installs a simple-git-hooks pre-push guard that runs `pnpm lint`, ensuring rebases and other rewritten commits pass the same lint chain as CI before they can be pushed.