### PR TITLE
fix(dashboard): centralize route ownership

### DIFF
--- a/packages/junior-dashboard/README.md
+++ b/packages/junior-dashboard/README.md
@@ -8,6 +8,9 @@ state.
 
 - `createDashboardApp` mounts the dashboard routes and receives host
   configuration through `JuniorDashboardOptions`.
+- `src/routes.ts` owns browser page paths and the full host forwarding list.
+  React routes, dashboard server routes, and core forwarding must use that
+  table instead of copying path strings.
 - Better Auth owns authentication; dashboard routes fail closed when identity
   or required configuration is missing.
 - API schemas under `src/api/` define the client/server boundary.

--- a/packages/junior-dashboard/src/app.ts
+++ b/packages/junior-dashboard/src/app.ts
@@ -30,6 +30,7 @@ import {
 import { dashboardRainbowProgressClass } from "./dashboardLoader";
 import { createMockReportingApi } from "./mock-reporting/routes";
 import { resolveDashboardBaseURL } from "./url";
+import { dashboardPagePaths } from "./routes";
 
 const DEFAULT_BASE_PATH = "/";
 const DEFAULT_AUTH_PATH = "/api/auth";
@@ -444,48 +445,6 @@ function readDashboardAvatarHeader(): ArrayBuffer {
     throw new Error("Junior dashboard avatar asset was not found");
   }
   return Uint8Array.from(readFileSync(assetUrl)).buffer;
-}
-
-function dashboardPagePaths(
-  basePath: string,
-  options: { componentGallery?: boolean } = {},
-): Array<{ nested?: boolean; path: string }> {
-  const paths: Array<{ nested?: boolean; path: string }> = [
-    { path: basePath },
-    {
-      nested: true,
-      path: basePath === "/" ? "/conversations" : `${basePath}/conversations`,
-    },
-    {
-      nested: true,
-      path: basePath === "/" ? "/people" : `${basePath}/people`,
-    },
-    {
-      nested: true,
-      path: basePath === "/" ? "/locations" : `${basePath}/locations`,
-    },
-    {
-      nested: true,
-      path: basePath === "/" ? "/system" : `${basePath}/system`,
-    },
-    {
-      path:
-        basePath === "/"
-          ? "/settings/api-tokens"
-          : `${basePath}/settings/api-tokens`,
-    },
-    {
-      nested: true,
-      path: basePath === "/" ? "/plugins" : `${basePath}/plugins`,
-    },
-  ];
-  if (options.componentGallery) {
-    paths.push({
-      nested: true,
-      path: basePath === "/" ? "/dev" : `${basePath}/dev`,
-    });
-  }
-  return paths;
 }
 
 function renderDashboard(basePath: string, agentName: string): Response {

--- a/packages/junior-dashboard/src/client/App.tsx
+++ b/packages/junior-dashboard/src/client/App.tsx
@@ -37,6 +37,7 @@ import {
   dashboardInteractiveTextClass,
 } from "./styles";
 import type { DashboardCoreData } from "./types";
+import { dashboardRoutes } from "../routes";
 
 const dashboardBackground = {
   backgroundColor: "#050507",
@@ -181,15 +182,15 @@ export function DashboardShell() {
               <Navigate replace to="/" />
             )
           }
-          path="/tasks"
+          path={dashboardRoutes.tasks.path}
         />
         <Route
           element={<LegacySystemRedirect section="locations" />}
-          path="/locations"
+          path={dashboardRoutes.locations.path}
         />
         <Route
           element={<LegacySystemRedirect section="locations" />}
-          path="/locations/:locationId"
+          path={dashboardRoutes.location.path}
         />
         <Route
           element={
@@ -199,7 +200,7 @@ export function DashboardShell() {
               <LocationsPage />
             )
           }
-          path="/system/locations"
+          path={dashboardRoutes.systemLocations.path}
         />
         <Route
           element={
@@ -209,7 +210,7 @@ export function DashboardShell() {
               <LocationDetailPage />
             )
           }
-          path="/system/locations/:locationId"
+          path={dashboardRoutes.systemLocation.path}
         />
         <Route
           element={
@@ -223,7 +224,7 @@ export function DashboardShell() {
               />
             )
           }
-          path="/"
+          path={dashboardRoutes.home.path}
         />
         <Route
           element={
@@ -237,9 +238,12 @@ export function DashboardShell() {
               />
             )
           }
-          path="/conversations/:conversationId"
+          path={dashboardRoutes.conversation.path}
         />
-        <Route element={<Navigate replace to="/" />} path="/conversations" />
+        <Route
+          element={<Navigate replace to="/" />}
+          path={dashboardRoutes.conversations.path}
+        />
         <Route
           element={
             loading ? (
@@ -254,11 +258,11 @@ export function DashboardShell() {
               <Navigate replace to="/" />
             )
           }
-          path="/dev/*"
+          path={dashboardRoutes.dev.path}
         />
         <Route
           element={<LegacySystemRedirect section="people" />}
-          path="/people"
+          path={dashboardRoutes.people.path}
         />
         <Route
           element={
@@ -268,13 +272,13 @@ export function DashboardShell() {
               <PersonProfilePage />
             )
           }
-          path="/people/:email"
+          path={dashboardRoutes.person.path}
         />
         <Route
           element={
             loading ? <LoadingView label="Loading people" /> : <PeoplePage />
           }
-          path="/system/people"
+          path={dashboardRoutes.systemPeople.path}
         />
         <Route
           element={
@@ -288,7 +292,7 @@ export function DashboardShell() {
               />
             )
           }
-          path="/system/*"
+          path={dashboardRoutes.system.path}
         />
         <Route
           element={
@@ -300,7 +304,7 @@ export function DashboardShell() {
               <Navigate replace to="/" />
             )
           }
-          path="/settings/api-tokens"
+          path={dashboardRoutes.settingsApiTokens.path}
         />
         <Route
           element={
@@ -312,9 +316,12 @@ export function DashboardShell() {
               <Navigate replace to="/" />
             )
           }
-          path="/plugins/:pluginName/:pageId/*"
+          path={dashboardRoutes.pluginPage.path}
         />
-        <Route element={<Navigate replace to="/" />} path="*" />
+        <Route
+          element={<Navigate replace to="/" />}
+          path={dashboardRoutes.fallback.path}
+        />
       </Routes>
       <span
         aria-hidden="true"

--- a/packages/junior-dashboard/src/index.ts
+++ b/packages/junior-dashboard/src/index.ts
@@ -1,1 +1,2 @@
 export { createDashboardApp, type JuniorDashboardOptions } from "./app";
+export { dashboardRoutePaths } from "./routes";

--- a/packages/junior-dashboard/src/routes.ts
+++ b/packages/junior-dashboard/src/routes.ts
@@ -1,0 +1,141 @@
+export const dashboardRoutes = {
+  conversation: { path: "/conversations/:conversationId" },
+  conversations: { path: "/conversations" },
+  dev: { componentGallery: true, path: "/dev/*" },
+  fallback: { path: "*" },
+  home: { path: "/" },
+  location: { path: "/locations/:locationId" },
+  locations: { path: "/locations" },
+  person: { path: "/people/:email" },
+  people: { path: "/people" },
+  pluginPage: { path: "/plugins/:pluginName/:pageId/*" },
+  settingsApiTokens: { path: "/settings/api-tokens" },
+  system: { path: "/system/*" },
+  systemLocation: { path: "/system/locations/:locationId" },
+  systemLocations: { path: "/system/locations" },
+  systemPeople: { path: "/system/people" },
+  tasks: { path: "/tasks" },
+} as const;
+
+interface DashboardPagePath {
+  nested?: boolean;
+  path: string;
+}
+
+function stripTrailingSlashes(value: string): string {
+  let end = value.length;
+  while (end > 1 && value.charCodeAt(end - 1) === 47) {
+    end -= 1;
+  }
+  return end === value.length ? value : value.slice(0, end);
+}
+
+function normalizePath(path: string | undefined, fallback: string): string {
+  const value = path?.trim() || fallback;
+  const withSlash = value.startsWith("/") ? value : `/${value}`;
+  return stripTrailingSlashes(withSlash);
+}
+
+function routeRoot(path: string): DashboardPagePath | undefined {
+  if (path === "*") {
+    return undefined;
+  }
+  const segments = path.split("/").filter(Boolean);
+  const dynamicIndex = segments.findIndex(
+    (segment) => segment === "*" || segment.startsWith(":"),
+  );
+  const rootSegments =
+    dynamicIndex === -1 ? segments : segments.slice(0, dynamicIndex);
+  return {
+    nested: dynamicIndex !== -1 || undefined,
+    path: rootSegments.length === 0 ? "/" : `/${rootSegments.join("/")}`,
+  };
+}
+
+function withBasePath(basePath: string, path: string): string {
+  if (basePath === "/") {
+    return path;
+  }
+  return path === "/" ? basePath : `${basePath}${path}`;
+}
+
+/** Resolve browser page paths the dashboard server must render. */
+export function dashboardPagePaths(
+  basePath: string,
+  options: { componentGallery?: boolean } = {},
+): DashboardPagePath[] {
+  const merged = new Map<string, DashboardPagePath>();
+  for (const route of Object.values(dashboardRoutes)) {
+    if ("componentGallery" in route && !options.componentGallery) {
+      continue;
+    }
+    const root = routeRoot(route.path);
+    if (!root) {
+      continue;
+    }
+    const current = merged.get(root.path);
+    merged.set(root.path, {
+      nested: current?.nested || root.nested || undefined,
+      path: root.path,
+    });
+  }
+
+  const roots = [...merged.values()].filter(
+    (candidate) =>
+      ![...merged.values()].some(
+        (route) =>
+          route.nested &&
+          route.path !== candidate.path &&
+          candidate.path.startsWith(`${route.path}/`),
+      ),
+  );
+  return roots.map((route) => ({
+    ...route,
+    path: withBasePath(basePath, route.path),
+  }));
+}
+
+/** List every path core must forward to the dashboard app. */
+export function dashboardRoutePaths(options: {
+  authPath?: string;
+  basePath?: string;
+  componentGallery?: boolean;
+}): string[] {
+  const basePath = normalizePath(options.basePath, "/");
+  const authPath = normalizePath(options.authPath, "/api/auth");
+  const pagePaths = dashboardPagePaths(basePath, options).flatMap((route) =>
+    route.nested ? [route.path, `${route.path}/*`] : [route.path],
+  );
+  const loginPath = basePath === "/" ? "/auth/login" : `${basePath}/auth/login`;
+
+  return [
+    ...pagePaths,
+    "/favicon.ico",
+    "/_junior/dashboard/avatar.png",
+    "/_junior/dashboard/client.js",
+    loginPath,
+    "/api/health",
+    "/api/runtime",
+    "/api/plugins",
+    "/api/plugins/*",
+    "/api/plugin-reports",
+    "/api/user-pages",
+    "/api/user-pages/*",
+    "/api/tasks",
+    "/api/tasks/*",
+    "/api/skills",
+    "/api/stats",
+    "/api/conversations",
+    "/api/conversations/*",
+    "/api/locations",
+    "/api/locations/*",
+    "/api/people",
+    "/api/people/*",
+    "/api/personal-tokens",
+    "/api/personal-tokens/*",
+    "/api/config",
+    "/api/me",
+    authPath,
+    `${authPath}/*`,
+  ];
+}

--- a/packages/junior-dashboard/tests/dashboard-host-routes.test.ts
+++ b/packages/junior-dashboard/tests/dashboard-host-routes.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, expect, it, vi } from "vitest";
 import { createApp, defineJuniorPlugins } from "@sentry/junior";
+import { defineJuniorPlugin } from "@sentry/junior-plugin-api";
 import { createDashboardApp } from "../src/app";
+import { dashboardRoutePaths } from "../src/routes";
 
 function concreteRoutePath(path: string): string | undefined {
   if (path === "*" || path === "/*") {
@@ -34,6 +36,7 @@ it("forwards every dashboard route through the Junior app", async () => {
   }));
   vi.doMock("#junior/config", () => ({
     createDashboardApp: createForwardingDashboard,
+    dashboardRoutePaths,
     functionMaxDurationSeconds: undefined,
     dashboard: {
       authRequired: false,
@@ -55,5 +58,55 @@ it("forwards every dashboard route through the Junior app", async () => {
       await response.text(),
       `${route.method} ${route.path} was not forwarded`,
     ).toBe(`dashboard:${route.path}`);
+  }
+});
+
+it("rejects plugin routes that conflict with dashboard routes", async () => {
+  vi.doMock("#junior/config", () => ({
+    createDashboardApp,
+    dashboardRoutePaths,
+    dashboard: undefined,
+    functionMaxDurationSeconds: undefined,
+    pluginRuntimeRegistrations: [],
+    pluginSet: undefined,
+    plugins: undefined,
+  }));
+
+  for (const path of [
+    "/api/plugins/*",
+    "/api/conversations/*",
+    "/api/locations/*",
+    "/api/people/*",
+    "/conversations/*",
+    "/locations/*",
+    "/people/*",
+    "/plugins/*",
+    "/system",
+    "/system/*",
+    "/api/user-pages/*",
+    "/*",
+    "/api/*",
+    "/:slug",
+    "/api/:section/*",
+  ]) {
+    await expect(
+      createApp({
+        dashboard: { authRequired: false },
+        plugins: defineJuniorPlugins([
+          defineJuniorPlugin({
+            manifest: {
+              name: "legacy-dashboard",
+              displayName: "Legacy Dashboard",
+              description: "Legacy dashboard route plugin",
+            },
+            hooks: {
+              routes: () => [{ path, handler: () => new Response("legacy") }],
+            },
+          }),
+        ]),
+      }),
+    ).rejects.toThrow(
+      `Plugin "legacy-dashboard" route "${path}" conflicts with core dashboard routes`,
+    );
   }
 });

--- a/packages/junior-dashboard/tests/dashboard-routes.test.ts
+++ b/packages/junior-dashboard/tests/dashboard-routes.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createApp, defineJuniorPlugins } from "@sentry/junior";
 import { defineJuniorPlugin } from "@sentry/junior-plugin-api";
 import { createDashboardApp } from "../src/app";
+import { dashboardRoutePaths } from "../src/routes";
 import {
   createDashboardAuth,
   type DashboardAuth,
@@ -68,6 +69,7 @@ function dashboard(session: DashboardSession | null) {
 function mockDashboardVirtualConfig() {
   vi.doMock("#junior/config", () => ({
     createDashboardApp,
+    dashboardRoutePaths,
     functionMaxDurationSeconds: undefined,
     dashboard: undefined,
     pluginRuntimeRegistrations: [],
@@ -446,6 +448,7 @@ describe("dashboard routes", () => {
       "/locations/destination-1",
       "/people",
       "/people/person%40sentry.io",
+      "/tasks",
       "/system",
       "/system/plugins/github",
       "/settings/api-tokens",

--- a/packages/junior/src/app.ts
+++ b/packages/junior/src/app.ts
@@ -159,9 +159,17 @@ type CreateDashboardApp = (
   options: JuniorDashboardRuntimeOptions,
 ) => DashboardApp;
 
+type DashboardRoutePaths = (options: JuniorDashboardOptions) => string[];
+
+interface DashboardRuntime {
+  createDashboardApp: CreateDashboardApp;
+  routePaths: DashboardRoutePaths;
+}
+
 interface JuniorVirtualConfig {
   functionMaxDurationSeconds?: number;
   createDashboardApp?: CreateDashboardApp;
+  dashboardRoutePaths?: DashboardRoutePaths;
   dashboard?: JuniorVirtualDashboardOptions;
   pluginSet?: JuniorPluginSet;
   plugins?: PluginCatalogConfig;
@@ -200,6 +208,7 @@ async function resolveVirtualConfig(): Promise<
   try {
     const mod: {
       createDashboardApp?: CreateDashboardApp;
+      dashboardRoutePaths?: DashboardRoutePaths;
       functionMaxDurationSeconds?: number;
       dashboard?: JuniorVirtualDashboardOptions;
       pluginSet?: JuniorPluginSet;
@@ -208,6 +217,7 @@ async function resolveVirtualConfig(): Promise<
     } = await import("#junior/config");
     return {
       createDashboardApp: mod.createDashboardApp,
+      dashboardRoutePaths: mod.dashboardRoutePaths,
       functionMaxDurationSeconds: mod.functionMaxDurationSeconds,
       dashboard: mod.dashboard,
       pluginSet: mod.pluginSet,
@@ -297,31 +307,50 @@ function validateBuildIncludesPluginRuntimeRegistrations(
   );
 }
 
-async function createDashboardRouteRegistrations(args: {
+function createDashboardRouteRegistrations(args: {
   dashboard: JuniorDashboardOptions | undefined;
-  createDashboardApp: CreateDashboardApp | undefined;
+  runtime: DashboardRuntime | undefined;
   pluginRoutes: PluginApiRouteRegistration[];
-}): Promise<HostRouteRegistration[]> {
-  if (!args.dashboard || args.dashboard.disabled) {
+}): HostRouteRegistration[] {
+  if (!args.dashboard || args.dashboard.disabled || !args.runtime) {
     return [];
   }
 
-  const createDashboardApp =
-    args.createDashboardApp ?? (await loadDashboardAppFactory());
   return dashboardRouteRegistrations({
     dashboard: args.dashboard,
-    createDashboardApp,
+    runtime: args.runtime,
     pluginRoutes: args.pluginRoutes,
   });
 }
 
-async function loadDashboardAppFactory(): Promise<CreateDashboardApp> {
+async function resolveDashboardRuntime(args: {
+  createDashboardApp: CreateDashboardApp | undefined;
+  dashboard: JuniorDashboardOptions | undefined;
+  routePaths: DashboardRoutePaths | undefined;
+}): Promise<DashboardRuntime | undefined> {
+  if (!args.dashboard || args.dashboard.disabled) {
+    return undefined;
+  }
+  if (args.createDashboardApp && args.routePaths) {
+    return {
+      createDashboardApp: args.createDashboardApp,
+      routePaths: args.routePaths,
+    };
+  }
+  const loaded = await loadDashboardRuntime();
+  return {
+    createDashboardApp: args.createDashboardApp ?? loaded.createDashboardApp,
+    routePaths: args.routePaths ?? loaded.routePaths,
+  };
+}
+
+async function loadDashboardRuntime(): Promise<DashboardRuntime> {
   try {
     const appRequire = createRequire(`${process.cwd()}/package.json`);
     const mod = await import(
       pathToFileURL(appRequire.resolve(DASHBOARD_PACKAGE_NAME)).href
     );
-    return dashboardAppFactoryFromModule(mod);
+    return dashboardRuntimeFromModule(mod);
   } catch (error) {
     if (isMissingDashboardPackage(error)) {
       throw new Error(
@@ -333,7 +362,7 @@ async function loadDashboardAppFactory(): Promise<CreateDashboardApp> {
   }
 }
 
-function dashboardAppFactoryFromModule(mod: unknown): CreateDashboardApp {
+function dashboardRuntimeFromModule(mod: unknown): DashboardRuntime {
   if (
     !mod ||
     typeof mod !== "object" ||
@@ -344,7 +373,20 @@ function dashboardAppFactoryFromModule(mod: unknown): CreateDashboardApp {
       '@sentry/junior-dashboard must export a "createDashboardApp" function',
     );
   }
-  return (mod as { createDashboardApp: CreateDashboardApp }).createDashboardApp;
+  if (
+    typeof (mod as { dashboardRoutePaths?: unknown }).dashboardRoutePaths !==
+    "function"
+  ) {
+    throw new Error(
+      '@sentry/junior-dashboard must export a "dashboardRoutePaths" function',
+    );
+  }
+  return {
+    createDashboardApp: (mod as { createDashboardApp: CreateDashboardApp })
+      .createDashboardApp,
+    routePaths: (mod as { dashboardRoutePaths: DashboardRoutePaths })
+      .dashboardRoutePaths,
+  };
 }
 
 function isMissingDashboardPackage(error: unknown): boolean {
@@ -358,83 +400,6 @@ function isMissingDashboardPackage(error: unknown): boolean {
   );
 }
 
-function stripTrailingSlashes(value: string): string {
-  let end = value.length;
-  while (end > 1 && value.charCodeAt(end - 1) === 47) {
-    end -= 1;
-  }
-  return end === value.length ? value : value.slice(0, end);
-}
-
-function normalizeDashboardPath(
-  path: string | undefined,
-  fallback: string,
-): string {
-  const value = path?.trim() || fallback;
-  const withSlash = value.startsWith("/") ? value : `/${value}`;
-  return stripTrailingSlashes(withSlash);
-}
-
-/** List every route path core forwards to the dashboard app and reserves from plugin routes. */
-function dashboardHostRoutePaths(dashboard: JuniorDashboardOptions): string[] {
-  const basePath = normalizeDashboardPath(dashboard.basePath, "/");
-  const authPath = normalizeDashboardPath(dashboard.authPath, "/api/auth");
-  const pagePath = (suffix: string) =>
-    basePath === "/" ? `/${suffix}` : `${basePath}/${suffix}`;
-  const conversationsPath = pagePath("conversations");
-  const peoplePath = pagePath("people");
-  const pagePaths = [
-    basePath,
-    conversationsPath,
-    `${conversationsPath}/*`,
-    pagePath("locations"),
-    `${pagePath("locations")}/*`,
-    peoplePath,
-    `${peoplePath}/*`,
-    pagePath("tasks"),
-    pagePath("system"),
-    `${pagePath("system")}/*`,
-    pagePath("plugins"),
-    `${pagePath("plugins")}/*`,
-    pagePath("settings/api-tokens"),
-  ];
-  if (dashboard.componentGallery) {
-    pagePaths.push(pagePath("dev"), `${pagePath("dev")}/*`);
-  }
-  const loginPath = basePath === "/" ? "/auth/login" : `${basePath}/auth/login`;
-
-  return [
-    ...pagePaths,
-    "/favicon.ico",
-    "/_junior/dashboard/avatar.png",
-    "/_junior/dashboard/client.js",
-    loginPath,
-    "/api/health",
-    "/api/runtime",
-    "/api/plugins",
-    "/api/plugins/*",
-    "/api/plugin-reports",
-    "/api/user-pages",
-    "/api/user-pages/*",
-    "/api/tasks",
-    "/api/tasks/*",
-    "/api/skills",
-    "/api/stats",
-    "/api/conversations",
-    "/api/conversations/*",
-    "/api/locations",
-    "/api/locations/*",
-    "/api/people",
-    "/api/people/*",
-    "/api/personal-tokens",
-    "/api/personal-tokens/*",
-    "/api/config",
-    "/api/me",
-    authPath,
-    `${authPath}/*`,
-  ];
-}
-
 function routePrefixCoversPath(routePrefix: string, path: string): boolean {
   return (
     routePrefix === "/" ||
@@ -443,8 +408,13 @@ function routePrefixCoversPath(routePrefix: string, path: string): boolean {
   );
 }
 
+function normalizeRoutePath(path: string): string {
+  const withSlash = path.startsWith("/") ? path : `/${path}`;
+  return withSlash.length === 1 ? withSlash : withSlash.replace(/\/+$/, "");
+}
+
 function routeSegments(path: string): string[] {
-  return normalizeDashboardPath(path, "/").split("/").filter(Boolean);
+  return normalizeRoutePath(path).split("/").filter(Boolean);
 }
 
 function routeSegmentMatches(pattern: string, value: string): boolean {
@@ -471,15 +441,14 @@ function routePatternMatchesConcretePath(
 }
 
 function routePatternExamples(routePath: string): string[] {
-  const normalized = normalizeDashboardPath(routePath, "/");
+  const normalized = normalizeRoutePath(routePath);
   if (!normalized.endsWith("/*") && !normalized.endsWith("/**")) {
     return [normalized];
   }
-  const prefix = normalizeDashboardPath(
+  const prefix = normalizeRoutePath(
     normalized.endsWith("/*")
       ? normalized.slice(0, -2)
       : normalized.slice(0, -3),
-    "/",
   );
   return [
     prefix,
@@ -502,20 +471,21 @@ function routePatternOverlaps(ownedPath: string, routePath: string): boolean {
 function dashboardOwnedRoutePath(
   routePath: string,
   dashboard: JuniorDashboardOptions,
+  routePaths: DashboardRoutePaths,
 ): boolean {
-  return dashboardHostRoutePaths(dashboard).some((path) =>
+  return routePaths(dashboard).some((path) =>
     routePatternOverlaps(path, routePath),
   );
 }
 
 function dashboardRouteRegistrations(args: {
   dashboard: JuniorDashboardOptions;
-  createDashboardApp: CreateDashboardApp;
+  runtime: DashboardRuntime;
   pluginRoutes: PluginApiRouteRegistration[];
 }): HostRouteRegistration[] {
   let app: DashboardApp | undefined;
   const fetch = (request: Request) => {
-    app ??= args.createDashboardApp({
+    app ??= args.runtime.createDashboardApp({
       ...args.dashboard,
       agentName: botConfig.userName,
       pluginRoutes: args.pluginRoutes,
@@ -526,7 +496,7 @@ function dashboardRouteRegistrations(args: {
     return app.fetch(request);
   };
 
-  return dashboardHostRoutePaths(args.dashboard).map((path) => ({
+  return args.runtime.routePaths(args.dashboard).map((path) => ({
     handler: fetch,
     path,
   }));
@@ -534,13 +504,14 @@ function dashboardRouteRegistrations(args: {
 
 function validateDashboardRouteOwnership(args: {
   dashboard: JuniorDashboardOptions | undefined;
+  routePaths: DashboardRoutePaths | undefined;
   routes: PluginRouteRegistration[];
 }): void {
-  if (!args.dashboard || args.dashboard.disabled) {
+  if (!args.dashboard || args.dashboard.disabled || !args.routePaths) {
     return;
   }
   for (const route of args.routes) {
-    if (dashboardOwnedRoutePath(route.path, args.dashboard)) {
+    if (dashboardOwnedRoutePath(route.path, args.dashboard, args.routePaths)) {
       throw new Error(
         `Plugin "${route.pluginName}" route "${route.path}" conflicts with core dashboard routes`,
       );
@@ -576,6 +547,11 @@ export async function createApp(options?: JuniorAppOptions): Promise<Hono> {
     );
   }
   const dashboard = options?.dashboard ?? virtualConfig?.dashboard;
+  const dashboardRuntime = await resolveDashboardRuntime({
+    createDashboardApp: virtualConfig?.createDashboardApp,
+    dashboard,
+    routePaths: virtualConfig?.dashboardRoutePaths,
+  });
   const configuredPlugins = options?.plugins ?? virtualConfig?.pluginSet;
   const plugins = pluginRuntimeRegistrationsFromPluginSet(configuredPlugins);
   const pluginConfig = configuredPlugins
@@ -646,7 +622,11 @@ export async function createApp(options?: JuniorAppOptions): Promise<Hono> {
       );
     }
     pluginRoutes = getPluginRoutes({ resourceEvents });
-    validateDashboardRouteOwnership({ dashboard, routes: pluginRoutes });
+    validateDashboardRouteOwnership({
+      dashboard,
+      routePaths: dashboardRuntime?.routePaths,
+      routes: pluginRoutes,
+    });
     if (dashboard && !dashboard.disabled) {
       pluginApiRoutes = getPluginApiRoutes();
     }
@@ -691,10 +671,10 @@ export async function createApp(options?: JuniorAppOptions): Promise<Hono> {
   mountRoutes(app, pluginRoutes);
   mountRoutes(
     app,
-    await createDashboardRouteRegistrations({
+    createDashboardRouteRegistrations({
       dashboard,
-      createDashboardApp: virtualConfig?.createDashboardApp,
       pluginRoutes: pluginApiRoutes,
+      runtime: dashboardRuntime,
     }),
   );
 

--- a/packages/junior/src/build/virtual-config.ts
+++ b/packages/junior/src/build/virtual-config.ts
@@ -23,10 +23,14 @@ function renderRuntimePluginImport(module: RuntimePluginModule): string {
 function renderDashboardImport(enabled: boolean): string[] {
   return enabled
     ? [
-        'import { createDashboardApp as juniorCreateDashboardApp } from "@sentry/junior-dashboard";',
+        'import { createDashboardApp as juniorCreateDashboardApp, dashboardRoutePaths as juniorDashboardRoutePaths } from "@sentry/junior-dashboard";',
         "export const createDashboardApp = juniorCreateDashboardApp;",
+        "export const dashboardRoutePaths = juniorDashboardRoutePaths;",
       ]
-    : ["export const createDashboardApp = undefined;"];
+    : [
+        "export const createDashboardApp = undefined;",
+        "export const dashboardRoutePaths = undefined;",
+      ];
 }
 
 function dashboardEnabled(

--- a/packages/junior/src/virtual-modules.d.ts
+++ b/packages/junior/src/virtual-modules.d.ts
@@ -19,6 +19,9 @@ declare module "#junior/config" {
         fetch(request: Request): Promise<Response> | Response;
       })
     | undefined;
+  export const dashboardRoutePaths:
+    | ((options: VirtualDashboardConfig) => string[])
+    | undefined;
   export const dashboard: VirtualDashboardConfig | undefined;
   export const functionMaxDurationSeconds: number;
   export const pluginSet: JuniorPluginSet | undefined;

--- a/packages/junior/tests/unit/app-config.test.ts
+++ b/packages/junior/tests/unit/app-config.test.ts
@@ -630,6 +630,7 @@ describe("createApp plugin config", () => {
   it("loads plugin instances from the Nitro virtual plugin set", async () => {
     vi.doMock("#junior/config", () => ({
       createDashboardApp: undefined,
+      dashboardRoutePaths: undefined,
       functionMaxDurationSeconds: undefined,
       dashboard: undefined,
       pluginSet: defineJuniorPlugins([
@@ -814,6 +815,16 @@ describe("createApp plugin config", () => {
     );
     vi.doMock("#junior/config", () => ({
       createDashboardApp,
+      dashboardRoutePaths: () => [
+        "/api/people",
+        "/api/plugins/*",
+        "/_junior/dashboard/avatar.png",
+        "/dev",
+        "/people",
+        "/plugins",
+        "/system",
+        "/system/*",
+      ],
       functionMaxDurationSeconds: undefined,
       dashboard: {
         authRequired: false,
@@ -892,61 +903,12 @@ describe("createApp plugin config", () => {
     await expect(peopleApi.text()).resolves.toBe("dashboard");
   });
 
-  it("rejects app-level plugin routes that conflict with core dashboard routes", async () => {
-    for (const path of [
-      "/api/plugins/*",
-      "/api/conversations/*",
-      "/api/locations/*",
-      "/api/people/*",
-      "/conversations/*",
-      "/locations/*",
-      "/people/*",
-      "/plugins/*",
-      "/system",
-      "/system/*",
-      "/api/user-pages/*",
-      "/*",
-      "/api/*",
-      "/:slug",
-      "/api/:section/*",
-    ]) {
-      await expect(
-        createApp({
-          dashboard: {
-            authRequired: false,
-            allowedGoogleDomains: ["sentry.io"],
-          },
-          plugins: defineJuniorPlugins([
-            defineJuniorPlugin({
-              manifest: {
-                name: "legacy-dashboard",
-                displayName: "Legacy Dashboard",
-                description: "Legacy dashboard route plugin",
-              },
-              hooks: {
-                routes() {
-                  return [
-                    {
-                      path,
-                      handler: () => new Response("legacy"),
-                    },
-                  ];
-                },
-              },
-            }),
-          ]),
-        }),
-      ).rejects.toThrow(
-        `Plugin "legacy-dashboard" route "${path}" conflicts with core dashboard routes`,
-      );
-    }
-  });
-
   it("configures Slack footer links from core dashboard options", async () => {
     vi.doMock("#junior/config", () => ({
       createDashboardApp: vi.fn((_options: unknown) => ({
         fetch: () => new Response("dashboard"),
       })),
+      dashboardRoutePaths: () => ["/"],
       functionMaxDurationSeconds: undefined,
       dashboard: undefined,
       pluginSet: defineJuniorPlugins([]),

--- a/packages/junior/tests/unit/build/virtual-config.test.ts
+++ b/packages/junior/tests/unit/build/virtual-config.test.ts
@@ -47,7 +47,10 @@ describe("renderVirtualConfig", () => {
     });
 
     expect(code).toContain(
-      'import { createDashboardApp as juniorCreateDashboardApp } from "@sentry/junior-dashboard";',
+      'import { createDashboardApp as juniorCreateDashboardApp, dashboardRoutePaths as juniorDashboardRoutePaths } from "@sentry/junior-dashboard";',
+    );
+    expect(code).toContain(
+      "export const dashboardRoutePaths = juniorDashboardRoutePaths;",
     );
     expect(code).toContain(
       'export const dashboard = {"allowedGoogleDomains":["sentry.io"]};',
@@ -63,6 +66,7 @@ describe("renderVirtualConfig", () => {
 
     expect(code).not.toContain("@sentry/junior-dashboard");
     expect(code).toContain("export const createDashboardApp = undefined;");
+    expect(code).toContain("export const dashboardRoutePaths = undefined;");
     expect(code).toContain('export const dashboard = {"disabled":true};');
   });
 });


### PR DESCRIPTION
Dashboard browser routes now come from one shared manifest used by React, the dashboard Hono app, and core forwarding. This fixes direct loads of `/tasks` and makes new dashboard pages flow through every server layer without copying path strings.

The root cause was route ownership split across separate client, dashboard server, and core forwarding lists. The dashboard package now owns the route manifest, the Nitro virtual module passes its forwarding paths into core, and the existing host-route contract also checks plugin collisions against those same paths.
