### PR TITLE
fix(memory): Accept canonical system actors

### DIFF
--- a/packages/junior-memory/src/process-session.ts
+++ b/packages/junior-memory/src/process-session.ts
@@ -143,10 +143,13 @@ function routeExtractedMemory(
     return "drop";
   }
   if (memory.kind === "preference") {
-    // Only a run attributed to exactly one run actor may store a preference; an
-    // empty actor set (system runs) fails closed to "drop".
-    const exactlyOneRunActor = Boolean(run.actor) && run.actors.length === 1;
-    if (!exactlyOneRunActor) {
+    // Only a run attributed to exactly one human run actor may store a preference.
+    const exactlyOneHumanRunActor =
+      run.actor !== undefined &&
+      run.actor.platform !== "system" &&
+      run.actors.length === 1 &&
+      run.actors[0]?.platform !== "system";
+    if (!exactlyOneHumanRunActor) {
       return "drop";
     }
     // Never downgrade an unproven first-person preference to conversation scope.

--- a/packages/junior-memory/src/scope.ts
+++ b/packages/junior-memory/src/scope.ts
@@ -81,7 +81,7 @@ function sourceConversationKey(ctx: MemoryRuntimeContext): string | undefined {
 
 function actorScopeKey(ctx: MemoryRuntimeContext): string | undefined {
   const actor = ctx.actor;
-  if (!actor?.userId) {
+  if (!actor || actor.platform === "system") {
     return undefined;
   }
   if (actor.platform === "slack") {

--- a/packages/junior-memory/src/types.ts
+++ b/packages/junior-memory/src/types.ts
@@ -1,9 +1,7 @@
 import {
-  localActorSchema,
-  localSourceSchema,
+  actorSchema,
   platformSchema,
-  slackActorSchema,
-  slackSourceSchema,
+  sourceSchema,
 } from "@sentry/junior-plugin-api";
 import { z } from "zod";
 
@@ -31,27 +29,12 @@ export type MemoryEmbeddingMetric = (typeof MEMORY_EMBEDDING_METRICS)[number];
 const nonEmptyStringSchema = z.string().min(1);
 
 /** Runtime-owned memory invocation fields used for scope and source authority. */
-export const slackMemoryRuntimeContextSchema = z
+export const memoryRuntimeContextSchema = z
   .object({
     conversationId: nonEmptyStringSchema.optional(),
-    actor: slackActorSchema.optional(),
-    source: slackSourceSchema,
+    actor: actorSchema.optional(),
+    source: sourceSchema,
   })
   .strict();
-
-/** Runtime-owned local memory invocation fields used for scope and source authority. */
-export const localMemoryRuntimeContextSchema = z
-  .object({
-    conversationId: nonEmptyStringSchema.optional(),
-    actor: localActorSchema.optional(),
-    source: localSourceSchema,
-  })
-  .strict();
-
-/** Runtime-owned memory invocation fields accepted by memory store operations. */
-export const memoryRuntimeContextSchema = z.union([
-  slackMemoryRuntimeContextSchema,
-  localMemoryRuntimeContextSchema,
-]);
 
 export type MemoryRuntimeContext = z.output<typeof memoryRuntimeContextSchema>;

--- a/packages/junior-memory/tests/storage.test.ts
+++ b/packages/junior-memory/tests/storage.test.ts
@@ -1775,7 +1775,12 @@ describe("memory plugin storage", () => {
 
   it("stores Slack conversation memories for system runs", async () => {
     const fixture = await createMemoryFixture();
+    const actor = { platform: "system" as const, name: "scheduler" };
     const { model } = extractionModel([
+      {
+        kind: "preference",
+        content: "Prefers concise deployment notes.",
+      },
       {
         kind: "knowledge",
         content: "Production deploys require a release marker.",
@@ -1793,12 +1798,12 @@ describe("memory plugin storage", () => {
               return completedRun({
                 conversationId: runtime.conversationId,
                 destination: slackDestination(runtime),
-                actor: { platform: "system", name: "scheduler" },
-                actors: [],
+                actor,
+                actors: [actor],
                 transcript: [
-                  contextMessage(
-                    "Production deploys require a release marker.",
-                    runtime.actor,
+                  instructionMessage(
+                    "I prefer concise deployment notes. Production deploys require a release marker.",
+                    actor,
                   ),
                 ],
                 source: runtime.source,

--- a/packages/junior-memory/tests/storage.test.ts
+++ b/packages/junior-memory/tests/storage.test.ts
@@ -1773,6 +1773,57 @@ describe("memory plugin storage", () => {
     }
   });
 
+  it("stores Slack conversation memories for system runs", async () => {
+    const fixture = await createMemoryFixture();
+    const { model } = extractionModel([
+      {
+        kind: "knowledge",
+        content: "Production deploys require a release marker.",
+      },
+    ]);
+    const runtime = slackContext();
+
+    try {
+      await processMemorySession(
+        processSessionContext({
+          db: memoryDb(fixture),
+          model,
+          run: {
+            async load() {
+              return completedRun({
+                conversationId: runtime.conversationId,
+                destination: slackDestination(runtime),
+                actor: { platform: "system", name: "scheduler" },
+                actors: [],
+                transcript: [
+                  contextMessage(
+                    "Production deploys require a release marker.",
+                    runtime.actor,
+                  ),
+                ],
+                source: runtime.source,
+              });
+            },
+          },
+        }),
+      );
+
+      await expect(
+        memoryDb(fixture).select().from(memorySqlSchema.juniorMemoryMemories),
+      ).resolves.toEqual([
+        expect.objectContaining({
+          content: "Production deploys require a release marker.",
+          scope: "conversation",
+          sourcePlatform: "slack",
+          subjectType: "conversation",
+          kind: "knowledge",
+        }),
+      ]);
+    } finally {
+      await fixture.close();
+    }
+  });
+
   it("stores a personal preference when every cited entry is a run-actor instruction", async () => {
     const fixture = await createMemoryFixture();
 
@@ -2854,7 +2905,8 @@ WHERE id = '${superseded.memory.id}'
       // shared lexical recency window can fill with newer workspace knowledge
       // before ranking sees the older actor preference.
       const query = "what time is it";
-      const preferenceContent = "Located in San Francisco and uses Pacific Time (PT).";
+      const preferenceContent =
+        "Located in San Francisco and uses Pacific Time (PT).";
       let nowMs = TEST_NOW_MS;
       const store = createMemoryStore(memoryDb(fixture), slackContext(), {
         // No embedder: force the pure lexical path that production noise hits.


### PR DESCRIPTION
Memory processing now uses the plugin API's canonical actor and source schemas, allowing scheduled and resource-event runs with system actors to process conversation-scoped memory instead of failing runtime validation.

System actors still cannot derive personal memory scope. The regression coverage exercises the production shape of a system actor running against a public Slack conversation.
