### PR TITLE
fix(dashboard): unify chart legend styling

### DIFF
--- a/packages/junior-dashboard/e2e/user-pages.spec.ts
+++ b/packages/junior-dashboard/e2e/user-pages.spec.ts
@@ -44,8 +44,8 @@ test("opens a registered plugin page from primary navigation", async ({
     page.getByRole("heading", { name: "Activity over time" }),
   ).toBeVisible();
   await expect(page.getByRole("heading", { name: /^\$/ })).toBeVisible();
-  await expect(page.getByText(/^Extraction \$/)).toBeVisible();
-  await expect(page.getByText(/^Recall \$/)).toBeVisible();
+  await expect(page.getByText(/^Extraction · \$/)).toBeVisible();
+  await expect(page.getByText(/^Recall · \$/)).toBeVisible();
   await expect(
     page.getByRole("img", {
       name: "Memory extraction and recall cost during the last 30 days",

--- a/packages/junior-dashboard/src/client/components/charts/ActivityChart.tsx
+++ b/packages/junior-dashboard/src/client/components/charts/ActivityChart.tsx
@@ -69,7 +69,7 @@ export function activityLabelIndexes(count: number): number[] {
   );
 }
 
-const chartAxisFontSizePx = 12;
+const chartAxisFontSizePx = 11;
 const ChartSvgScaleContext = createContext(1);
 
 /** Shared visual style for SVG chart axis labels. */
@@ -251,8 +251,7 @@ export function activityChartAverage(values: readonly number[]): number {
 }
 
 /** Shared visual style for average-line labels. */
-export const chartAverageLabelClassName =
-  "fill-white font-mono leading-none";
+export const chartAverageLabelClassName = "fill-white font-mono leading-none";
 
 /** Solid chip behind average labels so series colors never wash out the text. */
 const chartAverageLabelChip = "rgba(9, 12, 14, 0.92)";

--- a/packages/junior-dashboard/src/client/components/charts/ChartLegend.tsx
+++ b/packages/junior-dashboard/src/client/components/charts/ChartLegend.tsx
@@ -34,8 +34,8 @@ export function ChartLegend(props: {
             {item.label}
             {item.value !== undefined ? (
               <>
-                <span aria-hidden="true"> · </span>
-                {item.value}
+                {" "}
+                <span aria-hidden="true">·</span> {item.value}
               </>
             ) : null}
           </span>

--- a/packages/junior-dashboard/src/client/components/charts/ChartLegend.tsx
+++ b/packages/junior-dashboard/src/client/components/charts/ChartLegend.tsx
@@ -1,0 +1,46 @@
+import type { ReactNode } from "react";
+
+import { cn } from "../../styles";
+
+type ChartLegendItem = {
+  color: string;
+  key: string;
+  label: ReactNode;
+  value?: ReactNode;
+};
+
+/** Render chart series labels with shared spacing, markers, and values. */
+export function ChartLegend(props: {
+  ariaLabel: string;
+  inline?: boolean;
+  items: readonly ChartLegendItem[];
+}) {
+  return (
+    <ul
+      aria-label={props.ariaLabel}
+      className={cn(
+        "m-0 flex list-none flex-wrap gap-x-4 gap-y-1 p-0 font-mono text-2xs text-dashboard-text-muted",
+        !props.inline && "mt-4",
+      )}
+    >
+      {props.items.map((item) => (
+        <li className="flex items-center whitespace-nowrap" key={item.key}>
+          <i
+            aria-hidden="true"
+            className="mr-1.5 block size-2 shrink-0 rounded-full"
+            style={{ backgroundColor: item.color }}
+          />
+          <span>
+            {item.label}
+            {item.value !== undefined ? (
+              <>
+                <span aria-hidden="true"> · </span>
+                {item.value}
+              </>
+            ) : null}
+          </span>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/packages/junior-dashboard/src/client/components/charts/SystemMetricCharts.tsx
+++ b/packages/junior-dashboard/src/client/components/charts/SystemMetricCharts.tsx
@@ -95,7 +95,7 @@ function MetricChart(props: {
   const { chart, days } = props;
   const layout = createActivityChartLayout(250, {
     bottom: 34,
-    left: 64,
+    left: chart.metric === "costUsd" ? 80 : 64,
     right: 14,
     top: 22,
     width: 400,

--- a/packages/junior-dashboard/src/client/pages/locations/LocationActivityChart.tsx
+++ b/packages/junior-dashboard/src/client/pages/locations/LocationActivityChart.tsx
@@ -10,6 +10,7 @@ import {
   createActivityChartLayout,
   formatActivityDate,
 } from "../../components/charts/ActivityChart";
+import { ChartLegend } from "../../components/charts/ChartLegend";
 import { Card } from "../../components/layout/Card";
 import { CardHeader } from "../../components/layout/CardHeader";
 import { Tooltip } from "../../components/Tooltip";
@@ -32,10 +33,11 @@ export function LocationActivityChart(props: {
         description="Daily persisted conversations for this location."
         title="Conversation activity"
         trailing={
-          <span className="flex items-center gap-2">
-            <span className="size-2 rounded-full bg-cyan-400 shadow-[0_0_12px_rgba(34,211,238,0.5)]" />
-            90 days
-          </span>
+          <ChartLegend
+            ariaLabel="Conversation activity period"
+            inline
+            items={[{ color: "#22d3ee", key: "period", label: "90 days" }]}
+          />
         }
       />
       <div className="px-2 py-3 sm:px-4 sm:py-4">

--- a/packages/junior-dashboard/src/client/pages/locations/LocationDirectoryActivityChart.tsx
+++ b/packages/junior-dashboard/src/client/pages/locations/LocationDirectoryActivityChart.tsx
@@ -8,6 +8,7 @@ import {
   createActivityChartLayout,
   formatActivityDate,
 } from "../../components/charts/ActivityChart";
+import { ChartLegend } from "../../components/charts/ChartLegend";
 import { Card } from "../../components/layout/Card";
 import { CardHeader } from "../../components/layout/CardHeader";
 import { Tooltip } from "../../components/Tooltip";
@@ -34,14 +35,14 @@ export function LocationDirectoryActivityChart(props: {
         description="Daily public volume compared with private activity in aggregate."
         title="Conversations per day"
         trailing={
-          <span className="flex items-center gap-4">
-            <span className="flex items-center gap-2">
-              <span className="size-2 rounded-sm bg-cyan-400" /> public
-            </span>
-            <span className="flex items-center gap-2">
-              <span className="size-2 rounded-sm bg-amber-400" /> private
-            </span>
-          </span>
+          <ChartLegend
+            ariaLabel="Conversation visibility legend"
+            inline
+            items={[
+              { color: "#22d3ee", key: "public", label: "public" },
+              { color: "#fbbf24", key: "private", label: "private" },
+            ]}
+          />
         }
       />
       <div className="px-2 py-3 sm:px-4 sm:py-4">

--- a/packages/junior-dashboard/src/client/pages/memory/MemoryCostChart.tsx
+++ b/packages/junior-dashboard/src/client/pages/memory/MemoryCostChart.tsx
@@ -8,6 +8,7 @@ import {
   createActivityChartLayout,
   formatActivityDate,
 } from "../../components/charts/ActivityChart";
+import { ChartLegend } from "../../components/charts/ChartLegend";
 import type { TimeRangeDays } from "../../components/controls/TimeRangeSelector";
 import { Card } from "../../components/layout/Card";
 import { Tooltip } from "../../components/Tooltip";
@@ -46,7 +47,7 @@ export function MemoryCostChart(props: {
   const maximum = Math.max(0.01, ...dayTotals);
   const average = activityChartAverage(dayTotals);
   // Cost charts need a wider left gutter for currency tick labels.
-  const layout = createActivityChartLayout(200, { left: 64 });
+  const layout = createActivityChartLayout(200, { left: 112 });
   const step =
     days.length > 0 ? layout.plotWidth / days.length : layout.plotWidth;
   const barWidth = Math.max(2, Math.min(13, step * 0.68));
@@ -61,22 +62,23 @@ export function MemoryCostChart(props: {
           System-wide estimate across {formatRunCount(runs)} spanning extraction
           and recall.
         </p>
-        <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 font-mono text-xs text-dashboard-text-muted">
-          <span className="inline-flex items-center gap-1.5">
-            <span
-              aria-hidden="true"
-              className="h-2 w-2 rounded-[1px] bg-cyan-300"
-            />
-            Extraction {formatCostSummary({ total: extractionTotal })}
-          </span>
-          <span className="inline-flex items-center gap-1.5">
-            <span
-              aria-hidden="true"
-              className="h-2 w-2 rounded-[1px] bg-fuchsia-400"
-            />
-            Recall {formatCostSummary({ total: recallTotal })}
-          </span>
-        </div>
+        <ChartLegend
+          ariaLabel="Memory cost legend"
+          items={[
+            {
+              color: "#67e8f9",
+              key: "extraction",
+              label: "Extraction",
+              value: formatCostSummary({ total: extractionTotal }),
+            },
+            {
+              color: "#e879f9",
+              key: "recall",
+              label: "Recall",
+              value: formatCostSummary({ total: recallTotal }),
+            },
+          ]}
+        />
       </div>
 
       <div className="relative mt-4 overflow-hidden">

--- a/packages/junior-dashboard/src/client/pages/memory/MemoryTimeline.tsx
+++ b/packages/junior-dashboard/src/client/pages/memory/MemoryTimeline.tsx
@@ -6,6 +6,7 @@ import {
   createActivityChartLayout,
   formatActivityDate,
 } from "../../components/charts/ActivityChart";
+import { ChartLegend } from "../../components/charts/ChartLegend";
 import type { TimeRangeDays } from "../../components/controls/TimeRangeSelector";
 import { Card } from "../../components/layout/Card";
 import { Tooltip } from "../../components/Tooltip";
@@ -23,7 +24,8 @@ export function MemoryTimeline(props: {
 }) {
   const days = props.days.slice(-props.range);
   const layout = createActivityChartLayout(200);
-  const step = days.length > 0 ? layout.plotWidth / days.length : layout.plotWidth;
+  const step =
+    days.length > 0 ? layout.plotWidth / days.length : layout.plotWidth;
   const barWidth = Math.max(2, Math.min(13, step * 0.68));
   const totals = days.map((day) => day.personal + day.public);
   const maximum = Math.max(1, ...totals);
@@ -40,23 +42,7 @@ export function MemoryTimeline(props: {
         </p>
       </div>
 
-      <div
-        aria-label="Memory visibility legend"
-        className="mt-4 flex flex-wrap gap-4"
-      >
-        {series.map((item) => (
-          <span
-            className="inline-flex items-center gap-1.5 font-mono text-xs text-dashboard-text-muted"
-            key={item.key}
-          >
-            <i
-              className="size-2 rounded-sm"
-              style={{ backgroundColor: item.color }}
-            />
-            {item.label}
-          </span>
-        ))}
-      </div>
+      <ChartLegend ariaLabel="Memory visibility legend" items={series} />
 
       <div className="relative mt-3 overflow-hidden">
         <ChartSvg

--- a/packages/junior-dashboard/src/client/pages/people/PeopleActivityChart.tsx
+++ b/packages/junior-dashboard/src/client/pages/people/PeopleActivityChart.tsx
@@ -11,6 +11,7 @@ import {
   formatActivityDate,
   type ActivityChartLayout,
 } from "../../components/charts/ActivityChart";
+import { ChartLegend } from "../../components/charts/ChartLegend";
 import { Card } from "../../components/layout/Card";
 import { CardHeader } from "../../components/layout/CardHeader";
 import { Tooltip } from "../../components/Tooltip";
@@ -56,10 +57,11 @@ export function PeopleActivityChart(props: {
         description="Distinct verified actors grouped by recorded conversation activity."
         title="Active people per day"
         trailing={
-          <span className="flex items-center gap-2">
-            <span className="size-2 rounded-full bg-amber-400 shadow-[0_0_12px_rgba(251,191,36,0.55)]" />
-            people
-          </span>
+          <ChartLegend
+            ariaLabel="People activity legend"
+            inline
+            items={[{ color: "#fbbf24", key: "people", label: "people" }]}
+          />
         }
       />
       <div className="px-2 py-3 sm:px-4 sm:py-4">

--- a/packages/junior-dashboard/src/client/pages/system/PluginBarChart.tsx
+++ b/packages/junior-dashboard/src/client/pages/system/PluginBarChart.tsx
@@ -6,13 +6,14 @@ import {
   ChartSvg,
   createActivityChartLayout,
 } from "../../components/charts/ActivityChart";
+import { ChartLegend } from "../../components/charts/ChartLegend";
 import type { TimeRangeDays } from "../../components/controls/TimeRangeSelector";
 import { Tooltip } from "../../components/Tooltip";
 import { formatCostSummary } from "../../format";
 
 type Widget = NonNullable<PluginOperationalReport["widgets"]>[number];
 
-const colors = ["#67e8f9", "#6ee7b7", "#fbbf24", "#fb7185", "#a78bfa"];
+const colors = ["#67e8f9", "#6ee7b7", "#fbbf24", "#fb7185", "#a78bfa"] as const;
 const toneColors = {
   danger: "#fb7185",
   good: "#6ee7b7",
@@ -32,7 +33,7 @@ export function PluginBarChart(props: {
   const seriesFormat = commonSeriesFormat(widget);
   const layout = createActivityChartLayout(250, {
     bottom: 36,
-    left: seriesFormat === "usd" ? 72 : 56,
+    left: seriesFormat === "usd" ? 104 : 56,
     right: 12,
     top: 16,
     width: 520,
@@ -63,24 +64,16 @@ export function PluginBarChart(props: {
           </p>
         ) : null}
         {widget.series.length > 1 ? (
-          <div aria-label="Chart legend" className="mt-3 flex flex-wrap gap-3">
-            {widget.series.map((series, index) => (
-              <span
-                className="flex items-center gap-1.5 font-mono text-xs text-dashboard-text-muted"
-                key={series.key}
-              >
-                <i
-                  className="size-2 rounded-sm"
-                  style={{
-                    backgroundColor: series.tone
-                      ? toneColors[series.tone]
-                      : colors[index % colors.length],
-                  }}
-                />
-                {series.label}
-              </span>
-            ))}
-          </div>
+          <ChartLegend
+            ariaLabel="Chart legend"
+            items={widget.series.map((series, index) => ({
+              color: series.tone
+                ? toneColors[series.tone]
+                : colors[index % colors.length],
+              key: series.key,
+              label: series.label,
+            }))}
+          />
         ) : null}
       </div>
       {categories.length === 0 ? (
@@ -105,11 +98,7 @@ export function PluginBarChart(props: {
                   y1={y}
                   y2={y}
                 />
-                <ChartAxisLabel
-                  textAnchor="end"
-                  x={layout.left - 6}
-                  y={y + 3}
-                >
+                <ChartAxisLabel textAnchor="end" x={layout.left - 6} y={y + 3}>
                   {formatChartValue(tickValue, seriesFormat)}
                 </ChartAxisLabel>
               </g>

--- a/packages/junior-dashboard/src/client/pages/tasks/TaskExecutionStatusChart.tsx
+++ b/packages/junior-dashboard/src/client/pages/tasks/TaskExecutionStatusChart.tsx
@@ -7,6 +7,7 @@ import {
   createActivityChartLayout,
   formatActivityDate,
 } from "../../components/charts/ActivityChart";
+import { ChartLegend } from "../../components/charts/ChartLegend";
 import type { TimeRangeDays } from "../../components/controls/TimeRangeSelector";
 import { Card } from "../../components/layout/Card";
 import { Tooltip } from "../../components/Tooltip";
@@ -24,11 +25,10 @@ export function TaskExecutionStatusChart(props: {
 }) {
   const days = props.days.slice(-props.range);
   const layout = createActivityChartLayout(220);
-  const totals = days.map(
-    (day) => day.completed + day.failed + day.blocked,
-  );
+  const totals = days.map((day) => day.completed + day.failed + day.blocked);
   const maximum = Math.max(1, ...totals);
-  const step = days.length > 0 ? layout.plotWidth / days.length : layout.plotWidth;
+  const step =
+    days.length > 0 ? layout.plotWidth / days.length : layout.plotWidth;
   const barWidth = Math.max(2, Math.min(13, step * 0.68));
   const hasExecutions = totals.some((total) => total > 0);
 
@@ -43,23 +43,7 @@ export function TaskExecutionStatusChart(props: {
         </p>
       </div>
 
-      <div
-        aria-label="Task execution status legend"
-        className="mt-4 flex flex-wrap gap-4"
-      >
-        {series.map((item) => (
-          <span
-            className="inline-flex items-center gap-1.5 font-mono text-xs text-dashboard-text-muted"
-            key={item.key}
-          >
-            <i
-              className="size-2 rounded-sm"
-              style={{ backgroundColor: item.color }}
-            />
-            {item.label}
-          </span>
-        ))}
-      </div>
+      <ChartLegend ariaLabel="Task execution status legend" items={series} />
 
       <div className="relative mt-3 overflow-hidden">
         <ChartSvg

--- a/packages/junior-dashboard/tests/activity-chart.test.tsx
+++ b/packages/junior-dashboard/tests/activity-chart.test.tsx
@@ -16,7 +16,7 @@ import { ChartHeader } from "../src/client/components/charts/ChartHeader";
 import { SystemMetricCharts } from "../src/client/components/charts/SystemMetricCharts";
 
 describe("ChartAxisLabel", () => {
-  it("defaults to the shared 12px screen-size contract", () => {
+  it("defaults to the shared 11px screen-size contract", () => {
     const html = renderToStaticMarkup(
       <svg>
         <ChartAxisLabel x={0} y={0}>
@@ -25,7 +25,7 @@ describe("ChartAxisLabel", () => {
       </svg>,
     );
 
-    expect(html).toContain('font-size="12"');
+    expect(html).toContain('font-size="11"');
     expect(html).toContain(">12</text>");
   });
 

--- a/packages/junior-dashboard/tests/memory-cost-chart.test.tsx
+++ b/packages/junior-dashboard/tests/memory-cost-chart.test.tsx
@@ -23,11 +23,12 @@ describe("MemoryCostChart", () => {
         recallDays={costDays(0.005, 2)}
       />,
     );
-    const text = html.replaceAll(/<[^>]+>/g, "");
 
     expect(html).toContain("$0.01");
-    expect(text).toContain("Extraction · $0.005");
-    expect(text).toContain("Recall · $0.005");
+    expect(html).toContain(
+      'Extraction <span aria-hidden="true">·</span> $0.005',
+    );
+    expect(html).toContain('Recall <span aria-hidden="true">·</span> $0.005');
     expect(html).toContain(
       'aria-label="Memory extraction and recall cost during the last 30 days"',
     );

--- a/packages/junior-dashboard/tests/memory-cost-chart.test.tsx
+++ b/packages/junior-dashboard/tests/memory-cost-chart.test.tsx
@@ -23,10 +23,11 @@ describe("MemoryCostChart", () => {
         recallDays={costDays(0.005, 2)}
       />,
     );
+    const text = html.replaceAll(/<[^>]+>/g, "");
 
     expect(html).toContain("$0.01");
-    expect(html).toContain("Extraction $0.005");
-    expect(html).toContain("Recall $0.005");
+    expect(text).toContain("Extraction · $0.005");
+    expect(text).toContain("Recall · $0.005");
     expect(html).toContain(
       'aria-label="Memory extraction and recall cost during the last 30 days"',
     );
@@ -34,11 +35,7 @@ describe("MemoryCostChart", () => {
     expect(html).toContain(
       'aria-label="Jul 30: extraction $0.005, 1 run; recall $0.005, 2 runs"',
     );
-    expect(html).toMatch(
-      /fill="#67e8f9"[^>]+height="70"[^>]+y="94"/,
-    );
-    expect(html).toMatch(
-      /fill="#e879f9"[^>]+height="70"[^>]+y="24"/,
-    );
+    expect(html).toMatch(/fill="#67e8f9"[^>]+height="70"[^>]+y="94"/);
+    expect(html).toMatch(/fill="#e879f9"[^>]+height="70"[^>]+y="24"/);
   });
 });

--- a/packages/junior-dashboard/tests/telemetry-components.test.tsx
+++ b/packages/junior-dashboard/tests/telemetry-components.test.tsx
@@ -1522,7 +1522,7 @@ describe("dashboard canonical-event components", () => {
     );
     expect(html).toContain('aria-label="2026-07-31, Cost: $0.0042"');
     expect(html).toContain(">$0.0042</text>");
-    expect(html).toContain('x1="72"');
+    expect(html).toContain('x1="104"');
   });
 
   it("renders daily chart ranges from the shared page selection", () => {


### PR DESCRIPTION
Dashboard chart legends now use one shared React component for spacing, wrapping, compact text, circular markers, and marker alignment. Memory cost values use the same component and render as `Extraction · $value` and `Recall · $value`.

This removes duplicated legend markup across memory, task status, people, location, and plugin charts. Shared axis labels are one size smaller, and USD charts reserve enough left gutter to keep currency ticks visible.
