### PR TITLE
fix(agent): keep MCP provider failures out of action review

### DIFF
--- a/packages/junior-evals/evals/agent/providers.eval.ts
+++ b/packages/junior-evals/evals/agent/providers.eval.ts
@@ -64,6 +64,7 @@ describeEval("Skill Providers", slackEvals, (it) => {
       expect.arrayContaining([
         expect.objectContaining({
           name: "callMcpTool",
+          status: "ok",
           arguments: expect.objectContaining({
             tool_name: "mcp__eval-mcp__handbook-search",
             arguments: expect.objectContaining({
@@ -81,6 +82,7 @@ describeEval("Skill Providers", slackEvals, (it) => {
         }),
       ]),
     );
+    expect(visibleThreadReplies(result.session)).toHaveLength(1);
   });
 
   it("when an MCP tool has mutually exclusive filters, use only the provided filter", async ({

--- a/packages/junior/src/chat/tools/definition.ts
+++ b/packages/junior/src/chat/tools/definition.ts
@@ -71,6 +71,8 @@ interface BaseToolDefinition<
    * Return trusted host metadata for the exact dispatched action.
    *
    * Descriptions and annotations inform review; they do not grant authority.
+   * This projection runs before action review and must not activate providers
+   * or perform other external side effects.
    */
   resolveApprovalMetadata?(
     input: TInput,
@@ -131,6 +133,8 @@ export interface AnyToolDefinition extends ToolApprovalMetadata {
    * Return trusted host metadata for the exact dispatched action.
    *
    * Descriptions and annotations inform review; they do not grant authority.
+   * This projection runs before action review and must not activate providers
+   * or perform other external side effects.
    */
   resolveApprovalMetadata?(
     input: unknown,

--- a/packages/junior/src/chat/tools/skill/call-mcp-tool.ts
+++ b/packages/junior/src/chat/tools/skill/call-mcp-tool.ts
@@ -78,11 +78,7 @@ export function createCallMcpToolTool(mcpToolManager: CallMcpToolManager) {
           .optional(),
       })
       .passthrough(),
-    resolveApprovalMetadata: async ({ tool_name }) => {
-      const provider = parseMcpProviderFromToolName(tool_name);
-      if (provider) {
-        await mcpToolManager.activateProvider(provider);
-      }
+    resolveApprovalMetadata: ({ tool_name }) => {
       const activeTool = mcpToolManager
         .getResolvedActiveTools()
         .find((candidate) => candidate.name === tool_name);

--- a/packages/junior/tests/component/runtime/agent-run-mcp-progressive-loading.test.ts
+++ b/packages/junior/tests/component/runtime/agent-run-mcp-progressive-loading.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createSlackSource } from "@sentry/junior-plugin-api";
 import { renderCurrentInstruction } from "@/chat/current-instruction";
 import { getConversationEventStore } from "@/chat/db";
+import { McpProviderError } from "@/chat/mcp/errors";
 import type { PiMessage } from "@/chat/pi/messages";
 import type { ConversationPendingAuthState } from "@/chat/state/conversation";
 
@@ -16,6 +17,7 @@ const {
   continueCallCount,
   continueStopsOnAbort,
   deliverPrivateMessageMock,
+  directMcpProviderFailure,
   guardianDecision,
   guardianProposals,
   listToolsMock,
@@ -46,6 +48,7 @@ const {
   continueCallCount: { value: 0 },
   continueStopsOnAbort: { value: false },
   deliverPrivateMessageMock: vi.fn(),
+  directMcpProviderFailure: { value: false },
   guardianDecision: {
     value: "allow" as "allow" | "deny" | "unavailable",
   },
@@ -231,6 +234,28 @@ vi.mock("@earendil-works/pi-agent-core", async (importOriginal) => {
       promptMessages.push(message);
       promptSeedMessages.push([...this.state.messages]);
       this.state.messages.push(message);
+
+      if (directMcpProviderFailure.value) {
+        const callMcpTool = this.state.tools.find(
+          (tool) => tool.name === "callMcpTool",
+        );
+        if (!callMcpTool) {
+          throw new Error("callMcpTool missing");
+        }
+        try {
+          await this.executeTool(callMcpTool, "tool-call-provider-failure", {
+            tool_name: "mcp__demo__ping",
+            arguments: { query: "hello" },
+          });
+        } catch {
+          if (!this.aborted) {
+            this.state.messages.push(
+              assistantMessage("I couldn't connect to the demo provider."),
+            );
+          }
+          return {};
+        }
+      }
 
       const loadSkillTool = this.state.tools.find(
         (tool) => tool.name === "loadSkill",
@@ -722,6 +747,7 @@ describe("executeAgentRun progressive MCP loading", () => {
     continueCallCount.value = 0;
     continueStopsOnAbort.value = false;
     deliverPrivateMessageMock.mockReset();
+    directMcpProviderFailure.value = false;
     guardianDecision.value = "allow";
     guardianProposals.length = 0;
     listToolsMock.mockReset();
@@ -921,6 +947,56 @@ describe("executeAgentRun progressive MCP loading", () => {
       turnId: "turn-2",
       toolCallId: expect.any(String),
       toolName: "mcp__demo__ping",
+      decision: "allow",
+      riskLevel: "low",
+      userAuthorization: "high",
+    });
+  });
+
+  it("keeps MCP activation failures outside the fatal action-review boundary", async () => {
+    directMcpProviderFailure.value = true;
+    listToolsMock.mockReset();
+    listToolsMock.mockImplementation(async () => {
+      expect(guardianProposals).toHaveLength(1);
+      throw new McpProviderError({
+        phase: "connect",
+        provider: "demo",
+      });
+    });
+
+    const reply = finalReply(
+      await executeAgentRun(
+        makeAgentRunRequest("check the demo provider", {
+          conversationId: "conversation-provider-failure",
+          threadTs: "1712345.0098",
+          turnId: "turn-provider-failure",
+        }),
+      ),
+    );
+
+    expect(reply.text).toBe("I couldn't connect to the demo provider.");
+    expect(guardianProposals).toEqual([
+      expect.objectContaining({
+        input: {
+          arguments: { query: "hello" },
+          tool_name: "mcp__demo__ping",
+        },
+        tool: expect.objectContaining({
+          name: "callMcpTool",
+        }),
+      }),
+    ]);
+    expect(listToolsMock).toHaveBeenCalledOnce();
+    expect(callToolMock).not.toHaveBeenCalled();
+    expect(agentAfterToolResults).toHaveLength(1);
+    const events = await getConversationEventStore().loadCurrentHistory(
+      "conversation-provider-failure",
+    );
+    expect(events.map((event) => event.data)).toContainEqual({
+      type: "guardian_action_reviewed",
+      turnId: "turn-provider-failure",
+      toolCallId: "tool-call-provider-failure",
+      toolName: "callMcpTool",
       decision: "allow",
       riskLevel: "low",
       userAuthorization: "high",

--- a/packages/junior/tests/component/tool-support/pi-tool-adapter.test.ts
+++ b/packages/junior/tests/component/tool-support/pi-tool-adapter.test.ts
@@ -337,7 +337,7 @@ describe("Pi tool adapter", () => {
     );
   });
 
-  it("activates an MCP provider before reviewing the dispatched action", async () => {
+  it("reviews the MCP dispatcher before activating the requested provider", async () => {
     const sandbox = new SkillSandbox([], []);
     const execute = vi.fn(async () => ({
       content: [{ type: "text" as const, text: "deleted" }],
@@ -402,19 +402,30 @@ describe("Pi tool adapter", () => {
           arguments: { workspace: "preview-42" },
         },
         tool: expect.objectContaining({
-          annotations: managedTool.annotations,
-          description: managedTool.description,
-          dispatcherName: "callMcpTool",
-          name: managedTool.name,
+          annotations: {
+            destructiveHint: true,
+            idempotentHint: false,
+            openWorldHint: true,
+            readOnlyHint: false,
+          },
+          name: "callMcpTool",
         }),
       }),
       {},
     );
-    expect(activateProvider.mock.invocationCallOrder[0]).toBeLessThan(
-      review.mock.invocationCallOrder[0]!,
-    );
+    expect(activateProvider).toHaveBeenCalledWith("demo");
     expect(review.mock.invocationCallOrder[0]).toBeLessThan(
+      activateProvider.mock.invocationCallOrder[0]!,
+    );
+    expect(activateProvider.mock.invocationCallOrder[0]).toBeLessThan(
       execute.mock.invocationCallOrder[0]!,
+    );
+    expect(execute).toHaveBeenCalledWith(
+      { workspace: "preview-42" },
+      {
+        conversationPrivacy: "private",
+        toolCallId: "tool-mcp",
+      },
     );
   });
 

--- a/packages/junior/tests/unit/tools/call-mcp-tool.test.ts
+++ b/packages/junior/tests/unit/tools/call-mcp-tool.test.ts
@@ -60,7 +60,7 @@ describe("callMcpTool", () => {
       activateProvider: vi.fn(async () => true),
       getResolvedActiveTools: vi.fn(() => [
         {
-          name: "search",
+          name: "mcp__demo__search",
           rawName: "search",
           provider: "demo",
           description: "Search the remote workspace.",
@@ -78,7 +78,7 @@ describe("callMcpTool", () => {
 
     expect(
       await callMcpTool.resolveApprovalMetadata?.({
-        tool_name: "search",
+        tool_name: "mcp__demo__search",
         arguments: { query: "errors" },
       }),
     ).toEqual({
@@ -88,12 +88,13 @@ describe("callMcpTool", () => {
         readOnlyHint: true,
       },
       description: "Search the remote workspace.",
-      name: "search",
+      name: "mcp__demo__search",
       source: {
         id: "demo",
         description: "MCP provider demo",
       },
     });
+    expect(manager.activateProvider).not.toHaveBeenCalled();
   });
 
   it("preserves native MCP content from the managed tool", async () => {


### PR DESCRIPTION
MCP approval metadata now projects only already-active tool metadata, while lazy provider activation remains in `callMcpTool` execution after Guardian allows the action. A provider connection failure therefore stays a recoverable tool failure instead of being wrapped as unavailable action review and aborting the user-facing turn.

The root cause was external MCP activation running inside action review's fatal preparation boundary. The metadata contract now explicitly forbids external side effects, while conservative dispatcher annotations continue to require review when exact active-tool metadata is unavailable. Regression coverage verifies that the review decision is persisted before activation, a failed activation never calls the remote MCP action, and the agent can still produce a visible reply. The existing MCP provider, Guardian action, and MCP OAuth resume evals continue to pass.
