### PR TITLE
perf(memory): optimize lexical search

### DIFF
--- a/packages/docs/src/content/docs/cli/upgrade.md
+++ b/packages/docs/src/content/docs/cli/upgrade.md
@@ -58,8 +58,8 @@ An already-current database reports its migrations as existing:
 Checking database migrations...
   junior: up to date (8 migrations)
   junior-github: up to date (4 migrations)
-  junior-memory: up to date (5 migrations)
-Database is up to date (17 migrations).
+  junior-memory: up to date (6 migrations)
+Database is up to date (18 migrations).
 ```
 
 ## Failure behavior

--- a/packages/docs/src/content/docs/extend/memory-plugin.md
+++ b/packages/docs/src/content/docs/extend/memory-plugin.md
@@ -16,7 +16,7 @@ New apps created with `junior init` include `memoryPlugin()` in `plugins.ts` by 
 
 ## Prerequisites
 
-Provision a Postgres database with pgvector support before running migrations. The memory plugin migration creates the `vector` extension and stores 1536-dimensional embeddings. Most managed Postgres providers — Neon, Supabase, Railway, and AWS RDS/Aurora PostgreSQL with pgvector enabled — support this out of the box.
+Provision a Postgres database with pgvector support before running migrations. The memory plugin migrations create the `vector` and `btree_gin` extensions, store 1536-dimensional embeddings, and maintain a scope-aware full-text search index. Most managed Postgres providers — Neon, Supabase, Railway, and AWS RDS/Aurora PostgreSQL with pgvector enabled — support this out of the box.
 
 ## Install
 
@@ -95,7 +95,7 @@ After setting `DATABASE_URL`, run the upgrade command to apply the memory plugin
 pnpm junior upgrade
 ```
 
-On a fresh database, this creates the `vector` extension, the `junior_memory_memories` table, and the `junior_memory_embeddings` table with a `vector(1536)` column.
+On a fresh database, this creates the `vector` and `btree_gin` extensions, the `junior_memory_memories` table, and the `junior_memory_embeddings` table with a `vector(1536)` column.
 
 ## Verify
 
@@ -125,6 +125,7 @@ Public Slack channel memories are workspace-visible. A durable fact remembered i
 
 - **Plugin not active after registration**: `@sentry/junior-memory` was registered as a bare string instead of `memoryPlugin()`. Switch to the factory call and redeploy.
 - **Migration error — extension "vector" does not exist**: the Postgres database does not have pgvector available. Use a provider that supports pgvector or install it manually with `CREATE EXTENSION vector`.
+- **Migration error — extension "btree_gin" does not exist**: the Postgres database does not include the standard `btree_gin` extension. Enable it with your provider or install it manually with `CREATE EXTENSION btree_gin`.
 - **`DATABASE_URL` is required**: no database URL is configured. Set it in the deployment environment.
 - **Connection errors on non-Neon Postgres**: set `JUNIOR_DATABASE_DRIVER=postgres` for Railway, Supabase, AWS RDS, or self-hosted Postgres.
 - **Embedding dimension mismatch**: `AI_EMBEDDING_MODEL` was changed after memories were stored with a different model. Flush the `junior_memory_embeddings` table and re-run migrations to regenerate vectors with the new model.

--- a/packages/junior-memory/migrations/0006_friendly_hydra.sql
+++ b/packages/junior-memory/migrations/0006_friendly_hydra.sql
@@ -1,0 +1,4 @@
+CREATE EXTENSION IF NOT EXISTS btree_gin;--> statement-breakpoint
+DROP INDEX "junior_memory_memories_search_idx";--> statement-breakpoint
+ALTER TABLE "junior_memory_memories" ADD COLUMN "search_vector" "tsvector" GENERATED ALWAYS AS (to_tsvector('english', "content")) STORED;--> statement-breakpoint
+CREATE INDEX "junior_memory_memories_search_idx" ON "junior_memory_memories" USING gin ("scope","scope_key","search_vector") WHERE "junior_memory_memories"."archived_at_ms" IS NULL AND "junior_memory_memories"."superseded_at_ms" IS NULL AND "junior_memory_memories"."superseded_by_id" IS NULL;

