### PR TITLE
test(agent): add fixed model output fixture

### DIFF
--- a/packages/junior/tests/README.md
+++ b/packages/junior/tests/README.md
@@ -41,6 +41,10 @@ Slack HTTP tests use the global MSW setup in `msw/setup.ts`, handlers in
 Do not create per-test MSW servers or mock the Slack SDK for outbound contract
 tests.
 
+Agent integration tests use `fixtures/model-stream.ts` to set fixed model
+output. Use it with the real agent. Do not replace the agent runner only to
+control model output.
+
 ## Postgres Harness
 
 When `JUNIOR_TEST_DATABASE_URL` is configured, global setup creates a migrated

--- a/packages/junior/tests/fixtures/model-stream.ts
+++ b/packages/junior/tests/fixtures/model-stream.ts
@@ -1,0 +1,57 @@
+import type { StreamFn } from "@earendil-works/pi-agent-core";
+import type { AssistantMessage } from "@earendil-works/pi-ai";
+import {
+  createFauxCore,
+  fauxAssistantMessage,
+  fauxToolCall,
+  type FauxResponseStep,
+} from "@earendil-works/pi-ai/providers/faux";
+
+type FixedModelOutput =
+  | {
+      type: "text";
+      text: string;
+      waitFor?: Promise<unknown>;
+    }
+  | {
+      type: "toolCall";
+      name: string;
+      arguments: Parameters<typeof fauxToolCall>[1];
+      waitFor?: Promise<unknown>;
+    }
+  | {
+      type: "message";
+      message: AssistantMessage;
+      waitFor?: Promise<unknown>;
+    };
+
+function createAssistantMessage(output: FixedModelOutput): AssistantMessage {
+  if (output.type === "text") {
+    return fauxAssistantMessage(output.text);
+  }
+  if (output.type === "toolCall") {
+    return fauxAssistantMessage([fauxToolCall(output.name, output.arguments)], {
+      stopReason: "toolUse",
+    });
+  }
+  return output.message;
+}
+
+function createResponseStep(output: FixedModelOutput): FauxResponseStep {
+  const message = createAssistantMessage(output);
+  const { waitFor } = output;
+  if (!waitFor) {
+    return message;
+  }
+  return async () => {
+    await waitFor;
+    return message;
+  };
+}
+
+/** Set the model output returned for each model request. */
+export function createModelStream(outputs: FixedModelOutput[]): StreamFn {
+  const faux = createFauxCore({ api: "test", provider: "test" });
+  faux.setResponses(outputs.map(createResponseStep));
+  return faux.stream;
+}

--- a/packages/junior/tests/integration/durable-queue.test.ts
+++ b/packages/junior/tests/integration/durable-queue.test.ts
@@ -1,10 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { StreamFn } from "@earendil-works/pi-agent-core";
-import {
-  createFauxCore,
-  fauxAssistantMessage,
-  fauxToolCall,
-} from "@earendil-works/pi-ai/providers/faux";
+import { fauxAssistantMessage } from "@earendil-works/pi-ai/providers/faux";
 import { createSlackSource } from "@sentry/junior-plugin-api";
 import { createConversationWork } from "@/chat/app/conversation-work";
 import { FUNCTION_TIMEOUT_BUFFER_SECONDS, getChatConfig } from "@/chat/config";
@@ -56,6 +52,7 @@ import {
   queueSlackApiResponse,
   resetSlackApiMockState,
 } from "../msw/handlers/slack-api";
