### PR TITLE
test: enforce integration test boundaries

### DIFF
--- a/packages/junior/tests/README.md
+++ b/packages/junior/tests/README.md
@@ -15,8 +15,13 @@ documents the package-local harness and commands.
 
 Integration tests may fake an external boundary through the shared harnesses,
 but may not mock Junior-owned `@/` modules. `pnpm test-architecture:check`
-enforces this rule. A test that needs internal module replacement belongs in
-`component/` unless it is rewritten to use real wiring.
+also blocks Pi agent mocks, manufactured agent outcomes, scripted agent runners,
+and unsafe Slack double casts. Existing exceptions and their exact counts live
+in `../../../scripts/test-architecture-debt.json`. Do not increase them. Lower
+or remove an exception when its test moves to real wiring.
+
+A test that needs internal module replacement belongs in `component/` unless it
+is rewritten to use real wiring.
 
 Use `../../junior-evals/README.md` for model-dependent behavior and
 `../../docs/src/content/docs/contribute/local-agent-validation.md` for local

--- a/scripts/check-test-architecture.mjs
+++ b/scripts/check-test-architecture.mjs
@@ -3,17 +3,101 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const INTEGRATION_ROOT = "packages/junior/tests/integration";
-const INTERNAL_MOCK_PATTERN = /\bvi\.(?:doMock|mock)\(\s*["']@\//;
+const DEBT_PATH = "scripts/test-architecture-debt.json";
 
-/** Report integration tests that replace Junior-owned modules. */
-export function checkIntegrationInternalMocks(files) {
+const RULES = [
+  {
+    id: "internal-module-mock",
+    message: "integration tests must not mock Junior-owned @/ modules",
+    pattern: /\bvi\.(?:doMock|mock)\(\s*["']@\//g,
+  },
+  {
+    id: "pi-agent-mock",
+    message: "integration tests must not mock Pi's agent",
+    pattern:
+      /\bvi\.(?:doMock|mock)\(\s*["']@earendil-works\/pi-agent-core["']/g,
+  },
+  {
+    allowsDebt: true,
+    id: "manufactured-agent-outcome",
+    message:
+      "integration tests must run the real agent instead of manufacturing agent outcomes",
+    pattern: /\bcompletedAgentRun\b/g,
+  },
+  {
+    allowsDebt: true,
+    id: "scripted-agent-runner",
+    message:
+      "integration tests must use the model stream instead of a scripted agent runner",
+    pattern:
+      /\b(?:scriptedAssistantMessageRunner|createApiTurnScriptedRunner)\b/g,
+  },
+  {
+    id: "unsafe-slack-cast",
+    message:
+      "integration tests must use typed Slack fixtures instead of double casts",
+    pattern:
+      /\bas\s+unknown\s+as\s+(?:SlackAdapter|Thread|Message)(?:\b|\s*<)/g,
+  },
+];
+
+function countMatches(contents, pattern) {
+  return Array.from(contents.matchAll(pattern)).length;
+}
+
+function isPositiveInteger(value) {
+  return Number.isInteger(value) && value > 0;
+}
+
+/** Report integration test violations and stale exception counts. */
+export function checkIntegrationTestArchitecture(files, debt = {}) {
   const errors = [];
+  const ruleIds = new Set(RULES.map((rule) => rule.id));
 
-  for (const file of files) {
-    if (INTERNAL_MOCK_PATTERN.test(file.contents)) {
-      errors.push(
-        `${file.path}: integration tests must not mock Junior-owned @/ modules`,
-      );
+  for (const ruleId of Object.keys(debt)) {
+    if (!ruleIds.has(ruleId)) {
+      errors.push(`${DEBT_PATH}: unknown rule ${ruleId}`);
+    }
+  }
+
+  for (const rule of RULES) {
+    const configuredByPath = debt[rule.id] ?? {};
+    if (!rule.allowsDebt && Object.keys(configuredByPath).length > 0) {
+      errors.push(`${DEBT_PATH}: ${rule.id} does not allow exceptions`);
+    }
+    const allowedByPath = rule.allowsDebt ? configuredByPath : {};
+    const actualByPath = new Map(
+      files.map((file) => [
+        file.path,
+        countMatches(file.contents, rule.pattern),
+      ]),
+    );
+    const paths = new Set([
+      ...actualByPath.keys(),
+      ...Object.keys(allowedByPath),
+    ]);
+
+    for (const filePath of paths) {
+      const actual = actualByPath.get(filePath) ?? 0;
+      const allowed = allowedByPath[filePath] ?? 0;
+      if (
+        Object.hasOwn(allowedByPath, filePath) &&
+        !isPositiveInteger(allowed)
+      ) {
+        errors.push(
+          `${DEBT_PATH}: ${rule.id} exception for ${filePath} must be a positive integer`,
+        );
+        continue;
+      }
+      if (actual > allowed) {
+        errors.push(
+          `${filePath}: ${rule.message} (${actual} found, ${allowed} allowed)`,
+        );
+      } else if (actual < allowed) {
+        errors.push(
+          `${DEBT_PATH}: ${rule.id} allows ${allowed} in ${filePath}, but ${actual} found; lower or remove the exception`,
+        );
+      }
     }
   }
 
@@ -34,12 +118,21 @@ function collectIntegrationTests(root) {
     });
 }
 
+function readDebt(root) {
+  return JSON.parse(fs.readFileSync(path.join(root, DEBT_PATH), "utf8"));
+}
+
 function main() {
   const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
   const root = path.resolve(scriptDirectory, "..");
-  const errors = checkIntegrationInternalMocks(collectIntegrationTests(root));
+  const errors = checkIntegrationTestArchitecture(
+    collectIntegrationTests(root),
+    readDebt(root),
+  );
   if (errors.length === 0) {
-    console.log("Integration tests do not mock Junior wiring.");
+    console.log(
+      "Integration tests do not add to known test architecture debt.",
+    );
     return;
   }
   console.error(["Test architecture check failed:", ...errors].join("\n"));

--- a/scripts/check-test-architecture.test.mjs
+++ b/scripts/check-test-architecture.test.mjs
@@ -1,43 +1,161 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { checkIntegrationInternalMocks } from "./check-test-architecture.mjs";
+import { checkIntegrationTestArchitecture } from "./check-test-architecture.mjs";
+
+const TEST_PATH = "packages/junior/tests/integration/new.test.ts";
+
+function integrationTest(contents, path = TEST_PATH) {
+  return { path, contents };
+}
 
 test("rejects a new integration test that mocks a Junior module", () => {
   assert.deepEqual(
-    checkIntegrationInternalMocks([
-      {
-        path: "packages/junior/tests/integration/new.test.ts",
-        contents: 'vi.mock("@/chat/runtime", () => ({}));',
-      },
+    checkIntegrationTestArchitecture([
+      integrationTest('vi.mock("@/chat/runtime", () => ({}));'),
     ]),
     [
-      "packages/junior/tests/integration/new.test.ts: integration tests must not mock Junior-owned @/ modules",
+      `${TEST_PATH}: integration tests must not mock Junior-owned @/ modules (1 found, 0 allowed)`,
     ],
   );
 });
 
 test("rejects dynamic mocks of Junior modules", () => {
   assert.deepEqual(
-    checkIntegrationInternalMocks([
-      {
-        path: "packages/junior/tests/integration/new.test.ts",
-        contents: "vi.doMock(\n  '@/chat/runtime',\n  () => ({}),\n);",
-      },
+    checkIntegrationTestArchitecture([
+      integrationTest("vi.doMock(\n  '@/chat/runtime',\n  () => ({}),\n);"),
     ]),
     [
-      "packages/junior/tests/integration/new.test.ts: integration tests must not mock Junior-owned @/ modules",
+      `${TEST_PATH}: integration tests must not mock Junior-owned @/ modules (1 found, 0 allowed)`,
     ],
   );
 });
 
 test("allows external mocks", () => {
   assert.deepEqual(
-    checkIntegrationInternalMocks([
-      {
-        path: "packages/junior/tests/integration/provider.test.ts",
-        contents: 'vi.mock("@earendil-works/pi-agent-core", () => ({}));',
-      },
+    checkIntegrationTestArchitecture([
+      integrationTest('vi.mock("external-provider", () => ({}));'),
     ]),
     [],
+  );
+});
+
+test("rejects Pi agent mocks", () => {
+  assert.deepEqual(
+    checkIntegrationTestArchitecture([
+      integrationTest('vi.mock("@earendil-works/pi-agent-core", () => ({}));'),
+    ]),
+    [
+      `${TEST_PATH}: integration tests must not mock Pi's agent (1 found, 0 allowed)`,
+    ],
+  );
+});
+
+test("rejects manufactured agent outcomes", () => {
+  assert.deepEqual(
+    checkIntegrationTestArchitecture([
+      integrationTest(
+        'import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";',
+      ),
+    ]),
+    [
+      `${TEST_PATH}: integration tests must run the real agent instead of manufacturing agent outcomes (1 found, 0 allowed)`,
+    ],
+  );
+});
+
+test("rejects scripted agent runners", () => {
+  assert.deepEqual(
+    checkIntegrationTestArchitecture([
+      integrationTest(
+        "const runner = scriptedAssistantMessageRunner({ messages, result });",
+      ),
+    ]),
+    [
+      `${TEST_PATH}: integration tests must use the model stream instead of a scripted agent runner (1 found, 0 allowed)`,
+    ],
+  );
+});
+
+test("rejects unsafe Slack double casts", () => {
+  assert.deepEqual(
+    checkIntegrationTestArchitecture([
+      integrationTest("const thread = value as unknown as Thread;"),
+    ]),
+    [
+      `${TEST_PATH}: integration tests must use typed Slack fixtures instead of double casts (1 found, 0 allowed)`,
+    ],
+  );
+});
+
+test("allows an exact recorded exception count", () => {
+  assert.deepEqual(
+    checkIntegrationTestArchitecture(
+      [
+        integrationTest(
+          'import { completedAgentRun as finish } from "@/chat/runtime/agent-run-outcome";',
+        ),
+      ],
+      { "manufactured-agent-outcome": { [TEST_PATH]: 1 } },
+    ),
+    [],
+  );
+});
+
+test("rejects more violations than an exception allows", () => {
+  assert.deepEqual(
+    checkIntegrationTestArchitecture(
+      [
+        integrationTest(
+          "scriptedAssistantMessageRunner({});\nscriptedAssistantMessageRunner({});",
+        ),
+      ],
+      { "scripted-agent-runner": { [TEST_PATH]: 1 } },
+    ),
+    [
+      `${TEST_PATH}: integration tests must use the model stream instead of a scripted agent runner (2 found, 1 allowed)`,
+    ],
+  );
+});
+
+test("rejects a stale exception count", () => {
+  assert.deepEqual(
+    checkIntegrationTestArchitecture(
+      [integrationTest("scriptedAssistantMessageRunner({});")],
+      { "scripted-agent-runner": { [TEST_PATH]: 2 } },
+    ),
+    [
+      `scripts/test-architecture-debt.json: scripted-agent-runner allows 2 in ${TEST_PATH}, but 1 found; lower or remove the exception`,
+    ],
+  );
+});
+
+test("rejects unknown exception rules", () => {
+  assert.deepEqual(
+    checkIntegrationTestArchitecture([], {
+      "unknown-rule": { [TEST_PATH]: 1 },
+    }),
+    ["scripts/test-architecture-debt.json: unknown rule unknown-rule"],
+  );
+});
+
+test("rejects exceptions for rules with no existing debt", () => {
+  assert.deepEqual(
+    checkIntegrationTestArchitecture([], {
+      "pi-agent-mock": { [TEST_PATH]: 1 },
+    }),
+    [
+      "scripts/test-architecture-debt.json: pi-agent-mock does not allow exceptions",
+    ],
+  );
+});
+
+test("rejects invalid exception counts", () => {
+  assert.deepEqual(
+    checkIntegrationTestArchitecture([], {
+      "manufactured-agent-outcome": { [TEST_PATH]: 0 },
+    }),
+    [
+      `scripts/test-architecture-debt.json: manufactured-agent-outcome exception for ${TEST_PATH} must be a positive integer`,
+    ],
   );
 });

--- a/scripts/test-architecture-debt.json
+++ b/scripts/test-architecture-debt.json
@@ -1,0 +1,34 @@
+{
+  "manufactured-agent-outcome": {
+    "packages/junior/tests/integration/agent-continue-slack.test.ts": 3,
+    "packages/junior/tests/integration/agent-dispatch-recovery.test.ts": 3,
+    "packages/junior/tests/integration/agent-dispatch-work.test.ts": 4,
+    "packages/junior/tests/integration/agent-invocation-concurrency.test.ts": 4,
+    "packages/junior/tests/integration/agent-invocation-work.test.ts": 3,
+    "packages/junior/tests/integration/local-agent-runner.test.ts": 18,
+    "packages/junior/tests/integration/mcp-oauth-callback.test.ts": 2,
+    "packages/junior/tests/integration/oauth-callback.test.ts": 3,
+    "packages/junior/tests/integration/oauth-resume-slack.test.ts": 4,
+    "packages/junior/tests/integration/slack/assistant-thread-contract.test.ts": 2,
+    "packages/junior/tests/integration/slack/attachment-behavior.test.ts": 3,
+    "packages/junior/tests/integration/slack/attachment-media-behavior.test.ts": 4,
+    "packages/junior/tests/integration/slack/bot-handlers.test.ts": 24,
+    "packages/junior/tests/integration/slack/bot-image-hydration.test.ts": 2,
+    "packages/junior/tests/integration/slack/conversation-turn-steering-behavior.test.ts": 7,
+    "packages/junior/tests/integration/slack/message-changed-behavior.test.ts": 2,
+    "packages/junior/tests/integration/slack/message-changed-reply-contract.test.ts": 3,
+    "packages/junior/tests/integration/slack/message-content-behavior.test.ts": 2,
+    "packages/junior/tests/integration/slack/message-im-attachment-contract.test.ts": 2,
+    "packages/junior/tests/integration/slack/new-mention-behavior.test.ts": 2,
+    "packages/junior/tests/integration/slack/processing-reaction-behavior.test.ts": 6,
+    "packages/junior/tests/integration/slack/provider-default-config-behavior.test.ts": 2,
+    "packages/junior/tests/integration/slack/subscribed-message-behavior.test.ts": 2,
+    "packages/junior/tests/integration/slack/thread-continuity-behavior.test.ts": 2
+  },
+  "scripted-agent-runner": {
+    "packages/junior/tests/integration/api-turn-work.test.ts": 4,
+    "packages/junior/tests/integration/local-agent-runner.test.ts": 3,
+    "packages/junior/tests/integration/oauth-resume-slack.test.ts": 6,
+    "packages/junior/tests/integration/slack/finalized-reply-behavior.test.ts": 7
+  }
+}


### PR DESCRIPTION
The integration test architecture check now rejects new Junior or Pi agent mocks, manufactured agent results, scripted fake runners, and unsafe Slack double casts. Existing manufactured-result and scripted-runner uses are recorded by file and exact reference count; increases and stale counts fail, while rules with no existing exceptions cannot gain them.

This freezes the current baseline without changing runtime or test behavior, so later real-agent migrations can lower the exception file one slice at a time. The 13 checker tests, Junior type checks, and the full repository lint suite pass.

Refs #1425
