### PR TITLE
fix(tools): rank catalog searches by relevance

### DIFF
--- a/packages/junior/src/chat/tools/search-tools.ts
+++ b/packages/junior/src/chat/tools/search-tools.ts
@@ -9,6 +9,48 @@ export const SEARCH_TOOLS_NAME = "searchTools";
 const DEFAULT_MAX_RESULTS = 5;
 const MAX_RESULTS = 20;
 const MODEL_VISIBLE_DESCRIPTION_CAP = 180;
+// Identity, descriptive guidance, and source/schema context respectively.
+const SEARCH_FIELD_WEIGHTS = [8, 4, 1] as const;
+const BM25_K1 = 1.2;
+const BM25_B = 0.75;
+
+const SEARCH_STOP_WORDS = new Set([
+  "a",
+  "an",
+  "and",
+  "are",
+  "as",
+  "at",
+  "be",
+  "by",
+  "do",
+  "for",
+  "from",
+  "how",
+  "i",
+  "in",
+  "is",
+  "it",
+  "me",
+  "my",
+  "of",
+  "on",
+  "or",
+  "please",
+  "that",
+  "the",
+  "this",
+  "to",
+  "use",
+  "we",
+  "what",
+  "when",
+  "where",
+  "which",
+  "with",
+  "you",
+  "your",
+]);
 
 const searchToolsSourceSchema = z
   .object({
@@ -48,11 +90,36 @@ interface SourceSummary {
   description: string;
 }
 
-function normalize(value: string): string {
-  return value
-    .toLowerCase()
-    .replace(/[^a-z0-9_]+/g, " ")
-    .trim();
+interface SearchDocument {
+  name: string;
+  fields: [string[], string[], string[]];
+}
+
+function terms(value: string): string[] {
+  const chunks = value.match(/[\p{L}\p{N}]+/gu) ?? [];
+  const result: string[] = [];
+  for (const chunk of chunks) {
+    result.push(chunk.toLowerCase());
+    const expanded = chunk
+      .replace(/([a-z\d])([A-Z])/g, "$1 $2")
+      .replace(/([A-Z]+)([A-Z][a-z])/g, "$1 $2")
+      .toLowerCase()
+      .split(/\s+/);
+    if (expanded.length > 1) {
+      result.push(...expanded);
+    }
+  }
+  return result;
+}
+
+function queryTerms(query: string): string[] {
+  return [
+    ...new Set(
+      terms(query).filter(
+        (term) => term.length >= 2 && !SEARCH_STOP_WORDS.has(term),
+      ),
+    ),
+  ];
 }
 
 /** Summarize catalog descriptions before rendering them into model-visible data. */
@@ -77,51 +144,162 @@ function schemaText(schema: unknown): string {
   }
 }
 
-function searchableToolText(
+function searchableToolFields(
   name: string,
   definition: AnyToolDefinition,
-): string {
-  return normalize(
-    [
+): SearchDocument["fields"] {
+  return [
+    terms(
+      [
+        name,
+        definition.identity?.id,
+        definition.identity?.name,
+        definition.identity?.plugin,
+      ]
+        .filter(Boolean)
+        .join(" "),
+    ),
+    terms(
+      [
+        definition.description,
+        definition.promptSnippet,
+        ...(definition.promptGuidelines ?? []),
+      ]
+        .filter(Boolean)
+        .join(" "),
+    ),
+    terms(
+      [
+        definition.source?.id,
+        definition.source?.description,
+        schemaText(definition.inputSchema),
+        schemaText(definition.annotations ?? {}),
+      ]
+        .filter(Boolean)
+        .join(" "),
+    ),
+  ];
+}
+
+function prepareSearchDocuments(
+  tools: Record<string, AnyToolDefinition>,
+  source: string | null,
+): SearchDocument[] {
+  return Object.entries(tools)
+    .filter(([, definition]) =>
+      source ? definition.source?.id === source : true,
+    )
+    .map(([name, definition]) => ({
       name,
-      definition.identity?.id,
-      definition.identity?.name,
-      definition.identity?.plugin,
-      definition.source?.id,
-      definition.source?.description,
-      definition.description,
-      definition.promptSnippet,
-      ...(definition.promptGuidelines ?? []),
-      schemaText(definition.inputSchema),
-      JSON.stringify(definition.annotations ?? {}),
-    ]
-      .filter(Boolean)
-      .join(" "),
+      fields: searchableToolFields(name, definition),
+    }));
+}
+
+function averageFieldLengths(documents: SearchDocument[]): number[] {
+  if (documents.length === 0) {
+    return SEARCH_FIELD_WEIGHTS.map(() => 0);
+  }
+  return SEARCH_FIELD_WEIGHTS.map(
+    (_, fieldIndex) =>
+      documents.reduce(
+        (total, document) => total + document.fields[fieldIndex]!.length,
+        0,
+      ) / documents.length,
   );
 }
 
+function documentFrequencies(documents: SearchDocument[]): Map<string, number> {
+  const frequencies = new Map<string, number>();
+  for (const document of documents) {
+    const uniqueTerms = new Set(document.fields.flat());
+    for (const term of uniqueTerms) {
+      frequencies.set(term, (frequencies.get(term) ?? 0) + 1);
+    }
+  }
+  return frequencies;
+}
+
+function scoreSearchDocument(
+  document: SearchDocument,
+  query: string[],
+  frequencies: Map<string, number>,
+  documentCount: number,
+  averageLengths: number[],
+): number {
+  return query.reduce((score, term) => {
+    const documentFrequency = frequencies.get(term) ?? 0;
+    if (documentFrequency === 0) {
+      return score;
+    }
+    const weightedTermFrequency = document.fields.reduce(
+      (weighted, field, fieldIndex) => {
+        const termFrequency = field.filter(
+          (candidate) => candidate === term,
+        ).length;
+        if (termFrequency === 0) {
+          return weighted;
+        }
+        const averageLength = averageLengths[fieldIndex] ?? 0;
+        const lengthRatio =
+          averageLength === 0 ? 1 : field.length / averageLength;
+        return (
+          weighted +
+          SEARCH_FIELD_WEIGHTS[fieldIndex]! *
+            (termFrequency / (1 - BM25_B + BM25_B * lengthRatio))
+        );
+      },
+      0,
+    );
+    if (weightedTermFrequency === 0) {
+      return score;
+    }
+    const inverseDocumentFrequency = Math.log(
+      1 + (documentCount - documentFrequency + 0.5) / (documentFrequency + 0.5),
+    );
+    return (
+      score +
+      (inverseDocumentFrequency * weightedTermFrequency * (BM25_K1 + 1)) /
+        (weightedTermFrequency + BM25_K1)
+    );
+  }, 0);
+}
+
+/** Rank matching catalog tools while keeping source filtering deterministic. */
 function searchCatalogTools(
   tools: Record<string, AnyToolDefinition>,
   query: string,
   source: string | null,
 ): string[] {
-  const entries = Object.entries(tools).sort(([left], [right]) =>
-    left.localeCompare(right),
-  );
-  const sourceEntries = source
-    ? entries.filter(([, definition]) => definition.source?.id === source)
-    : entries;
-  if (!normalize(query)) {
-    return sourceEntries.map(([name]) => name);
+  const documents = prepareSearchDocuments(tools, source);
+  if (!query.trim()) {
+    return documents
+      .map(({ name }) => name)
+      .sort((left, right) => left.localeCompare(right));
   }
 
-  const terms = normalize(query).split(/\s+/).filter(Boolean);
-  return sourceEntries
-    .filter(([name, definition]) => {
-      const text = searchableToolText(name, definition);
-      return terms.every((term) => text.includes(term));
-    })
-    .map(([name]) => name);
+  const searchTerms = queryTerms(query);
+  if (searchTerms.length === 0) {
+    return [];
+  }
+  const averageLengths = averageFieldLengths(documents);
+  const frequencies = documentFrequencies(documents);
+  return documents
+    .map((document) => ({
+      name: document.name,
+      score: scoreSearchDocument(
+        document,
+        searchTerms,
+        frequencies,
+        documents.length,
+        averageLengths,
+      ),
+    }))
+    .filter(({ score }) => score > 0)
+    .sort(
+      (left, right) =>
+        right.score - left.score || left.name.localeCompare(right.name),
+    )
+    .map(({ name }) => name);
 }
 
 function callNotes(definition: AnyToolDefinition): string[] {

--- a/packages/junior/tests/unit/tools/search-tools.test.ts
+++ b/packages/junior/tests/unit/tools/search-tools.test.ts
@@ -74,11 +74,23 @@ function catalog() {
   };
 }
 
-function rankedCatalog() {
+function mixedCatalog() {
   const githubSource = {
     id: "github",
     description:
       "GitHub deployment, issue, pull request, release, and repository workflows via GitHub App",
+  };
+  const linearSource = {
+    id: "linear",
+    description: "Linear issue tracking via hosted MCP server",
+  };
+  const memorySource = {
+    id: "memory",
+    description: "Long-term Junior memory storage and recall",
+  };
+  const notionSource = {
+    id: "notion",
+    description: "Notion page search and summarization",
   };
   return {
     github_cloneRepository: tool({
@@ -137,6 +149,64 @@ function rankedCatalog() {
       inputSchema: Type.Object({
         repo: Type.String(),
         number: Type.Integer({ description: "Pull request number." }),
+      }),
+    }),
+    mcp__linear__create_issue: tool({
+      description: "Create a new Linear issue.",
+      source: linearSource,
+      exposure: "deferred",
+      inputSchema: Type.Object({
+        title: Type.String({ description: "Issue title." }),
+        team: Type.String({ description: "Team name or ID." }),
+      }),
+    }),
+    mcp__linear__create_issue_label: tool({
+      description: "Create a new Linear issue label.",
+      source: linearSource,
+      exposure: "deferred",
+      inputSchema: Type.Object({
+        name: Type.String({ description: "Label name." }),
+      }),
+    }),
+    mcp__linear__get_issue: tool({
+      description: "Retrieve detailed information about a Linear issue by ID.",
+      source: linearSource,
+      exposure: "deferred",
+      inputSchema: Type.Object({
+        id: Type.String({ description: "Issue ID or identifier." }),
+      }),
+    }),
+    memory_createMemory: tool({
+      description: "Store an explicit long-term memory.",
+      source: memorySource,
+      exposure: "deferred",
+      inputSchema: Type.Object({
+        content: Type.String({ description: "Memory content." }),
+      }),
+    }),
+    memory_searchMemories: tool({
+      description: "Search active memories visible in the current context.",
+      source: memorySource,
+      exposure: "deferred",
+      inputSchema: Type.Object({
+        query: Type.String({ description: "Targeted memory recall query." }),
+      }),
+    }),
+    "mcp__notion__notion-fetch": tool({
+      description:
+        "Retrieve a Notion page, database, or data source by URL or ID.",
+      source: notionSource,
+      exposure: "deferred",
+      inputSchema: Type.Object({
+        id: Type.String({ description: "Notion entity URL or ID." }),
+      }),
+    }),
+    "mcp__notion__notion-search": tool({
+      description: "Search the Notion workspace and connected sources.",
+      source: notionSource,
+      exposure: "deferred",
+      inputSchema: Type.Object({
+        query: Type.String({ description: "Semantic workspace search query." }),
       }),
     }),
     systemTime: tool({
@@ -285,7 +355,7 @@ describe("searchTools", () => {
   });
 
   it("ranks production search variations by relevant catalog metadata", async () => {
-    const searchTools = createSearchToolsTool(rankedCatalog());
+    const searchTools = createSearchToolsTool(mixedCatalog());
     const cases = [
       ["clone repository", "github_cloneRepository", "github"],
       ["repository clone", "github_cloneRepository", "github"],
@@ -307,6 +377,7 @@ describe("searchTools", () => {
       ],
       ["search code repository", "github_getRepository", "github"],
       ["create issue", "github_createIssue", "github"],
+      ["create issue", "mcp__linear__create_issue", "linear"],
       ["create pull request", "github_createPullRequest", "github"],
       ["GitHub create pull request", "github_createPullRequest", "github"],
       ["update pull request", "github_updatePullRequest", "github"],
@@ -326,15 +397,24 @@ describe("searchTools", () => {
   });
 
   it("returns related candidates for broad production queries", async () => {
-    const searchTools = createSearchToolsTool(rankedCatalog());
+    const searchTools = createSearchToolsTool(mixedCatalog());
     const cases = [
-      ["pull request checks details diff comments", "github_getPullRequest"],
-      ["search pull requests commits code github", "github_getPullRequest"],
+      [
+        "pull request checks details diff comments",
+        "github_getPullRequest",
+        "github",
+      ],
+      [
+        "search pull requests commits code github",
+        "github_getPullRequest",
+        "github",
+      ],
+      ["issue", "mcp__linear__get_issue", "linear"],
     ] as const;
 
-    for (const [query, expectedTool] of cases) {
+    for (const [query, expectedTool, source] of cases) {
       const result = await searchTools.execute!(
-        { query, source: "github", max_results: 20 },
+        { query, source, max_results: 20 },
         {},
       );
 
@@ -346,11 +426,11 @@ describe("searchTools", () => {
   });
 
   it("does not match partial words or unrelated production queries", async () => {
-    const searchTools = createSearchToolsTool(rankedCatalog());
+    const searchTools = createSearchToolsTool(mixedCatalog());
 
     for (const [query, source] of [
       ["version", undefined],
-      ["waterdog", "github"],
+      ["waterdog", "memory"],
     ] as const) {
       const result = await searchTools.execute!(
         { query, source, max_results: 20 },
@@ -366,6 +446,27 @@ describe("searchTools", () => {
         },
       });
     }
+  });
+
+  it("lists provider tools when a production search omits its query", async () => {
+    const searchTools = createSearchToolsTool(mixedCatalog());
+
+    const result = await searchTools.execute!(
+      { source: "notion", max_results: 20 },
+      {},
+    );
+
+    expect(result).toMatchObject({
+      query: null,
+      source: "notion",
+      total_eligible_tools: 2,
+      total_matches: 2,
+      returned_tools: 2,
+      tools: [
+        { tool_name: "mcp__notion__notion-fetch" },
+        { tool_name: "mcp__notion__notion-search" },
+      ],
+    });
   });
 
   it("returns known sources without throwing for an unknown source", async () => {

--- a/packages/junior/tests/unit/tools/search-tools.test.ts
+++ b/packages/junior/tests/unit/tools/search-tools.test.ts
@@ -74,6 +74,79 @@ function catalog() {
   };
 }
 
+function rankedCatalog() {
+  const githubSource = {
+    id: "github",
+    description:
+      "GitHub deployment, issue, pull request, release, and repository workflows via GitHub App",
+  };
+  return {
+    github_cloneRepository: tool({
+      description:
+        "Clone a GitHub repository into the sandbox workspace. The destination must not already exist.",
+      source: githubSource,
+      exposure: "deferred",
+      inputSchema: Type.Object({
+        repo: Type.String({
+          description: 'Repository in "owner/name" format.',
+        }),
+        directory: Type.Optional(
+          Type.String({ description: "Destination directory." }),
+        ),
+      }),
+    }),
+    github_createIssue: tool({
+      description: "Create a GitHub issue with a conversation footer.",
+      source: githubSource,
+      exposure: "deferred",
+      inputSchema: Type.Object({
+        repo: Type.String(),
+        title: Type.String({ description: "Issue title." }),
+      }),
+    }),
+    github_createPullRequest: tool({
+      description: "Create a GitHub pull request with a conversation footer.",
+      source: githubSource,
+      exposure: "deferred",
+      inputSchema: Type.Object({
+        repo: Type.String(),
+        title: Type.String({ description: "Pull request title." }),
+      }),
+    }),
+    github_getPullRequest: tool({
+      description:
+        "Get a GitHub pull request and its current details for inspection.",
+      source: githubSource,
+      exposure: "deferred",
+      inputSchema: Type.Object({
+        repo: Type.String(),
+        number: Type.Integer({ description: "Pull request number." }),
+      }),
+    }),
+    github_getRepository: tool({
+      description: "Get a GitHub repository and its metadata.",
+      source: githubSource,
+      exposure: "deferred",
+      inputSchema: Type.Object({ repo: Type.String() }),
+    }),
+    github_updatePullRequest: tool({
+      description:
+        "Update an existing GitHub pull request's title, body, base branch, or state.",
+      source: githubSource,
+      exposure: "deferred",
+      inputSchema: Type.Object({
+        repo: Type.String(),
+        number: Type.Integer({ description: "Pull request number." }),
+      }),
+    }),
+    systemTime: tool({
+      description:
+        "Return current system time. Do not use for historical or timezone-conversion requests.",
+      inputSchema: Type.Object({}),
+    }),
+  };
+}
+
 describe("searchTools", () => {
   it("discovers catalog tools from metadata and returns their schemas", async () => {
     const searchTools = createSearchToolsTool(catalog());
@@ -209,6 +282,90 @@ describe("searchTools", () => {
       returned_tools: 0,
       tools: [],
     });
+  });
+
+  it("ranks production search variations by relevant catalog metadata", async () => {
+    const searchTools = createSearchToolsTool(rankedCatalog());
+    const cases = [
+      ["clone repository", "github_cloneRepository", "github"],
+      ["repository clone", "github_cloneRepository", "github"],
+      ["clone repository sandbox", "github_cloneRepository", "github"],
+      [
+        "clone repository inspect source code commits",
+        "github_cloneRepository",
+        "github",
+      ],
+      [
+        "clone repository inspect GitHub source code pull requests commits",
+        "github_cloneRepository",
+        "github",
+      ],
+      [
+        "clone repository list code contents",
+        "github_cloneRepository",
+        undefined,
+      ],
+      ["search code repository", "github_getRepository", "github"],
+      ["create issue", "github_createIssue", "github"],
+      ["create pull request", "github_createPullRequest", "github"],
+      ["GitHub create pull request", "github_createPullRequest", "github"],
+      ["update pull request", "github_updatePullRequest", "github"],
+    ] as const;
+
+    for (const [query, expectedTool, source] of cases) {
+      const result = await searchTools.execute!(
+        { query, source, max_results: 1 },
+        {},
+      );
+
+      expect({
+        query,
+        tools: result.tools.map(({ tool_name }) => tool_name),
+      }).toEqual({ query, tools: [expectedTool] });
+    }
+  });
+
+  it("returns related candidates for broad production queries", async () => {
+    const searchTools = createSearchToolsTool(rankedCatalog());
+    const cases = [
+      ["pull request checks details diff comments", "github_getPullRequest"],
+      ["search pull requests commits code github", "github_getPullRequest"],
+    ] as const;
+
+    for (const [query, expectedTool] of cases) {
+      const result = await searchTools.execute!(
+        { query, source: "github", max_results: 20 },
+        {},
+      );
+
+      expect({
+        query,
+        tools: result.tools.map(({ tool_name }) => tool_name),
+      }).toEqual({ query, tools: expect.arrayContaining([expectedTool]) });
+    }
+  });
+
+  it("does not match partial words or unrelated production queries", async () => {
+    const searchTools = createSearchToolsTool(rankedCatalog());
+
+    for (const [query, source] of [
+      ["version", undefined],
+      ["waterdog", "github"],
+    ] as const) {
+      const result = await searchTools.execute!(
+        { query, source, max_results: 20 },
+        {},
+      );
+
+      expect({ query, result }).toMatchObject({
+        query,
+        result: {
+          total_matches: 0,
+          returned_tools: 0,
+          tools: [],
+        },
+      });
+    }
   });
 
   it("returns known sources without throwing for an unknown source", async () => {


### PR DESCRIPTION
`searchTools` now tokenizes catalog metadata and ranks partial matches with field-weighted BM25 scoring. Natural agent queries with extra capability words can still surface the most relevant tool, while exact token matching prevents substring false positives. Source filtering, empty-query listing, and result bounds stay unchanged.

The previous search required every normalized query term to appear in one tool's metadata, so an overconstrained query could return no tools even when its key terms identified an available capability. The regression matrix covers recent production query shapes, including the repository query from #1349 and `version` not matching `timezone-conversion`.

This supersedes #1349 by fixing generic catalog retrieval directly instead of returning the entire source catalog after a miss or adding GitHub-specific prompt guidance.
