### PR TITLE
fix(config): Warn on unregistered config defaults

### DIFF
--- a/packages/docs/src/content/docs/cli/check.md
+++ b/packages/docs/src/content/docs/cli/check.md
@@ -56,6 +56,8 @@ For each file it validates:
 
 For official `@sentry/junior-*` plugin packages, the command warns when the installed package version differs from `@sentry/junior`. This catches partial updates without requiring migration-specific checks.
 
+The command also compares literal `configDefaults` keys in app source files with discovered plugin content. Unknown keys emit a warning without failing validation. Runtime startup performs the authoritative check against the configured plugin set.
+
 When the target already contains Junior app markers such as `app/SOUL.md`, `app/WORLD.md`, `app/DESCRIPTION.md`, `app/skills/`, or `app/plugins/`, the command also checks the app-root Markdown files:
 
 - `app/SOUL.md` for assistant personality. Missing emits a warning.

--- a/packages/docs/src/content/docs/reference/config-and-env.md
+++ b/packages/docs/src/content/docs/reference/config-and-env.md
@@ -152,7 +152,7 @@ const app = await createApp({
 });
 ```
 
-Keys must be registered plugin config keys. Channel-scoped overrides (`jr-rpc config set`) take precedence.
+Keys should be registered plugin config keys. Junior retains unregistered defaults but warns at startup because they usually indicate missing plugin wiring. Channel-scoped overrides (`jr-rpc config set`) take precedence.
 
 ## Sandbox configuration
 

--- a/packages/junior/src/app.ts
+++ b/packages/junior/src/app.ts
@@ -101,7 +101,7 @@ export interface JuniorAppOptions {
     /** Slack emoji shown after a turn completes. Defaults to `white_check_mark`. */
     completedReactionEmoji?: string;
   };
-  /** Install-wide provider defaults (`provider.key` format). Channel overrides take precedence. */
+  /** Install-wide provider defaults. Unregistered `provider.key` entries warn at startup. */
   configDefaults?: Record<string, unknown>;
   /** Queue consumer wiring for the durable conversation worker. */
   conversationWork?: VercelConversationWorkCallbackOptions;
@@ -247,6 +247,16 @@ function hasConfiguredPluginCatalog(
     config.packages?.length ||
     Object.keys(config.manifests ?? {}).length,
   );
+}
+
+function warnUnregisteredConfigDefaults(
+  defaults: Record<string, unknown> | undefined,
+): void {
+  for (const key of Object.keys(defaults ?? {})) {
+    if (!pluginCatalogRuntime.isConfigKey(key)) {
+      logWarn("config.default.unregistered", { "app.config.key": key });
+    }
+  }
 }
 
 function pluginPackageNames(config: PluginCatalogConfig | undefined): string[] {
@@ -638,6 +648,7 @@ export async function createApp(options?: JuniorAppOptions): Promise<Hono> {
       );
     setSandboxResourceConfig(options?.sandbox);
     setConfigDefaults(options?.configDefaults);
+    warnUnregisteredConfigDefaults(options?.configDefaults);
     if (options?.slack) {
       setSlackReactionConfig(options.slack);
     }

--- a/packages/junior/src/chat/configuration/defaults.ts
+++ b/packages/junior/src/chat/configuration/defaults.ts
@@ -1,5 +1,3 @@
-import { pluginCatalogRuntime } from "@/chat/plugins/catalog-runtime";
-
 let installDefaults: Record<string, unknown> = {};
 
 function cloneDefaults(
@@ -18,7 +16,7 @@ function isConfigDefaultsRecord(
   );
 }
 
-/** Store install-wide config defaults; keys must be registered plugin config keys. */
+/** Store install-wide configuration defaults. */
 export function setConfigDefaults(
   defaults: Record<string, unknown> | undefined,
 ): void {
@@ -31,14 +29,6 @@ export function setConfigDefaults(
     throw new Error(
       "configDefaults must be an object keyed by plugin config key",
     );
-  }
-
-  for (const key of Object.keys(defaults)) {
-    if (!pluginCatalogRuntime.isConfigKey(key)) {
-      throw new Error(
-        `configDefaults: "${key}" is not a registered plugin config key`,
-      );
-    }
   }
 
   installDefaults = cloneDefaults(defaults);

--- a/packages/junior/src/cli/check.ts
+++ b/packages/junior/src/cli/check.ts
@@ -898,7 +898,7 @@ async function validateAppSourceFiles(
       for (const keyMatch of block.matchAll(/["']([^"']+)["']\s*:/g)) {
         const key = keyMatch[1];
         if (key && !registeredConfigKeys.has(key)) {
-          errors.push(
+          warnings.push(
             `${sourcePath}: configDefaults key "${key}" is not a registered plugin config key`,
           );
         }

--- a/packages/junior/tests/unit/app-config.test.ts
+++ b/packages/junior/tests/unit/app-config.test.ts
@@ -241,9 +241,8 @@ describe("createApp plugin config", () => {
     ).rejects.toThrow("Plugin package names must be valid npm package names");
   });
 
-  it("rolls back plugin config when config default validation fails", async () => {
+  it("allows config defaults for an unregistered plugin key", async () => {
     const tempRoot = await makeTempDir();
-    await writePluginPackage(tempRoot, "@acme/base-plugin", "base");
     await writePluginPackage(tempRoot, "@acme/next-plugin", "next");
     await fs.writeFile(
       path.join(tempRoot, "package.json"),
@@ -251,7 +250,6 @@ describe("createApp plugin config", () => {
         name: "temp-junior-app",
         private: true,
         dependencies: {
-          "@acme/base-plugin": "1.0.0",
           "@acme/next-plugin": "1.0.0",
         },
       }),
@@ -260,23 +258,14 @@ describe("createApp plugin config", () => {
     process.chdir(tempRoot);
 
     await createApp({
-      plugins: defineJuniorPlugins(["@acme/base-plugin"]),
-      configDefaults: { "base.org": "sentry" },
+      plugins: defineJuniorPlugins(["@acme/next-plugin"]),
+      configDefaults: { "missing.org": "sentry" },
     });
-
-    await expect(
-      createApp({
-        plugins: defineJuniorPlugins(["@acme/next-plugin"]),
-        configDefaults: { "missing.org": "sentry" },
-      }),
-    ).rejects.toThrow(
-      'configDefaults: "missing.org" is not a registered plugin config key',
-    );
 
     expect(
       pluginCatalogRuntime.getProviders().map((plugin) => plugin.manifest.name),
-    ).toEqual(["base"]);
-    expect(getConfigDefaults()).toEqual({ "base.org": "sentry" });
+    ).toEqual(["next"]);
+    expect(getConfigDefaults()).toEqual({ "missing.org": "sentry" });
   });
 
   it("fails startup and rolls back config when a configured plugin package is missing", async () => {

--- a/packages/junior/tests/unit/cli/check-cli.test.ts
+++ b/packages/junior/tests/unit/cli/check-cli.test.ts
@@ -409,7 +409,7 @@ describe("check cli", () => {
     ).toBe(true);
   });
 
-  it("fails when app configDefaults references an unregistered plugin key", async () => {
+  it("warns when app configDefaults references an unregistered plugin key", async () => {
     const repoRoot = makeTempDir("junior-validate-config-defaults-");
     writeFile(
       path.join(repoRoot, "package.json"),
@@ -459,15 +459,11 @@ describe("check cli", () => {
     );
 
     const lines: string[] = [];
-    await expect(
-      runCheck(repoRoot, {
-        info: (line) => lines.push(line),
-        warn: (line) => lines.push(line),
-        error: (line) => lines.push(line),
-      }),
-    ).rejects.toThrow(
-      "Validation failed (1 error, 1 plugin manifest, 0 skill directories checked).",
-    );
+    await runCheck(repoRoot, {
+      info: (line) => lines.push(line),
+      warn: (line) => lines.push(line),
+      error: (line) => lines.push(line),
+    });
 
     expect(
       lines.some((line) =>
@@ -476,6 +472,9 @@ describe("check cli", () => {
         ),
       ),
     ).toBe(true);
+    expect(lines.at(-1)).toContain(
+      "Validation passed (1 plugin manifest, 0 skill directories checked).",
+    );
   });
 
   it("accepts configDefaults from JS-defined packaged plugin manifests", async () => {

--- a/packages/junior/tests/unit/config/config-defaults.test.ts
+++ b/packages/junior/tests/unit/config/config-defaults.test.ts
@@ -37,10 +37,10 @@ describe("install config defaults", () => {
     expect(getConfigDefaults()).toEqual({});
   });
 
-  it("rejects keys that are not registered plugin config keys", () => {
-    expect(() => setConfigDefaults({ "unknown.key": "value" })).toThrow(
-      "not a registered plugin config key",
-    );
+  it("stores unregistered plugin config keys", () => {
+    setConfigDefaults({ "unknown.key": "value" });
+
+    expect(getConfigDefaults()).toEqual({ "unknown.key": "value" });
   });
 
   it("rejects null defaults", () => {


### PR DESCRIPTION
Unregistered `configDefaults` keys no longer abort app startup or fail `junior check`. Junior retains the configured values, emits a structured startup warning for each unknown key, and reports the static source check as a non-fatal warning.

The authoritative warning lives at the `createApp()` boundary, where the configured plugin set is available, so rollback remains silent and malformed `configDefaults` containers still fail validation as before.
