### PR TITLE
test(slack): use typed Chat SDK fixtures

### DIFF
--- a/packages/junior/tests/README.md
+++ b/packages/junior/tests/README.md
@@ -41,6 +41,11 @@ Slack HTTP tests use the global MSW setup in `msw/setup.ts`, handlers in
 Do not create per-test MSW servers or mock the Slack SDK for outbound contract
 tests.
 
+Use `fixtures/slack-harness.ts` to build Slack messages and threads. Messages
+use the Chat SDK `Message`. Threads and sent messages include the required Chat
+SDK fields and methods. Do not cast partial objects to `SlackAdapter`, `Thread`,
+or `Message`.
+
 Agent integration tests use `fixtures/model-stream.ts` to set fixed model
 output. Use it with the real agent. Do not replace the agent runner only to
 control model output.

--- a/packages/junior/tests/component/task-execution/slack-conversation-work.test.ts
+++ b/packages/junior/tests/component/task-execution/slack-conversation-work.test.ts
@@ -1,11 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { Message, ThreadImpl, type StateAdapter, type Thread } from "chat";
-import type { SlackAdapter } from "@chat-adapter/slack";
+import { ThreadImpl, type Message, type StateAdapter, type Thread } from "chat";
 import {
   CooperativeTurnYieldError,
   TurnInputDeferredError,
 } from "@/chat/runtime/turn";
 import { getSlackClient } from "@/chat/slack/client";
