### PR TITLE
feat(memory): publish personal memories

### DIFF
--- a/packages/docs/src/content/docs/extend/memory-plugin.md
+++ b/packages/docs/src/content/docs/extend/memory-plugin.md
@@ -78,26 +78,34 @@ For non-Neon managed Postgres (Railway, Supabase, AWS RDS, or self-hosted), set 
 
 ## Manage personal memories
 
-Signed-in users can search, page through, and forget their personal memories
+Signed-in users can search, page through, publish, and forget their personal memories
 from the top-level **Memories** dashboard page. The page shows viewer-scoped
 memory totals, embedding coverage, and history on **Overview**. The separate
 **Memories** view provides search and collections for preferences,
 automatically learned memories, and explicitly saved memories. Each record
 explains whether Junior learned it automatically or saved it because the user
 asked. Overview groups the viewer's active memories by type and how they were
-added. Forgetting archives the memory so Junior no longer recalls it.
+added. Personal memories tied to a provider workspace can be made public to
+that workspace. Stored content stays canonical; publishing snapshots a display
+label as separate subject metadata for the dashboard and recall prompt. Owners
+can forget their published personal memories; shared workspace knowledge
+remains view-only. Forgetting archives the memory so Junior no longer recalls
+it.
 
 The plugin also exposes authenticated REST resources:
 
-| Method   | Path                               | Purpose                                       |
-| -------- | ---------------------------------- | --------------------------------------------- |
-| `GET`    | `/api/plugins/memory/dashboard`    | Read viewer-scoped memory totals and timeline |
-| `GET`    | `/api/plugins/memory/memories`     | List memories with `q`, `cursor`, and `limit` |
-| `GET`    | `/api/plugins/memory/memories/:id` | Read one personal memory                      |
-| `DELETE` | `/api/plugins/memory/memories/:id` | Forget one personal memory                    |
+| Method   | Path                                       | Purpose                                          |
+| -------- | ------------------------------------------ | ------------------------------------------------ |
+| `GET`    | `/api/plugins/memory/dashboard`            | Read viewer-scoped memory totals and timeline    |
+| `GET`    | `/api/plugins/memory/memories`             | List memories with `q`, `cursor`, and `limit`    |
+| `GET`    | `/api/plugins/memory/memories/:id`         | Read one personal memory                         |
+| `POST`   | `/api/plugins/memory/memories/:id/publish` | Make one workspace-backed personal memory public |
+| `DELETE` | `/api/plugins/memory/memories/:id`         | Forget one personal memory                       |
 
-Personal API tokens can use the read endpoints. Deletion requires an
-authenticated dashboard browser session.
+Personal API tokens can use the read endpoints. Publishing and deletion require
+an authenticated dashboard browser session. User-subject memories include a
+structured `subject` projection with the published display label when
+available; stored `content` remains canonical and subject-less.
 
 ## Run migrations
 
@@ -131,7 +139,10 @@ What do you remember about my preferences?
 
 Junior should recall the preference without prompting.
 
-Public Slack channel memories are workspace-visible. A durable fact remembered in a public channel or public-channel thread can be recalled from another public channel in the same Slack workspace. Private Slack and local conversation memories remain scoped to their original conversation.
+Workspace-public memories can be recalled from public conversations in the same
+provider workspace. Private conversation memories remain scoped to their
+original conversation, and local identities without a workspace cannot publish
+personal memories.
 
 ## Failure modes
 

