### PR TITLE
feat(dashboard): group conversations by activity

### DIFF
--- a/packages/junior-dashboard/src/client/conversations/ConversationSidebar.tsx
+++ b/packages/junior-dashboard/src/client/conversations/ConversationSidebar.tsx
@@ -6,7 +6,6 @@ import { useArchiveConversation } from "./queries";
 import {
   conversationDisplayTitle,
   conversationPath,
-  formatRelativeTime,
   slackLocationLabel,
   visualStatusForConversation,
 } from "../format";
@@ -14,10 +13,18 @@ import { cn } from "../styles";
 import type { Conversation } from "../types";
 import { ActiveIndicator } from "../components/ActiveIndicator";
 import { AnimatedList } from "./AnimatedList";
+import {
+  buildConversationSections,
+  type ConversationSection,
+} from "./conversationSections";
 import { EmptyTelemetry } from "../components/EmptyTelemetry";
 import { SearchInput } from "../components/SearchInput";
 
-const conversationKey = (conversation: Conversation) => conversation.id;
+type ConversationSidebarEntry =
+  | { key: string; kind: "section"; label: string }
+  | { conversation: Conversation; key: string; kind: "conversation" };
+
+const conversationEntryKey = (entry: ConversationSidebarEntry) => entry.key;
 
 /** Render the compact personal conversation picker used by the home workspace. */
 export function ConversationSidebar(props: {
@@ -26,11 +33,18 @@ export function ConversationSidebar(props: {
   loading: boolean;
   query: string;
   selectedId?: string;
+  timeZone: string;
   onQueryChange(value: string): void;
 }) {
   const [archivedConversation, setArchivedConversation] =
     useState<Conversation>();
   const [archiveError, setArchiveError] = useState<Conversation>();
+  const entries = conversationSidebarEntries(
+    buildConversationSections(props.conversations, {
+      nowMs: Date.now(),
+      timeZone: props.timeZone,
+    }),
+  );
   return (
     <aside className="relative grid h-full min-h-0 min-w-0 grid-rows-[auto_auto_minmax(0,1fr)] overflow-hidden border-r border-white/[0.07] bg-white/[0.02]">
       <div className="px-5 pb-3 pt-5">
@@ -74,21 +88,27 @@ export function ConversationSidebar(props: {
                 </div>
               ) : undefined
             }
-            getKey={conversationKey}
-            items={props.conversations}
-            renderItem={(conversation) => (
-              <ConversationSidebarRow
-                conversation={conversation}
-                onArchiveError={setArchiveError}
-                onArchived={(conversation) => {
-                  setArchiveError((current) =>
-                    current?.id === conversation.id ? undefined : current,
-                  );
-                  setArchivedConversation(conversation);
-                }}
-                selected={conversation.id === props.selectedId}
-              />
-            )}
+            getKey={conversationEntryKey}
+            items={entries}
+            renderItem={(entry) =>
+              entry.kind === "section" ? (
+                <h3 className="m-0 px-3 pb-1 pt-4 font-display text-[0.72rem] font-semibold uppercase tracking-[0.08em] text-dashboard-text-muted/60">
+                  {entry.label}
+                </h3>
+              ) : (
+                <ConversationSidebarRow
+                  conversation={entry.conversation}
+                  onArchiveError={setArchiveError}
+                  onArchived={(conversation) => {
+                    setArchiveError((current) =>
+                      current?.id === conversation.id ? undefined : current,
+                    );
+                    setArchivedConversation(conversation);
+                  }}
+                  selected={entry.conversation.id === props.selectedId}
+                />
+              )
+            }
             role="navigation"
           />
         )}
@@ -113,6 +133,23 @@ export function ConversationSidebar(props: {
   );
 }
 
+function conversationSidebarEntries(
+  sections: ConversationSection[],
+): ConversationSidebarEntry[] {
+  return sections.flatMap((section) => [
+    {
+      key: `section-${section.key}`,
+      kind: "section" as const,
+      label: section.label,
+    },
+    ...section.conversations.map((conversation) => ({
+      conversation,
+      key: `conversation-${conversation.id}`,
+      kind: "conversation" as const,
+    })),
+  ]);
+}
+
 function ConversationSidebarRow(props: {
   conversation: Conversation;
   onArchiveError(conversation: Conversation): void;
@@ -135,7 +172,7 @@ function ConversationSidebarRow(props: {
       <Link
         aria-current={props.selected ? "page" : undefined}
         className={cn(
-          "block min-w-0 rounded-lg border border-transparent px-3 py-3 text-inherit no-underline transition-all hover:border-white/[0.07] hover:bg-white/[0.035]",
+          "block min-w-0 rounded-lg border border-transparent px-3 py-3 text-inherit no-underline transition-all hover:bg-white/[0.035]",
           props.selected && "border-cyan-300/20 bg-cyan-300/[0.07]",
         )}
         to={conversationPath(props.conversation.id)}
@@ -157,21 +194,15 @@ function ConversationSidebarRow(props: {
             {title}
           </div>
         </div>
-        <div className="ml-3.5 mt-1.5 flex min-w-0 items-center gap-1.5 font-mono text-xs leading-tight text-dashboard-text-muted">
-          <span className="shrink-0">
-            {formatRelativeTime(props.conversation.lastSeenAt)}
-          </span>
-          {location ? (
-            <>
-              <span aria-hidden="true">·</span>
-              <span className="truncate">{location}</span>
-            </>
-          ) : null}
-        </div>
+        {location ? (
+          <div className="ml-3.5 mt-1.5 truncate font-mono text-xs leading-tight text-dashboard-text-muted">
+            {location}
+          </div>
+        ) : null}
       </Link>
       <button
         aria-label={`Archive ${title}`}
-        className="pointer-events-none absolute right-2 top-1/2 z-10 grid size-8 -translate-y-1/2 place-items-center rounded-md border border-white/15 bg-[#111719] text-dashboard-text-muted opacity-0 shadow-[-8px_0_12px_rgba(9,12,14,0.8)] transition hover:border-white/30 hover:text-dashboard-text focus:pointer-events-auto focus:opacity-100 focus:outline-none focus:ring-2 focus:ring-cyan-300/35 group-focus-within:pointer-events-auto group-focus-within:opacity-100 group-hover:pointer-events-auto group-hover:opacity-100"
+        className="pointer-events-none absolute right-2 top-1/2 z-10 grid size-8 -translate-y-1/2 place-items-center rounded-md bg-[#111719] text-dashboard-text-muted opacity-0 shadow-[-8px_0_12px_rgba(9,12,14,0.8)] transition hover:text-dashboard-text focus:pointer-events-auto focus:opacity-100 focus:outline-none focus:ring-2 focus:ring-cyan-300/35 group-focus-within:pointer-events-auto group-focus-within:opacity-100 group-hover:pointer-events-auto group-hover:opacity-100"
         disabled={archive.isPending}
         onClick={() =>
           archive.mutate({

--- a/packages/junior-dashboard/src/client/conversations/ConversationWorkspace.tsx
+++ b/packages/junior-dashboard/src/client/conversations/ConversationWorkspace.tsx
@@ -83,6 +83,7 @@ export function ConversationWorkspace(props: { data: DashboardCoreData }) {
           onQueryChange={setQuery}
           query={query}
           selectedId={selectedId}
+          timeZone={props.data.config.timeZone}
         />
       </div>
       <section

--- a/packages/junior-dashboard/src/client/conversations/conversationSections.ts
+++ b/packages/junior-dashboard/src/client/conversations/conversationSections.ts
@@ -1,0 +1,80 @@
+import type { Conversation } from "../types";
+
+export type ConversationSection = {
+  conversations: Conversation[];
+  key: string;
+  label: string;
+};
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** Group conversations into progressively broader activity sections. */
+export function buildConversationSections(
+  conversations: Conversation[],
+  options: { nowMs: number; timeZone: string },
+): ConversationSection[] {
+  const nowDay = calendarDay(options.nowMs, options.timeZone);
+  const sections = new Map<string, ConversationSection>();
+  const sorted = [...conversations].sort(
+    (left, right) => activityTime(right) - activityTime(left),
+  );
+
+  for (const conversation of sorted) {
+    const time = activityTime(conversation);
+    const section = conversationSection(time, nowDay, options.timeZone);
+    const existing = sections.get(section.key);
+    if (existing) {
+      existing.conversations.push(conversation);
+    } else {
+      sections.set(section.key, { ...section, conversations: [conversation] });
+    }
+  }
+
+  return [...sections.values()];
+}
+
+function activityTime(conversation: Conversation): number {
+  const time = Date.parse(conversation.lastSeenAt);
+  return Number.isFinite(time) ? time : Number.NEGATIVE_INFINITY;
+}
+
+function conversationSection(
+  time: number,
+  nowDay: number,
+  timeZone: string,
+): Pick<ConversationSection, "key" | "label"> {
+  if (!Number.isFinite(time)) return { key: "older", label: "Older" };
+
+  const day = calendarDay(time, timeZone);
+  const ageInDays = Math.max(0, Math.floor((nowDay - day) / DAY_MS));
+  if (ageInDays === 0) return { key: "today", label: "Today" };
+  if (ageInDays === 1) return { key: "yesterday", label: "Yesterday" };
+  if (ageInDays < 7) {
+    return {
+      key: `day-${day}`,
+      label: new Intl.DateTimeFormat(undefined, {
+        timeZone,
+        weekday: "long",
+      }).format(time),
+    };
+  }
+  if (ageInDays < 14) return { key: "last-week", label: "Last week" };
+  if (ageInDays < 21) return { key: "2-weeks", label: "2 weeks ago" };
+  if (ageInDays < 28) return { key: "3-weeks", label: "3 weeks ago" };
+  return { key: "older", label: "Older" };
+}
+
+function calendarDay(time: number, timeZone: string): number {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    day: "numeric",
+    month: "numeric",
+    timeZone,
+    year: "numeric",
+  }).formatToParts(time);
+  const values = new Map(parts.map((part) => [part.type, Number(part.value)]));
+  return Date.UTC(
+    values.get("year") ?? 0,
+    (values.get("month") ?? 1) - 1,
+    values.get("day") ?? 1,
+  );
+}

--- a/packages/junior-dashboard/src/client/conversations/conversationSections.ts
+++ b/packages/junior-dashboard/src/client/conversations/conversationSections.ts
@@ -52,7 +52,7 @@ function conversationSection(
   if (ageInDays < 7) {
     return {
       key: `day-${day}`,
-      label: new Intl.DateTimeFormat(undefined, {
+      label: new Intl.DateTimeFormat("en-US", {
         timeZone,
         weekday: "long",
       }).format(time),

--- a/packages/junior-dashboard/tests/conversationSections.test.ts
+++ b/packages/junior-dashboard/tests/conversationSections.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import { buildConversationSections } from "../src/client/conversations/conversationSections";
+import type { Conversation } from "../src/client/types";
+
+function conversation(id: string, lastSeenAt: string): Conversation {
+  return {
+    cumulativeDurationMs: 0,
+    displayTitle: id,
+    id,
+    lastProgressAt: lastSeenAt,
+    lastSeenAt,
+    startedAt: lastSeenAt,
+    status: "completed",
+    surface: "internal",
+  };
+}
+
+describe("conversation activity sections", () => {
+  it("keeps recent conversations first and broadens older date groups", () => {
+    const sections = buildConversationSections(
+      [
+        conversation("older", "2026-06-20T12:00:00-07:00"),
+        conversation("two-weeks", "2026-07-19T12:00:00-07:00"),
+        conversation("today-later", "2026-08-03T11:00:00-07:00"),
+        conversation("last-week", "2026-07-26T12:00:00-07:00"),
+        conversation("today-earlier", "2026-08-03T09:00:00-07:00"),
+        conversation("yesterday", "2026-08-02T12:00:00-07:00"),
+        conversation("weekday", "2026-08-01T12:00:00-07:00"),
+        conversation("three-weeks", "2026-07-12T12:00:00-07:00"),
+      ],
+      {
+        nowMs: Date.parse("2026-08-03T12:00:00-07:00"),
+        timeZone: "America/Los_Angeles",
+      },
+    );
+
+    expect(
+      sections.map((section) => ({
+        conversations: section.conversations.map((item) => item.id),
+        label: section.label,
+      })),
+    ).toEqual([
+      {
+        conversations: ["today-later", "today-earlier"],
+        label: "Today",
+      },
+      { conversations: ["yesterday"], label: "Yesterday" },
+      { conversations: ["weekday"], label: "Saturday" },
+      { conversations: ["last-week"], label: "Last week" },
+      { conversations: ["two-weeks"], label: "2 weeks ago" },
+      { conversations: ["three-weeks"], label: "3 weeks ago" },
+      { conversations: ["older"], label: "Older" },
+    ]);
+  });
+});


### PR DESCRIPTION
The personal conversation sidebar now groups conversations into progressively broader activity windows: today, yesterday, recent weekdays, weekly buckets, and older activity. Conversations remain newest-first within each section, and grouping follows the dashboard timezone.

Rows use the section heading for recency and reserve their secondary line for channel or location context. Search, selection, archive/undo behavior, and keyboard focus remain intact, while row and archive-action hover borders have been removed for a quieter list.
