### PR TITLE
fix(slack): Resolve passive transcript actors

### DIFF
--- a/packages/junior/src/chat/app/factory.ts
+++ b/packages/junior/src/chat/app/factory.ts
@@ -40,6 +40,10 @@ import { standardModelId } from "@/chat/model-profile";
 import { cancelSubscriptions as cancelEventSubscriptions } from "@/chat/resource-events/store";
 import { recordSubscribedReplyRoute } from "@/chat/conversations/projection";
 import { createSlackDispatchTurnRunner } from "@/chat/slack/dispatch-turn";
+import {
+  ensureSlackMessageActorIdentity,
+  getMessageActorIdentity,
+} from "@/chat/services/message-actor-identity";
 
 export interface CreateSlackRuntimeOptions {
   getSlackAdapter: () => SlackAdapter;
@@ -88,6 +92,25 @@ export function createSlackRuntime(options: CreateSlackRuntimeOptions) {
       services.conversationMemory.compactConversationIfNeeded,
     hydrateConversationVisionContext:
       services.visionContext.hydrateConversationVisionContext,
+    resolveBackfillMessageActors: async (messages, destination) => {
+      if (destination.platform !== "slack") {
+        throw new Error("Slack turn backfill requires a Slack destination");
+      }
+      await Promise.all(
+        messages
+          .filter((message) => {
+            const actor = getMessageActorIdentity(message);
+            return !message.author.isMe && !actor?.fullName && !actor?.userName;
+          })
+          .map((message) =>
+            ensureSlackMessageActorIdentity(
+              message,
+              destination.teamId,
+              services.replyExecutor.lookupSlackUser,
+            ),
+          ),
+      );
+    },
   });
   const replyToThread = createReplyToThread({
     getSlackAdapter: options.getSlackAdapter,

--- a/packages/junior/src/chat/app/factory.ts
+++ b/packages/junior/src/chat/app/factory.ts
@@ -100,7 +100,12 @@ export function createSlackRuntime(options: CreateSlackRuntimeOptions) {
         messages
           .filter((message) => {
             const actor = getMessageActorIdentity(message);
-            return !message.author.isMe && !actor?.fullName && !actor?.userName;
+            return (
+              !message.author.isMe &&
+              Boolean(actor?.userId) &&
+              !actor?.fullName &&
+              !actor?.userName
+            );
           })
           .map((message) =>
             ensureSlackMessageActorIdentity(

--- a/packages/junior/src/chat/runtime/turn-preparation.ts
+++ b/packages/junior/src/chat/runtime/turn-preparation.ts
@@ -67,6 +67,10 @@ export interface PrepareTurnStateDeps {
     conversation: ThreadConversationState,
     context: TurnContext & { threadTs?: string },
   ) => Promise<void>;
+  resolveBackfillMessageActors: (
+    messages: Message[],
+    destination: PrepareTurnStateInput["destination"],
+  ) => Promise<void>;
 }
 
 function hasPendingImageHydration(
@@ -94,6 +98,7 @@ async function seedConversationBackfill(
     messageId: string;
     messageCreatedAtMs: number;
   },
+  resolveMessageActors: (messages: Message[]) => Promise<void>,
 ): Promise<"recent_messages" | "thread_fetch"> {
   if (conversation.messages.length > 0 || conversation.compactions.length > 0) {
     return "recent_messages";
@@ -102,15 +107,20 @@ async function seedConversationBackfill(
   const seeded: ConversationMessage[] = [];
   let source: "recent_messages" | "thread_fetch" = "recent_messages";
 
+  let fetchedNewestFirst: Message[] | undefined;
   try {
-    const fetchedNewestFirst: Message[] = [];
+    const fetched: Message[] = [];
     for await (const entry of thread.messages) {
-      fetchedNewestFirst.push(entry);
-      if (fetchedNewestFirst.length >= BACKFILL_MESSAGE_LIMIT) {
+      fetched.push(entry);
+      if (fetched.length >= BACKFILL_MESSAGE_LIMIT) {
         break;
       }
     }
-    fetchedNewestFirst.reverse();
+    fetchedNewestFirst = fetched.reverse();
+  } catch {}
+
+  if (fetchedNewestFirst) {
+    await resolveMessageActors(fetchedNewestFirst);
     for (const entry of fetchedNewestFirst) {
       const text = getBackfillText(entry);
       if (text) {
@@ -120,7 +130,7 @@ async function seedConversationBackfill(
     if (seeded.length > 0) {
       source = "thread_fetch";
     }
-  } catch {}
+  }
 
   if (seeded.length === 0) {
     try {
@@ -128,6 +138,7 @@ async function seedConversationBackfill(
     } catch {}
 
     const fromRecent = thread.recentMessages.slice(-BACKFILL_MESSAGE_LIMIT);
+    await resolveMessageActors(fromRecent);
     for (const entry of fromRecent) {
       const text = getBackfillText(entry);
       if (text) {
@@ -177,10 +188,16 @@ export function createPrepareTurnState(deps: PrepareTurnStateDeps) {
 
     const backfillSource = args.skipBackfill
       ? undefined
-      : await seedConversationBackfill(args.thread, conversation, {
-          messageId: args.message.id,
-          messageCreatedAtMs: args.message.metadata.dateSent.getTime(),
-        });
+      : await seedConversationBackfill(
+          args.thread,
+          conversation,
+          {
+            messageId: args.message.id,
+            messageCreatedAtMs: args.message.metadata.dateSent.getTime(),
+          },
+          (messages) =>
+            deps.resolveBackfillMessageActors(messages, args.destination),
+        );
     for (const queued of args.queuedMessages ?? []) {
       const queuedMessage = toConversationMessage({
         entry: queued.message,
@@ -224,7 +241,10 @@ export function createPrepareTurnState(deps: PrepareTurnStateDeps) {
         threadTs: getThreadTs(args.context.threadId),
       });
       if (conversationId) {
-        await persistConversationVisionCache(conversationId, conversation.vision);
+        await persistConversationVisionCache(
+          conversationId,
+          conversation.vision,
+        );
       }
     }
 

--- a/packages/junior/tests/integration/slack/bot-handlers.test.ts
+++ b/packages/junior/tests/integration/slack/bot-handlers.test.ts
@@ -3066,9 +3066,29 @@ describe("bot handlers (integration)", () => {
 
     expect(capturedContexts).toHaveLength(1);
     expect(capturedContexts[0]).toContain("<thread-transcript>");
+    expect(capturedContexts[0]).toContain('author="Test User"');
+    expect(capturedContexts[0]).toContain("[user] Test User:");
     expect(capturedContexts[0]).toContain("Original production issue summary.");
     expect(capturedContexts[0]).not.toContain(
       "Can you include the regression window?",
+    );
+    const report = projectConversationReportEventPage({
+      canExposePayload: true,
+      events: await getConversationEventStore().loadHistory(threadId),
+    });
+    expect(report).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          data: expect.objectContaining({
+            actorIdentity: expect.objectContaining({
+              fullName: "Test User",
+              slackUserName: "testuser",
+            }),
+            text: "Original production issue summary.",
+            type: "message",
+          }),
+        }),
+      ]),
     );
   });
 

--- a/packages/junior/tests/integration/slack/bot-handlers.test.ts
+++ b/packages/junior/tests/integration/slack/bot-handlers.test.ts
@@ -3058,7 +3058,19 @@ describe("bot handlers (integration)", () => {
       author: { userId: "U-current", userName: "bob", isBot: false },
     });
     currentMessage.metadata.dateSent = new Date(1_700_000_001_000);
-    thread.recentMessages = [priorMessage, currentMessage];
+    const syntheticMessage = createTestMessage({
+      id: "msg-first-synthetic",
+      threadId,
+      text: "Automated deployment context.",
+      author: {
+        fullName: "unknown",
+        isBot: true,
+        userId: "unknown",
+        userName: "unknown",
+      },
+    });
+    syntheticMessage.metadata.dateSent = new Date(1_700_000_000_500);
+    thread.recentMessages = [priorMessage, syntheticMessage, currentMessage];
 
     await slackRuntime.handleNewMention(thread, currentMessage, {
       destination: createTestDestination(thread),
@@ -3069,6 +3081,7 @@ describe("bot handlers (integration)", () => {
     expect(capturedContexts[0]).toContain('author="Test User"');
     expect(capturedContexts[0]).toContain("[user] Test User:");
     expect(capturedContexts[0]).toContain("Original production issue summary.");
+    expect(capturedContexts[0]).toContain("Automated deployment context.");
     expect(capturedContexts[0]).not.toContain(
       "Can you include the regression window?",
     );


### PR DESCRIPTION
Slack thread backfill now resolves each human message actor through workspace profile data before storing conversation messages. Passive participants therefore appear by display name in agent context and reporting transcripts instead of as raw provider IDs.

The mailbox path already resolved actors, but backfill from thread history bypassed that boundary. The shared runtime now accepts one narrow actor-resolution capability from Slack composition and keeps the existing thread-fetch fallback behavior. Existing stored transcripts are unchanged.
