### PR TITLE
style(dashboard): increase small text size

### DIFF
--- a/packages/junior-dashboard/src/client/components/ProfileMenu.tsx
+++ b/packages/junior-dashboard/src/client/components/ProfileMenu.tsx
@@ -139,19 +139,19 @@ export function ProfileMenu({
       >
         <span className="hidden items-center gap-2 sm:flex">
           <span className="flex items-baseline gap-1 whitespace-nowrap tabular-nums">
-            <span className="text-[0.58rem] font-medium uppercase tracking-[0.1em] text-dashboard-text-muted">
+            <span className="text-xs font-medium uppercase tracking-[0.1em] text-dashboard-text-muted">
               7d
             </span>
-            <span className="text-[0.72rem] font-semibold text-dashboard-text">
+            <span className="text-xs font-semibold text-dashboard-text">
               {sevenDaySpend}
             </span>
           </span>
           <span aria-hidden="true" className="h-3 w-px bg-white/10" />
           <span className="flex items-baseline gap-1 whitespace-nowrap tabular-nums">
-            <span className="text-[0.58rem] font-medium uppercase tracking-[0.1em] text-dashboard-text-muted">
+            <span className="text-xs font-medium uppercase tracking-[0.1em] text-dashboard-text-muted">
               30d
             </span>
-            <span className="text-[0.72rem] font-semibold text-dashboard-text">
+            <span className="text-xs font-semibold text-dashboard-text">
               {thirtyDaySpend}
             </span>
           </span>

--- a/packages/junior-dashboard/src/client/conversations/ConversationPage.tsx
+++ b/packages/junior-dashboard/src/client/conversations/ConversationPage.tsx
@@ -80,7 +80,7 @@ export function ConversationPage(props: {
       <section className="min-w-0">
         <Card className="relative mb-3 grid gap-2 border-white/[0.07] bg-white/[0.025] p-3 md:mb-5 md:grid-cols-[minmax(0,1fr)_auto] md:gap-3 md:p-5">
           <div className="min-w-0">
-            <div className="mb-1 hidden font-mono text-[0.62rem] uppercase tracking-[0.16em] text-cyan-200/65 md:mb-2 md:block">
+            <div className="mb-1 hidden font-mono text-xs uppercase tracking-[0.16em] text-cyan-200/65 md:mb-2 md:block">
               Conversation
             </div>
             <div className="min-w-0">
@@ -88,7 +88,7 @@ export function ConversationPage(props: {
                 {conversationDisplayTitle(conversation)}
               </h2>
             </div>
-            <div className="mt-1.5 min-w-0 font-mono text-[0.68rem] leading-snug text-dashboard-text-muted md:mt-2">
+            <div className="mt-1.5 min-w-0 font-mono text-xs leading-snug text-dashboard-text-muted md:mt-2">
               <ConversationIdentity
                 conversation={conversation}
                 conversationId={conversationId}
@@ -96,7 +96,7 @@ export function ConversationPage(props: {
               />
             </div>
           </div>
-          <div className="flex min-w-0 flex-row flex-wrap items-center gap-x-3 gap-y-2 self-start font-mono text-[0.65rem] leading-snug text-dashboard-text-muted md:flex-col md:items-end md:text-right">
+          <div className="flex min-w-0 flex-row flex-wrap items-center gap-x-3 gap-y-2 self-start font-mono text-xs leading-snug text-dashboard-text-muted md:flex-col md:items-end md:text-right">
             <div className="break-words">
               updated{" "}
               {formatRelativeTime(
@@ -473,7 +473,7 @@ function ConversationStats(props: {
   return (
     <div className="col-span-full mt-1 hidden border-t border-white/[0.07] pt-3 md:block">
       <MetricList
-        className="break-words text-[0.72rem] leading-[1.5] text-dashboard-text-muted"
+        className="break-words text-xs leading-[1.5] text-dashboard-text-muted"
         items={stats}
       />
     </div>

--- a/packages/junior-dashboard/src/client/conversations/ConversationSidebar.tsx
+++ b/packages/junior-dashboard/src/client/conversations/ConversationSidebar.tsx
@@ -33,7 +33,7 @@ export function ConversationSidebar(props: {
   return (
     <aside className="relative grid h-full min-h-0 min-w-0 grid-rows-[auto_auto_minmax(0,1fr)] overflow-hidden border-r border-white/[0.07] bg-white/[0.02]">
       <div className="px-5 pb-3 pt-5">
-        <div className="mb-2 flex items-center gap-2 font-mono text-[0.62rem] uppercase tracking-[0.16em] text-cyan-200/65">
+        <div className="mb-2 flex items-center gap-2 font-mono text-xs uppercase tracking-[0.16em] text-cyan-200/65">
           <MessageSquareText aria-hidden="true" size={13} />
           Your trail
         </div>
@@ -41,7 +41,7 @@ export function ConversationSidebar(props: {
           <h2 className="m-0 font-display text-xl font-medium leading-tight text-dashboard-text">
             Conversations
           </h2>
-          <div className="rounded border border-white/[0.08] bg-black/20 px-2.5 py-1 font-mono text-[0.62rem] text-dashboard-text-muted">
+          <div className="rounded border border-white/[0.08] bg-black/20 px-2.5 py-1 font-mono text-xs text-dashboard-text-muted">
             {props.loading ? "…" : props.conversations.length}
           </div>
         </div>
@@ -154,7 +154,7 @@ function ConversationSidebarRow(props: {
             {title}
           </div>
         </div>
-        <div className="ml-3.5 mt-1.5 flex min-w-0 items-center gap-1.5 font-mono text-[0.62rem] leading-tight text-dashboard-text-muted">
+        <div className="ml-3.5 mt-1.5 flex min-w-0 items-center gap-1.5 font-mono text-xs leading-tight text-dashboard-text-muted">
           <span className="shrink-0">
             {formatRelativeTime(props.conversation.lastSeenAt)}
           </span>

--- a/packages/junior-dashboard/src/tailwind.css
+++ b/packages/junior-dashboard/src/tailwind.css
@@ -10,6 +10,8 @@
   --font-mono:
     "Geist Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
     "Liberation Mono", monospace;
+  --text-xs: 0.8125rem;
+  --text-xs--line-height: 1rem;
   --color-dashboard-text: #f4f4f5;
   --color-dashboard-text-muted: #a1a1aa;
   --color-dashboard-surface-panel: #09090b;


### PR DESCRIPTION
Raises the dashboard small-text baseline from 12px to 13px and moves conversation sidebar metadata, conversation header details, and personal spend labels onto the shared `text-xs` token. This improves readability while preserving the existing layout and visual hierarchy.

Visual QA covered 1600px, 1334px, 1024px, and 390px viewports with no clipping, horizontal overflow, or browser errors. The dashboard typecheck, lint, CSS build, full package build, and repository pre-push checks pass.