+import { createModelStream } from "../fixtures/model-stream";
 
 /**
  * Turn-lifecycle product outcomes for one conversation under the durable queue.
@@ -80,13 +77,6 @@ function almostSpentStartedAtMs(remainingMs: number): number {
   return Date.now() - requestBudgetMs() + remainingMs;
 }
 
-/** Model stream that returns one completed assistant reply per call. */
-function streamReplies(...texts: string[]): StreamFn {
-  const faux = createFauxCore({ api: "test", provider: "test" });
-  faux.setResponses(texts.map((text) => fauxAssistantMessage(text)));
-  return faux.stream;
-}
-
 /**
  * First model step calls a real no-side-effect tool so the agent reaches a
  * safe mid-work boundary. The next model step waits on `holdAfterTool` so the
@@ -97,25 +87,18 @@ function streamMidWorkThenReplies(
   holdAfterTool: Promise<void>,
   ...finalTexts: string[]
 ): StreamFn {
-  const faux = createFauxCore({ api: "test", provider: "test" });
   const [firstFinal, ...restFinals] = finalTexts;
   if (!firstFinal) {
     throw new Error("streamMidWorkThenReplies requires at least one final text");
   }
-  faux.setResponses([
-    fauxAssistantMessage([fauxToolCall("systemTime", {})], {
-      stopReason: "toolUse",
-    }),
+  return createModelStream([
+    { type: "toolCall", name: "systemTime", arguments: {} },
     // Held long enough for the host deadline to force park at the tool boundary.
-    async () => {
-      await holdAfterTool;
-      return fauxAssistantMessage(firstFinal);
-    },
+    { type: "text", text: firstFinal, waitFor: holdAfterTool },
     // Resume after park (and any aborted in-flight call) still has a final reply.
-    fauxAssistantMessage(firstFinal),
-    ...restFinals.map((text) => fauxAssistantMessage(text)),
+    { type: "text", text: firstFinal },
+    ...restFinals.map((text) => ({ type: "text" as const, text })),
   ]);
-  return faux.stream;
 }
 
 /**
@@ -128,36 +111,23 @@ function streamMidWorkThenHoldOnResume(
   holdOnResume: Promise<void>,
   ...finalTexts: string[]
 ): StreamFn {
-  const faux = createFauxCore({ api: "test", provider: "test" });
   const [firstFinal, ...restFinals] = finalTexts;
   if (!firstFinal) {
     throw new Error(
       "streamMidWorkThenHoldOnResume requires at least one final text",
     );
   }
-  faux.setResponses([
-    fauxAssistantMessage([fauxToolCall("systemTime", {})], {
-      stopReason: "toolUse",
-    }),
-    async () => {
-      await holdAfterTool;
-      return fauxAssistantMessage(firstFinal);
-    },
+  return createModelStream([
+    { type: "toolCall", name: "systemTime", arguments: {} },
+    { type: "text", text: firstFinal, waitFor: holdAfterTool },
     // Aborted first-slice model call may still consume a slot.
-    async () => {
-      await holdOnResume;
-      return fauxAssistantMessage(firstFinal);
-    },
+    { type: "text", text: firstFinal, waitFor: holdOnResume },
     // Fresh resume model call: hold until the second host deadline is spent.
-    async () => {
-      await holdOnResume;
-      return fauxAssistantMessage(firstFinal);
-    },
+    { type: "text", text: firstFinal, waitFor: holdOnResume },
     // Leftover replies if the turn somehow continues, plus later mentions.
-    fauxAssistantMessage(firstFinal),
-    ...restFinals.map((text) => fauxAssistantMessage(text)),
+    { type: "text", text: firstFinal },
+    ...restFinals.map((text) => ({ type: "text" as const, text })),
   ]);
-  return faux.stream;
 }
 
 /**
@@ -179,7 +149,9 @@ async function slack(
   await state.connect();
   const wakes = createConversationWorkQueueTestAdapter();
   const adapter = createSlackAdapterFixture();
-  const modelStream = options.modelStream ?? streamReplies("Deploy checked.");
+  const modelStream =
+    options.modelStream ??
+    createModelStream([{ type: "text", text: "Deploy checked." }]);
   const agentRunner: AgentRunner = options.agentRunner ?? {
     run: async (request) => await executeAgentRun(request, modelStream),
   };
@@ -418,7 +390,10 @@ describe("durable queue contract", () => {
     it("runs one mention to one reply and leaves the conversation free", async () => {
       const q = await slack({
         // Second reply is for the later user mention in expectNextTurn.
-        modelStream: streamReplies("Deploy checked.", "Deploy checked."),
+        modelStream: createModelStream([
+          { type: "text", text: "Deploy checked." },
+          { type: "text", text: "Deploy checked." },
+        ]),
       });
       await expect(q.send()).resolves.toMatchObject({ status: 200 });
       await expect(q.next()).resolves.toEqual({ status: "completed" });
@@ -587,7 +562,10 @@ describe("durable queue contract", () => {
       const startedAtMs = almostSpentStartedAtMs(remainingMs);
       const deadlineAtMs = startedAtMs + requestBudgetMs();
       const q = await slack({
-        modelStream: streamReplies("Deploy checked.", "Deploy checked."),
+        modelStream: createModelStream([
+          { type: "text", text: "Deploy checked." },
+          { type: "text", text: "Deploy checked." },
+        ]),
       });
 
       await expect(q.send()).resolves.toMatchObject({ status: 200 });
@@ -715,7 +693,9 @@ describe("durable queue contract", () => {
             if (attempts === 1) throw new Error("agent unavailable");
             return await executeAgentRun(
               request,
-              streamReplies("Deploy checked."),
+              createModelStream([
+                { type: "text", text: "Deploy checked." },
+              ]),
             );
           },
         },
@@ -743,7 +723,9 @@ describe("durable queue contract", () => {
             }
             return await executeAgentRun(
               request,
-              streamReplies("Deploy checked."),
+              createModelStream([
+                { type: "text", text: "Deploy checked." },
+              ]),
             );
           },
         },
@@ -785,7 +767,9 @@ describe("durable queue contract", () => {
             );
             return await executeAgentRun(
               request,
-              streamReplies("Deploy checked."),
+              createModelStream([
+                { type: "text", text: "Deploy checked." },
+              ]),
             );
           },
         },

--- a/packages/junior/tests/integration/slack/bot-handlers.test.ts
+++ b/packages/junior/tests/integration/slack/bot-handlers.test.ts
@@ -1,6 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
-  createFauxCore,
   fauxAssistantMessage,
   fauxText,
   fauxThinking,
@@ -49,6 +48,7 @@ import * as piClient from "@/chat/pi/client";
 import {
   deliverAssistantMessagesForTest,
 } from "../../fixtures/agent-runner";
+import { createModelStream } from "../../fixtures/model-stream";
 
 const emptyThreadReplies = async () => [];
 
@@ -708,17 +708,16 @@ describe("bot handlers (integration)", () => {
                 reasoningLevel: "medium",
                 source: "configured",
               });
-              const faux = createFauxCore({
-                api: "test",
-                provider: "test",
-              });
-              faux.setResponses([
-                fauxAssistantMessage([
-                  fauxThinking("Check the final answer."),
-                  fauxText(finalText),
-                ]),
+              const modelStream = createModelStream([
+                {
+                  type: "message",
+                  message: fauxAssistantMessage([
+                    fauxThinking("Check the final answer."),
+                    fauxText(finalText),
+                  ]),
+                },
               ]);
-              return executeAgentRun(request, faux.stream);
+              return executeAgentRun(request, modelStream);
             },
           },
         },


### PR DESCRIPTION
Agent integration tests can now set fixed model output through one shared fixture. The durable queue and Slack handler suites keep the real Pi agent and Junior wiring while replacing only the model edge.

The fixture uses plain output steps for text, tool calls, delayed output, and complete assistant messages. This removes local provider setup and establishes the first reusable slice of #1425 without changing product behavior.

Refs #1425
