### PR TITLE
fix(dashboard): distinguish memory events from reasoning

### DIFF
--- a/packages/junior-dashboard/src/client/conversations/ConversationTranscript.tsx
+++ b/packages/junior-dashboard/src/client/conversations/ConversationTranscript.tsx
@@ -1,10 +1,20 @@
 import { Fragment, type ClipboardEventHandler, type ReactNode } from "react";
 import {
+  Activity,
   Bot,
+  Brain,
+  Calendar,
+  Check,
   CircleAlert,
+  Database,
   Diff,
+  Info,
+  KeyRound,
+  Link,
   Minimize2,
   Send,
+  Sparkles,
+  TriangleAlert,
   type LucideIcon,
 } from "lucide-react";
 
@@ -334,10 +344,15 @@ function VisibleTranscriptEntries(props: {
         )
       }
       renderStructuredEvent={(entry) => (
-        <TranscriptStructuredEventView
-          part={entry.part}
-          timestamp={entry.timestamp}
-        />
+        <TranscriptRailEvent
+          icon={structuredEventIcon(entry.part.presentation.icon)}
+          kind="structured_event"
+        >
+          <TranscriptStructuredEventView
+            part={entry.part}
+            timestamp={entry.timestamp}
+          />
+        </TranscriptRailEvent>
       )}
       renderSubagent={(entry) => (
         <TranscriptRailEvent kind="subagent">
@@ -480,15 +495,17 @@ type TranscriptRailEventKind =
   | "compaction"
   | "handoff"
   | "resource_event"
+  | "structured_event"
   | "subagent";
 
 /** Anchor noteworthy transcript events to the same visual rail as turn markers. */
 function TranscriptRailEvent(props: {
   children: ReactNode;
+  icon?: LucideIcon;
   kind: TranscriptRailEventKind;
 }) {
   const marker = transcriptRailMarker(props.kind);
-  const Icon = marker.icon;
+  const Icon = props.icon ?? marker.icon;
 
   return (
     <div className="relative min-w-0" data-transcript-rail-event={props.kind}>
@@ -517,6 +534,12 @@ function transcriptRailMarker(kind: TranscriptRailEventKind): {
       icon: Diff,
     };
   }
+  if (kind === "structured_event") {
+    return {
+      className: "border-violet-300/35 text-violet-200",
+      icon: Activity,
+    };
+  }
   if (kind === "subagent") {
     return {
       className: "border-cyan-300/35 text-cyan-200",
@@ -533,6 +556,28 @@ function transcriptRailMarker(kind: TranscriptRailEventKind): {
     className: "border-amber-300/35 text-amber-200",
     icon: Minimize2,
   };
+}
+
+const structuredEventIcons: Record<
+  NonNullable<TranscriptStructuredEventEntry["part"]["presentation"]["icon"]>,
+  LucideIcon
+> = {
+  activity: Activity,
+  brain: Brain,
+  calendar: Calendar,
+  check: Check,
+  database: Database,
+  info: Info,
+  key: KeyRound,
+  link: Link,
+  sparkles: Sparkles,
+  warning: TriangleAlert,
+};
+
+function structuredEventIcon(
+  icon: TranscriptStructuredEventEntry["part"]["presentation"]["icon"],
+): LucideIcon {
+  return icon ? structuredEventIcons[icon] : Activity;
 }
 
 function RedactedTranscriptView(props: {
@@ -577,10 +622,15 @@ function RedactedTranscriptView(props: {
         )
       }
       renderStructuredEvent={(entry) => (
-        <TranscriptStructuredEventView
-          part={entry.part}
-          timestamp={entry.timestamp}
-        />
+        <TranscriptRailEvent
+          icon={structuredEventIcon(entry.part.presentation.icon)}
+          kind="structured_event"
+        >
+          <TranscriptStructuredEventView
+            part={entry.part}
+            timestamp={entry.timestamp}
+          />
+        </TranscriptRailEvent>
       )}
       renderSubagent={(entry) => (
         <TranscriptRailEvent kind="subagent">

--- a/packages/junior-dashboard/src/client/conversations/TranscriptReasoningView.tsx
+++ b/packages/junior-dashboard/src/client/conversations/TranscriptReasoningView.tsx
@@ -1,4 +1,4 @@
-import { Brain } from "lucide-react";
+import { Lightbulb } from "lucide-react";
 
 import { formatMessageTimestamp } from "../format";
 import type { TranscriptViewReasoningPart } from "../types";
@@ -23,7 +23,7 @@ export function TranscriptReasoningView(props: {
         className="mt-0.5 inline-flex size-4 shrink-0 items-center justify-center text-dashboard-text-muted"
         title="Reasoning"
       >
-        <Brain aria-hidden="true" size={14} strokeWidth={1.8} />
+        <Lightbulb aria-hidden="true" size={14} strokeWidth={1.8} />
       </span>
       <TranscriptHeadingRow
         left={

--- a/packages/junior-dashboard/src/client/conversations/TranscriptStructuredEventView.tsx
+++ b/packages/junior-dashboard/src/client/conversations/TranscriptStructuredEventView.tsx
@@ -1,38 +1,8 @@
-import {
-  Activity,
-  Brain,
-  Calendar,
-  Check,
-  Database,
-  Info,
-  KeyRound,
-  Link,
-  Sparkles,
-  TriangleAlert,
-  type LucideIcon,
-} from "lucide-react";
-
 import { formatMessageTimestamp } from "../format";
 import type { TranscriptViewStructuredEventPart } from "../types";
 import { HighlightText, useTranscriptSearch } from "./transcriptSearch";
 
 type TranscriptPresentationEventPart = TranscriptViewStructuredEventPart;
-
-const icons: Record<
-  NonNullable<TranscriptPresentationEventPart["presentation"]["icon"]>,
-  LucideIcon
-> = {
-  activity: Activity,
-  brain: Brain,
-  calendar: Calendar,
-  check: Check,
-  database: Database,
-  info: Info,
-  key: KeyRound,
-  link: Link,
-  sparkles: Sparkles,
-  warning: TriangleAlert,
-};
 
 /** Render one structured event with core-owned transcript interaction. */
 export function TranscriptStructuredEventView(props: {
@@ -41,12 +11,13 @@ export function TranscriptStructuredEventView(props: {
 }) {
   const search = useTranscriptSearch();
   const presentation = props.part.presentation;
-  const Icon = presentation.icon ? icons[presentation.icon] : Activity;
   const timestamp = formatMessageTimestamp(props.timestamp);
   const details = presentation.details ?? [];
+  const surfaceClass =
+    "min-w-0 rounded-lg border border-violet-300/10 bg-violet-300/[0.035] px-3 py-2 font-mono text-[0.82rem] leading-tight";
   const body =
     details.length > 0 ? (
-      <div className="grid gap-2 pb-1 pl-6 pt-2">
+      <div className="grid gap-2 pb-1 pt-2">
         {details.map((detail, index) => (
           <div
             className="rounded border border-white/[0.06] bg-white/[0.025] px-3 py-2.5"
@@ -77,12 +48,9 @@ export function TranscriptStructuredEventView(props: {
       </div>
     ) : null;
   const header = (
-    <div className="grid min-w-0 grid-cols-[1rem_minmax(0,1fr)_auto] items-start gap-2 max-md:grid-cols-[1rem_minmax(0,1fr)]">
-      <span className="mt-0.5 inline-flex size-4 items-center justify-center text-dashboard-text-muted">
-        <Icon aria-hidden="true" size={14} strokeWidth={1.8} />
-      </span>
+    <div className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-start gap-2 max-md:grid-cols-[minmax(0,1fr)]">
       <div className="min-w-0">
-        <div className="font-medium text-dashboard-text-muted">
+        <div className="font-display text-[0.88rem] font-semibold text-violet-100">
           <HighlightText text={presentation.title} />
         </div>
         {presentation.preview ? (
@@ -101,14 +69,14 @@ export function TranscriptStructuredEventView(props: {
 
   if (details.length === 0 || search.active) {
     return (
-      <div className="py-1.5 font-mono text-[0.82rem] leading-tight">
+      <div className={surfaceClass}>
         {header}
         {body}
       </div>
     );
   }
   return (
-    <details className="group/plugin-event py-1.5 font-mono text-[0.82rem] leading-tight">
+    <details className={`group/plugin-event ${surfaceClass}`}>
       <summary className="cursor-pointer list-none transition-colors hover:text-dashboard-text focus-visible:outline focus-visible:outline-1 focus-visible:outline-cyan-300/55 [&::-webkit-details-marker]:hidden">
         {header}
       </summary>

--- a/packages/junior-dashboard/src/mock-reporting/fixtures.ts
+++ b/packages/junior-dashboard/src/mock-reporting/fixtures.ts
@@ -410,8 +410,7 @@ function dashboardQaConversation(nowMs: number): ConversationDetailReport {
         turnId: "qa-turn",
         presentation: {
           icon: "brain",
-          title: "Memories captured",
-          preview: "2 memories",
+          title: "2 memories captured",
           details: [
             {
               title: "Use pnpm for repository commands.",

--- a/packages/junior-dashboard/tests/pluginEventTranscript.test.ts
+++ b/packages/junior-dashboard/tests/pluginEventTranscript.test.ts
@@ -54,8 +54,7 @@ describe("plugin event transcript projection", () => {
           turnId: "turn-1",
           presentation: {
             icon: "brain",
-            title: "Memories captured",
-            preview: "2 memories",
+            title: "2 memories captured",
             details: [
               {
                 title: "Use pnpm.",
@@ -91,14 +90,13 @@ describe("plugin event transcript projection", () => {
           version: 1,
           turnId: "turn-1",
           presentation: {
-            title: "Memory captured",
-            preview: "Use pnpm.",
+            title: "1 memory captured",
           },
         }),
       ]),
     );
 
-    expect(markdown).toContain("### Memory captured");
+    expect(markdown).toContain("### 1 memory captured");
     expect(markdown).toContain("2026-01-01T00:00:01.000Z - +1.0s");
   });
 

--- a/packages/junior-dashboard/tests/telemetry-components.test.tsx
+++ b/packages/junior-dashboard/tests/telemetry-components.test.tsx
@@ -542,6 +542,28 @@ describe("dashboard canonical-event components", () => {
     expect(html).toContain("Agent response failed");
   });
 
+  it("anchors structured events to the transcript rail", () => {
+    const html = renderTranscript(
+      conversation([
+        event(0, {
+          type: "structured_event",
+          namespace: "memory",
+          name: "memories_captured",
+          version: 1,
+          turnId: "turn-1",
+          presentation: {
+            icon: "brain",
+            title: "2 memories captured",
+          },
+        }),
+      ]),
+    );
+
+    expect(html).toContain('data-transcript-rail-event="structured_event"');
+    expect(html).toContain("lucide-brain");
+    expect(html).toContain("2 memories captured");
+  });
+
   it("keeps recalled memory context collapsed on its user message", () => {
     const html = renderTranscript(
       conversation([

--- a/packages/junior-dashboard/tests/transcriptReasoning.test.tsx
+++ b/packages/junior-dashboard/tests/transcriptReasoning.test.tsx
@@ -20,6 +20,8 @@ describe("transcript reasoning", () => {
 
     expect(html).toContain("<details");
     expect(html).toContain('aria-label="Reasoning"');
+    expect(html).toContain("lucide-lightbulb");
+    expect(html).not.toContain("lucide-brain");
     expect(html).toContain("Inspect the inputs before searching.");
     expect(html).toContain("group-open/reasoning:hidden");
     expect(html).toContain("group-open/reasoning:inline");

--- a/packages/junior-memory/src/events.ts
+++ b/packages/junior-memory/src/events.ts
@@ -3,8 +3,6 @@ import { z } from "zod";
 import { MEMORY_KINDS, MEMORY_SCOPES } from "./types";
 import type { MemoryRecord } from "./store";
 
-const MAX_EVENT_PREVIEW_CHARS = 500;
-
 const capturedMemorySchema = z
   .object({
     content: z.string().min(1),
@@ -14,12 +12,6 @@ const capturedMemorySchema = z
     scope: z.enum(MEMORY_SCOPES),
   })
   .strict();
-
-function eventPreview(content: string): string {
-  const trimmed = content.trim();
-  if (trimmed.length <= MAX_EVENT_PREVIEW_CHARS) return trimmed;
-  return `${trimmed.slice(0, MAX_EVENT_PREVIEW_CHARS - 3).trimEnd()}...`;
-}
 
 const capturedMemoriesSchema = z
   .object({
@@ -42,11 +34,7 @@ function renderCapturedMemories(
   if (count === 0) return undefined;
   return {
     icon: "brain" as const,
-    title: count === 1 ? "Memory captured" : "Memories captured",
-    preview:
-      count === 1
-        ? eventPreview(event.memories[0]!.content)
-        : `${count} memories`,
+    title: `${count} ${count === 1 ? "memory" : "memories"} captured`,
     details: event.memories.map((memory) => ({
       title: memory.content,
       metadata: [memory.kind, memory.scope],

--- a/packages/junior-memory/tests/events.test.ts
+++ b/packages/junior-memory/tests/events.test.ts
@@ -20,7 +20,7 @@ describe("memory conversation events", () => {
     ).toBeUndefined();
   });
 
-  it("bounds a single-memory preview to the presentation contract", () => {
+  it("uses a count-aware title and keeps the full memory in details", () => {
     const content = `Long memory ${"x".repeat(1_000)}`;
 
     const presentation = memoriesCapturedEvent.renderEvent({
@@ -35,8 +35,31 @@ describe("memory conversation events", () => {
       ],
     });
 
-    expect(presentation?.preview).toHaveLength(500);
-    expect(presentation?.preview).toMatch(/\.\.\.$/);
+    expect(presentation?.title).toBe("1 memory captured");
+    expect(presentation?.preview).toBeUndefined();
     expect(presentation?.details?.[0]?.title).toBe(content);
+  });
+
+  it("pluralizes captured memory counts", () => {
+    const presentation = memoriesCapturedEvent.renderEvent({
+      memories: [
+        {
+          content: "Use pnpm.",
+          id: "memory-1",
+          kind: "preference",
+          observedAtMs: 1,
+          scope: "personal",
+        },
+        {
+          content: "Keep events expandable.",
+          id: "memory-2",
+          kind: "knowledge",
+          observedAtMs: 2,
+          scope: "conversation",
+        },
+      ],
+    });
+
+    expect(presentation?.title).toBe("2 memories captured");
   });
 });

--- a/packages/junior/tests/unit/api/conversation-events.test.ts
+++ b/packages/junior/tests/unit/api/conversation-events.test.ts
@@ -56,8 +56,7 @@ describe("conversation report event projection", () => {
       renderEvent(value) {
         return {
           icon: "brain",
-          title: "Memories captured",
-          preview: `${value.count} memories`,
+          title: `${value.count} memories captured`,
         };
       },
     });
@@ -98,8 +97,7 @@ describe("conversation report event projection", () => {
             turnId: "turn-1",
             presentation: {
               icon: "brain",
-              title: "Memories captured",
-              preview: "2 memories",
+              title: "2 memories captured",
             },
           },
         },


### PR DESCRIPTION
Memory capture events now render as count-aware, bordered structured events on the conversation rail, while reasoning rows use a lightbulb instead of the memory brain icon. Collapsed events read as `1 memory captured` or `N memories captured`, with the captured memory details still available when expanded.

The rail treatment uses each structured event’s configured presentation icon, keeping other plugin events consistent as well. The final collapsed and expanded states were visually checked at desktop and mobile widths.