--- a/packages/junior-dashboard/e2e/user-pages.spec.ts
+++ b/packages/junior-dashboard/e2e/user-pages.spec.ts
@@ -349,3 +349,73 @@ test("searches, paginates, and forgets plugin page records", async ({
   await expect(page.getByText("No memories yet.")).toBeVisible();
   expect(browserErrors).toEqual([]);
 });
+
+test("publishes a private memory from the memory details", async ({ page }) => {
+  let published = false;
+  let publishRequests = 0;
+  await page.route("**/api/user-pages/memory/memories*", async (route) => {
+    await route.fulfill({
+      json: {
+        type: "list",
+        emptyText: "No memories yet.",
+        records: [
+          {
+            actions: published
+              ? [
+                  {
+                    confirmation: "Forget this memory?",
+                    href: "/api/plugins/memory/memories/memory-ooo",
+                    label: "Forget",
+                    method: "DELETE",
+                    tone: "danger",
+                  },
+                ]
+              : [
+                  {
+                    confirmation:
+                      "Make this memory public to the workspace where it was created?",
+                    href: "/api/plugins/memory/memories/memory-ooo/publish",
+                    label: "Make Public",
+                    method: "POST",
+                    tone: "neutral",
+                  },
+                ],
+            id: "memory-ooo",
+            metadata: [
+              { label: "Type", value: "Knowledge" },
+              { label: "Visibility", value: published ? "Public" : "Private" },
+              { label: "Remembered", value: "Aug 4, 2026, 10:00 AM" },
+            ],
+            title: published
+              ? "David Cramer — Out of office August 10–14, 2026."
+              : "Out of office August 10–14, 2026.",
+          },
+        ],
+        searchPlaceholder: "Search memories",
+      },
+    });
+  });
+  await page.route(
+    "**/api/plugins/memory/memories/memory-ooo/publish",
+    async (route) => {
+      publishRequests += 1;
+      expect(route.request().method()).toBe("POST");
+      published = true;
+      await route.fulfill({ status: 204 });
+    },
+  );
+
+  await page.goto(`${server.baseURL}/plugins/memory/memories/library`);
+  await page
+    .getByRole("button", { name: /^Out of office August 10–14, 2026/ })
+    .click();
+  page.once("dialog", (dialog) => dialog.accept());
+  await page.getByRole("button", { name: "Make public" }).click();
+
+  await expect(
+    page.getByRole("button", {
+      name: /^David Cramer — Out of office August 10–14, 2026/,
+    }),
+  ).toBeVisible();
+  expect(publishRequests).toBe(1);
+});

--- a/packages/junior-dashboard/src/client/http.ts
+++ b/packages/junior-dashboard/src/client/http.ts
@@ -76,6 +76,19 @@ export async function deleteDashboardResource(path: string): Promise<void> {
   if (!response.ok) throw new DashboardApiError(path, response.status);
 }
 
+/** Run one authenticated dashboard resource action without a request body. */
+export async function mutateDashboardResource(
+  path: string,
+  method: "DELETE" | "POST",
+): Promise<void> {
+  const response = await fetch(path, {
+    credentials: "same-origin",
+    method,
+  });
+  if (response.status === 401) restartDashboardSignIn();
+  if (!response.ok) throw new DashboardApiError(path, response.status);
+}
+
 /** Fetch one authenticated dashboard JSON resource and validate its response. */
 export async function fetchDashboardJson<T>(
   schema: ZodType<T>,

--- a/packages/junior-dashboard/src/client/pages/memory/MemoryPage.tsx
+++ b/packages/junior-dashboard/src/client/pages/memory/MemoryPage.tsx
@@ -666,25 +666,31 @@ function MemoryDetails(props: {
   const source = metadataValue(props.record, "Source");
   const visibility = metadataValue(props.record, "Visibility");
   const isPublic = visibility === "Public";
+  const forgetAction = props.record.actions?.find(
+    (recordAction) => recordAction.tone === "danger",
+  );
+  const ownedByViewer = !isPublic || Boolean(forgetAction);
   const story =
     learned === "Automatic"
       ? `Junior learned this from a ${source} conversation on ${shortDate(remembered)}.`
       : learned === "Explicit"
-        ? isPublic
-          ? `Someone asked Junior to remember this on ${shortDate(remembered)}.`
-          : `You asked Junior to remember this on ${shortDate(remembered)}.`
+        ? ownedByViewer
+          ? `You asked Junior to remember this on ${shortDate(remembered)}.`
+          : `Someone asked Junior to remember this on ${shortDate(remembered)}.`
         : `Junior recorded this on ${shortDate(remembered)}.`;
   const scopeCopy = isPublic
     ? `It is stored as workspace ${kind.toLowerCase()} for future channels.`
-    : `It is stored as a ${kind.toLowerCase()} for future conversations.`;
+    : kind === "Knowledge"
+      ? "It is stored as personal knowledge for future conversations."
+      : `It is stored as a ${kind.toLowerCase()} for future conversations.`;
   const hiddenMetadata = props.inline
     ? ["Type", "Learned", "Source", "Memory ID"]
     : ["Learned", "Source", "Memory ID"];
   const visibleMetadata = (props.record.metadata ?? []).filter(
     (item) => !hiddenMetadata.includes(item.label),
   );
-  const forgetAction = props.record.actions?.find(
-    (recordAction) => recordAction.tone === "danger",
+  const publishAction = props.record.actions?.find(
+    (recordAction) => recordAction.label === "Make Public",
   );
 
   return (
@@ -791,16 +797,31 @@ function MemoryDetails(props: {
               ))}
             </dl>
           ) : null}
-          {forgetAction ? (
-            <button
-              className="mt-4 inline-flex cursor-pointer items-center gap-2 rounded border border-rose-300/15 bg-rose-300/[0.035] px-3 py-2 font-mono text-[0.62rem] uppercase tracking-[0.08em] text-rose-200/75 transition-colors hover:border-rose-300/30 hover:bg-rose-300/[0.07] hover:text-rose-100"
-              disabled={props.action.isPending}
-              onClick={() => props.onAction(forgetAction)}
-              type="button"
-            >
-              <Trash2 aria-hidden="true" size={13} />
-              Forget this memory
-            </button>
+          {publishAction || forgetAction ? (
+            <div className="mt-4 flex flex-wrap gap-2">
+              {publishAction ? (
+                <button
+                  className="inline-flex cursor-pointer items-center gap-2 rounded border border-cyan-300/15 bg-cyan-300/[0.035] px-3 py-2 font-mono text-[0.62rem] uppercase tracking-[0.08em] text-cyan-100/75 transition-colors hover:border-cyan-300/30 hover:bg-cyan-300/[0.07] hover:text-cyan-50"
+                  disabled={props.action.isPending}
+                  onClick={() => props.onAction(publishAction)}
+                  type="button"
+                >
+                  <Globe2 aria-hidden="true" size={13} />
+                  Make public
+                </button>
+              ) : null}
+              {forgetAction ? (
+                <button
+                  className="inline-flex cursor-pointer items-center gap-2 rounded border border-rose-300/15 bg-rose-300/[0.035] px-3 py-2 font-mono text-[0.62rem] uppercase tracking-[0.08em] text-rose-200/75 transition-colors hover:border-rose-300/30 hover:bg-rose-300/[0.07] hover:text-rose-100"
+                  disabled={props.action.isPending}
+                  onClick={() => props.onAction(forgetAction)}
+                  type="button"
+                >
+                  <Trash2 aria-hidden="true" size={13} />
+                  Forget this memory
+                </button>
+              ) : null}
+            </div>
           ) : isPublic ? (
             <div className="mt-4 inline-flex items-center gap-2 rounded border border-white/[0.08] px-3 py-2 font-mono text-[0.62rem] uppercase tracking-[0.08em] text-dashboard-text-muted">
               <Globe2 aria-hidden="true" size={13} />

--- a/packages/junior-dashboard/src/client/pages/user/pluginUserPageData.ts
+++ b/packages/junior-dashboard/src/client/pages/user/pluginUserPageData.ts
@@ -11,7 +11,7 @@ import {
   type PluginUserPageLink,
 } from "@sentry/junior-plugin-api";
 
-import { deleteDashboardResource, fetchDashboardJson } from "../../http";
+import { fetchDashboardJson, mutateDashboardResource } from "../../http";
 
 export type PluginUserPageRecord = PluginUserPageContent["records"][number];
 export type PluginUserPageRecordAction = NonNullable<
@@ -83,7 +83,7 @@ export function usePluginUserPageData(page: PluginUserPageLink) {
   );
   const action = useMutation({
     mutationFn: (recordAction: PluginUserPageRecordAction) =>
-      deleteDashboardResource(recordAction.href),
+      mutateDashboardResource(recordAction.href, recordAction.method),
     onMutate: () => ({ pluginName: page.pluginName }),
     onSuccess: async (_result, _recordAction, context) => {
       await queryClient.resetQueries({

--- a/packages/junior-evals/evals/memory/personal.eval.ts
+++ b/packages/junior-evals/evals/memory/personal.eval.ts
@@ -137,6 +137,51 @@ describeEval("Personal Memory", slackEvals, (it) => {
     });
   });
 
+  const outOfOfficeThread = {
+    id: "thread-memory-out-of-office",
+    channel_id: "CMEMORYOUTOFOFFICE",
+    thread_ts: "17000000.000003",
+  };
+
+  it("when explicitly asked to remember expiring availability, store actor knowledge", async ({
+    run,
+  }) => {
+    await clearMemories();
+    const userText =
+      "Please remember that I will be out of office from August 10 through August 14, 2026 for a family trip. Expire this memory at 2026-08-15T00:00:00-07:00.";
+    const result = await run({
+      overrides: memoryPluginOverrides,
+      initialEvents: [mention(userText, { thread: outOfOfficeThread })],
+      criteria: rubric({
+        pass: [
+          "The assistant stores the actor's out-of-office dates and family-trip reason as an expiring personal memory.",
+          "The assistant does not expose hidden scope, actor, Slack, or subject identifiers.",
+        ],
+        fail: [
+          "Do not reject the memory merely because it is temporary; it has an exact expiration.",
+          "Do not store the fact as shared conversation knowledge.",
+        ],
+      }),
+    });
+
+    const rows = await readActiveMemories(outOfOfficeThread);
+    expect(rows).toEqual([
+      expect.objectContaining({
+        expiresAtMs: Date.parse("2026-08-15T00:00:00-07:00"),
+        kind: "knowledge",
+        scope: "personal",
+        subjectType: "user",
+      }),
+    ]);
+    await expectActorMemorySemantics({
+      assistantText: visibleAssistantText(result),
+      expectedMeaning:
+        "The actor will be out of office from August 10 through August 14, 2026 for a family trip.",
+      storedMemories: rows,
+      userText,
+    });
+  });
+
   const explicitDuplicateThread = {
     id: "thread-memory-explicit-duplicate",
     channel_id: "CMEMORYEXPLICITDUPLICATE",

--- a/packages/junior-memory/migrations/0007_low_giant_girl.sql
+++ b/packages/junior-memory/migrations/0007_low_giant_girl.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "junior_memory_memories" ADD COLUMN "subject_label" text;

--- a/packages/junior-memory/migrations/meta/0007_snapshot.json
+++ b/packages/junior-memory/migrations/meta/0007_snapshot.json
@@ -1,0 +1,392 @@
+{
+  "id": "45986158-4179-4170-92dd-1adb6157a191",
+  "prevId": "f18fa309-6485-40f3-921a-5d65552fbdf6",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.junior_memory_embeddings": {
+      "name": "junior_memory_embeddings",
+      "schema": "",
+      "columns": {
+        "memory_id": {
+          "name": "memory_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dimensions": {
+          "name": "dimensions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metric": {
+          "name": "metric",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at_ms": {
+          "name": "created_at_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "junior_memory_embeddings_model_idx": {
+          "name": "junior_memory_embeddings_model_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dimensions",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "metric",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "junior_memory_embeddings_memory_id_junior_memory_memories_id_fk": {
+          "name": "junior_memory_embeddings_memory_id_junior_memory_memories_id_fk",
+          "tableFrom": "junior_memory_embeddings",
+          "tableTo": "junior_memory_memories",
+          "columnsFrom": ["memory_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "junior_memory_embeddings_metric_check": {
+          "name": "junior_memory_embeddings_metric_check",
+          "value": "\"junior_memory_embeddings\".\"metric\" IN ('cosine')"
+        },
+        "junior_memory_embeddings_dimensions_check": {
+          "name": "junior_memory_embeddings_dimensions_check",
+          "value": "\"junior_memory_embeddings\".\"dimensions\" = 1536"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.junior_memory_memories": {
+      "name": "junior_memory_memories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_key": {
+          "name": "scope_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_label": {
+          "name": "subject_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "to_tsvector('english', \"content\")",
+            "type": "stored"
+          }
+        },
+        "source_platform": {
+          "name": "source_platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_key": {
+          "name": "source_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_at_ms": {
+          "name": "observed_at_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at_ms": {
+          "name": "created_at_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at_ms": {
+          "name": "expires_at_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "superseded_at_ms": {
+          "name": "superseded_at_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "superseded_by_id": {
+          "name": "superseded_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at_ms": {
+          "name": "archived_at_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archive_reason": {
+          "name": "archive_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "junior_memory_memories_visible_idx": {
+          "name": "junior_memory_memories_visible_idx",
+          "columns": [
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at_ms",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"junior_memory_memories\".\"archived_at_ms\" IS NULL AND \"junior_memory_memories\".\"superseded_at_ms\" IS NULL AND \"junior_memory_memories\".\"superseded_by_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_memory_memories_expiration_idx": {
+          "name": "junior_memory_memories_expiration_idx",
+          "columns": [
+            {
+              "expression": "expires_at_ms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"junior_memory_memories\".\"archived_at_ms\" IS NULL AND \"junior_memory_memories\".\"expires_at_ms\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_memory_memories_search_idx": {
+          "name": "junior_memory_memories_search_idx",
+          "columns": [
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"junior_memory_memories\".\"archived_at_ms\" IS NULL AND \"junior_memory_memories\".\"superseded_at_ms\" IS NULL AND \"junior_memory_memories\".\"superseded_by_id\" IS NULL",
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "junior_memory_memories_idempotency_idx": {
+          "name": "junior_memory_memories_idempotency_idx",
+          "columns": [
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"junior_memory_memories\".\"idempotency_key\" IS NOT NULL AND \"junior_memory_memories\".\"archived_at_ms\" IS NULL AND \"junior_memory_memories\".\"superseded_at_ms\" IS NULL AND \"junior_memory_memories\".\"superseded_by_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "junior_memory_memories_scope_check": {
+          "name": "junior_memory_memories_scope_check",
+          "value": "\"junior_memory_memories\".\"scope\" IN ('personal', 'conversation')"
+        },
+        "junior_memory_memories_kind_check": {
+          "name": "junior_memory_memories_kind_check",
+          "value": "\"junior_memory_memories\".\"type\" IN (\n        'preference',\n        'procedure',\n        'knowledge'\n      )"
+        },
+        "junior_memory_memories_subject_type_check": {
+          "name": "junior_memory_memories_subject_type_check",
+          "value": "\"junior_memory_memories\".\"subject_type\" IN ('user', 'conversation', 'general')"
+        },
+        "junior_memory_memories_subject_key_check": {
+          "name": "junior_memory_memories_subject_key_check",
+          "value": "(\"junior_memory_memories\".\"subject_type\" = 'general' AND \"junior_memory_memories\".\"subject_key\" IS NULL) OR (\"junior_memory_memories\".\"subject_type\" IN ('user', 'conversation') AND \"junior_memory_memories\".\"subject_key\" IS NOT NULL AND length(\"junior_memory_memories\".\"subject_key\") > 0)"
+        },
+        "junior_memory_memories_source_platform_check": {
+          "name": "junior_memory_memories_source_platform_check",
+          "value": "\"junior_memory_memories\".\"source_platform\" IN ('slack', 'local')"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/junior-memory/migrations/meta/_journal.json
+++ b/packages/junior-memory/migrations/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1785878952301,
       "tag": "0006_friendly_hydra",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1785888179976,
+      "tag": "0007_low_giant_girl",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/junior-memory/src/agent.ts
+++ b/packages/junior-memory/src/agent.ts
@@ -122,6 +122,7 @@ const memoryReviewDecisionSchema = z.discriminatedUnion("decision", [
       kind: memoryKindSchema,
       content: z.string().min(1),
       expiresAtMs: z.number().finite().optional(),
+      target: z.enum(["actor", "conversation"]),
     })
     .strict(),
   z
@@ -136,7 +137,7 @@ const memoryReviewResponseSchema = z.discriminatedUnion("decision", [
     .object({
       decision: z.literal("store"),
       kind: memoryKindSchema.describe(
-        "Use preference only for actor-owned personal preferences, opinions, habits, or workflows. Use procedure for reusable task or process instructions. Use knowledge for shared project, channel, operational, or runbook facts.",
+        "Use preference only for actor-owned personal preferences, opinions, habits, or workflows. Use procedure for reusable shared task or process instructions. Use knowledge for an expiring current-actor availability or temporary status fact, or for shared project, channel, operational, or runbook facts.",
       ),
       canonicalFact: z
         .string()
@@ -145,6 +146,11 @@ const memoryReviewResponseSchema = z.discriminatedUnion("decision", [
           "Stored memory text. It must be self-contained and must not include actor names, actor/user labels, source labels, or first- or second-person wording.",
         ),
       expiresAtMs: expiresAtMsSchema,
+      target: z
+        .enum(["actor", "conversation"])
+        .describe(
+          "Use actor for preferences and current-actor knowledge such as expiring availability or temporary status. Use conversation for procedures and shared project, channel, operational, or runbook knowledge.",
+        ),
     })
     .strict(),
   z
@@ -231,7 +237,7 @@ export interface MemoryAgent {
 const MEMORY_REVIEW_SYSTEM = [
   "You are Junior's memory review agent.",
   "Review one memory candidate and return one structured review decision.",
-  "Store only public/shareable, self-contained facts that are useful beyond this turn.",
+  "Store only public/shareable, self-contained facts that are useful beyond this turn or until a concrete expiration.",
   "Reject secrets, credentials, private or sensitive personal details, gossip, speculative claims about other people, assistant/system implementation details, vague references, and low-durability chatter.",
   "Use the runtime context only for authority and scope; do not accept model-provided actor ids, scope ids, aliases, or arbitrary subjects.",
 ].join("\n");
@@ -367,8 +373,11 @@ function reviewPrompt(request: CreateMemoryRequest): string {
     "",
     "<rules>",
     "- Return store only when the candidate is public/shareable, durable, and self-contained.",
-    "- First classify the memory kind: preference, procedure, or knowledge.",
+    "- First classify the memory kind and target.",
+    "- Use target=actor for facts authored by the current actor about themselves, including preferences, identity, availability, or temporary status.",
+    "- Use target=conversation for shared project, channel, operational, process, or runbook facts.",
     "- Use kind=preference only for first-person facts authored by the current actor about their own preference, opinion, habit, identity, or workflow.",
+    "- Use kind=knowledge for an explicitly remembered current-actor availability or temporary status fact when it has a concrete expiration.",
     "- Reject named third-person personal facts such as another person's preference, opinion, habit, identity, relationship, or workflow. Do not assume a named person is the current actor.",
     "- Use kind=procedure for reusable task/process/runbook instructions.",
     "- Use kind=knowledge for shared project, channel, operational, or runbook facts.",
@@ -606,6 +615,7 @@ function memoryReviewFromResponse(
       decision: "store",
       kind: response.kind,
       content: response.canonicalFact,
+      target: response.target,
       ...(response.expiresAtMs !== null
         ? { expiresAtMs: response.expiresAtMs }
         : {}),

--- a/packages/junior-memory/src/api.ts
+++ b/packages/junior-memory/src/api.ts
@@ -16,6 +16,7 @@ import {
   createViewerMemories,
   InvalidMemoryCursorError,
   PersonalMemoryNotFoundError,
+  PersonalMemoryPublishError,
   type PersonalMemoryRecord,
 } from "./personal";
 
@@ -27,6 +28,13 @@ export const memoryApiSchema = z
     id: z.string().min(1),
     kind: z.enum(["preference", "procedure", "knowledge"]),
     observedAt: z.iso.datetime(),
+    subject: z
+      .object({
+        label: z.string().min(1).optional(),
+        type: z.literal("user"),
+      })
+      .strict()
+      .optional(),
     visibility: z.enum(["private", "public"]),
   })
   .strict();
@@ -118,6 +126,14 @@ function apiMemory(
     id: memory.id,
     kind: memory.kind,
     observedAt: new Date(memory.observedAtMs).toISOString(),
+    ...(memory.subjectType === "user"
+      ? {
+          subject: {
+            ...(memory.subjectLabel ? { label: memory.subjectLabel } : {}),
+            type: "user" as const,
+          },
+        }
+      : {}),
     visibility: memory.visibility,
   };
 }
@@ -141,13 +157,18 @@ export function createMemoryApi(options: MemoryApiOptions): PluginRouteApp {
 
       const url = new URL(request.url);
       const memoryPath = /^\/memories\/([^/]+)$/.exec(url.pathname);
+      const publishPath = /^\/memories\/([^/]+)\/publish$/.exec(url.pathname);
       const isCollection = url.pathname === "/memories";
       const isDashboard = url.pathname === "/dashboard";
-      if (!isCollection && !isDashboard && !memoryPath) {
+      if (!isCollection && !isDashboard && !memoryPath && !publishPath) {
         return json({ error: "Not found." }, 404);
       }
       const isRead = request.method === "GET" || request.method === "HEAD";
-      if (!isRead && !(memoryPath && request.method === "DELETE")) {
+      if (
+        !isRead &&
+        !(memoryPath && request.method === "DELETE") &&
+        !(publishPath && request.method === "POST")
+      ) {
         return json({ error: "Method not allowed." }, 405);
       }
 
@@ -226,6 +247,14 @@ export function createMemoryApi(options: MemoryApiOptions): PluginRouteApp {
             status: 204,
           });
         }
+
+        if (publishPath && request.method === "POST") {
+          await memories.publish(decodeURIComponent(publishPath[1]!));
+          return new Response(null, {
+            headers: { "cache-control": "no-store" },
+            status: 204,
+          });
+        }
       } catch (error) {
         if (
           error instanceof z.ZodError ||
@@ -235,6 +264,9 @@ export function createMemoryApi(options: MemoryApiOptions): PluginRouteApp {
         }
         if (error instanceof PersonalMemoryNotFoundError) {
           return json({ error: error.message }, 404);
+        }
+        if (error instanceof PersonalMemoryPublishError) {
+          return json({ error: error.message }, 400);
         }
         throw error;
       }

--- a/packages/junior-memory/src/db/schema.ts
+++ b/packages/junior-memory/src/db/schema.ts
@@ -40,6 +40,7 @@ export const juniorMemoryMemories = pgTable(
     kind: text("type", { enum: MEMORY_KINDS }).notNull(),
     subjectType: text("subject_type", { enum: MEMORY_SUBJECT_TYPES }).notNull(),
     subjectKey: text("subject_key"),
+    subjectLabel: text("subject_label"),
     content: text("content").notNull(),
     searchVector: tsvector("search_vector").generatedAlwaysAs(
       sql`to_tsvector('english', "content")`,

--- a/packages/junior-memory/src/personal-store.ts
+++ b/packages/junior-memory/src/personal-store.ts
@@ -4,10 +4,22 @@
  * A user may have several linked identities. This store combines their
  * identity-scoped personal memories with authorized public workspace scopes.
  */
-import { and, asc, desc, eq, gt, ilike, like, lt, or, sql } from "drizzle-orm";
+import {
+  and,
+  asc,
+  desc,
+  eq,
+  gt,
+  ilike,
+  inArray,
+  like,
+  lt,
+  or,
+  sql,
+} from "drizzle-orm";
 import { z } from "zod";
 import { juniorMemoryEmbeddings, juniorMemoryMemories } from "./db/schema";
-import type { ResolvedMemoryScope } from "./scope";
+import type { ResolvedMemoryScope, ViewerMemoryScopes } from "./scope";
 import {
   activeVisiblePredicate,
   archiveExpiredMemoryBatch,
@@ -57,7 +69,9 @@ export interface PersonalMemoryPage {
 
 /** Safe provenance attached to one viewer-visible memory. */
 export type PersonalMemoryRecord = MemoryRecord & {
+  manageable: boolean;
   origin: "automatic" | "explicit" | "other";
+  publishable: boolean;
   sourcePlatform: "local" | "slack";
   visibility: MemoryVisibility;
 };
@@ -91,14 +105,24 @@ export class PersonalMemoryNotFoundError extends Error {
   }
 }
 
+/** Expected failure when a personal memory has no public workspace target. */
+export class PersonalMemoryPublishError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PersonalMemoryPublishError";
+  }
+}
+
 /** Viewer-scoped memory operations shared by dashboard and REST. */
 export interface PersonalMemoryCollection {
-  /** Archive one exact personal memory owned by a linked identity. */
+  /** Archive one exact memory managed by a linked identity. */
   archive(id: string): Promise<MemoryRecord>;
   /** Read one exact memory visible to a linked identity. */
   get(id: string): Promise<PersonalMemoryRecord>;
   /** List one stable page across every authorized viewer scope. */
   list(input: PersonalMemoryPageInput): Promise<PersonalMemoryPage>;
+  /** Publish one personal memory to its provider workspace. */
+  publish(id: string): Promise<PersonalMemoryRecord>;
   /** Summarize active memories across every authorized viewer scope. */
   stats(): Promise<PersonalMemoryStats>;
   /** Read memory creation history across every authorized viewer scope. */
@@ -149,11 +173,35 @@ function memoryVisibility(
 
 function personalMemoryRecord(
   row: typeof juniorMemoryMemories.$inferSelect,
+  options: {
+    privateScopeKeys: Set<string>;
+    publicScopes: ResolvedMemoryScope[];
+    workspaceScopesByPrivateKey: ReadonlyMap<string, ResolvedMemoryScope>;
+  },
 ): PersonalMemoryRecord {
   const memory = parseMemoryRow(row);
+  const ownsSubject = Boolean(
+    row.subjectType === "user" &&
+    row.subjectKey &&
+    options.privateScopeKeys.has(row.subjectKey),
+  );
+  const targetScope = options.workspaceScopesByPrivateKey.get(row.scopeKey);
+  const publishable = Boolean(
+    row.scope === "personal" &&
+    row.subjectType === "user" &&
+    row.subjectKey === row.scopeKey &&
+    targetScope &&
+    options.publicScopes.some(
+      (scope) =>
+        scope.scope === targetScope.scope &&
+        scope.scopeKey === targetScope.scopeKey,
+    ),
+  );
   return {
     ...memory,
+    manageable: row.scope === "personal" || ownsSubject,
     origin: memoryOrigin(row.idempotencyKey),
+    publishable,
     sourcePlatform: row.sourcePlatform,
     visibility: memoryVisibility(memory.scope),
   };
@@ -177,15 +225,49 @@ function emptyStats(): PersonalMemoryStats {
 /** Build storage operations for every memory scope linked to one viewer. */
 export function createPersonalMemoryCollection(
   db: MemoryDb,
-  scopes: {
-    privateScopes: ResolvedMemoryScope[];
-    publicScopes: ResolvedMemoryScope[];
-  },
-  options: { now?: () => number } = {},
+  scopes: ViewerMemoryScopes,
+  options: {
+    now?: () => number;
+    ownerLabels?: ReadonlyMap<string, string>;
+  } = {},
 ): PersonalMemoryCollection {
-  const { privateScopes, publicScopes } = scopes;
+  const { privateScopes, publicScopes, workspaceScopesByPrivateKey } = scopes;
   const allScopes = [...privateScopes, ...publicScopes];
+  const privateScopeKeys = new Set(
+    privateScopes.map((scope) => scope.scopeKey),
+  );
   const getNowMs = () => options.now?.() ?? Date.now();
+
+  function record(row: typeof juniorMemoryMemories.$inferSelect) {
+    return personalMemoryRecord(row, {
+      privateScopeKeys,
+      publicScopes,
+      workspaceScopesByPrivateKey,
+    });
+  }
+
+  function manageablePredicate(nowMs: number) {
+    const predicates = [];
+    const privateActive = activeVisiblePredicate({
+      nowMs,
+      scopes: privateScopes,
+    });
+    if (privateActive) predicates.push(privateActive);
+    const publicActive = activeVisiblePredicate({
+      nowMs,
+      scopes: publicScopes,
+    });
+    if (publicActive && privateScopeKeys.size > 0) {
+      predicates.push(
+        and(
+          publicActive,
+          eq(juniorMemoryMemories.subjectType, "user"),
+          inArray(juniorMemoryMemories.subjectKey, [...privateScopeKeys]),
+        ),
+      );
+    }
+    return predicates.length > 0 ? or(...predicates) : undefined;
+  }
 
   function scopesForVisibility(
     visibility: MemoryVisibility | undefined,
@@ -199,11 +281,7 @@ export function createPersonalMemoryCollection(
     async archive(id) {
       const memoryId = nonEmptyStringSchema.parse(id);
       const nowMs = getNowMs();
-      // Forget is personal-only; public workspace memories stay shared.
-      const predicate = activeVisiblePredicate({
-        nowMs,
-        scopes: privateScopes,
-      });
+      const predicate = manageablePredicate(nowMs);
       if (!predicate) {
         throw new PersonalMemoryNotFoundError();
       }
@@ -239,7 +317,7 @@ export function createPersonalMemoryCollection(
       if (!rows[0]) {
         throw new PersonalMemoryNotFoundError();
       }
-      return personalMemoryRecord(rows[0]);
+      return record(rows[0]);
     },
 
     async list(input) {
@@ -291,7 +369,8 @@ export function createPersonalMemoryCollection(
         )
         .limit(input.limit + 1);
       const hasNextPage = rows.length > input.limit;
-      const memories = rows.slice(0, input.limit).map(personalMemoryRecord);
+      const pageRows = rows.slice(0, input.limit);
+      const memories = pageRows.map(record);
       const last = memories.at(-1);
       return {
         memories,
@@ -304,6 +383,55 @@ export function createPersonalMemoryCollection(
             }
           : {}),
       };
+    },
+
+    async publish(id) {
+      const memoryId = nonEmptyStringSchema.parse(id);
+      const nowMs = getNowMs();
+      const predicate = activeVisiblePredicate({
+        nowMs,
+        scopes: privateScopes,
+      });
+      if (!predicate) throw new PersonalMemoryNotFoundError();
+      const rows = await db
+        .select()
+        .from(juniorMemoryMemories)
+        .where(and(predicate, eq(juniorMemoryMemories.id, memoryId)))
+        .limit(1);
+      const row = rows[0];
+      if (!row) throw new PersonalMemoryNotFoundError();
+      const subjectLabel = options.ownerLabels?.get(row.scopeKey)?.trim();
+      if (!subjectLabel) {
+        throw new PersonalMemoryPublishError(
+          "Memory owner name is unavailable.",
+        );
+      }
+      const targetScope = workspaceScopesByPrivateKey.get(row.scopeKey);
+      const canPublish =
+        row.subjectType === "user" &&
+        row.subjectKey === row.scopeKey &&
+        targetScope &&
+        publicScopes.some(
+          (scope) =>
+            scope.scope === targetScope.scope &&
+            scope.scopeKey === targetScope.scopeKey,
+        );
+      if (!canPublish || !targetScope) {
+        throw new PersonalMemoryPublishError(
+          "This personal memory has no workspace audience.",
+        );
+      }
+      const updated = await db
+        .update(juniorMemoryMemories)
+        .set({
+          scope: targetScope.scope,
+          scopeKey: targetScope.scopeKey,
+          subjectLabel,
+        })
+        .where(and(predicate, eq(juniorMemoryMemories.id, memoryId)))
+        .returning();
+      if (!updated[0]) throw new PersonalMemoryNotFoundError();
+      return record(updated[0]);
     },
 
     async stats() {

--- a/packages/junior-memory/src/personal.ts
+++ b/packages/junior-memory/src/personal.ts
@@ -11,7 +11,7 @@ import {
   type MemoryVisibility,
   type PersonalMemoryRecord,
 } from "./personal-store";
-import { deriveViewerMemoryScopes } from "./scope";
+import { deriveViewerMemoryScopes, identityScopeKey } from "./scope";
 import type { MemoryDb, MemoryRecord } from "./store";
 import type { MemoryKind } from "./types";
 
@@ -49,6 +49,7 @@ export class InvalidMemoryCursorError extends Error {
 }
 
 export { PersonalMemoryNotFoundError } from "./personal-store";
+export { PersonalMemoryPublishError } from "./personal-store";
 export type { MemoryVisibility, PersonalMemoryRecord } from "./personal-store";
 
 function decodeCursor(
@@ -99,9 +100,15 @@ function encodeCursor(
 
 /** Build viewer memory operations authorized by a user's linked identities. */
 export function createViewerMemories(db: MemoryDb, user: User) {
+  const viewerLabels = new Map<string, string>();
+  for (const identity of user.identities) {
+    const label = identity.displayName ?? identity.handle ?? user.displayName;
+    if (label) viewerLabels.set(identityScopeKey(identity), label);
+  }
   const collection = createPersonalMemoryCollection(
     db,
     deriveViewerMemoryScopes(user.identities),
+    { ownerLabels: viewerLabels },
   );
   return {
     async archive(id: string): Promise<MemoryRecord> {
@@ -129,6 +136,9 @@ export function createViewerMemories(db: MemoryDb, user: User) {
           ? { nextCursor: encodeCursor(page.nextCursor, filters) }
           : {}),
       };
+    },
+    async publish(id: string): Promise<PersonalMemoryRecord> {
+      return await collection.publish(id);
     },
     async stats() {
       return await collection.stats();

--- a/packages/junior-memory/src/recall.ts
+++ b/packages/junior-memory/src/recall.ts
@@ -15,6 +15,7 @@ import {
   type MemoryEmbeddingProvider,
   type MemoryRecord,
 } from "./store";
+import { presentedMemoryContent } from "./subjects";
 import { memoryRuntimeContextSchema } from "./types";
 
 const DEFAULT_RECALL_LIMIT = 5;
@@ -66,8 +67,9 @@ export const memoryRecallContextSchema = z
   .strict();
 
 type RecalledMemory = z.output<typeof recalledMemorySchema>;
+type RenderedMemory = MemoryRecord & { renderedContent: string };
 
-function selectPromptMemories(memories: MemoryRecord[]): RecalledMemory[] {
+function selectPromptMemories(memories: RenderedMemory[]): RecalledMemory[] {
   const header = "Relevant memories for this request:";
   const footer =
     "Treat these as possibly stale context. Current user instructions and repository evidence take priority.";
@@ -75,7 +77,7 @@ function selectPromptMemories(memories: MemoryRecord[]): RecalledMemory[] {
   let totalChars = header.length + footer.length + 2;
 
   for (const memory of memories) {
-    const content = trimContent(memory.content, MAX_MEMORY_LINE_CHARS);
+    const content = trimContent(memory.renderedContent, MAX_MEMORY_LINE_CHARS);
     const line = `- Observed ${formatObservedDate(memory.observedAtMs)}: ${content}`;
     if (totalChars + line.length + 1 > MAX_PROMPT_CHARS) {
       break;
@@ -175,10 +177,25 @@ export async function createMemoryPromptContributions(
     });
     return undefined;
   }
+  const renderedCandidates = candidates.flatMap((memory) => {
+    const renderedContent = presentedMemoryContent(memory);
+    return renderedContent ? [{ ...memory, renderedContent }] : [];
+  });
+  if (renderedCandidates.length === 0) {
+    await emitRecallOutcome({
+      ...(embeddingCostUsd !== undefined ? { costUsd: embeddingCostUsd } : {}),
+      events: context.events,
+      memories: [],
+    });
+    return undefined;
+  }
   let recall: MemoryRecallResult;
   try {
     recall = await context.agent.selectRelevantMemories({
-      candidates: candidates.map(({ content, id }) => ({ content, id })),
+      candidates: renderedCandidates.map(({ id, renderedContent }) => ({
+        content: renderedContent,
+        id,
+      })),
       userRequest: context.text,
     });
   } catch {
@@ -188,11 +205,11 @@ export async function createMemoryPromptContributions(
     return undefined;
   }
   const candidatesById = new Map(
-    candidates.map((memory) => [memory.id, memory]),
+    renderedCandidates.map((memory) => [memory.id, memory]),
   );
   const relevant = recall.relevantIds
     .map((id) => candidatesById.get(id))
-    .filter((memory): memory is MemoryRecord => memory !== undefined)
+    .filter((memory): memory is RenderedMemory => memory !== undefined)
     .slice(0, DEFAULT_RECALL_LIMIT);
   const selected = selectPromptMemories(relevant);
   const costUsd = addUsd(embeddingCostUsd, recall.costUsd);

--- a/packages/junior-memory/src/scope.ts
+++ b/packages/junior-memory/src/scope.ts
@@ -17,6 +17,18 @@ export interface ResolvedMemorySubject {
   subjectType: MemorySubjectType;
 }
 
+/** Viewer-authorized personal, workspace, and publish-target scopes. */
+export interface ViewerMemoryScopes {
+  privateScopes: ResolvedMemoryScope[];
+  publicScopes: ResolvedMemoryScope[];
+  workspaceScopesByPrivateKey: ReadonlyMap<string, ResolvedMemoryScope>;
+}
+
+type MemoryIdentity = Pick<
+  Identity,
+  "provider" | "providerSubjectId" | "providerTenantId"
+>;
+
 function uniqueScopes(scopes: ResolvedMemoryScope[]): ResolvedMemoryScope[] {
   return [
     ...new Map(
@@ -25,43 +37,44 @@ function uniqueScopes(scopes: ResolvedMemoryScope[]): ResolvedMemoryScope[] {
   ];
 }
 
+/** Build the personal scope key for one provider identity. */
+export function identityScopeKey(identity: MemoryIdentity): string {
+  return identity.providerTenantId
+    ? `${identity.provider}:${identity.providerTenantId}:${identity.providerSubjectId}`
+    : `${identity.provider}:${identity.providerSubjectId}`;
+}
+
+function workspaceScope(identity: MemoryIdentity) {
+  if (!identity.providerTenantId) return undefined;
+  return {
+    scope: "conversation" as const,
+    scopeKey: `${identity.provider}:${identity.providerTenantId}`,
+  };
+}
+
 /** Derive viewer-visible memory scopes from canonical provider identities. */
-export function deriveViewerMemoryScopes(identities: Identity[]): {
-  privateScopes: ResolvedMemoryScope[];
-  publicScopes: ResolvedMemoryScope[];
-} {
-  const privateScopes = identities.flatMap((identity) => {
-    if (identity.provider === "local") {
-      return [
-        {
-          scope: "personal" as const,
-          scopeKey: `local:${identity.providerSubjectId}`,
-        },
-      ];
-    }
-    if (identity.provider === "slack" && identity.providerTenantId) {
-      return [
-        {
-          scope: "personal" as const,
-          scopeKey: `slack:${identity.providerTenantId}:${identity.providerSubjectId}`,
-        },
-      ];
-    }
-    return [];
+export function deriveViewerMemoryScopes(
+  identities: Identity[],
+): ViewerMemoryScopes {
+  const privateScopes = identities.map((identity) => ({
+    scope: "personal" as const,
+    scopeKey: identityScopeKey(identity),
+  }));
+  const publicScopes = identities.flatMap((identity) => {
+    const scope = workspaceScope(identity);
+    return scope ? [scope] : [];
   });
-  const publicScopes = identities.flatMap((identity) =>
-    identity.provider === "slack" && identity.providerTenantId
-      ? [
-          {
-            scope: "conversation" as const,
-            scopeKey: `slack:${identity.providerTenantId}`,
-          },
-        ]
-      : [],
-  );
+  const workspaceScopesByPrivateKey = new Map<string, ResolvedMemoryScope>();
+  for (const identity of identities) {
+    const scope = workspaceScope(identity);
+    if (scope) {
+      workspaceScopesByPrivateKey.set(identityScopeKey(identity), scope);
+    }
+  }
   return {
     privateScopes: uniqueScopes(privateScopes),
     publicScopes: uniqueScopes(publicScopes),
+    workspaceScopesByPrivateKey,
   };
 }
 
@@ -85,9 +98,16 @@ function actorScopeKey(ctx: MemoryRuntimeContext): string | undefined {
     return undefined;
   }
   if (actor.platform === "slack") {
-    return `slack:${actor.teamId}:${actor.userId}`;
+    return identityScopeKey({
+      provider: actor.platform,
+      providerTenantId: actor.teamId,
+      providerSubjectId: actor.userId,
+    });
   }
-  return `local:${actor.userId}`;
+  return identityScopeKey({
+    provider: actor.platform,
+    providerSubjectId: actor.userId,
+  });
 }
 
 /** Derive the authority-bearing key for a requested memory scope. */

--- a/packages/junior-memory/src/store.ts
+++ b/packages/junior-memory/src/store.ts
@@ -136,6 +136,7 @@ const memoryRowSchema = z
     sourceKey: z.string().min(1),
     sourcePlatform: z.enum(MEMORY_SOURCE_PLATFORMS),
     subjectKey: optionalNonEmptyStringSchema,
+    subjectLabel: optionalNonEmptyStringSchema,
     subjectType: z.enum(MEMORY_SUBJECT_TYPES),
     supersededAtMs: optionalNumberSchema,
     supersededById: optionalStringSchema,
@@ -172,6 +173,7 @@ const memoryRecordSchema = z
     id: nonEmptyStringSchema,
     observedAtMs: numberSchema,
     scope: z.enum(MEMORY_SCOPES),
+    subjectLabel: nonEmptyStringSchema.optional(),
     subjectType: z.enum(MEMORY_SUBJECT_TYPES),
     supersededAtMs: numberSchema.optional(),
     supersededById: nonEmptyStringSchema.optional(),
@@ -395,6 +397,7 @@ export function parseMemoryRow(row: unknown): MemoryRecord {
     id: parsed.id,
     scope: parsed.scope,
     kind: parsed.kind,
+    ...(parsed.subjectLabel ? { subjectLabel: parsed.subjectLabel } : {}),
     subjectType: parsed.subjectType,
     content: parsed.content,
     observedAtMs: parsed.observedAtMs,
@@ -1004,6 +1007,7 @@ async function searchVisibleLexicalMemories(args: {
         sourceKey: candidates.sourceKey,
         sourcePlatform: candidates.sourcePlatform,
         subjectKey: candidates.subjectKey,
+        subjectLabel: candidates.subjectLabel,
         subjectType: candidates.subjectType,
         supersededAtMs: candidates.supersededAtMs,
         supersededById: candidates.supersededById,
@@ -1483,7 +1487,19 @@ export function createMemoryStore(
       if (rows.length > 1) {
         throw new Error("Memory id prefix is ambiguous.");
       }
-      const memory = parseMemoryRow(rows[0]);
+      const row = rows[0];
+      if (row.scope === "conversation" && row.subjectType === "user") {
+        let actorScope: ResolvedMemoryScope | undefined;
+        try {
+          actorScope = deriveMemoryScope(runtimeContext, "personal");
+        } catch {
+          // A public user memory has no manager when the runtime has no actor.
+        }
+        if (!actorScope || row.subjectKey !== actorScope.scopeKey) {
+          throw new Error("Memory was not found in the current context.");
+        }
+      }
+      const memory = parseMemoryRow(row);
       const updated = await db
         .update(juniorMemoryMemories)
         .set({

--- a/packages/junior-memory/src/subjects.ts
+++ b/packages/junior-memory/src/subjects.ts
@@ -1,0 +1,12 @@
+import type { MemoryRecord } from "./store";
+
+/** Return self-contained model-visible content without exposing subject keys. */
+export function presentedMemoryContent(
+  memory: MemoryRecord,
+): string | undefined {
+  if (memory.subjectType !== "user") return memory.content;
+  if (memory.subjectLabel) {
+    return `About ${memory.subjectLabel}: ${memory.content}`;
+  }
+  return memory.scope === "personal" ? memory.content : undefined;
+}

--- a/packages/junior-memory/src/tools.ts
+++ b/packages/junior-memory/src/tools.ts
@@ -22,12 +22,14 @@ import {
   parseCreateMemoryRequest,
   parseMemoryReview,
   type MemoryAgent,
+  type MemoryReview,
 } from "./agent";
 import {
   memoryRuntimeContextSchema,
   type MemoryKind,
   type MemoryRuntimeContext,
 } from "./types";
+import { presentedMemoryContent } from "./subjects";
 
 export type MemoryReviewer = Pick<MemoryAgent, "reviewCreateRequest">;
 
@@ -359,11 +361,13 @@ function createInput(
   } satisfies CreateMemoryInput;
 }
 
-function targetForKind(kind: MemoryKind): "actor" | "conversation" {
-  if (kind === "preference") {
-    return "actor";
-  }
-  return "conversation";
+/** Enforce kind ownership even when model review returns a conflicting target. */
+function storageTarget(
+  review: Pick<Extract<MemoryReview, { decision: "store" }>, "kind" | "target">,
+): "actor" | "conversation" {
+  if (review.kind === "preference") return "actor";
+  if (review.kind === "procedure") return "conversation";
+  return review.target;
 }
 
 /** Return the model-visible projection without hidden ownership/source fields. */
@@ -377,6 +381,13 @@ function compactMemory(memory: MemoryRecord): MemoryToolProjection {
       ? { expiresAtMs: memory.expiresAtMs }
       : {}),
   });
+}
+
+function compactPresentedMemory(
+  memory: MemoryRecord,
+  content: string,
+): MemoryToolProjection {
+  return compactMemory({ ...memory, content });
 }
 
 function memoryToolResult<TData extends Record<string, unknown>>(
@@ -400,7 +411,7 @@ export function createMemoryCreateTool(context: MemoryCreateToolContext) {
       readOnlyHint: false,
     },
     description:
-      "Explicit memory-write tool. Use only when the latest user message directly asks Junior to remember, store, save, or forget-and-replace a public/shareable fact. Do not use for ordinary statements like 'I prefer X', 'I use Y', or 'X goes before Y' unless the user also asks you to remember/store/save it; passive memory learning handles those after the visible reply. Pass one self-contained natural-language candidate preserving the user's explicit memory intent. Do not ask the user to rephrase ordinary first-person facts, and do not rewrite them into display-name or third-person wording. Do not include secrets, private personal details, medical/legal/financial/sensitive facts, or another person's personal preference, opinion, habit, identity, relationship, workflow, or private life. Runtime context derives actor, scope, source, and subject ids; the memory agent decides canonical stored content and memory kind, then the plugin derives storage target from kind.",
+      "Explicit memory-write tool. Use only when the latest user message directly asks Junior to remember, store, save, or forget-and-replace a public/shareable fact. Do not use for ordinary statements like 'I prefer X', 'I use Y', or 'X goes before Y' unless the user also asks you to remember/store/save it; passive memory learning handles those after the visible reply. Pass one self-contained natural-language candidate preserving the user's explicit memory intent. Do not ask the user to rephrase ordinary first-person facts, and do not rewrite them into display-name or third-person wording. Do not include secrets, private personal details, medical/legal/financial/sensitive facts, or another person's personal preference, opinion, habit, identity, relationship, workflow, or private life. Runtime context derives actor, scope, source, and subject ids; the memory agent decides canonical stored content, memory kind, and whether the fact belongs to the actor or conversation.",
     executionMode: "sequential",
     inputSchema: createMemoryInputSchema,
     outputSchema: memoryCreateOutputSchema,
@@ -466,7 +477,7 @@ export function createMemoryCreateTool(context: MemoryCreateToolContext) {
       );
       const result = await (async () => {
         try {
-          if (targetForKind(review.kind) === "conversation") {
+          if (storageTarget(review) === "conversation") {
             return await store.createConversationMemory(memoryInput);
           }
           return await store.createMemory(memoryInput);
@@ -534,7 +545,10 @@ export function createMemoryListTool(context: MemoryToolContext) {
         limit: boundedLimit(parsedInput.limit, DEFAULT_RESULT_LIMIT),
       });
       return memoryToolResult("listMemories", {
-        memories: memories.map(compactMemory),
+        memories: memories.flatMap((memory) => {
+          const content = presentedMemoryContent(memory);
+          return content ? [compactPresentedMemory(memory, content)] : [];
+        }),
       });
     },
   });
@@ -563,7 +577,10 @@ export function createMemorySearchTool(context: MemoryToolContext) {
         limit: boundedLimit(parsedInput.limit, DEFAULT_SEARCH_LIMIT),
       });
       return memoryToolResult("searchMemories", {
-        memories: memories.map(compactMemory),
+        memories: memories.flatMap((memory) => {
+          const content = presentedMemoryContent(memory);
+          return content ? [compactPresentedMemory(memory, content)] : [];
+        }),
       });
     },
   });

--- a/packages/junior-memory/src/user-pages.ts
+++ b/packages/junior-memory/src/user-pages.ts
@@ -26,6 +26,14 @@ function visibilityLabel(visibility: MemoryVisibility): string {
   return visibility === "public" ? "Public" : "Private";
 }
 
+function memoryTitle(memory: PersonalMemoryRecord): string {
+  return memory.visibility === "public" &&
+    memory.subjectType === "user" &&
+    memory.subjectLabel
+    ? `${memory.subjectLabel} — ${memory.content}`
+    : memory.content;
+}
+
 function pageFilter(filter: string | undefined): {
   visibility?: MemoryVisibility;
 } {
@@ -63,8 +71,20 @@ export function createMemoryUserPage(): PluginUserPageDefinition {
         ...(page.nextCursor ? { nextCursor: page.nextCursor } : {}),
         searchPlaceholder: "Search memories",
         records: page.memories.map((memory) => ({
-          actions:
-            memory.visibility === "private"
+          actions: [
+            ...(memory.publishable
+              ? [
+                  {
+                    confirmation:
+                      "Make this memory public to the workspace where it was created?",
+                    href: `/api/plugins/memory/memories/${encodeURIComponent(memory.id)}/publish`,
+                    label: "Make Public",
+                    method: "POST" as const,
+                    tone: "neutral" as const,
+                  },
+                ]
+              : []),
+            ...(memory.manageable
               ? [
                   {
                     confirmation: "Forget this memory?",
@@ -74,9 +94,10 @@ export function createMemoryUserPage(): PluginUserPageDefinition {
                     tone: "danger" as const,
                   },
                 ]
-              : [],
+              : []),
+          ],
           id: memory.id,
-          title: memory.content,
+          title: memoryTitle(memory),
           metadata: [
             { label: "Type", value: titleCase(memory.kind) },
             { label: "Learned", value: originLabel(memory.origin) },
@@ -85,6 +106,14 @@ export function createMemoryUserPage(): PluginUserPageDefinition {
               label: "Visibility",
               value: visibilityLabel(memory.visibility),
             },
+            ...(memory.visibility === "public" && memory.subjectType === "user"
+              ? [
+                  {
+                    label: "About",
+                    value: memory.subjectLabel ?? "Identity unavailable",
+                  },
+                ]
+              : []),
             { label: "Remembered", value: rememberedDate(memory.createdAtMs) },
             { label: "Observed", value: rememberedDate(memory.observedAtMs) },
             {

--- a/packages/junior-memory/tests/storage.test.ts
+++ b/packages/junior-memory/tests/storage.test.ts
@@ -35,6 +35,7 @@ import { createMemoryAgent, type CreateMemoryRequest } from "../src/agent";
 import { createMemoryCliCommand } from "../src/cli";
 import { memoryPlugin } from "../src/plugin";
 import { processMemorySession } from "../src/process-session";
+import { createMemoryPromptContributions } from "../src/recall";
 import {
   createMemoryCreateTool,
   createMemoryListTool,
@@ -507,6 +508,7 @@ function allowMemory(
         decision: "store",
         kind: target === "actor" ? "preference" : "knowledge",
         content: testCanonicalContent(candidate.content),
+        target,
         ...(candidate.expiresAtMs !== undefined
           ? { expiresAtMs: candidate.expiresAtMs }
           : {}),
@@ -536,6 +538,7 @@ describe("memory plugin storage", () => {
             kind: "preference",
             canonicalFact: "Uses qa-structured-output in CLI QA.",
             expiresAtMs: null,
+            target: "actor",
           },
         };
       },
@@ -551,6 +554,7 @@ describe("memory plugin storage", () => {
       decision: "store",
       kind: "preference",
       content: "Uses qa-structured-output in CLI QA.",
+      target: "actor",
     });
     expect(calls[0]?.schema).toBeDefined();
   });
@@ -2218,6 +2222,14 @@ ORDER BY created_at_ms ASC
           {
             actions: [
               {
+                confirmation:
+                  "Make this memory public to the workspace where it was created?",
+                href: `/api/plugins/memory/memories/${personal.memory.id}/publish`,
+                label: "Make Public",
+                method: "POST",
+                tone: "neutral",
+              },
+              {
                 confirmation: "Forget this memory?",
                 href: `/api/plugins/memory/memories/${personal.memory.id}`,
                 label: "Forget",
@@ -2386,7 +2398,10 @@ ORDER BY created_at_ms ASC
         idempotencyKey: "session:api:private",
         kind: "knowledge",
       });
-      const viewer = viewerUser([firstContext.actor!, secondContext.actor!]);
+      const viewer = {
+        ...viewerUser([firstContext.actor!, secondContext.actor!]),
+        displayName: "David Cramer",
+      };
       const resolveUser = vi.fn(async () => viewer);
       const api = createMemoryApi({
         db: memoryDb(fixture),
@@ -2560,6 +2575,130 @@ ORDER BY created_at_ms ASC
         personal: 2,
         public: 1,
       });
+
+      const publishResponse = await api.fetch(
+        new Request(`http://localhost/memories/${first.memory.id}/publish`, {
+          method: "POST",
+        }),
+        requestContext,
+      );
+      expect(publishResponse.status).toBe(204);
+      const publishedDetailResponse = await api.fetch(
+        new Request(`http://localhost/memories/${first.memory.id}`),
+        requestContext,
+      );
+      expect(publishedDetailResponse.status).toBe(200);
+      expect(
+        memoryApiSchema.parse(await publishedDetailResponse.json()),
+      ).toMatchObject({
+        content: "Prefers concise release notes.",
+        id: first.memory.id,
+        subject: { label: "David Cramer", type: "user" },
+        visibility: "public",
+      });
+      const otherViewerContext = slackContext({
+        channelId: "C888",
+        teamId: "T123",
+        userId: "U888",
+      });
+      const otherToolContext = {
+        agent: rejectMemory,
+        db: memoryDb(fixture),
+        ...otherViewerContext,
+      };
+      await expect(
+        createMemoryListTool(otherToolContext).execute({ limit: 20 }, {}),
+      ).resolves.toMatchObject({
+        memories: expect.arrayContaining([
+          expect.objectContaining({
+            content: "About David Cramer: Prefers concise release notes.",
+            id: first.memory.id,
+          }),
+        ]),
+      });
+      await expect(
+        createMemoryRemoveTool(otherToolContext).execute(
+          { id: first.memory.id },
+          {},
+        ),
+      ).rejects.toThrow("Memory was not found in the current context.");
+      const ownerToolMemory = await firstStore.createMemory({
+        content: "Prefers owner-managed public memories.",
+        idempotencyKey: "tool:api:owner-managed",
+        kind: "preference",
+      });
+      const ownerPublishResponse = await api.fetch(
+        new Request(
+          `http://localhost/memories/${ownerToolMemory.memory.id}/publish`,
+          { method: "POST" },
+        ),
+        requestContext,
+      );
+      expect(ownerPublishResponse.status).toBe(204);
+      await expect(
+        createMemoryRemoveTool({
+          agent: rejectMemory,
+          db: memoryDb(fixture),
+          ...firstContext,
+        }).execute({ id: ownerToolMemory.memory.id }, {}),
+      ).resolves.toMatchObject({
+        memory: { id: ownerToolMemory.memory.id },
+      });
+      const publicMemoryPage = memoryPlugin().userPages?.[0];
+      if (!publicMemoryPage) throw new Error("Expected Memory dashboard page");
+      await expect(
+        publicMemoryPage.read(
+          {
+            db: memoryDb(fixture),
+            log: noopLogger,
+            plugin: { name: "memory" },
+            viewer: viewerUser([otherViewerContext.actor!]),
+          },
+          { limit: 20 },
+        ),
+      ).resolves.toMatchObject({
+        records: expect.arrayContaining([
+          expect.objectContaining({
+            actions: [],
+            id: first.memory.id,
+            title: "David Cramer — Prefers concise release notes.",
+          }),
+        ]),
+      });
+      const recallInputs: unknown[] = [];
+      const contributions = await createMemoryPromptContributions({
+        actor: otherViewerContext.actor,
+        agent: {
+          selectRelevantMemories(input) {
+            recallInputs.push(input);
+            return { relevantIds: input.candidates.map(({ id }) => id) };
+          },
+        },
+        db: memoryDb(fixture),
+        log: noopLogger,
+        source: otherViewerContext.source,
+        text: "concise release notes",
+      });
+      expect(recallInputs).toEqual([
+        expect.objectContaining({
+          candidates: [
+            expect.objectContaining({
+              content: "About David Cramer: Prefers concise release notes.",
+              id: first.memory.id,
+            }),
+          ],
+        }),
+      ]);
+      expect(contributions?.[0]?.renderPrompt()).toContain(
+        "About David Cramer: Prefers concise release notes.",
+      );
+      const publishedDeleteResponse = await api.fetch(
+        new Request(`http://localhost/memories/${first.memory.id}`, {
+          method: "DELETE",
+        }),
+        requestContext,
+      );
+      expect(publishedDeleteResponse.status).toBe(204);
 
       const deleteResponse = await api.fetch(
         new Request(`http://localhost/memories/${second.memory.id}`, {
@@ -3493,6 +3632,35 @@ WHERE id = '${superseded.memory.id}'
         },
       });
       expect(reviewedRequests[0]).not.toHaveProperty("expiresAtMs");
+      await createMemoryCreateTool({
+        ...context,
+        agent: {
+          reviewCreateRequest() {
+            return {
+              content: "Prefers risk summaries first.",
+              decision: "store",
+              kind: "preference",
+              target: "conversation",
+            };
+          },
+        },
+      }).execute(
+        { content: "I prefer risk summaries first." },
+        { toolCallId: "tool-create-conflicting-preference" },
+      );
+      await expect(
+        memoryDb(fixture)
+          .select()
+          .from(memorySqlSchema.juniorMemoryMemories)
+          .where(
+            eq(
+              memorySqlSchema.juniorMemoryMemories.content,
+              "Prefers risk summaries first.",
+            ),
+          ),
+      ).resolves.toEqual([
+        expect.objectContaining({ kind: "preference", scope: "personal" }),
+      ]);
       await expect(
         createMemoryCreateTool({
           ...context,
@@ -3533,6 +3701,9 @@ WHERE id = '${superseded.memory.id}'
         memories: [
           expect.objectContaining({
             content: "Incident notes live in Linear.",
+          }),
+          expect.objectContaining({
+            content: "Prefers risk summaries first.",
           }),
           expect.objectContaining({
             content: "Prefers terse status updates.",

--- a/packages/junior-plugin-api/src/user-pages.ts
+++ b/packages/junior-plugin-api/src/user-pages.ts
@@ -38,7 +38,7 @@ const pluginUserPageActionSchema = z
       .max(500)
       .regex(/^\/api\/plugins\/[a-z][a-z0-9-]*(?:\/|$)/),
     label: nonBlankStringSchema.max(80),
-    method: z.literal("DELETE"),
+    method: z.enum(["DELETE", "POST"]),
     tone: z.enum(["danger", "neutral"]).optional(),
   })
   .strict();

--- a/packages/junior/tests/component/memory-plugin-storage.test.ts
+++ b/packages/junior/tests/component/memory-plugin-storage.test.ts
@@ -56,6 +56,7 @@ vi.mock("@/chat/pi/client", () => ({
       decision: "store",
       expiresAtMs: null,
       kind: "preference",
+      target: "actor",
     },
   })),
   embedTexts: vi.fn(async ({ texts }: { texts: string[] }) => ({


### PR DESCRIPTION
Users can now publish one of their personal memories from the Memories dashboard when that memory belongs to an identity with a provider workspace. The owner can still forget the published memory, while shared workspace knowledge remains view-only.

## Memory model

A memory has two separate concerns:

- `subjectType` and `subjectKey` describe who or what it is about.
- `scope` and `scopeKey` describe who may recall it.

Explicit memory review now returns both `kind` and `target`, which allows an expiring availability fact to be `knowledge` about the current actor. Runtime keeps preferences actor-scoped and procedures conversation-scoped even if model review returns a conflicting target, so the model never controls identity keys or bypasses those ownership rules.

Publishing changes only the audience. Canonical content, provenance, and embeddings remain unchanged while the personal scope moves to the provider workspace scope.

## Subject label snapshot

Publishing stores a nullable `subject_label` beside the structured user subject. This is presentation metadata, not authority and not embedding input. Memory-owned surfaces render canonical content such as `Out of office August 10–14` as `About Morgan: Out of office August 10–14` when model-visible self-contained text is required.

The same snapshot is used by automatic recall, list/search tools, REST responses, and dashboard records. REST preserves canonical `content` and adds a structured user `subject`. A public user memory without a label is omitted from model-visible recall and tool output rather than risk misattribution.

The tradeoff is deliberate: a later display-name change does not rewrite an existing memory. Expiring status memories make that acceptable for this MVP, and label refresh can be added later if proven necessary.

## Ownership and actions

The memory page adds **Make Public** for publishable personal memories and retains owner-only **Forget** after publication. Owned public memories continue to say “You asked Junior”; shared public memories retain generic workspace language.

Ownership is also enforced in the low-level archive path. A public user-subject memory can be removed through the chat `removeMemory` tool only when its subject matches the current actor. Conversation-subject memory keeps the existing shared-memory behavior.

The shared plugin user-page action contract supports POST as well as DELETE, and memory exposes `POST /api/plugins/memory/memories/:id/publish`.

## MVP boundary

- Publishing requires an identity with a provider workspace; local identities without one cannot publish.
- Publishing is dashboard-only; “remember publicly” chat wording is deferred.
- Owners can forget a published memory, but there is no make-private action yet.
- Workspace-public recall keeps the existing public-conversation boundary.
- Identity-name-only search is not added; retrieval still ranks canonical memory content.
- Automatic learning never publishes a personal memory.
- The nullable `subject_label` column requires the included memory migration.

Review should start with `personal-store.ts` for publication and dashboard ownership, `store.ts` for the low-level archive guard, and `subjects.ts` for the small presentation rule.

Coverage includes canonical-content publication, the stored subject label, identity-aware recall/tools/REST/dashboard output, owner and non-owner chat removal, out-of-office agent interpretation, migration metadata, and the Chromium dashboard publish flow. Focused tests, builds, typechecks, formatting, package lint, commit hooks, and the full pre-push suite pass.