+import { createJuniorSlackAdapter } from "@/chat/slack/adapter";
 import { recoverConversationWork } from "@/chat/task-execution/heartbeat";
 import {
   appendAndEnqueueInboundMessage,
@@ -38,6 +38,7 @@ import {
   persistThreadStateById,
 } from "@/chat/runtime/thread-state";
 import { createTestChatRuntime } from "../../fixtures/chat-runtime";
+import { createTestMessage } from "../../fixtures/slack-harness";
 import {
   getCapturedSlackApiCalls,
   resetSlackApiMockState,
@@ -158,17 +159,18 @@ describe("Slack conversation work execution", () => {
     const state = getStateAdapter();
     await state.connect();
     const slackAdapter = createSlackAdapterFixture();
-    const message = new Message({
+    const message = createTestMessage({
       id: "1712345.0002",
       threadId: CONVERSATION_ID,
       text: "",
+      dateSent: new Date(1_000),
+      isMention: true,
       attachments: [
         {
           type: "image",
           url: "https://example.com/attachment-only.png",
         },
       ],
-      metadata: { dateSent: new Date(1_000), edited: false },
       formatted: {
         type: "root",
         children: [
@@ -212,7 +214,6 @@ describe("Slack conversation work execution", () => {
         isMe: false,
       },
     });
-    message.isMention = true;
     const thread = new ThreadImpl({
       adapter: slackAdapter,
       stateAdapter: state,
@@ -1087,12 +1088,12 @@ describe("Slack conversation work execution", () => {
     const runtime: SlackWorkerOptions["runtime"] = {
       handleNewMention: async (_thread, _message, hooks) => {
         await hooks.ack?.();
-        const followUp = new Message({
+        const followUp = createTestMessage({
           id: "1712345.1002",
           threadId: conversationId,
           text: "steer this assistant thread",
           attachments: [],
-          metadata: { dateSent: new Date(1_000), edited: false },
+          dateSent: new Date(1_000),
           formatted: { type: "root", children: [] },
           raw: {
             channel: dmChannelId,
@@ -1303,23 +1304,17 @@ describe("Slack conversation work execution", () => {
     const queue = createConversationWorkQueueTestAdapter();
     const state = getStateAdapter();
     await state.connect();
-    const resolveTokenForTeam = vi.fn(
-      async (teamId: string, isEnterpriseInstall?: boolean) => ({
+    const getInstallation = vi.fn(
+      async (teamId: string, isEnterpriseInstall: boolean) => ({
         botUserId: SLACK_BOT_USER_ID,
-        token: `xoxb-${isEnterpriseInstall ? "enterprise" : teamId}`,
+        botToken: `xoxb-${isEnterpriseInstall ? "enterprise" : teamId}`,
       }),
     );
-    const requestContextRun = vi.fn(
-      async (_context: unknown, fn: () => Promise<void>) => await fn(),
-    );
-    const slackAdapter = {
-      botUserId: SLACK_BOT_USER_ID,
-      initialize: vi.fn(async () => {}),
-      requestContext: {
-        run: requestContextRun,
+    const slackAdapter = createJuniorSlackAdapter({
+      installationProvider: {
+        getInstallation,
       },
-      resolveTokenForTeam,
-    } as unknown as SlackAdapter;
+    });
 
     await requestConversationWork({
       conversationId: CONVERSATION_ID,
@@ -1352,11 +1347,7 @@ describe("Slack conversation work execution", () => {
       }),
     ).resolves.toEqual({ status: "completed" });
 
-    expect(resolveTokenForTeam).toHaveBeenCalledWith("T123", undefined);
-    expect(requestContextRun).toHaveBeenCalledWith(
-      expect.objectContaining({ token: "xoxb-T123" }),
-      expect.any(Function),
-    );
+    expect(getInstallation).toHaveBeenCalledWith("T123", false);
     expect(observedToken).toBe("xoxb-T123");
   });
 

--- a/packages/junior/tests/fixtures/chat-runtime.ts
+++ b/packages/junior/tests/fixtures/chat-runtime.ts
@@ -1,4 +1,3 @@
-import type { SlackAdapter } from "@chat-adapter/slack";
 import {
   createSlackRuntime,
   type CreateSlackRuntimeOptions,
@@ -18,7 +17,7 @@ export function createTestChatRuntime(
   return {
     slackAdapter,
     slackRuntime: createSlackRuntime({
-      getSlackAdapter: () => slackAdapter as unknown as SlackAdapter,
+      getSlackAdapter: () => slackAdapter,
       now: args.now,
       services: args.services,
     }),

--- a/packages/junior/tests/fixtures/slack-harness.ts
+++ b/packages/junior/tests/fixtures/slack-harness.ts
@@ -1,11 +1,16 @@
 import type {
   Adapter,
   Author,
+  ChatElement,
   Channel,
-  Message,
+  PostableMessage,
+  PostableObject,
+  ScheduledMessage,
   SentMessage,
   Thread,
 } from "chat";
+import { isPostableObject, Message } from "chat";
+import { SlackAdapter } from "@chat-adapter/slack";
 import type { Destination } from "@sentry/junior-plugin-api";
 
 // ── Helpers ──────────────────────────────────────────────────────────
@@ -64,6 +69,15 @@ export function createTestAuthor(overrides?: Partial<Author>): Author {
 
 // ── Test Message ─────────────────────────────────────────────────────
 
+export interface SlackRawMessage {
+  channel?: string;
+  event_ts?: string;
+  thread_ts?: string;
+  ts?: string;
+  [key: string]: unknown;
+}
+
+/** Create a Chat SDK message with fixed Slack data. */
 export function createTestMessage(args: {
   text?: string;
   id?: string;
@@ -71,50 +85,152 @@ export function createTestMessage(args: {
   author?: Partial<Author>;
   isMention?: boolean;
   attachments?: Message["attachments"];
+  dateSent?: Date;
   formatted?: Message["formatted"];
-  raw?: Record<string, unknown>;
-}): Message {
+  raw?: SlackRawMessage;
+}): Message<SlackRawMessage> {
   const threadId = args.threadId ?? "slack:C0TEST:1700000000.000";
   const threadParts = threadId.split(":");
   const inferredChannel = threadParts.length === 3 ? threadParts[1] : undefined;
   const inferredTs = threadParts.length === 3 ? threadParts[2] : undefined;
-  return {
+  return new Message({
     id: args.id ?? "msg-1",
     threadId,
     text: args.text ?? "hello",
     author: createTestAuthor(args.author),
     isMention: args.isMention,
     attachments: args.attachments ?? [],
-    metadata: { dateSent: new Date(), edited: false },
+    metadata: { dateSent: args.dateSent ?? new Date(), edited: false },
     formatted: args.formatted ?? { type: "root", children: [] },
     raw: args.raw ?? {
       ...(inferredChannel ? { channel: inferredChannel } : {}),
       ...(inferredTs ? { ts: inferredTs, thread_ts: inferredTs } : {}),
     },
-    toJSON() {
-      return {} as ReturnType<Message["toJSON"]>;
+  });
+}
+
+function createTestSentMessage<TRawMessage>(
+  message: Message<TRawMessage>,
+  callbacks: {
+    onDelete?: () => void;
+    onEdit?: (value: unknown) => void;
+  } = {},
+): SentMessage<TRawMessage> {
+  let sentMessage: SentMessage<TRawMessage>;
+  const methods: Pick<
+    SentMessage<TRawMessage>,
+    "addReaction" | "delete" | "edit" | "removeReaction"
+  > = {
+    async addReaction() {},
+    async delete() {
+      callbacks.onDelete?.();
     },
-  } as unknown as Message;
+    async edit(newContent) {
+      message.text = postedText(newContent);
+      callbacks.onEdit?.(newContent);
+      return sentMessage;
+    },
+    async removeReaction() {},
+  };
+  sentMessage = Object.assign(message, methods);
+  return sentMessage;
+}
+
+function postedText(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (value && typeof value === "object" && "markdown" in value) {
+    const { markdown } = value as { markdown?: unknown };
+    if (typeof markdown === "string") {
+      return markdown;
+    }
+  }
+  return String(value);
+}
+
+function createSchedule(channelId: string): Thread["schedule"] {
+  return async (_message, options): Promise<ScheduledMessage> => ({
+    scheduledMessageId: "scheduled-1",
+    channelId,
+    postAt: options.postAt,
+    raw: {},
+    async cancel() {},
+  });
+}
+
+function createPost(args: {
+  adapter: Adapter;
+  record?: (
+    value: unknown,
+    kind: "stream" | "value",
+  ) => {
+    id: string;
+    onDelete: () => void;
+    onEdit: (value: unknown) => void;
+  };
+  threadId: string;
+}): Thread["post"] {
+  function post<T extends PostableObject>(message: T): Promise<T>;
+  function post(
+    message: string | PostableMessage | ChatElement,
+  ): Promise<SentMessage>;
+  async function post(message: unknown): Promise<unknown> {
+    if (isPostableObject(message)) {
+      const recorded = args.record?.(message, "value");
+      message.onPosted({
+        adapter: args.adapter,
+        messageId: recorded?.id ?? "sent-1",
+        threadId: args.threadId,
+      });
+      return message;
+    }
+
+    let value = message;
+    let kind: "stream" | "value" = "value";
+    if (
+      message &&
+      typeof message === "object" &&
+      Symbol.asyncIterator in message
+    ) {
+      kind = "stream";
+      let text = "";
+      for await (const chunk of message as AsyncIterable<string>) {
+        text += chunk;
+      }
+      value = text;
+    }
+
+    const recorded = args.record?.(value, kind);
+    return createTestSentMessage(
+      createTestMessage({
+        id: recorded?.id ?? "sent-1",
+        text: postedText(value),
+        threadId: args.threadId,
+      }),
+      recorded,
+    );
+  }
+  return post;
 }
 
 // ── Fake Slack Adapter ───────────────────────────────────────────────
 
-export class FakeSlackAdapter {
-  readonly name = "slack";
-
+export class FakeSlackAdapter extends SlackAdapter {
   // Providing a bot user id opts this fixture into single-workspace install
   // mode: runWithSlackInstallation requires defaultBotTokenProvider (and a
   // resolved bot user id) before it runs worker-claimed Slack turns. Leaving
   // it unset keeps the legacy behavior, including generic leading-mention
   // stripping instead of exact bot-id stripping.
-  readonly botUserId?: string;
-  readonly defaultBotTokenProvider?: () => string;
-
   constructor(options?: { botUserId?: string }) {
-    if (options?.botUserId) {
-      this.botUserId = options.botUserId;
-      this.defaultBotTokenProvider = () => "xoxb-test-token";
-    }
+    super(
+      options?.botUserId
+        ? {
+            botToken: "xoxb-test-token",
+            botUserId: options.botUserId,
+          }
+        : {},
+    );
   }
 
   readonly statusCalls: Array<{
@@ -134,9 +250,9 @@ export class FakeSlackAdapter {
     title: string;
   }> = [];
 
-  async initialize(): Promise<void> {}
+  override async initialize(): Promise<void> {}
 
-  async setAssistantTitle(
+  override async setAssistantTitle(
     channelId: string,
     threadTs: string,
     title: string,
@@ -144,7 +260,7 @@ export class FakeSlackAdapter {
     this.titleCalls.push({ channelId, threadTs, title });
   }
 
-  async setSuggestedPrompts(
+  override async setSuggestedPrompts(
     channelId: string,
     threadTs: string,
     prompts: Array<{ message: string; title: string }>,
@@ -152,7 +268,7 @@ export class FakeSlackAdapter {
     this.promptCalls.push({ channelId, threadTs, prompts });
   }
 
-  async setAssistantStatus(
+  override async setAssistantStatus(
     channelId: string,
     threadTs: string,
     text: string,
@@ -160,6 +276,19 @@ export class FakeSlackAdapter {
   ): Promise<void> {
     this.statusCalls.push({ channelId, threadTs, text, loadingMessages });
   }
+}
+
+function createThreadAdapter(): Adapter {
+  const adapter = new FakeSlackAdapter();
+  return new Proxy(adapter, {
+    get(target, property, receiver) {
+      if (property === "name") {
+        return "test";
+      }
+      const value = Reflect.get(target, property, receiver);
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+  });
 }
 
 // ── Test Thread ──────────────────────────────────────────────────────
@@ -235,7 +364,7 @@ export async function createTestThread(args: {
   let seededThreadState = false;
   let seededChannelState = false;
 
-  const stubAdapter = { name: "test" } as Adapter;
+  const stubAdapter = createThreadAdapter();
   const channelRef = args.channelStateRef ?? { value: {} };
 
   // Constructor args own the fixture snapshot for this id. Always apply them so
@@ -301,12 +430,11 @@ export async function createTestThread(args: {
     mentionUser(userId: string) {
       return `<@${userId}>`;
     },
-    post: (async () => undefined) as unknown as Channel["post"],
-    postEphemeral: (async () => null) as unknown as Channel["postEphemeral"],
-    schedule: (async () => ({
-      id: "scheduled-1",
-      cancel: async () => undefined,
-    })) as unknown as Channel["schedule"],
+    post: createPost({ adapter: stubAdapter, threadId: channelId }),
+    async postEphemeral() {
+      return null;
+    },
+    schedule: createSchedule(channelId),
     get state(): Promise<Record<string, unknown>> {
       return loadChannelState();
     },
@@ -323,17 +451,19 @@ export async function createTestThread(args: {
       await writeAdapterState(channelStateKey(channelId), channelRef.value);
     },
     async startTyping(): Promise<void> {},
-    fetchMetadata: (async () => ({
-      id: channelId,
-      metadata: {},
-    })) as unknown as Channel["fetchMetadata"],
+    async fetchMetadata() {
+      return {
+        id: channelId,
+        metadata: {},
+      };
+    },
     threads(): AsyncIterable<never> {
       return (async function* () {})();
     },
     toJSON() {
       return {
         _type: "chat:Channel" as const,
-        adapterName: "test",
+        adapterName: stubAdapter.name,
         id: channelId,
         isDM: false,
       };
@@ -359,46 +489,36 @@ export async function createTestThread(args: {
     get state(): Promise<Record<string, unknown>> {
       return loadThreadState();
     },
-    async post(message: unknown): Promise<SentMessage> {
-      let entry: unknown;
-      let kind: "stream" | "value";
-      if (
-        message &&
-        typeof message === "object" &&
-        Symbol.asyncIterator in (message as Record<PropertyKey, unknown>)
-      ) {
-        kind = "stream";
-        let text = "";
-        for await (const chunk of message as AsyncIterable<string>) {
-          text += chunk;
-        }
-        entry = text;
-      } else {
-        kind = "value";
-        entry = message;
-      }
-      const postId = Symbol("post");
-      posts.push(entry);
-      postKinds.push(kind);
-      postIds.push(postId);
-      const sent = {
-        id: `sent-${posts.length}`,
-        text: String(entry),
-        async delete() {
-          const idx = postIds.indexOf(postId);
-          if (idx === -1) return;
-          posts.splice(idx, 1);
-          postKinds.splice(idx, 1);
-          postIds.splice(idx, 1);
-        },
-      } as unknown as SentMessage;
-      return sent;
+    post: createPost({
+      adapter: stubAdapter,
+      threadId: id,
+      record(entry, kind) {
+        const postId = Symbol("post");
+        posts.push(entry);
+        postKinds.push(kind);
+        postIds.push(postId);
+        return {
+          id: `sent-${posts.length}`,
+          onDelete() {
+            const idx = postIds.indexOf(postId);
+            if (idx === -1) return;
+            posts.splice(idx, 1);
+            postKinds.splice(idx, 1);
+            postIds.splice(idx, 1);
+          },
+          onEdit(value) {
+            const idx = postIds.indexOf(postId);
+            if (idx === -1) return;
+            posts[idx] = value;
+            postKinds[idx] = "value";
+          },
+        };
+      },
+    }),
+    async postEphemeral() {
+      return null;
     },
-    postEphemeral: (async () => null) as unknown as Thread["postEphemeral"],
-    schedule: (async () => ({
-      id: "scheduled-1",
-      cancel: async () => undefined,
-    })) as unknown as Thread["schedule"],
+    schedule: createSchedule(channelId),
     async startTyping(): Promise<void> {},
     async subscribe(): Promise<void> {
       subscribed = true;
@@ -427,7 +547,7 @@ export async function createTestThread(args: {
       await writeAdapterState(threadStateKey(id), stateData);
     },
     createSentMessageFromMessage(message: Message): SentMessage {
-      return message as unknown as SentMessage;
+      return createTestSentMessage(message);
     },
     async getParticipants(): Promise<Author[]> {
       return [];
@@ -450,7 +570,7 @@ export async function createTestThread(args: {
     toJSON() {
       return {
         _type: "chat:Thread" as const,
-        adapterName: "test",
+        adapterName: stubAdapter.name,
         id,
         channelId,
         isDM: false,
@@ -473,11 +593,6 @@ type AssertAssignable<_TSub extends TSuper, TSuper> = true;
 
 type _ThreadCheck = AssertAssignable<TestThread, Thread>;
 
-type _MessageCheck = AssertAssignable<
-  ReturnType<typeof createTestMessage>,
-  Message
->;
-
 // Prevent unused-type warnings
-void (0 as unknown as _ThreadCheck);
-void (0 as unknown as _MessageCheck);
+const threadCheck: _ThreadCheck = true;
+void threadCheck;

--- a/packages/junior/tests/fixtures/slack-harness.ts
+++ b/packages/junior/tests/fixtures/slack-harness.ts
@@ -223,14 +223,15 @@ export class FakeSlackAdapter extends SlackAdapter {
   // it unset keeps the legacy behavior, including generic leading-mention
   // stripping instead of exact bot-id stripping.
   constructor(options?: { botUserId?: string }) {
-    super(
-      options?.botUserId
+    super({
+      signingSecret: "test-signing-secret",
+      ...(options?.botUserId
         ? {
             botToken: "xoxb-test-token",
             botUserId: options.botUserId,
           }
-        : {},
-    );
+        : {}),
+    });
   }
 
   readonly statusCalls: Array<{

--- a/packages/junior/tests/integration/slack/new-mention-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/new-mention-behavior.test.ts
@@ -131,17 +131,15 @@ describe("Slack behavior: new mention", () => {
       text: "<@U0APP> first queued request",
       isMention: true,
       threadId: thread.id,
+      dateSent: new Date(1700001234000),
     });
     const latest = createTestMessage({
       id: "m-latest",
       text: "<@U0APP> latest request",
       isMention: true,
       threadId: thread.id,
+      dateSent: new Date(1700001235000),
     });
-    // The transcript is ordered by created_at; the queued message genuinely
-    // arrived before the triggering mention.
-    (queued.metadata as { dateSent: Date }).dateSent = new Date(1700001234000);
-    (latest.metadata as { dateSent: Date }).dateSent = new Date(1700001235000);
 
     await slackRuntime.handleNewMention(thread, latest, {
       destination: createTestDestination(thread),

--- a/packages/junior/tests/unit/slack/slack-harness.test.ts
+++ b/packages/junior/tests/unit/slack/slack-harness.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, it } from "vitest";
+import { Message } from "chat";
 import { disconnectStateAdapter } from "@/chat/state/adapter";
 import {
+  createTestMessage,
   createTestThread,
   FakeSlackAdapter,
 } from "../../fixtures/slack-harness";
@@ -14,9 +16,39 @@ describe("slack harness fixture", () => {
     expect(new FakeSlackAdapter().name).toBe("slack");
   });
 
+  it("creates a Chat SDK message with typed Slack data", () => {
+    const dateSent = new Date("2026-08-11T12:00:00.000Z");
+    const message = createTestMessage({
+      id: "message-1",
+      threadId: "slack:C0TEST:1700000000.000",
+      text: "hello",
+      dateSent,
+      raw: {
+        channel: "C0TEST",
+        ts: "1700000000.100",
+        thread_ts: "1700000000.000",
+      },
+    });
+
+    expect(message).toBeInstanceOf(Message);
+    expect(message.toJSON()).toMatchObject({
+      _type: "chat:Message",
+      id: "message-1",
+      metadata: { dateSent: dateSent.toISOString(), edited: false },
+      raw: {
+        channel: "C0TEST",
+        ts: "1700000000.100",
+        thread_ts: "1700000000.000",
+      },
+      text: "hello",
+      threadId: "slack:C0TEST:1700000000.000",
+    });
+  });
+
   it("uses explicit channelId when provided", async () => {
     const thread = await createTestThread({ id: "thread-3", channelId: "C-3" });
 
+    expect(thread.adapter.name).toBe("test");
     expect(thread.channelId).toBe("C-3");
     expect(thread.channel.id).toBe("C-3");
   });
@@ -46,6 +78,20 @@ describe("slack harness fixture", () => {
 
     expect(thread.posts).toEqual(["same"]);
     expect(thread.postKinds).toEqual(["stream"]);
+  });
+
+  it("keeps a sent message and recorded post aligned after an edit", async () => {
+    const thread = await createTestThread({
+      id: "slack:C0TEST:1700000000.000",
+    });
+    const sent = await thread.post("before");
+
+    const edited = await sent.edit("after");
+
+    expect(edited).toBe(sent);
+    expect(sent.text).toBe("after");
+    expect(thread.posts).toEqual(["after"]);
+    expect(thread.postKinds).toEqual(["value"]);
   });
 
   it("does not inherit leftover adapter scratch when reusing a thread id", async () => {

--- a/packages/junior/tests/unit/slack/slack-harness.test.ts
+++ b/packages/junior/tests/unit/slack/slack-harness.test.ts
@@ -16,6 +16,23 @@ describe("slack harness fixture", () => {
     expect(new FakeSlackAdapter().name).toBe("slack");
   });
 
+  it("ignores the environment bot token when no bot user is requested", () => {
+    const previousToken = process.env.SLACK_BOT_TOKEN;
+    process.env.SLACK_BOT_TOKEN = "xoxb-environment-token";
+
+    try {
+      const adapter = new FakeSlackAdapter();
+
+      expect(() => adapter.webClient).toThrow("No bot token available");
+    } finally {
+      if (previousToken === undefined) {
+        delete process.env.SLACK_BOT_TOKEN;
+      } else {
+        process.env.SLACK_BOT_TOKEN = previousToken;
+      }
+    }
+  });
+
   it("creates a Chat SDK message with typed Slack data", () => {
     const dateSent = new Date("2026-08-11T12:00:00.000Z");
     const message = createTestMessage({


### PR DESCRIPTION
Slack tests now use actual Chat SDK messages, sent messages, threads, channels, and Slack adapters through shared helpers. Durable Slack session coverage now uses a real adapter with an in-memory installation provider, so it tests installation token binding without replacing the adapter's private behavior.

This removes partial objects that were forced to look like Chat SDK types while keeping test delivery in memory. All 17 shared-harness test files pass with 171 tests, along with Junior type checks and the repository lint and test architecture checks.

Refs #1425
