### PR TITLE
fix(slack): add team read scope

### DIFF
--- a/packages/docs/src/content/docs/start-here/slack-app-setup.md
+++ b/packages/docs/src/content/docs/start-here/slack-app-setup.md
@@ -43,6 +43,7 @@ Grant the smallest scopes that cover the Slack features you enable. A typical Ju
 | Slash command configured by `JUNIOR_SLASH_COMMAND` | `commands`                                                                   |
 | Thread context in public/private channels and DMs  | `channels:history`, `groups:history`, `im:history`, `mpim:history` as needed |
 | File/image context and generated files             | `files:read`, `files:write` when file workflows are enabled                  |
+| Direct links back to Slack conversations           | `team:read`                                                                  |
 | Slack assistant status/title surfaces              | Assistant scopes required by your Slack app configuration                    |
 
 Slack requires reinstalling the app after scope changes. Reinstall before debugging runtime behavior.

--- a/packages/junior/slack-manifest.yml
+++ b/packages/junior/slack-manifest.yml
@@ -38,6 +38,7 @@ oauth_config:
       - reactions:read
       - reactions:write
       - search:read.public
+      - team:read
       - users:read
       - users:read.email
 settings:


### PR DESCRIPTION
Junior now requests `team:read` in the bundled Slack manifest and documents that it powers direct links back to Slack conversations.

The `team.info` lookup introduced for workspace-domain resolution requires this scope, but the manifest did not include it. Existing installations must add the scope and reinstall or reauthorize the Slack app; runtime behavior remains best effort when the scope is unavailable.
