### PR TITLE
perf(sql): cap runtime statements at 30 seconds

### DIFF
--- a/packages/docs/src/content/docs/reference/config-and-env.md
+++ b/packages/docs/src/content/docs/reference/config-and-env.md
@@ -40,6 +40,8 @@ related:
 | `JUNIOR_TIMEZONE`                           | No          | Default IANA timezone for scheduler authoring when the scheduler plugin is enabled. Defaults to `America/Los_Angeles`.                                                                           |
 | `AI_GATEWAY_API_KEY`                        | No          | AI gateway auth if used in your setup.                                                                                                                                                           |
 
+Junior runtime database connections set PostgreSQL `statement_timeout` to 30 seconds for both the Neon and node-postgres drivers. `junior upgrade` does not apply this runtime limit because schema migrations can legitimately take longer.
+
 `JUNIOR_CROSS_ACTOR_MID_RUN_MODE=follow_up` keeps another actor's mid-run ask
 for its own turn. Set it to `steer` to preserve collaborative steering across
 actors. In `follow_up` mode, a user can start one message with `!!` to steer the

--- a/packages/junior/src/cli/upgrade.ts
+++ b/packages/junior/src/cli/upgrade.ts
@@ -107,6 +107,7 @@ export async function runUpgrade(
   const sqlExecutor: JuniorSqlExecutor = createJuniorSqlExecutor({
     connectionString: sql.databaseUrl,
     driver: sql.driver,
+    statementTimeoutMs: false,
   });
   try {
     const pluginSet =

--- a/packages/junior/src/db/executor.ts
+++ b/packages/junior/src/db/executor.ts
@@ -3,13 +3,24 @@ import { createNeonJuniorSqlExecutor } from "./neon";
 import { createPostgresJuniorSqlExecutor } from "./postgres";
 import type { SqlDriver } from "@/chat/config";
 
+export const DEFAULT_SQL_STATEMENT_TIMEOUT_MS = 30_000;
+
 /** Create the SQL executor appropriate for the configured database URL. */
 export function createJuniorSqlExecutor(args: {
   connectionString: string;
   driver: SqlDriver;
+  statementTimeoutMs?: number | false;
 }): JuniorSqlExecutor {
+  const statementTimeoutMs =
+    args.statementTimeoutMs ?? DEFAULT_SQL_STATEMENT_TIMEOUT_MS;
   if (args.driver === "postgres") {
-    return createPostgresJuniorSqlExecutor(args);
+    return createPostgresJuniorSqlExecutor({
+      connectionString: args.connectionString,
+      statementTimeoutMs,
+    });
   }
-  return createNeonJuniorSqlExecutor(args);
+  return createNeonJuniorSqlExecutor({
+    connectionString: args.connectionString,
+    statementTimeoutMs,
+  });
 }

--- a/packages/junior/src/db/neon.ts
+++ b/packages/junior/src/db/neon.ts
@@ -142,11 +142,13 @@ class NeonExecutor implements NeonJuniorSqlExecutor {
 /** Create the shared Neon-backed Junior SQL executor. */
 export function createNeonJuniorSqlExecutor(args: {
   connectionString: string;
+  statementTimeoutMs?: number | false;
 }): NeonJuniorSqlExecutor {
   return new NeonExecutor(
     new Pool({
       connectionString: args.connectionString,
       max: 3,
+      statement_timeout: args.statementTimeoutMs,
     }),
   );
 }

--- a/packages/junior/src/db/postgres.ts
+++ b/packages/junior/src/db/postgres.ts
@@ -141,12 +141,14 @@ class PostgresExecutor implements JuniorSqlExecutor {
 export function createPostgresJuniorSqlExecutor(args: {
   applicationName?: string;
   connectionString: string;
+  statementTimeoutMs?: number | false;
 }): JuniorSqlExecutor {
   return new PostgresExecutor(
     new Pool({
       application_name: args.applicationName,
       connectionString: args.connectionString,
       max: 3,
+      statement_timeout: args.statementTimeoutMs,
     }),
   );
 }

--- a/packages/junior/tests/integration/conversation-sql.test.ts
+++ b/packages/junior/tests/integration/conversation-sql.test.ts
@@ -636,6 +636,26 @@ VALUES ('host-migration', 9999999999999)
   });
 
   it.skipIf(!hasJuniorPostgresTestDatabase())(
+    "cancels runtime queries after the configured statement timeout",
+    async () => {
+      const fixture = await createEmptyJuniorSqlFixture();
+      const executor = createPostgresJuniorSqlExecutor({
+        connectionString: fixture.connectionString,
+        statementTimeoutMs: 10,
+      });
+
+      try {
+        await expect(
+          executor.query("SELECT pg_sleep(0.05)"),
+        ).rejects.toMatchObject({ code: "57014" });
+      } finally {
+        await executor.close();
+        await fixture.close();
+      }
+    },
+  );
+
+  it.skipIf(!hasJuniorPostgresTestDatabase())(
     "serializes concurrent core migrations",
     async () => {
       const fixture = await createEmptyJuniorSqlFixture();

--- a/packages/junior/tests/unit/sql/executor.test.ts
+++ b/packages/junior/tests/unit/sql/executor.test.ts
@@ -1,6 +1,11 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { JuniorSqlExecutor } from "@/db/db";
-import { createJuniorSqlExecutor } from "@/db/executor";
+import {
+  createJuniorSqlExecutor,
+  DEFAULT_SQL_STATEMENT_TIMEOUT_MS,
+} from "@/db/executor";
+import { createNeonJuniorSqlExecutor } from "@/db/neon";
+import { createPostgresJuniorSqlExecutor } from "@/db/postgres";
 const EXECUTORS = vi.hoisted(() => ({
   neon: executor("neon"),
   postgres: executor("postgres"),
@@ -30,6 +35,10 @@ vi.mock("@/db/postgres", () => ({
 }));
 
 describe("createJuniorSqlExecutor", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("uses node-postgres for the postgres driver", () => {
     expect(
       createJuniorSqlExecutor({
@@ -37,6 +46,10 @@ describe("createJuniorSqlExecutor", () => {
         driver: "postgres",
       }),
     ).toBe(EXECUTORS.postgres);
+    expect(createPostgresJuniorSqlExecutor).toHaveBeenCalledWith({
+      connectionString: "postgres://junior:junior@localhost:5432/junior",
+      statementTimeoutMs: DEFAULT_SQL_STATEMENT_TIMEOUT_MS,
+    });
   });
 
   it("uses Neon for the neon driver", () => {
@@ -46,6 +59,24 @@ describe("createJuniorSqlExecutor", () => {
         driver: "neon",
       }),
     ).toBe(EXECUTORS.neon);
+    expect(createNeonJuniorSqlExecutor).toHaveBeenCalledWith({
+      connectionString: "postgres://junior:junior@example.test/junior",
+      statementTimeoutMs: DEFAULT_SQL_STATEMENT_TIMEOUT_MS,
+    });
+  });
+
+  it("allows migration executors to disable the runtime timeout", () => {
+    expect(
+      createJuniorSqlExecutor({
+        connectionString: "postgres://junior:junior@example.test/junior",
+        driver: "neon",
+        statementTimeoutMs: false,
+      }),
+    ).toBe(EXECUTORS.neon);
+    expect(createNeonJuniorSqlExecutor).toHaveBeenCalledWith({
+      connectionString: "postgres://junior:junior@example.test/junior",
+      statementTimeoutMs: false,
+    });
   });
 
   it("passes non-URL connection strings to the configured driver", () => {


### PR DESCRIPTION
Runtime SQL connections now set PostgreSQL `statement_timeout` to 30 seconds through both the Neon and node-postgres drivers. Statements that exceed the limit are canceled by Postgres and continue through the existing error boundary instead of consuming a connection indefinitely.

`junior upgrade` explicitly skips the runtime limit because schema migrations can legitimately take longer. The integration coverage verifies that Postgres cancels an over-limit statement with error code `57014`.
