### PR TITLE
fix(tools): Recover from source-scoped search misses

### DIFF
--- a/packages/junior-github/skills/github-code/SKILL.md
+++ b/packages/junior-github/skills/github-code/SKILL.md
@@ -23,6 +23,7 @@ Use `git` and `gh` for repository work. Use `github_createPullRequest`, not `gh 
 - Base conclusions on repository evidence. Do not claim a check ran unless it did.
 - For Junior-owned pull requests, push the branch before creating the PR. The runtime supplies repository-scoped GitHub App credentials for both; try the operations before requesting remediation and never ask for a user token.
 - Use `github_cloneRepository` instead of shelling out to `git clone` when a repository is not already available in the sandbox.
+- A failed catalog match is not a repository access failure. Report missing access only after a GitHub operation returns an upstream denial.
 - A tool-routing denial requires the named tool; only an upstream denial justifies permission remediation.
 - Stop for ambiguous targets, missing access, destructive operations, or unresolved upstream permission failures.
 

--- a/packages/junior-github/skills/github-code/SPEC.md
+++ b/packages/junior-github/skills/github-code/SPEC.md
@@ -10,6 +10,7 @@ Guide evidence-first GitHub repository work from inspection through a reviewable
 - Preserve unrelated work and reject destructive Git operations.
 - Treat shallow clones as inspection checkouts; fetch/deepen before history-dependent operations and never force-push around missing ancestry.
 - Install repository dependencies with the detected package manager's locked/frozen mode before verification when dependencies are absent.
+- Discover repository cloning with a narrow GitHub catalog query and distinguish catalog misses from upstream access failures.
 - For every completed repository edit, create or update a pushed PR unless the user explicitly opts out; default new PRs to draft while honoring explicit ready-for-review instructions.
 - Write conventional PR titles that match the current dominant change.
 - Write short reviewer-facing PR bodies in ASD-STE100 English; explain what changed and why, add only context the diff cannot show, and omit empty ceremony or fixed templates.

--- a/packages/junior/src/chat/tools/search-tools.ts
+++ b/packages/junior/src/chat/tools/search-tools.ts
@@ -174,7 +174,7 @@ function selectedSourceSummaries(
 
 function renderSearchToolsDescription(knownSources: SourceSummary[]): string {
   const intro =
-    "Search the executable tool catalog. Deferred tools are grouped by source; use searchTools with source to inspect one source, then executeTool with the exact returned tool_name.";
+    "Search the executable tool catalog. Deferred tools are grouped by source; use searchTools with source to inspect one source, then executeTool with the exact returned tool_name. A source-scoped query with no text matches returns that source's tools for recovery.";
   if (knownSources.length === 0) {
     return intro;
   }
@@ -257,10 +257,18 @@ export function createSearchToolsTool(
       const sourceExists =
         requestedSource === null ||
         knownSources.some((candidate) => candidate.id === requestedSource);
-      const allMatches = sourceExists
+      const queryMatches = sourceExists
         ? searchCatalogTools(catalogTools, query ?? "", requestedSource)
         : [];
-      const matches = allMatches.slice(0, maxResults);
+      const sourceFallback =
+        requestedSource !== null &&
+        sourceExists &&
+        (query ?? "").trim() &&
+        queryMatches.length === 0;
+      const resultTools = sourceFallback
+        ? searchCatalogTools(catalogTools, "", requestedSource)
+        : queryMatches;
+      const matches = resultTools.slice(0, maxResults);
       const sources = !sourceExists
         ? knownSources
         : (query ?? "").trim()
@@ -288,7 +296,7 @@ export function createSearchToolsTool(
         sources,
         total_catalog_tools: Object.keys(catalogTools).length,
         total_eligible_tools: totalEligibleTools,
-        total_matches: allMatches.length,
+        total_matches: queryMatches.length,
         returned_tools: renderedTools.length,
         execution_tool: "executeTool" as const,
         tools: renderedTools,

--- a/packages/junior/tests/unit/tools/search-tools.test.ts
+++ b/packages/junior/tests/unit/tools/search-tools.test.ts
@@ -206,8 +206,80 @@ describe("searchTools", () => {
       ],
       total_eligible_tools: 1,
       total_matches: 0,
-      returned_tools: 0,
-      tools: [],
+      returned_tools: 1,
+      tools: [
+        {
+          tool_name: "memory_createMemory",
+        },
+      ],
+    });
+  });
+
+  it("returns source tools when an overconstrained query has no matches", async () => {
+    const searchTools = createSearchToolsTool({
+      github_cloneRepository: tool({
+        description: "Clone a GitHub repository into the sandbox workspace.",
+        identity: {
+          id: "github.cloneRepository",
+          name: "cloneRepository",
+          plugin: "github",
+        },
+        source: {
+          id: "github",
+          description: "GitHub repository workflows via GitHub App",
+        },
+        exposure: "deferred",
+        inputSchema: Type.Object(
+          {
+            repo: Type.String(),
+          },
+          { additionalProperties: false },
+        ),
+      }),
+      github_createPullRequest: tool({
+        description: "Create a GitHub pull request.",
+        identity: {
+          id: "github.createPullRequest",
+          name: "createPullRequest",
+          plugin: "github",
+        },
+        source: {
+          id: "github",
+          description: "GitHub repository workflows via GitHub App",
+        },
+        exposure: "deferred",
+        inputSchema: Type.Object(
+          {
+            repo: Type.String(),
+          },
+          { additionalProperties: false },
+        ),
+      }),
+    });
+
+    const result = await searchTools.execute!(
+      {
+        source: "github",
+        query:
+          "clone repository inspect GitHub source code pull requests commits",
+        max_results: 10,
+      },
+      {},
+    );
+
+    expect(result).toMatchObject({
+      source: "github",
+      total_eligible_tools: 2,
+      total_matches: 0,
+      returned_tools: 2,
+      tools: [
+        {
+          tool_name: "github_cloneRepository",
+        },
+        {
+          tool_name: "github_createPullRequest",
+        },
+      ],
     });
   });
 


### PR DESCRIPTION
Source-scoped catalog searches can return no tools when a natural-language query contains more terms than any single tool matches. This can make available provider capabilities look unavailable and cause the agent to report an access failure without attempting an operation.

When an explicitly selected source exists but a nonempty query has no matches, `searchTools` now returns that source’s bounded catalog while preserving `total_matches: 0`. The GitHub skill also requires an upstream denial before reporting missing repository access.

Regression coverage uses the overconstrained repository query that reproduced the failure and verifies that the source tools remain available for execution.