--- a/packages/junior-memory/migrations/meta/0006_snapshot.json
+++ b/packages/junior-memory/migrations/meta/0006_snapshot.json
@@ -1,0 +1,386 @@
+{
+  "id": "f18fa309-6485-40f3-921a-5d65552fbdf6",
+  "prevId": "6948ea3f-2e44-49ce-aa94-8a993ce61cec",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.junior_memory_embeddings": {
+      "name": "junior_memory_embeddings",
+      "schema": "",
+      "columns": {
+        "memory_id": {
+          "name": "memory_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dimensions": {
+          "name": "dimensions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metric": {
+          "name": "metric",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at_ms": {
+          "name": "created_at_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "junior_memory_embeddings_model_idx": {
+          "name": "junior_memory_embeddings_model_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dimensions",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "metric",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "junior_memory_embeddings_memory_id_junior_memory_memories_id_fk": {
+          "name": "junior_memory_embeddings_memory_id_junior_memory_memories_id_fk",
+          "tableFrom": "junior_memory_embeddings",
+          "tableTo": "junior_memory_memories",
+          "columnsFrom": ["memory_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "junior_memory_embeddings_metric_check": {
+          "name": "junior_memory_embeddings_metric_check",
+          "value": "\"junior_memory_embeddings\".\"metric\" IN ('cosine')"
+        },
+        "junior_memory_embeddings_dimensions_check": {
+          "name": "junior_memory_embeddings_dimensions_check",
+          "value": "\"junior_memory_embeddings\".\"dimensions\" = 1536"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.junior_memory_memories": {
+      "name": "junior_memory_memories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_key": {
+          "name": "scope_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "to_tsvector('english', \"content\")",
+            "type": "stored"
+          }
+        },
+        "source_platform": {
+          "name": "source_platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_key": {
+          "name": "source_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_at_ms": {
+          "name": "observed_at_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at_ms": {
+          "name": "created_at_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at_ms": {
+          "name": "expires_at_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "superseded_at_ms": {
+          "name": "superseded_at_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "superseded_by_id": {
+          "name": "superseded_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at_ms": {
+          "name": "archived_at_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archive_reason": {
+          "name": "archive_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "junior_memory_memories_visible_idx": {
+          "name": "junior_memory_memories_visible_idx",
+          "columns": [
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at_ms",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"junior_memory_memories\".\"archived_at_ms\" IS NULL AND \"junior_memory_memories\".\"superseded_at_ms\" IS NULL AND \"junior_memory_memories\".\"superseded_by_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_memory_memories_expiration_idx": {
+          "name": "junior_memory_memories_expiration_idx",
+          "columns": [
+            {
+              "expression": "expires_at_ms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"junior_memory_memories\".\"archived_at_ms\" IS NULL AND \"junior_memory_memories\".\"expires_at_ms\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_memory_memories_search_idx": {
+          "name": "junior_memory_memories_search_idx",
+          "columns": [
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"junior_memory_memories\".\"archived_at_ms\" IS NULL AND \"junior_memory_memories\".\"superseded_at_ms\" IS NULL AND \"junior_memory_memories\".\"superseded_by_id\" IS NULL",
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "junior_memory_memories_idempotency_idx": {
+          "name": "junior_memory_memories_idempotency_idx",
+          "columns": [
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"junior_memory_memories\".\"idempotency_key\" IS NOT NULL AND \"junior_memory_memories\".\"archived_at_ms\" IS NULL AND \"junior_memory_memories\".\"superseded_at_ms\" IS NULL AND \"junior_memory_memories\".\"superseded_by_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "junior_memory_memories_scope_check": {
+          "name": "junior_memory_memories_scope_check",
+          "value": "\"junior_memory_memories\".\"scope\" IN ('personal', 'conversation')"
+        },
+        "junior_memory_memories_kind_check": {
+          "name": "junior_memory_memories_kind_check",
+          "value": "\"junior_memory_memories\".\"type\" IN (\n        'preference',\n        'procedure',\n        'knowledge'\n      )"
+        },
+        "junior_memory_memories_subject_type_check": {
+          "name": "junior_memory_memories_subject_type_check",
+          "value": "\"junior_memory_memories\".\"subject_type\" IN ('user', 'conversation', 'general')"
+        },
+        "junior_memory_memories_subject_key_check": {
+          "name": "junior_memory_memories_subject_key_check",
+          "value": "(\"junior_memory_memories\".\"subject_type\" = 'general' AND \"junior_memory_memories\".\"subject_key\" IS NULL) OR (\"junior_memory_memories\".\"subject_type\" IN ('user', 'conversation') AND \"junior_memory_memories\".\"subject_key\" IS NOT NULL AND length(\"junior_memory_memories\".\"subject_key\") > 0)"
+        },
+        "junior_memory_memories_source_platform_check": {
+          "name": "junior_memory_memories_source_platform_check",
+          "value": "\"junior_memory_memories\".\"source_platform\" IN ('slack', 'local')"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/junior-memory/migrations/meta/_journal.json
+++ b/packages/junior-memory/migrations/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1785293874649,
       "tag": "0005_short_jamie_braddock",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1785878952301,
+      "tag": "0006_friendly_hydra",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/junior-memory/src/db/schema.ts
+++ b/packages/junior-memory/src/db/schema.ts
@@ -8,6 +8,7 @@ import { sql } from "drizzle-orm";
 import {
   bigint,
   check,
+  customType,
   index,
   integer,
   pgTable,
@@ -24,6 +25,12 @@ import {
   MEMORY_KINDS,
 } from "../types";
 
+const tsvector = customType<{ data: string }>({
+  dataType() {
+    return "tsvector";
+  },
+});
+
 export const juniorMemoryMemories = pgTable(
   "junior_memory_memories",
   {
@@ -34,6 +41,9 @@ export const juniorMemoryMemories = pgTable(
     subjectType: text("subject_type", { enum: MEMORY_SUBJECT_TYPES }).notNull(),
     subjectKey: text("subject_key"),
     content: text("content").notNull(),
+    searchVector: tsvector("search_vector").generatedAlwaysAs(
+      sql`to_tsvector('english', "content")`,
+    ),
     sourcePlatform: text("source_platform", {
       enum: MEMORY_SOURCE_PLATFORMS,
     }).notNull(),
@@ -59,7 +69,7 @@ export const juniorMemoryMemories = pgTable(
         sql`${table.archivedAtMs} IS NULL AND ${table.expiresAtMs} IS NOT NULL`,
       ),
     index("junior_memory_memories_search_idx")
-      .using("gin", sql`to_tsvector('english', ${table.content})`)
+      .using("gin", table.scope, table.scopeKey, table.searchVector)
       .where(
         sql`${table.archivedAtMs} IS NULL AND ${table.supersededAtMs} IS NULL AND ${table.supersededById} IS NULL`,
       ),

--- a/packages/junior-memory/src/store.ts
+++ b/packages/junior-memory/src/store.ts
@@ -128,6 +128,7 @@ const memoryRowSchema = z
     id: z.string().min(1),
     idempotencyKey: optionalStringSchema,
     observedAtMs: z.coerce.number(),
+    searchVector: z.string().optional(),
     scope: z.enum(MEMORY_SCOPES),
     scopeKey: z.string().min(1),
     sourceKey: z.string().min(1),
@@ -966,7 +967,7 @@ async function searchVisibleLexicalMemories(args: {
     )
     FROM unnest(tsvector_to_array(${queryVector})) AS query_terms(term)
   )`;
-  const textsearch = sql`to_tsvector('english', ${juniorMemoryMemories.content})`;
+  const textsearch = juniorMemoryMemories.searchVector;
   const textRank = sql<number>`ts_rank_cd(${textsearch}, ${tsquery})`;
   const rows = await args.db
     .select({

--- a/packages/junior-memory/tests/operational-report.test.ts
+++ b/packages/junior-memory/tests/operational-report.test.ts
@@ -3,6 +3,7 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   createLocalPgliteFixture,
+  pgliteBtreeGinExtension,
   pgliteVectorExtension,
   type LocalPgliteFixture,
 } from "@sentry/junior-testing/pglite";
@@ -31,7 +32,10 @@ type MemoryFixture = LocalPgliteFixture<MemoryDb>;
 
 async function createMemoryFixture(): Promise<MemoryFixture> {
   const fixture = await createLocalPgliteFixture<MemoryDb>(memorySqlSchema, {
-    extensions: { vector: pgliteVectorExtension },
+    extensions: {
+      btree_gin: pgliteBtreeGinExtension,
+      vector: pgliteVectorExtension,
+    },
   });
   const migrations = (await readdir(resolve(__dirname, "../migrations")))
     .filter((filename) => filename.endsWith(".sql"))

--- a/packages/junior-memory/tests/retrieval-quality.test.ts
+++ b/packages/junior-memory/tests/retrieval-quality.test.ts
@@ -3,6 +3,7 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   createLocalPgliteFixture,
+  pgliteBtreeGinExtension,
   pgliteVectorExtension,
   type LocalPgliteFixture,
 } from "@sentry/junior-testing/pglite";
@@ -44,7 +45,10 @@ function testEmbedder(
 
 async function createFixture(): Promise<MemoryFixture> {
   const fixture = await createLocalPgliteFixture<MemoryDb>(memorySqlSchema, {
-    extensions: { vector: pgliteVectorExtension },
+    extensions: {
+      btree_gin: pgliteBtreeGinExtension,
+      vector: pgliteVectorExtension,
+    },
   });
   const migrationsDir = resolve(__dirname, "../migrations");
   const migrations = (await readdir(migrationsDir))

--- a/packages/junior-memory/tests/storage.test.ts
+++ b/packages/junior-memory/tests/storage.test.ts
@@ -3,6 +3,7 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   createLocalPgliteFixture,
+  pgliteBtreeGinExtension,
   pgliteVectorExtension,
   type LocalPgliteFixture,
 } from "@sentry/junior-testing/pglite";
@@ -179,7 +180,10 @@ async function runMemoryCli(fixture: MemoryFixture, argv: string[]) {
 
 async function createMemoryFixture(): Promise<MemoryFixture> {
   const fixture = await createLocalPgliteFixture<MemoryDb>(memorySqlSchema, {
-    extensions: { vector: pgliteVectorExtension },
+    extensions: {
+      btree_gin: pgliteBtreeGinExtension,
+      vector: pgliteVectorExtension,
+    },
   });
   const migrationsDir = resolve(__dirname, "../migrations");
   const migrations = (await readdir(migrationsDir))

--- a/packages/junior-testing/src/pglite.ts
+++ b/packages/junior-testing/src/pglite.ts
@@ -4,12 +4,13 @@ import {
   type PGliteOptions,
   type Transaction,
 } from "@electric-sql/pglite";
+import { btree_gin as pgliteBtreeGinExtension } from "@electric-sql/pglite/contrib/btree_gin";
 import { vector as pgliteVectorExtension } from "@electric-sql/pglite/vector";
 import { drizzle } from "drizzle-orm/pglite";
 
 type PgliteQueryClient = PGlite | Transaction;
 
-export { pgliteVectorExtension };
+export { pgliteBtreeGinExtension, pgliteVectorExtension };
 
 export interface LocalPgliteFixture<TDatabase> {
   client: PGlite;

--- a/packages/junior/tests/component/memory-plugin-storage.test.ts
+++ b/packages/junior/tests/component/memory-plugin-storage.test.ts
@@ -214,6 +214,32 @@ WHERE table_name = 'junior_memory_memories'
 `,
         ),
       ).resolves.toEqual([{ table_name: "junior_memory_memories" }]);
+
+      await expect(
+        fixture.sql.query<{ extname: string }>(
+          "SELECT extname FROM pg_extension WHERE extname = 'btree_gin'",
+        ),
+      ).resolves.toEqual([{ extname: "btree_gin" }]);
+
+      await expect(
+        fixture.sql.query<{ is_generated: string }>(
+          `
+SELECT is_generated
+FROM information_schema.columns
+WHERE table_name = 'junior_memory_memories'
+  AND column_name = 'search_vector'
+`,
+        ),
+      ).resolves.toEqual([{ is_generated: "ALWAYS" }]);
+
+      const [searchIndex] = await fixture.sql.query<{ indexdef: string }>(`
+SELECT indexdef
+FROM pg_indexes
+WHERE indexname = 'junior_memory_memories_search_idx'
+`);
+      expect(searchIndex?.indexdef).toContain(
+        "USING gin (scope, scope_key, search_vector)",
+      );
     } finally {
       NEON.sql = undefined;
       await fixture.close();


### PR DESCRIPTION
Memory lexical search now ranks a stored generated `tsvector` and uses a GIN index keyed by memory scope and scope key. This avoids rebuilding the content vector for every matching row and keeps common search terms from reading matches in unrelated scopes.

The migration enables `btree_gin`, adds the generated search column, and rebuilds the search index. It rewrites the memory table once, so larger installations should apply it during lower traffic. In a local 200,000-row benchmark, the representative query improved from 25.6ms to 9.1ms.
