### PR TITLE
style(docs): soften homepage color scheme

### DIFF
--- a/packages/docs/src/styles/custom.css
+++ b/packages/docs/src/styles/custom.css
@@ -57,12 +57,12 @@ html:root[data-theme="light"] {
 }
 
 body:has(.jr-home) {
-  background: #0a0a0f;
+  background: var(--ve-bg);
   color: var(--jr-cream);
 }
 
 body:has(.jr-home) .header {
-  background: #0d0d14;
+  background: var(--ve-bg-soft);
   border-bottom: 4px solid var(--jr-acid);
 }
 
@@ -74,17 +74,17 @@ body:has(.jr-home) site-search button {
 }
 
 body:has(.jr-home) site-search button {
-  background: #15151d;
-  border: 1px solid #34343f;
+  background: var(--ve-surface-raised);
+  border: 1px solid var(--ve-line);
   border-radius: 0.5rem;
   box-shadow: none;
 }
 
 body:has(.jr-home) .page {
-  background-color: #0a0a0f;
+  background-color: var(--ve-bg);
   background-image: radial-gradient(
     circle,
-    rgba(204, 255, 0, 0.16) 1px,
+    var(--ve-accent-soft) 1px,
     transparent 1px
   );
   background-size: 17px 17px;

--- a/packages/docs/src/styles/custom.css
+++ b/packages/docs/src/styles/custom.css
@@ -288,6 +288,7 @@ body:has(.jr-home) main {
 
 .jr-sticker-slack {
   background: var(--jr-cream);
+  color: var(--jr-black);
   padding: 1rem;
   transform: rotate(-6deg);
 }
@@ -407,6 +408,7 @@ body:has(.jr-home) main {
 
 .jr-sticker-more {
   background: var(--jr-cream);
+  color: var(--jr-black);
   flex-direction: row;
   font-size: 0.78rem;
   gap: 0.4rem;

--- a/packages/docs/src/styles/custom.css
+++ b/packages/docs/src/styles/custom.css
@@ -57,32 +57,37 @@ html:root[data-theme="light"] {
 }
 
 body:has(.jr-home) {
-  background: var(--jr-acid);
-  color: var(--jr-black);
+  background: #0a0a0f;
+  color: var(--jr-cream);
 }
 
 body:has(.jr-home) .header {
-  background: var(--jr-cream);
-  border-bottom: 4px solid var(--jr-black);
+  background: #0d0d14;
+  border-bottom: 4px solid var(--jr-acid);
 }
 
 body:has(.jr-home) .site-title,
 body:has(.jr-home) .social-icons a,
 body:has(.jr-home) starlight-theme-select label,
 body:has(.jr-home) site-search button {
-  color: var(--jr-black);
+  color: var(--jr-cream);
 }
 
 body:has(.jr-home) site-search button {
-  background: #fff;
-  border: 3px solid var(--jr-black);
-  border-radius: 0;
-  box-shadow: 4px 4px 0 var(--jr-black);
+  background: #15151d;
+  border: 1px solid #34343f;
+  border-radius: 0.5rem;
+  box-shadow: none;
 }
 
 body:has(.jr-home) .page {
-  background-color: var(--jr-acid);
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='17' height='17' viewBox='0 0 17 17'%3E%3Ccircle cx='1.5' cy='1.5' r='1.2' fill='%23000' fill-opacity='.17'/%3E%3C/svg%3E");
+  background-color: #0a0a0f;
+  background-image: radial-gradient(
+    circle,
+    rgba(204, 255, 0, 0.16) 1px,
+    transparent 1px
+  );
+  background-size: 17px 17px;
 }
 
 body:has(.jr-home) main {
@@ -146,7 +151,7 @@ body:has(.jr-home) main {
 }
 
 .jr-home-mega {
-  color: var(--jr-black);
+  color: var(--jr-acid);
   display: block;
   font-family: "Arial Black", Impact, Haettenschweiler, sans-serif;
   font-size: clamp(5.2rem, 18vw, 16rem);
@@ -214,7 +219,7 @@ body:has(.jr-home) main {
 }
 
 .jr-home {
-  color: var(--jr-black);
+  color: var(--jr-cream);
   margin: -4rem auto 0;
   max-width: 86rem;
   padding: 0 1.25rem 4rem;
@@ -327,7 +332,7 @@ body:has(.jr-home) main {
 }
 
 .jr-flow-arrow-green {
-  color: #5ca800;
+  color: var(--jr-acid);
   transform: rotate(6deg);
 }
 
@@ -441,7 +446,7 @@ body:has(.jr-home) main {
 }
 
 .jr-section-number {
-  color: var(--jr-black) !important;
+  color: var(--jr-acid) !important;
   font-family: "Arial Black", Impact, sans-serif;
   font-size: 0.8rem;
   font-weight: 900;
@@ -451,7 +456,6 @@ body:has(.jr-home) main {
 
 .jr-proof-copy h2,
 .jr-card h2 {
-  color: var(--jr-black);
   font-family: "Arial Black", Impact, sans-serif;
   font-weight: 950;
   letter-spacing: -0.055em;
@@ -461,11 +465,12 @@ body:has(.jr-home) main {
 }
 
 .jr-proof-copy h2 {
+  color: var(--jr-cream);
   font-size: clamp(3rem, 6vw, 5.5rem);
 }
 
 .jr-proof-copy > p:not(.jr-section-number) {
-  color: var(--jr-black);
+  color: var(--jr-cream);
   font-size: 1.05rem;
   font-weight: 700;
   line-height: 1.5;
@@ -670,6 +675,7 @@ body:has(.jr-home) main {
   display: grid;
   gap: 1.5rem;
   grid-template-columns: repeat(3, 1fr);
+  margin-inline: clamp(0.5rem, 2.5vw, 2.5rem);
   padding-bottom: clamp(5rem, 9vw, 9rem);
 }
 
@@ -720,6 +726,7 @@ body:has(.jr-home) main {
 }
 
 .jr-card h2 {
+  color: var(--jr-black);
   font-size: clamp(2.2rem, 4vw, 3.7rem);
   hyphens: none;
   overflow-wrap: normal;
@@ -790,7 +797,7 @@ body:has(.jr-home) main {
 }
 
 .jr-made-this {
-  color: var(--jr-black) !important;
+  color: var(--jr-cream) !important;
   font-size: 0.8rem;
   font-style: italic;
   margin: 0 0 1rem auto;
@@ -804,7 +811,7 @@ body:has(.jr-home) main {
 }
 
 body:has(.jr-home) footer {
-  color: var(--jr-black);
+  color: var(--jr-cream);
 }
 
 @media (max-width: 64rem) {

--- a/packages/docs/src/styles/homepage-mocks.css
+++ b/packages/docs/src/styles/homepage-mocks.css
@@ -261,6 +261,7 @@
   background: var(--jr-cream);
   border: 4px solid var(--jr-black);
   box-shadow: 7px 7px 0 var(--jr-black);
+  color: var(--jr-black);
   margin: 1.5rem 0 1.25rem;
   padding: 1rem;
   transform: rotate(1deg);

--- a/packages/docs/src/styles/homepage-mocks.css
+++ b/packages/docs/src/styles/homepage-mocks.css
@@ -1,11 +1,14 @@
 .jr-real-work {
-  margin-inline: calc(50% - 50vw);
+  box-sizing: border-box;
+  margin-block: clamp(2rem, 4vw, 4rem) clamp(3rem, 6vw, 6rem);
+  margin-inline: calc(50% - 50vw + clamp(1rem, 4vw, 4rem));
   padding: clamp(5rem, 9vw, 9rem) max(1.25rem, calc((100vw - 86rem) / 2));
   position: relative;
+  width: calc(100vw - clamp(2rem, 8vw, 8rem));
 }
 
 .jr-real-work::before {
-  background: var(--jr-cream);
+  background: var(--jr-acid);
   border-block: 5px solid var(--jr-black);
   content: "";
   inset: 0;


### PR DESCRIPTION
The homepage now uses the docs charcoal palette as its primary canvas, reserving acid green for the wordmark, accents, and the real-work showcase. Cream remains on smaller paper-like cards, preserving Junior’s existing visual language while making the page substantially easier on the eyes.

The showcase and capability cards are inset with responsive gutters, while the ticker stays full-width as the deliberate section divider. The content and responsive layout are otherwise unchanged.
