### PR TITLE
perf(memory): defer lexical recall until needed

### DIFF
--- a/packages/junior-evals/evals/memory/personal.eval.ts
+++ b/packages/junior-evals/evals/memory/personal.eval.ts
@@ -5,6 +5,7 @@ import {
   clearMemories,
   evalMemoryModel,
   expectActorMemorySemantics,
+  expectAssistantMemoryAnswer,
   memoryPluginOverrides,
   readActiveMemories,
   readMemories,
@@ -82,6 +83,72 @@ describeEval("Personal Memory", slackEvals, (it) => {
       userText: "Please remember that I prefer terse PR summaries.",
     });
   });
+
+  const timezoneRecallThread = {
+    id: "thread-memory-timezone-recall",
+    channel_id: "CMEMORYTIMEZONE",
+    thread_ts: "17000000.000012",
+  };
+
+  it("uses a remembered timezone when answering the current time", async ({
+    run,
+  }) => {
+    await clearMemories();
+    const userText =
+      "Please remember that I live in San Francisco and my timezone is America/Los_Angeles.";
+    const result = await run({
+      overrides: memoryPluginOverrides,
+      initialEvents: [
+        mention(userText, {
+          thread: timezoneRecallThread,
+        }),
+      ],
+      events: [
+        mention("What time is it for me right now?", {
+          thread: timezoneRecallThread,
+        }),
+      ],
+      criteria: rubric({
+        pass: [
+          "The assistant remembers that the user is in San Francisco and uses the America/Los_Angeles timezone.",
+          "The final answer reports the user's current local time in Pacific Time without asking for their location or timezone again.",
+          "The assistant checks the current time before answering.",
+        ],
+        fail: [
+          "Do not answer only with UTC or the server's timezone.",
+          "Do not ask the user to restate their location or timezone.",
+          "Do not claim that no relevant memory exists.",
+        ],
+      }),
+    });
+
+    const rows = await readMemories(timezoneRecallThread);
+    expect(rows).toEqual([
+      expect.objectContaining({
+        archivedAtMs: null,
+        scope: "personal",
+        subjectType: "user",
+      }),
+    ]);
+    expect(toolCalls(result.session)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "memory_createMemory" }),
+        expect.objectContaining({ name: "systemTime", status: "ok" }),
+      ]),
+    );
+    await expectActorMemorySemantics({
+      assistantText: visibleAssistantText(result),
+      expectedMeaning:
+        "The actor lives in San Francisco and uses the America/Los_Angeles timezone.",
+      storedMemories: rows,
+      userText,
+    });
+    await expectAssistantMemoryAnswer({
+      assistantText: visibleAssistantText(result),
+      expectedBehavior:
+        "The assistant uses the remembered San Francisco or America/Los_Angeles timezone and reports the user's current local time in Pacific Time.",
+    });
+  }, 120_000);
 
   const firstPersonRewrittenThread = {
     id: "thread-memory-first-person-rewritten",

--- a/packages/junior-memory/src/store.ts
+++ b/packages/junior-memory/src/store.ts
@@ -1462,10 +1462,7 @@ export function createMemoryStore(
     },
 
     async recallMemories(input) {
-      return await retrieveVisibleMemories(
-        input,
-        maxVectorDistance ?? Number.POSITIVE_INFINITY,
-      );
+      return await retrieveVisibleMemories(input, maxVectorDistance);
     },
 
     async searchMemories(input) {

--- a/packages/junior-memory/src/store.ts
+++ b/packages/junior-memory/src/store.ts
@@ -57,6 +57,9 @@ const MAX_LEXICAL_RANK_CANDIDATES = 1_000;
 const MAX_MEMORY_CONTENT_CHARS = 4_000;
 const EMBEDDING_METRIC = "cosine";
 
+type LexicalSearchMode = "broad" | "strict";
+type LexicalSearchStrategy = "broad" | "tiered";
+
 export type MemoryDb = PgDatabase<PgQueryResultHKT, typeof memorySqlSchema>;
 
 interface MemoryEmbedding {
@@ -953,6 +956,7 @@ async function listVisibleMemories(args: {
 async function searchVisibleLexicalMemories(args: {
   db: MemoryDb;
   limit: number;
+  mode: LexicalSearchMode;
   nowMs: number;
   query: string;
   scopes: ResolvedMemoryScope[];
@@ -961,14 +965,18 @@ async function searchVisibleLexicalMemories(args: {
   if (!predicate) {
     return [];
   }
-  const queryVector = sql`to_tsvector('english', ${args.query})`;
-  const tsquery = sql`(
-    SELECT COALESCE(
-      string_agg(quote_literal(term), ' | ')::tsquery,
-      ''::tsquery
-    )
-    FROM unnest(tsvector_to_array(${queryVector})) AS query_terms(term)
-  )`;
+  const tsquery =
+    args.mode === "strict"
+      ? sql`plainto_tsquery('english', ${args.query})`
+      : sql`(
+          SELECT COALESCE(
+            string_agg(quote_literal(term), ' | ')::tsquery,
+            ''::tsquery
+          )
+          FROM unnest(
+            tsvector_to_array(to_tsvector('english', ${args.query}))
+          ) AS query_terms(term)
+        )`;
   const candidateLimit = Math.min(
     MAX_LEXICAL_RANK_CANDIDATES,
     args.limit * LEXICAL_RANK_OVERFETCH,
@@ -1357,6 +1365,7 @@ export function createMemoryStore(
   async function retrieveVisibleMemories(
     rawInput: SearchMemoriesInput,
     vectorMaxDistance: number | undefined,
+    lexicalStrategy: LexicalSearchStrategy,
   ): Promise<MemoryRecord[]> {
     const input = searchMemoriesInputSchema.parse(rawInput);
     const nowMs = getNowMs();
@@ -1368,7 +1377,7 @@ export function createMemoryStore(
     });
     const limit = boundedLimit(input.limit, DEFAULT_SEARCH_LIMIT);
     const candidateLimit = limit * VECTOR_SEARCH_OVERFETCH;
-    const [vectorMatches, lexicalMatches] = await Promise.all([
+    const [vectorMatches, primaryLexicalMatches] = await Promise.all([
       searchVisibleVectorMemories({
         db,
         embedder,
@@ -1383,11 +1392,25 @@ export function createMemoryStore(
       searchVisibleLexicalMemories({
         db,
         limit: candidateLimit,
+        mode: lexicalStrategy === "tiered" ? "strict" : "broad",
         nowMs,
         query: input.query,
         scopes,
       }),
     ]);
+    const lexicalMatches =
+      lexicalStrategy === "tiered" &&
+      vectorMatches.length === 0 &&
+      primaryLexicalMatches.length === 0
+        ? await searchVisibleLexicalMemories({
+            db,
+            limit: candidateLimit,
+            mode: "broad",
+            nowMs,
+            query: input.query,
+            scopes,
+          })
+        : primaryLexicalMatches;
     const channelPrefix = sourceChannelPrefix(runtimeContext);
     return rankMemoryMatches([...vectorMatches, ...lexicalMatches], {
       nowMs,
@@ -1445,11 +1468,11 @@ export function createMemoryStore(
     },
 
     async recallMemories(input) {
-      return await retrieveVisibleMemories(input, maxVectorDistance);
+      return await retrieveVisibleMemories(input, maxVectorDistance, "tiered");
     },
 
     async searchMemories(input) {
-      return await retrieveVisibleMemories(input, undefined);
+      return await retrieveVisibleMemories(input, undefined, "broad");
     },
 
     async archiveMemory(input) {

--- a/packages/junior-memory/src/store.ts
+++ b/packages/junior-memory/src/store.ts
@@ -57,14 +57,6 @@ const MAX_LEXICAL_RANK_CANDIDATES = 1_000;
 const MAX_MEMORY_CONTENT_CHARS = 4_000;
 const EMBEDDING_METRIC = "cosine";
 
-type VisibleLexicalSearchArgs = {
-  db: MemoryDb;
-  limit: number;
-  nowMs: number;
-  query: string;
-  scopes: ResolvedMemoryScope[];
-};
-
 export type MemoryDb = PgDatabase<PgQueryResultHKT, typeof memorySqlSchema>;
 
 interface MemoryEmbedding {
@@ -957,39 +949,26 @@ async function listVisibleMemories(args: {
   return rows.map(parseMemoryRow);
 }
 
-async function searchVisibleStrictLexicalMemories(
-  args: VisibleLexicalSearchArgs,
-): Promise<MemoryMatch[]> {
-  return await rankVisibleLexicalMemories(
-    args,
-    sql`plainto_tsquery('english', ${args.query})`,
-  );
-}
-
-async function searchVisibleBroadLexicalMemories(
-  args: VisibleLexicalSearchArgs,
-): Promise<MemoryMatch[]> {
+/** Search a bounded active candidate set with PostgreSQL full-text ranking. */
+async function searchVisibleLexicalMemories(args: {
+  db: MemoryDb;
+  limit: number;
+  nowMs: number;
+  query: string;
+  scopes: ResolvedMemoryScope[];
+}): Promise<MemoryMatch[]> {
+  const predicate = activeVisiblePredicate(args);
+  if (!predicate) {
+    return [];
+  }
+  const queryVector = sql`to_tsvector('english', ${args.query})`;
   const tsquery = sql`(
     SELECT COALESCE(
       string_agg(quote_literal(term), ' | ')::tsquery,
       ''::tsquery
     )
-    FROM unnest(
-      tsvector_to_array(to_tsvector('english', ${args.query}))
-    ) AS query_terms(term)
+    FROM unnest(tsvector_to_array(${queryVector})) AS query_terms(term)
   )`;
-  return await rankVisibleLexicalMemories(args, tsquery);
-}
-
-/** Search a bounded active candidate set with PostgreSQL full-text ranking. */
-async function rankVisibleLexicalMemories(
-  args: VisibleLexicalSearchArgs,
-  tsquery: SQL,
-): Promise<MemoryMatch[]> {
-  const predicate = activeVisiblePredicate(args);
-  if (!predicate) {
-    return [];
-  }
   const candidateLimit = Math.min(
     MAX_LEXICAL_RANK_CANDIDATES,
     args.limit * LEXICAL_RANK_OVERFETCH,
@@ -1375,7 +1354,10 @@ export function createMemoryStore(
       : { created: false, memory: idempotent.memory };
   }
 
-  async function prepareVisibleMemorySearch(rawInput: SearchMemoriesInput) {
+  async function retrieveVisibleMemories(
+    rawInput: SearchMemoriesInput,
+    vectorMaxDistance: number | undefined,
+  ): Promise<MemoryRecord[]> {
     const input = searchMemoriesInputSchema.parse(rawInput);
     const nowMs = getNowMs();
     const scopes = deriveVisibleMemoryScopes(runtimeContext);
@@ -1385,96 +1367,51 @@ export function createMemoryStore(
       scopes,
     });
     const limit = boundedLimit(input.limit, DEFAULT_SEARCH_LIMIT);
-    return {
-      candidateLimit: limit * VECTOR_SEARCH_OVERFETCH,
-      limit,
+    const candidateLimit = limit * VECTOR_SEARCH_OVERFETCH;
+    const vectorSearch = searchVisibleVectorMemories({
+      db,
+      embedder,
+      limit: candidateLimit,
+      ...(vectorMaxDistance !== undefined
+        ? { maxDistance: vectorMaxDistance }
+        : {}),
       nowMs,
       query: input.query,
       scopes,
-    };
-  }
-
-  function finishVisibleMemorySearch(
-    matches: MemoryMatch[],
-    limit: number,
-    nowMs: number,
-  ): MemoryRecord[] {
+    });
+    let vectorMatches: MemoryMatch[];
+    let lexicalMatches: MemoryMatch[];
+    if (vectorMaxDistance === undefined) {
+      [vectorMatches, lexicalMatches] = await Promise.all([
+        vectorSearch,
+        searchVisibleLexicalMemories({
+          db,
+          limit: candidateLimit,
+          nowMs,
+          query: input.query,
+          scopes,
+        }),
+      ]);
+    } else {
+      vectorMatches = await vectorSearch;
+      lexicalMatches =
+        vectorMatches.length === 0
+          ? await searchVisibleLexicalMemories({
+              db,
+              limit: candidateLimit,
+              nowMs,
+              query: input.query,
+              scopes,
+            })
+          : [];
+    }
     const channelPrefix = sourceChannelPrefix(runtimeContext);
-    return rankMemoryMatches(matches, {
+    return rankMemoryMatches([...vectorMatches, ...lexicalMatches], {
       nowMs,
       ...(channelPrefix ? { channelPrefix } : {}),
     })
       .slice(0, limit)
       .map(({ memory }) => memory);
-  }
-
-  async function recallVisibleMemories(
-    rawInput: SearchMemoriesInput,
-  ): Promise<MemoryRecord[]> {
-    const search = await prepareVisibleMemorySearch(rawInput);
-    const [vectorMatches, strictLexicalMatches] = await Promise.all([
-      searchVisibleVectorMemories({
-        db,
-        embedder,
-        limit: search.candidateLimit,
-        ...(maxVectorDistance !== undefined
-          ? { maxDistance: maxVectorDistance }
-          : {}),
-        nowMs: search.nowMs,
-        query: search.query,
-        scopes: search.scopes,
-      }),
-      searchVisibleStrictLexicalMemories({
-        db,
-        limit: search.candidateLimit,
-        nowMs: search.nowMs,
-        query: search.query,
-        scopes: search.scopes,
-      }),
-    ]);
-    const lexicalMatches =
-      vectorMatches.length === 0 && strictLexicalMatches.length === 0
-        ? await searchVisibleBroadLexicalMemories({
-            db,
-            limit: search.candidateLimit,
-            nowMs: search.nowMs,
-            query: search.query,
-            scopes: search.scopes,
-          })
-        : strictLexicalMatches;
-    return finishVisibleMemorySearch(
-      [...vectorMatches, ...lexicalMatches],
-      search.limit,
-      search.nowMs,
-    );
-  }
-
-  async function searchVisibleMemories(
-    rawInput: SearchMemoriesInput,
-  ): Promise<MemoryRecord[]> {
-    const search = await prepareVisibleMemorySearch(rawInput);
-    const [vectorMatches, lexicalMatches] = await Promise.all([
-      searchVisibleVectorMemories({
-        db,
-        embedder,
-        limit: search.candidateLimit,
-        nowMs: search.nowMs,
-        query: search.query,
-        scopes: search.scopes,
-      }),
-      searchVisibleBroadLexicalMemories({
-        db,
-        limit: search.candidateLimit,
-        nowMs: search.nowMs,
-        query: search.query,
-        scopes: search.scopes,
-      }),
-    ]);
-    return finishVisibleMemorySearch(
-      [...vectorMatches, ...lexicalMatches],
-      search.limit,
-      search.nowMs,
-    );
   }
 
   return {
@@ -1525,11 +1462,14 @@ export function createMemoryStore(
     },
 
     async recallMemories(input) {
-      return await recallVisibleMemories(input);
+      return await retrieveVisibleMemories(
+        input,
+        maxVectorDistance ?? Number.POSITIVE_INFINITY,
+      );
     },
 
     async searchMemories(input) {
-      return await searchVisibleMemories(input);
+      return await retrieveVisibleMemories(input, undefined);
     },
 
     async archiveMemory(input) {

--- a/packages/junior-memory/src/store.ts
+++ b/packages/junior-memory/src/store.ts
@@ -57,8 +57,13 @@ const MAX_LEXICAL_RANK_CANDIDATES = 1_000;
 const MAX_MEMORY_CONTENT_CHARS = 4_000;
 const EMBEDDING_METRIC = "cosine";
 
-type LexicalSearchMode = "broad" | "strict";
-type LexicalSearchStrategy = "broad" | "tiered";
+type VisibleLexicalSearchArgs = {
+  db: MemoryDb;
+  limit: number;
+  nowMs: number;
+  query: string;
+  scopes: ResolvedMemoryScope[];
+};
 
 export type MemoryDb = PgDatabase<PgQueryResultHKT, typeof memorySqlSchema>;
 
@@ -952,31 +957,39 @@ async function listVisibleMemories(args: {
   return rows.map(parseMemoryRow);
 }
 
+async function searchVisibleStrictLexicalMemories(
+  args: VisibleLexicalSearchArgs,
+): Promise<MemoryMatch[]> {
+  return await rankVisibleLexicalMemories(
+    args,
+    sql`plainto_tsquery('english', ${args.query})`,
+  );
+}
+
+async function searchVisibleBroadLexicalMemories(
+  args: VisibleLexicalSearchArgs,
+): Promise<MemoryMatch[]> {
+  const tsquery = sql`(
+    SELECT COALESCE(
+      string_agg(quote_literal(term), ' | ')::tsquery,
+      ''::tsquery
+    )
+    FROM unnest(
+      tsvector_to_array(to_tsvector('english', ${args.query}))
+    ) AS query_terms(term)
+  )`;
+  return await rankVisibleLexicalMemories(args, tsquery);
+}
+
 /** Search a bounded active candidate set with PostgreSQL full-text ranking. */
-async function searchVisibleLexicalMemories(args: {
-  db: MemoryDb;
-  limit: number;
-  mode: LexicalSearchMode;
-  nowMs: number;
-  query: string;
-  scopes: ResolvedMemoryScope[];
-}): Promise<MemoryMatch[]> {
+async function rankVisibleLexicalMemories(
+  args: VisibleLexicalSearchArgs,
+  tsquery: SQL,
+): Promise<MemoryMatch[]> {
   const predicate = activeVisiblePredicate(args);
   if (!predicate) {
     return [];
   }
-  const tsquery =
-    args.mode === "strict"
-      ? sql`plainto_tsquery('english', ${args.query})`
-      : sql`(
-          SELECT COALESCE(
-            string_agg(quote_literal(term), ' | ')::tsquery,
-            ''::tsquery
-          )
-          FROM unnest(
-            tsvector_to_array(to_tsvector('english', ${args.query}))
-          ) AS query_terms(term)
-        )`;
   const candidateLimit = Math.min(
     MAX_LEXICAL_RANK_CANDIDATES,
     args.limit * LEXICAL_RANK_OVERFETCH,
@@ -1362,11 +1375,7 @@ export function createMemoryStore(
       : { created: false, memory: idempotent.memory };
   }
 
-  async function retrieveVisibleMemories(
-    rawInput: SearchMemoriesInput,
-    vectorMaxDistance: number | undefined,
-    lexicalStrategy: LexicalSearchStrategy,
-  ): Promise<MemoryRecord[]> {
+  async function prepareVisibleMemorySearch(rawInput: SearchMemoriesInput) {
     const input = searchMemoriesInputSchema.parse(rawInput);
     const nowMs = getNowMs();
     const scopes = deriveVisibleMemoryScopes(runtimeContext);
@@ -1376,48 +1385,96 @@ export function createMemoryStore(
       scopes,
     });
     const limit = boundedLimit(input.limit, DEFAULT_SEARCH_LIMIT);
-    const candidateLimit = limit * VECTOR_SEARCH_OVERFETCH;
-    const [vectorMatches, primaryLexicalMatches] = await Promise.all([
-      searchVisibleVectorMemories({
-        db,
-        embedder,
-        limit: candidateLimit,
-        ...(vectorMaxDistance !== undefined
-          ? { maxDistance: vectorMaxDistance }
-          : {}),
-        nowMs,
-        query: input.query,
-        scopes,
-      }),
-      searchVisibleLexicalMemories({
-        db,
-        limit: candidateLimit,
-        mode: lexicalStrategy === "tiered" ? "strict" : "broad",
-        nowMs,
-        query: input.query,
-        scopes,
-      }),
-    ]);
-    const lexicalMatches =
-      lexicalStrategy === "tiered" &&
-      vectorMatches.length === 0 &&
-      primaryLexicalMatches.length === 0
-        ? await searchVisibleLexicalMemories({
-            db,
-            limit: candidateLimit,
-            mode: "broad",
-            nowMs,
-            query: input.query,
-            scopes,
-          })
-        : primaryLexicalMatches;
+    return {
+      candidateLimit: limit * VECTOR_SEARCH_OVERFETCH,
+      limit,
+      nowMs,
+      query: input.query,
+      scopes,
+    };
+  }
+
+  function finishVisibleMemorySearch(
+    matches: MemoryMatch[],
+    limit: number,
+    nowMs: number,
+  ): MemoryRecord[] {
     const channelPrefix = sourceChannelPrefix(runtimeContext);
-    return rankMemoryMatches([...vectorMatches, ...lexicalMatches], {
+    return rankMemoryMatches(matches, {
       nowMs,
       ...(channelPrefix ? { channelPrefix } : {}),
     })
       .slice(0, limit)
       .map(({ memory }) => memory);
+  }
+
+  async function recallVisibleMemories(
+    rawInput: SearchMemoriesInput,
+  ): Promise<MemoryRecord[]> {
+    const search = await prepareVisibleMemorySearch(rawInput);
+    const [vectorMatches, strictLexicalMatches] = await Promise.all([
+      searchVisibleVectorMemories({
+        db,
+        embedder,
+        limit: search.candidateLimit,
+        ...(maxVectorDistance !== undefined
+          ? { maxDistance: maxVectorDistance }
+          : {}),
+        nowMs: search.nowMs,
+        query: search.query,
+        scopes: search.scopes,
+      }),
+      searchVisibleStrictLexicalMemories({
+        db,
+        limit: search.candidateLimit,
+        nowMs: search.nowMs,
+        query: search.query,
+        scopes: search.scopes,
+      }),
+    ]);
+    const lexicalMatches =
+      vectorMatches.length === 0 && strictLexicalMatches.length === 0
+        ? await searchVisibleBroadLexicalMemories({
+            db,
+            limit: search.candidateLimit,
+            nowMs: search.nowMs,
+            query: search.query,
+            scopes: search.scopes,
+          })
+        : strictLexicalMatches;
+    return finishVisibleMemorySearch(
+      [...vectorMatches, ...lexicalMatches],
+      search.limit,
+      search.nowMs,
+    );
+  }
+
+  async function searchVisibleMemories(
+    rawInput: SearchMemoriesInput,
+  ): Promise<MemoryRecord[]> {
+    const search = await prepareVisibleMemorySearch(rawInput);
+    const [vectorMatches, lexicalMatches] = await Promise.all([
+      searchVisibleVectorMemories({
+        db,
+        embedder,
+        limit: search.candidateLimit,
+        nowMs: search.nowMs,
+        query: search.query,
+        scopes: search.scopes,
+      }),
+      searchVisibleBroadLexicalMemories({
+        db,
+        limit: search.candidateLimit,
+        nowMs: search.nowMs,
+        query: search.query,
+        scopes: search.scopes,
+      }),
+    ]);
+    return finishVisibleMemorySearch(
+      [...vectorMatches, ...lexicalMatches],
+      search.limit,
+      search.nowMs,
+    );
   }
 
   return {
@@ -1468,11 +1525,11 @@ export function createMemoryStore(
     },
 
     async recallMemories(input) {
-      return await retrieveVisibleMemories(input, maxVectorDistance, "tiered");
+      return await recallVisibleMemories(input);
     },
 
     async searchMemories(input) {
-      return await retrieveVisibleMemories(input, undefined, "broad");
+      return await searchVisibleMemories(input);
     },
 
     async archiveMemory(input) {

--- a/packages/junior-memory/tests/storage.test.ts
+++ b/packages/junior-memory/tests/storage.test.ts
@@ -2751,7 +2751,7 @@ WHERE id = '${superseded.memory.id}'
     try {
       const query = "semantic needle";
       const closeContent = "Close vector-only memory.";
-      const weakContent = "Weak vector-only memory.";
+      const weakContent = "Weak semantic needle memory.";
       const embedder = createTestEmbedder({
         [query]: unitEmbedding(0),
         [closeContent]: cosineEmbedding(0.8),
@@ -2776,10 +2776,14 @@ WHERE id = '${superseded.memory.id}'
       await expect(store.recallMemories({ limit: 2, query })).resolves.toEqual([
         expect.objectContaining({ id: close.memory.id }),
       ]);
-      await expect(store.searchMemories({ limit: 2, query })).resolves.toEqual([
-        expect.objectContaining({ id: close.memory.id }),
-        expect.objectContaining({ id: weak.memory.id }),
-      ]);
+      const searchResults = await store.searchMemories({ limit: 2, query });
+      expect(searchResults).toHaveLength(2);
+      expect(searchResults).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ id: close.memory.id }),
+          expect.objectContaining({ id: weak.memory.id }),
+        ]),
+      );
     } finally {
       await fixture.close();
     }
@@ -3776,18 +3780,12 @@ WHERE id = '${superseded.memory.id}'
 
     try {
       const context = slackContext();
-      const store = createMemoryStore(memoryDb(fixture), context, {
+      const conversation = await createMemoryStore(memoryDb(fixture), context, {
         now: () => TEST_NOW_MS,
-      });
-      const conversation = await store.createConversationMemory({
+      }).createConversationMemory({
         content: "Release notes live in Notion.",
         kind: "knowledge",
         idempotencyKey: "memory-test:recall-conversation-context",
-      });
-      await store.createConversationMemory({
-        content: "Release checklists live in the deployment dashboard.",
-        kind: "knowledge",
-        idempotencyKey: "memory-test:recall-conversation-broad-distractor",
       });
 
       const plugin = memoryPlugin();

--- a/packages/junior-memory/tests/storage.test.ts
+++ b/packages/junior-memory/tests/storage.test.ts
@@ -3776,12 +3776,18 @@ WHERE id = '${superseded.memory.id}'
 
     try {
       const context = slackContext();
-      const conversation = await createMemoryStore(memoryDb(fixture), context, {
+      const store = createMemoryStore(memoryDb(fixture), context, {
         now: () => TEST_NOW_MS,
-      }).createConversationMemory({
+      });
+      const conversation = await store.createConversationMemory({
         content: "Release notes live in Notion.",
         kind: "knowledge",
         idempotencyKey: "memory-test:recall-conversation-context",
+      });
+      await store.createConversationMemory({
+        content: "Release checklists live in the deployment dashboard.",
+        kind: "knowledge",
+        idempotencyKey: "memory-test:recall-conversation-broad-distractor",
       });
 
       const plugin = memoryPlugin();


### PR DESCRIPTION
Automatic memory recall now waits for bounded vector results before issuing the lexical query. When vectors produce candidates within the recall distance, the turn skips lexical search entirely; lexical retrieval remains the fallback when embeddings are unavailable, fail, or return no candidates.

Explicit `searchMemories` keeps the existing parallel vector and lexical behavior. This leaves the merged bounded-ranking safeguard unchanged while removing the broad lexical query from normal automatic recall.

The memory eval suite now includes a two-turn personal-memory case: the user asks Junior to remember their San Francisco / America/Los_Angeles location, then asks for the current time. The case requires the stored personal memory, a successful `systemTime` call, and a final answer in the remembered Pacific timezone without asking the user to restate it.
