### PR TITLE
feat(dashboard): add personal spend to profile menu

### DIFF
--- a/packages/junior-dashboard/e2e/conversations.spec.ts
+++ b/packages/junior-dashboard/e2e/conversations.spec.ts
@@ -376,8 +376,10 @@ test("groups the signed-in profile and session actions in the header", async ({
     name: "Open profile menu for Dashboard User",
   });
   await expect(trigger).toBeVisible();
+  await expect(trigger).toContainText("7d$0.07");
+  await expect(trigger).toContainText("30d$0.07");
   await expect(trigger).toHaveAttribute("aria-expanded", "false");
-  await trigger.click();
+  await trigger.hover();
 
   const popover = page.locator("#profile-popover");
   await expect(popover.getByText("morgan@sentry.io")).toBeVisible();
@@ -385,11 +387,15 @@ test("groups the signed-in profile and session actions in the header", async ({
     popover.getByRole("link", { name: "My profile" }),
   ).toHaveAttribute("href", "/people/morgan%40sentry.io");
   await expect(popover.getByRole("button", { name: "Log out" })).toBeVisible();
+  await popover.getByRole("link", { name: "My profile" }).hover();
+  await page.waitForTimeout(200);
+  await expect(popover).toBeVisible();
 
   await page.keyboard.press("Escape");
   await expect(popover).toHaveCount(0);
   await expect(trigger).toBeFocused();
 
+  await page.mouse.move(0, 0);
   await trigger.click();
   const signOutRequest = page.waitForRequest(
     (request) =>

--- a/packages/junior-dashboard/src/client/App.tsx
+++ b/packages/junior-dashboard/src/client/App.tsx
@@ -9,6 +9,7 @@ import {
 
 import {
   useDashboardCoreData,
+  usePersonalSpendData,
   usePluginUserPagesData,
   useSystemData,
 } from "./api";
@@ -60,6 +61,7 @@ export function DashboardShell() {
   }
   const loading = !data && !query.error;
   const loggedIn = Boolean(data?.config.authRequired && data.me.user.email);
+  const personalSpendQuery = usePersonalSpendData(loggedIn);
   const primaryUserPages = loggedIn
     ? userPages.filter((page) => page.navigation === "primary")
     : [];
@@ -163,6 +165,7 @@ export function DashboardShell() {
               <ProfileMenu
                 identity={data!.me}
                 onSignOut={signOut}
+                spend={personalSpendQuery.data}
                 userPages={userPages}
               />
             </div>

--- a/packages/junior-dashboard/src/client/api.ts
+++ b/packages/junior-dashboard/src/client/api.ts
@@ -10,6 +10,7 @@ import {
   actorProfileReportSchema,
   locationDetailReportSchema,
   locationDirectoryReportSchema,
+  personalSpendReportSchema,
 } from "@sentry/junior/api/schema";
 import {
   pluginOperationalReportFeedSchema,
@@ -23,6 +24,23 @@ import { fetchDashboardJson } from "./http";
 import type { DashboardCoreData, SystemData } from "./types";
 
 const dashboardMetadataStaleTimeMs = 5 * 60_000;
+const PERSONAL_SPEND_REFRESH_MS = 5 * 60_000;
+const MIN_PERSONAL_SPEND_REFRESH_MS = 1_000;
+
+/** Schedule the next spend refresh from the age of the server-cached report. */
+export function personalSpendRefreshDelay(
+  generatedAt: string | undefined,
+  nowMs = Date.now(),
+): number {
+  if (!generatedAt) return PERSONAL_SPEND_REFRESH_MS;
+  const generatedAtMs = Date.parse(generatedAt);
+  if (!Number.isFinite(generatedAtMs)) return PERSONAL_SPEND_REFRESH_MS;
+  const ageMs = Math.max(0, nowMs - generatedAtMs);
+  return Math.max(
+    MIN_PERSONAL_SPEND_REFRESH_MS,
+    PERSONAL_SPEND_REFRESH_MS - ageMs,
+  );
+}
 
 /** Fetch dashboard shell data shared across browser routes. */
 export function useDashboardCoreData() {
@@ -105,6 +123,24 @@ export function useActorProfileData(email: string | undefined) {
         signal,
       ),
     retry: false,
+  });
+}
+
+/** Fetch and refresh the authenticated viewer's rolling model spend. */
+export function usePersonalSpendData(enabled: boolean) {
+  return useQuery({
+    enabled,
+    queryKey: ["dashboard", "personal-spend"],
+    queryFn: ({ signal }) =>
+      fetchDashboardJson(
+        personalSpendReportSchema,
+        "/api/people/me/spend",
+        signal,
+      ),
+    refetchInterval: (query) =>
+      personalSpendRefreshDelay(query.state.data?.generatedAt),
+    retry: false,
+    staleTime: 0,
   });
 }
 

--- a/packages/junior-dashboard/src/client/components/ProfileMenu.tsx
+++ b/packages/junior-dashboard/src/client/components/ProfileMenu.tsx
@@ -1,9 +1,15 @@
 import { Boxes, ChevronDown, KeyRound, LogOut, UserRound } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import {
+  useEffect,
+  useRef,
+  useState,
+  type PointerEvent as ReactPointerEvent,
+} from "react";
 import { Link } from "react-router";
+import type { PersonalSpendReport } from "@sentry/junior/api/schema";
 import type { PluginUserPageLink } from "@sentry/junior-plugin-api";
 
-import { peoplePath } from "../format";
+import { formatCostSummary, peoplePath } from "../format";
 import { pluginUserPagePath } from "../pages/user/PluginUserPage";
 import { cn } from "../styles";
 import type { Identity } from "../types";
@@ -11,8 +17,12 @@ import type { Identity } from "../types";
 type ProfileMenuProps = {
   identity: Identity;
   onSignOut(): Promise<void>;
+  spend?: PersonalSpendReport;
   userPages: PluginUserPageLink[];
 };
+
+const HOVER_OPEN_DELAY_MS = 80;
+const HOVER_CLOSE_DELAY_MS = 140;
 
 function initials(name: string | null | undefined, email: string): string {
   const words = name?.trim().split(/\s+/).filter(Boolean) ?? [];
@@ -30,13 +40,50 @@ function initials(name: string | null | undefined, email: string): string {
 export function ProfileMenu({
   identity,
   onSignOut,
+  spend,
   userPages,
 }: ProfileMenuProps) {
   const [open, setOpen] = useState(false);
   const rootRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
+  const openTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined,
+  );
+  const closeTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined,
+  );
   const email = identity.user.email!;
   const name = identity.user.name?.trim() || email;
+  const sevenDaySpend = spend
+    ? formatCostSummary({ total: spend.sevenDaysUsd })
+    : "—";
+  const thirtyDaySpend = spend
+    ? formatCostSummary({ total: spend.thirtyDaysUsd })
+    : "—";
+
+  function clearHoverTimers() {
+    if (openTimerRef.current) clearTimeout(openTimerRef.current);
+    if (closeTimerRef.current) clearTimeout(closeTimerRef.current);
+    openTimerRef.current = undefined;
+    closeTimerRef.current = undefined;
+  }
+
+  function openOnHover(event: ReactPointerEvent<HTMLDivElement>) {
+    if (event.pointerType !== "mouse") return;
+    clearHoverTimers();
+    openTimerRef.current = setTimeout(() => setOpen(true), HOVER_OPEN_DELAY_MS);
+  }
+
+  function closeOnHover(event: ReactPointerEvent<HTMLDivElement>) {
+    if (event.pointerType !== "mouse") return;
+    clearHoverTimers();
+    closeTimerRef.current = setTimeout(
+      () => setOpen(false),
+      HOVER_CLOSE_DELAY_MS,
+    );
+  }
+
+  useEffect(() => clearHoverTimers, []);
 
   useEffect(() => {
     if (!open) return;
@@ -63,32 +110,64 @@ export function ProfileMenu({
   }, [open]);
 
   return (
-    <div className="relative" ref={rootRef}>
+    <div
+      className="relative"
+      onBlurCapture={(event) => {
+        if (!event.currentTarget.contains(event.relatedTarget as Node | null)) {
+          setOpen(false);
+        }
+      }}
+      onPointerEnter={openOnHover}
+      onPointerLeave={closeOnHover}
+      ref={rootRef}
+    >
       <button
         aria-controls="profile-popover"
         aria-expanded={open}
-        aria-label={`Open profile menu for ${name}`}
+        aria-haspopup="true"
+        aria-label={`${open ? "Close" : "Open"} profile menu for ${name}. Personal model spend: 7 days ${sevenDaySpend}, 30 days ${thirtyDaySpend}.`}
         className={cn(
-          "flex h-9 cursor-pointer items-center gap-2 rounded border border-white/15 bg-dashboard-surface-raised px-1.5 text-dashboard-text transition-colors hover:border-white/30 hover:bg-dashboard-surface-hover hover:text-dashboard-text focus-visible:outline focus-visible:outline-2 focus-visible:outline-[#beaaff]/70",
-          open &&
-            "border-white/30 bg-dashboard-surface-hover text-dashboard-text",
+          "group flex h-10 cursor-pointer items-center gap-2 rounded-lg border-0 bg-transparent px-1.5 text-dashboard-text transition-colors hover:bg-white/[0.06] hover:text-dashboard-text focus-visible:outline focus-visible:outline-2 focus-visible:outline-[#beaaff]/70",
+          open && "bg-white/[0.08] text-dashboard-text",
         )}
-        onClick={() => setOpen((value) => !value)}
+        onClick={(event) => {
+          clearHoverTimers();
+          setOpen(event.detail === 0 ? (value) => !value : true);
+        }}
         ref={triggerRef}
         type="button"
       >
+        <span className="hidden items-center gap-2 sm:flex">
+          <span className="flex items-baseline gap-1 whitespace-nowrap tabular-nums">
+            <span className="text-[0.58rem] font-medium uppercase tracking-[0.1em] text-dashboard-text-muted">
+              7d
+            </span>
+            <span className="text-[0.72rem] font-semibold text-dashboard-text">
+              {sevenDaySpend}
+            </span>
+          </span>
+          <span aria-hidden="true" className="h-3 w-px bg-white/10" />
+          <span className="flex items-baseline gap-1 whitespace-nowrap tabular-nums">
+            <span className="text-[0.58rem] font-medium uppercase tracking-[0.1em] text-dashboard-text-muted">
+              30d
+            </span>
+            <span className="text-[0.72rem] font-semibold text-dashboard-text">
+              {thirtyDaySpend}
+            </span>
+          </span>
+        </span>
         <span
           aria-hidden="true"
-          className="grid size-6 place-items-center rounded-full bg-[#beaaff] text-[0.68rem] font-bold tracking-wide text-black"
+          className="grid size-7 place-items-center rounded-full bg-[#beaaff] text-[0.68rem] font-bold tracking-wide text-black shadow-sm shadow-black/40"
         >
           {initials(identity.user.name, email)}
         </span>
-        <span className="max-w-32 truncate text-[0.8rem] font-semibold max-sm:hidden">
-          {identity.user.name?.trim() || "My profile"}
-        </span>
         <ChevronDown
           aria-hidden="true"
-          className={cn("transition-transform", open && "rotate-180")}
+          className={cn(
+            "text-dashboard-text-muted transition-[color,transform] group-hover:text-dashboard-text",
+            open && "rotate-180 text-dashboard-text",
+          )}
           size={14}
           strokeWidth={2}
         />
@@ -96,7 +175,7 @@ export function ProfileMenu({
 
       {open ? (
         <div
-          className="absolute right-0 top-[calc(100%+0.5rem)] z-20 w-64 rounded-lg border border-white/15 bg-dashboard-surface-raised p-1.5 shadow-2xl shadow-black/60"
+          className="absolute right-0 top-[calc(100%+0.5rem)] z-20 w-64 rounded-xl bg-dashboard-surface-raised/95 p-1.5 shadow-2xl shadow-black/75 backdrop-blur-xl"
           id="profile-popover"
         >
           <div className="border-b border-white/10 px-2.5 py-2.5">
@@ -110,7 +189,7 @@ export function ProfileMenu({
             ) : null}
           </div>
           <Link
-            className="mt-1 flex items-center gap-2.5 px-2.5 py-2 text-[0.82rem] font-semibold text-dashboard-text no-underline transition-colors hover:bg-white/10 hover:text-dashboard-text focus-visible:bg-white/10 focus-visible:text-dashboard-text focus-visible:outline-none"
+            className="mt-1 flex items-center gap-2.5 rounded-md px-2.5 py-2 text-[0.82rem] font-semibold text-dashboard-text no-underline transition-colors hover:bg-white/10 hover:text-dashboard-text focus-visible:bg-white/10 focus-visible:text-dashboard-text focus-visible:outline-none"
             onClick={() => setOpen(false)}
             to={peoplePath(email)}
           >
@@ -118,7 +197,7 @@ export function ProfileMenu({
             My profile
           </Link>
           <Link
-            className="flex items-center gap-2.5 px-2.5 py-2 text-[0.82rem] font-semibold text-dashboard-text no-underline transition-colors hover:bg-white/10 hover:text-dashboard-text focus-visible:bg-white/10 focus-visible:text-dashboard-text focus-visible:outline-none"
+            className="flex items-center gap-2.5 rounded-md px-2.5 py-2 text-[0.82rem] font-semibold text-dashboard-text no-underline transition-colors hover:bg-white/10 hover:text-dashboard-text focus-visible:bg-white/10 focus-visible:text-dashboard-text focus-visible:outline-none"
             onClick={() => setOpen(false)}
             to="/settings/api-tokens"
           >
@@ -129,7 +208,7 @@ export function ProfileMenu({
             .filter((page) => page.navigation === "profile")
             .map((page) => (
               <Link
-                className="flex items-center gap-2.5 px-2.5 py-2 text-[0.82rem] font-semibold text-dashboard-text no-underline transition-colors hover:bg-white/10 hover:text-dashboard-text focus-visible:bg-white/10 focus-visible:text-dashboard-text focus-visible:outline-none"
+                className="flex items-center gap-2.5 rounded-md px-2.5 py-2 text-[0.82rem] font-semibold text-dashboard-text no-underline transition-colors hover:bg-white/10 hover:text-dashboard-text focus-visible:bg-white/10 focus-visible:text-dashboard-text focus-visible:outline-none"
                 key={`${page.pluginName}:${page.id}`}
                 onClick={() => setOpen(false)}
                 to={pluginUserPagePath(page.pluginName, page.id)}
@@ -139,7 +218,7 @@ export function ProfileMenu({
               </Link>
             ))}
           <button
-            className="flex w-full cursor-pointer items-center gap-2.5 border-0 bg-transparent px-2.5 py-2 text-left text-[0.82rem] font-semibold text-dashboard-text transition-colors hover:bg-white/10 hover:text-dashboard-text focus-visible:bg-white/10 focus-visible:text-dashboard-text focus-visible:outline-none"
+            className="flex w-full cursor-pointer items-center gap-2.5 rounded-md border-0 bg-transparent px-2.5 py-2 text-left text-[0.82rem] font-semibold text-dashboard-text transition-colors hover:bg-white/10 hover:text-dashboard-text focus-visible:bg-white/10 focus-visible:text-dashboard-text focus-visible:outline-none"
             onClick={() => {
               setOpen(false);
               void onSignOut();

--- a/packages/junior-dashboard/src/mock-reporting/fixtures.ts
+++ b/packages/junior-dashboard/src/mock-reporting/fixtures.ts
@@ -19,6 +19,7 @@ import type {
   LocationDirectoryReport,
   LocationSummaryReport,
   PeopleActivityDayReport,
+  PersonalSpendReport,
 } from "@sentry/junior/api/schema";
 
 const ACTIVE_CONVERSATION_ID = "slack:CQA123:1770003600.000200";
@@ -1284,6 +1285,28 @@ export function readMockPeopleProfile(
     totals,
     windowEnd: `${activityDays.at(-1)!.date}T00:00:00.000Z`,
     windowStart: `${activityDays[0]!.date}T00:00:00.000Z`,
+  };
+}
+
+/** Build mock rolling spend from the same personal activity used by People. */
+export function readMockPersonalSpend(
+  email: string,
+): PersonalSpendReport | undefined {
+  const profile = readMockPeopleProfile(email);
+  if (!profile) return undefined;
+  const spend = (days: number) =>
+    Math.round(
+      profile.activityDays
+        .slice(-days)
+        .reduce((sum, day) => sum + (day.costUsd ?? 0), 0) * 1e12,
+    ) / 1e12;
+  return {
+    generatedAt: profile.generatedAt,
+    sevenDaysUsd: spend(7),
+    source: "conversation_index",
+    thirtyDaysUsd: spend(30),
+    windowEnd: profile.generatedAt,
+    windowStart: profile.activityDays.at(-30)!.date + "T00:00:00.000Z",
   };
 }
 

--- a/packages/junior-dashboard/src/mock-reporting/routes.ts
+++ b/packages/junior-dashboard/src/mock-reporting/routes.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import { jsonResponse } from "@sentry/junior/api";
+import { jsonResponse, type JuniorApiVariables } from "@sentry/junior/api";
 import {
   apiErrorSchema,
   actorDirectoryReportSchema,
@@ -15,6 +15,7 @@ import {
   locationDetailReportSchema,
   locationDirectoryReportSchema,
   locationParamsSchema,
+  personalSpendReportSchema,
   personParamsSchema,
 } from "@sentry/junior/api/schema";
 import {
@@ -26,6 +27,7 @@ import {
   readMockLocationDirectory,
   readMockPeopleDirectory,
   readMockPeopleProfile,
+  readMockPersonalSpend,
 } from "./fixtures";
 
 function errorResponse(error: string, status: 400 | 404): Response {
@@ -33,12 +35,21 @@ function errorResponse(error: string, status: 400 | 404): Response {
 }
 
 /** Create the reporting API used exclusively by local dashboard mocks. */
-export function createMockReportingApi(): Hono {
-  const app = new Hono();
+export function createMockReportingApi(): Hono<{
+  Variables: JuniorApiVariables;
+}> {
+  const app = new Hono<{ Variables: JuniorApiVariables }>();
 
   app.get("/people", () =>
     jsonResponse(actorDirectoryReportSchema, readMockPeopleDirectory()),
   );
+  app.get("/people/me/spend", (context) => {
+    const email = context.get("verifiedViewerEmail");
+    const report = email ? readMockPersonalSpend(email) : undefined;
+    return report
+      ? jsonResponse(personalSpendReportSchema, report)
+      : errorResponse("Person not found.", 404);
+  });
   app.get("/people/:email", (c) => {
     const params = personParamsSchema.safeParse(c.req.param());
     if (!params.success) {

--- a/packages/junior-dashboard/tests/client-api.test.ts
+++ b/packages/junior-dashboard/tests/client-api.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ConversationReportEvent } from "@sentry/junior/api/schema";
 
+import { personalSpendRefreshDelay } from "../src/client/api";
 import {
   conversationDetailQueryOptions,
   readConversationData,
@@ -112,6 +113,18 @@ describe("dashboard client API", () => {
     } as unknown as Parameters<typeof interval>[0];
 
     expect(interval(query)).toBe(2_000);
+  });
+
+  it("refreshes spend from the age of the server-cached report", () => {
+    const nowMs = Date.parse("2026-08-03T12:00:00.000Z");
+
+    expect(personalSpendRefreshDelay(undefined, nowMs)).toBe(5 * 60_000);
+    expect(personalSpendRefreshDelay("2026-08-03T11:55:30.000Z", nowMs)).toBe(
+      30_000,
+    );
+    expect(personalSpendRefreshDelay("2026-08-03T11:54:00.000Z", nowMs)).toBe(
+      1_000,
+    );
   });
 
   it("does not redirect for non-auth product API failures", async () => {

--- a/packages/junior/src/api/people/routes.ts
+++ b/packages/junior/src/api/people/routes.ts
@@ -2,12 +2,16 @@ import { Hono } from "hono";
 import { registerApiRoutes, type ApiRoute, type JuniorApiEnv } from "../route";
 import listRoute from "./list";
 import profileRoute from "./profile";
-
-const routes: ApiRoute[] = [listRoute, profileRoute];
+import { createPersonalSpendRoute } from "./spend";
 
 /** Create the HTTP routes owned by the People API. */
 export function createPeopleRoutes(): Hono<JuniorApiEnv> {
   const app = new Hono<JuniorApiEnv>();
+  const routes: ApiRoute[] = [
+    createPersonalSpendRoute(),
+    listRoute,
+    profileRoute,
+  ];
   registerApiRoutes(app, routes);
   return app;
 }

--- a/packages/junior/src/api/people/spend.query.ts
+++ b/packages/junior/src/api/people/spend.query.ts
@@ -1,0 +1,89 @@
+import { and, eq, gte, lte, sql } from "drizzle-orm";
+import { getDb } from "@/chat/db";
+import {
+  juniorConversations,
+  juniorIdentities,
+  juniorUsers,
+} from "@/db/schema";
+import type { PersonalSpendReport } from "../schema/person";
+import {
+  normalizeEmail,
+  peopleTreeAggregateColumns,
+  peopleTreeConversation,
+  peopleTreeMetricsJoin,
+  verifiedActorWhere,
+} from "./shared";
+
+const SEVEN_DAY_OFFSET = 6;
+const THIRTY_DAY_OFFSET = 29;
+
+function addUsd(current: number, next: number): number {
+  return Math.round((current + next) * 1e12) / 1e12;
+}
+
+function spendWindow(nowMs: number) {
+  const end = new Date(nowMs);
+  const currentDay = new Date(end);
+  currentDay.setUTCHours(0, 0, 0, 0);
+  const sevenDayStart = new Date(currentDay);
+  sevenDayStart.setUTCDate(sevenDayStart.getUTCDate() - SEVEN_DAY_OFFSET);
+  const thirtyDayStart = new Date(currentDay);
+  thirtyDayStart.setUTCDate(thirtyDayStart.getUTCDate() - THIRTY_DAY_OFFSET);
+  return { end, sevenDayStart, thirtyDayStart };
+}
+
+/** Read one viewer's rolling model spend with one bounded aggregate query. */
+export async function readPersonalSpendFromSql(
+  email: string,
+  nowMs = Date.now(),
+): Promise<PersonalSpendReport> {
+  const normalizedEmail = normalizeEmail(email);
+  const { end, sevenDayStart, thirtyDayStart } = spendWindow(nowMs);
+  const activityDate = sql<string>`TO_CHAR(
+    ${juniorConversations.lastActivityAt} AT TIME ZONE 'UTC',
+    'YYYY-MM-DD'
+  )`;
+  const metricsJoin = peopleTreeMetricsJoin();
+  const rows = normalizedEmail
+    ? await getDb()
+        .select({
+          costUsd: peopleTreeAggregateColumns.costUsd,
+          date: activityDate,
+        })
+        .from(juniorConversations)
+        .innerJoin(
+          juniorIdentities,
+          eq(juniorIdentities.id, juniorConversations.actorIdentityId),
+        )
+        .innerJoin(juniorUsers, eq(juniorUsers.id, juniorIdentities.userId))
+        .leftJoin(peopleTreeConversation, metricsJoin)
+        .where(
+          and(
+            verifiedActorWhere(normalizedEmail),
+            gte(juniorConversations.lastActivityAt, thirtyDayStart),
+            lte(juniorConversations.lastActivityAt, end),
+          ),
+        )
+        .groupBy(activityDate)
+    : [];
+
+  const sevenDayStartDate = sevenDayStart.toISOString().slice(0, 10);
+  let sevenDaysUsd = 0;
+  let thirtyDaysUsd = 0;
+  for (const row of rows) {
+    if (row.costUsd === null) continue;
+    thirtyDaysUsd = addUsd(thirtyDaysUsd, row.costUsd);
+    if (row.date >= sevenDayStartDate) {
+      sevenDaysUsd = addUsd(sevenDaysUsd, row.costUsd);
+    }
+  }
+
+  return {
+    generatedAt: new Date(nowMs).toISOString(),
+    sevenDaysUsd,
+    source: "conversation_index",
+    thirtyDaysUsd,
+    windowEnd: end.toISOString(),
+    windowStart: thirtyDayStart.toISOString(),
+  };
+}

--- a/packages/junior/src/api/people/spend.ts
+++ b/packages/junior/src/api/people/spend.ts
@@ -1,0 +1,55 @@
+import { throwApiError } from "../http";
+import { defineApiRoute, type ApiRoute } from "../route";
+import {
+  personalSpendReportSchema,
+  type PersonalSpendReport,
+} from "../schema/person";
+import { readPersonalSpendFromSql } from "./spend.query";
+
+const PERSONAL_SPEND_CACHE_TTL_MS = 5 * 60_000;
+
+type SpendCacheEntry = {
+  expiresAtMs: number;
+  report: Promise<PersonalSpendReport>;
+};
+
+/** Create the self-only spend route with an app-scoped five-minute cache. */
+export function createPersonalSpendRoute(): ApiRoute<
+  typeof personalSpendReportSchema
+> {
+  const cache = new Map<string, SpendCacheEntry>();
+
+  async function read(email: string): Promise<PersonalSpendReport> {
+    const normalizedEmail = email.trim().toLowerCase();
+    const nowMs = Date.now();
+    const cached = cache.get(normalizedEmail);
+    if (cached && cached.expiresAtMs > nowMs) {
+      return cached.report;
+    }
+    cache.delete(normalizedEmail);
+
+    const report = readPersonalSpendFromSql(normalizedEmail, nowMs);
+    const entry = {
+      expiresAtMs: nowMs + PERSONAL_SPEND_CACHE_TTL_MS,
+      report,
+    };
+    cache.set(normalizedEmail, entry);
+    try {
+      return await report;
+    } catch (error) {
+      if (cache.get(normalizedEmail) === entry) cache.delete(normalizedEmail);
+      throw error;
+    }
+  }
+
+  return defineApiRoute({
+    method: "get",
+    path: "/me/spend",
+    responseSchema: personalSpendReportSchema,
+    handler: async (context) => {
+      const email = context.get("verifiedViewerEmail");
+      if (!email) throwApiError(403, "Verified viewer email required.");
+      return read(email);
+    },
+  });
+}

--- a/packages/junior/src/api/schema.ts
+++ b/packages/junior/src/api/schema.ts
@@ -44,6 +44,7 @@ export type {
 export {
   actorDirectoryReportSchema,
   actorProfileReportSchema,
+  personalSpendReportSchema,
   personParamsSchema,
 } from "./schema/person";
 export {
@@ -67,6 +68,7 @@ export type {
   ActorSummaryReport,
   ActorTotalsReport,
   PeopleActivityDayReport,
+  PersonalSpendReport,
   PersonParams,
 } from "./schema/person";
 export { apiErrorSchema } from "./schema/common";

--- a/packages/junior/src/api/schema/person.ts
+++ b/packages/junior/src/api/schema/person.ts
@@ -81,6 +81,17 @@ export const actorProfileReportSchema = z
   })
   .strict();
 
+export const personalSpendReportSchema = z
+  .object({
+    generatedAt: z.string(),
+    sevenDaysUsd: z.number().finite().nonnegative(),
+    source: z.literal("conversation_index"),
+    thirtyDaysUsd: z.number().finite().nonnegative(),
+    windowEnd: z.string(),
+    windowStart: z.string(),
+  })
+  .strict();
+
 export type ActorIdentity = z.infer<typeof actorIdentitySchema>;
 export type ConversationSummaryReport = z.infer<
   typeof conversationSummaryReportSchema
@@ -98,4 +109,5 @@ export type ActorTotalsReport = z.infer<typeof actorTotalsReportSchema>;
 export type ActorSummaryReport = z.infer<typeof actorSummaryReportSchema>;
 export type ActorDirectoryReport = z.infer<typeof actorDirectoryReportSchema>;
 export type ActorProfileReport = z.infer<typeof actorProfileReportSchema>;
+export type PersonalSpendReport = z.infer<typeof personalSpendReportSchema>;
 export type PersonParams = z.infer<typeof personParamsSchema>;

--- a/packages/junior/tests/integration/api/people/spend.test.ts
+++ b/packages/junior/tests/integration/api/people/spend.test.ts
@@ -1,0 +1,147 @@
+import { Hono } from "hono";
+import { eq } from "drizzle-orm";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { createJuniorApi, type JuniorApiVariables } from "@/api";
+import { personalSpendReportSchema } from "@/api/schema";
+import { createSqlStore } from "@/chat/conversations/sql/store";
+import { juniorConversations } from "@/db/schema";
+import { createConfiguredJuniorSqlFixture } from "../../../fixtures/sql";
+import { seedPeople } from "./fixture";
+
+function authenticatedApi(email: string) {
+  const app = new Hono<{ Variables: JuniorApiVariables }>();
+  app.use("*", async (context, next) => {
+    context.set("verifiedViewerEmail", email);
+    await next();
+  });
+  app.route("/", createJuniorApi());
+  return app;
+}
+
+describe("personal spend API", () => {
+  afterEach(() => vi.useRealTimers());
+
+  test("returns cached seven and thirty day spend from one viewer", async () => {
+    vi.useFakeTimers({ now: new Date("2026-06-15T12:00:00.000Z") });
+    const fixture = createConfiguredJuniorSqlFixture();
+    const store = createSqlStore(fixture.sql);
+
+    try {
+      await seedPeople(fixture);
+      await fixture.sql
+        .db()
+        .update(juniorConversations)
+        .set({ usage: { cost: { total: 0.1 } } })
+        .where(eq(juniorConversations.conversationId, "slack:C1:123"));
+      await fixture.sql
+        .db()
+        .update(juniorConversations)
+        .set({ usage: { cost: { total: 0.2 } } })
+        .where(eq(juniorConversations.conversationId, "slack:C4:456"));
+      await store.recordActivity({
+        actor: {
+          email: "alice@example.com",
+          platform: "slack",
+          slackUserId: "U1",
+          teamId: "T1",
+        },
+        conversationId: "slack:C1:older",
+        destination: {
+          channelId: "C1",
+          platform: "slack",
+          teamId: "T1",
+        },
+        nowMs: Date.parse("2026-05-25T12:00:00.000Z"),
+        source: "slack",
+      });
+      await store.recordExecution({
+        conversationId: "slack:C1:older",
+        createdAtMs: Date.parse("2026-05-25T12:00:00.000Z"),
+        execution: {
+          runId: "older-turn",
+          status: "idle",
+          updatedAtMs: Date.parse("2026-05-25T12:01:00.000Z"),
+        },
+        lastActivityAtMs: Date.parse("2026-05-25T12:01:00.000Z"),
+        metrics: { durationMs: 100, usage: { cost: { total: 0.4 } } },
+        source: "slack",
+        updatedAtMs: Date.parse("2026-05-25T12:01:00.000Z"),
+      });
+      await store.recordActivity({
+        actor: {
+          email: "alice@example.com",
+          platform: "slack",
+          slackUserId: "U1",
+          teamId: "T1",
+        },
+        conversationId: "slack:C1:future",
+        destination: {
+          channelId: "C1",
+          platform: "slack",
+          teamId: "T1",
+        },
+        nowMs: Date.parse("2026-06-16T12:00:00.000Z"),
+        source: "slack",
+      });
+      await store.recordExecution({
+        conversationId: "slack:C1:future",
+        createdAtMs: Date.parse("2026-06-16T12:00:00.000Z"),
+        execution: {
+          runId: "future-turn",
+          status: "idle",
+          updatedAtMs: Date.parse("2026-06-16T12:01:00.000Z"),
+        },
+        lastActivityAtMs: Date.parse("2026-06-16T12:01:00.000Z"),
+        metrics: { durationMs: 100, usage: { cost: { total: 10 } } },
+        source: "slack",
+        updatedAtMs: Date.parse("2026-06-16T12:01:00.000Z"),
+      });
+
+      const app = authenticatedApi("Alice@Example.com");
+      const firstResponse = await app.request(
+        "http://localhost/api/people/me/spend",
+      );
+      const first = personalSpendReportSchema.parse(await firstResponse.json());
+      expect(first).toMatchObject({
+        sevenDaysUsd: 0.3,
+        thirtyDaysUsd: 0.7,
+      });
+
+      await fixture.sql
+        .db()
+        .update(juniorConversations)
+        .set({ usage: { cost: { total: 1.1 } } })
+        .where(eq(juniorConversations.conversationId, "slack:C1:123"));
+
+      const cachedResponse = await app.request(
+        "http://localhost/api/people/me/spend",
+      );
+      const cached = personalSpendReportSchema.parse(
+        await cachedResponse.json(),
+      );
+      expect(cached).toEqual(first);
+
+      vi.advanceTimersByTime(5 * 60_000 + 1);
+      const refreshedResponse = await app.request(
+        "http://localhost/api/people/me/spend",
+      );
+      const refreshed = personalSpendReportSchema.parse(
+        await refreshedResponse.json(),
+      );
+      expect(refreshed).toMatchObject({
+        sevenDaysUsd: 1.3,
+        thirtyDaysUsd: 1.7,
+      });
+      expect(refreshed.generatedAt).not.toBe(first.generatedAt);
+    } finally {
+      await fixture.close();
+    }
+  });
+
+  test("requires a verified viewer", async () => {
+    const response = await createJuniorApi().request(
+      "http://localhost/api/people/me/spend",
+    );
+    expect(response.status).toBe(403);
+  });
+});


### PR DESCRIPTION
The dashboard profile control now opens on hover while preserving click, touch, keyboard, outside-click, and Escape behavior. Its borderless treatment is softer, and the header shows the authenticated viewer’s estimated 7-day and 30-day model spend.

Spend comes from a self-only People API projection backed by one bounded 30-day aggregate query and an app-scoped five-minute single-flight cache. Client refresh timing accounts for the age of server-cached reports so cache layers do not compound staleness. Database coverage protects rolling windows, cache expiry, authentication, and future-dated rows; browser coverage protects hover travel and existing menu actions.
