### PR TITLE
test: run agent dispatch through real loop

### DIFF
--- a/packages/junior/tests/fixtures/agent-dispatch.ts
+++ b/packages/junior/tests/fixtures/agent-dispatch.ts
@@ -6,11 +6,14 @@ import {
 } from "@sentry/junior-plugin-api";
 import { createOrGetDispatch } from "@/chat/agent-dispatch/store";
 import { buildAgentDispatchInboundMessage } from "@/chat/agent-dispatch/work";
+import { executeAgentRun } from "@/chat/agent";
 import type { ConversationWorkerContext } from "@/chat/task-execution/worker";
 import { createSlackRuntime } from "@/chat/app/factory";
 import { createJuniorSlackAdapter } from "@/chat/slack/adapter";
 import type { CredentialSubject } from "@/chat/credentials/context";
 import type { JuniorRuntimeServiceOverrides } from "@/chat/app/services";
+import { createAgentRunner } from "@/chat/runtime/agent-runner";
+import type { StreamFn } from "@earendil-works/pi-agent-core";
 import { vi } from "vitest";
 
 /** Build a rollout-compatible signed dispatch callback request. */
@@ -52,6 +55,15 @@ export function createAgentDispatchTestRuntime(
       }),
     services: { replyExecutor },
   });
+}
+
+/** Build a dispatch harness that fakes only model output. */
+export function createAgentDispatchModelHarness(streamFn: StreamFn) {
+  const agentRunner = createAgentRunner(executeAgentRun, { streamFn });
+  return {
+    agentRunner,
+    runtime: createAgentDispatchTestRuntime({ agentRunner }),
+  };
 }
 
 /** Create a durable dispatch record for integration tests. */

--- a/packages/junior/tests/fixtures/model-stream.ts
+++ b/packages/junior/tests/fixtures/model-stream.ts
@@ -20,6 +20,11 @@ type FixedModelOutput =
       waitFor?: Promise<unknown>;
     }
   | {
+      type: "error";
+      errorMessage: string;
+      waitFor?: Promise<unknown>;
+    }
+  | {
       type: "message";
       message: AssistantMessage;
       waitFor?: Promise<unknown>;
@@ -32,6 +37,12 @@ function createAssistantMessage(output: FixedModelOutput): AssistantMessage {
   if (output.type === "toolCall") {
     return fauxAssistantMessage([fauxToolCall(output.name, output.arguments)], {
       stopReason: "toolUse",
+    });
+  }
+  if (output.type === "error") {
+    return fauxAssistantMessage("", {
+      stopReason: "error",
+      errorMessage: output.errorMessage,
     });
   }
   return output.message;

--- a/packages/junior/tests/integration/agent-dispatch-recovery.test.ts
+++ b/packages/junior/tests/integration/agent-dispatch-recovery.test.ts
@@ -39,7 +39,9 @@ import { slackApiOutbox } from "../fixtures/slack-api-outbox";
 import { resetSlackApiMockState } from "../msw/handlers/slack-api";
 import { turnCursorKey } from "@/chat/task-execution/turn-cursor-keys";
 import { deliverAssistantMessagesForTest } from "../fixtures/agent-runner";
+import { createModelStream } from "../fixtures/model-stream";
 import {
+  createAgentDispatchModelHarness as createModelHarness,
   createAgentDispatchTestRecord as createDispatch,
   createAgentDispatchTestRuntime as createDispatchRuntime,
   createAgentDispatchWorkerContext as createContext,
@@ -62,33 +64,14 @@ describe("agent dispatch recovery", () => {
 
   it("projects the diagnostic from a terminal model failure", async () => {
     const dispatch = await createDispatch("model-failure-detail");
-    const runtime = createDispatchRuntime({
-      agentRunner: {
-        run: vi.fn(async (request) => {
-          await request.durability.onInputCommitted?.();
-          return completedAgentRun({
-            text: "",
-            piMessages: [
-              {
-                role: "user",
-                content: [{ type: "text", text: dispatch.input }],
-                timestamp: dispatch.createdAtMs,
-              },
-            ],
-            diagnostics: {
-              assistantMessageCount: 0,
-              errorMessage: "Model provider quota exhausted",
-              modelId: "test-model",
-              outcome: "provider_error",
-              toolCalls: [],
-              toolErrorCount: 0,
-              toolResultCount: 0,
-              usedPrimaryText: false,
-            },
-          });
-        }),
-      },
-    });
+    const { runtime } = createModelHarness(
+      createModelStream([
+        {
+          type: "error",
+          errorMessage: "Model provider quota exhausted",
+        },
+      ]),
+    );
     await expect(
       runtime.runDispatchTurn(dispatch, { ack: vi.fn(async () => {}) }),
     ).resolves.toMatchObject({

--- a/packages/junior/tests/integration/agent-dispatch-work.test.ts
+++ b/packages/junior/tests/integration/agent-dispatch-work.test.ts
@@ -14,22 +14,19 @@ import {
 } from "@/chat/agent-dispatch/work";
 import { disconnectStateAdapter, getStateAdapter } from "@/chat/state/adapter";
 import { JUNIOR_THREAD_STATE_TTL_MS } from "@/chat/state/ttl";
-import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 import { createConversationWorkQueueTestAdapter } from "../fixtures/conversation-work";
 import { processConversationQueueMessage } from "@/chat/task-execution/vercel-callback";
-import {
-  listTurnSummaries,
-  recordTurnSummary,
-} from "@/chat/task-execution/turn-cursor";
+import { recordTurnSummary } from "@/chat/task-execution/turn-cursor";
 import { persistConversationMessages } from "@/chat/conversations/messages";
 import { coerceThreadConversationState } from "@/chat/state/conversation";
+import { getUserMessageInstructionText } from "@/chat/pi/transcript";
 import { slackApiOutbox } from "../fixtures/slack-api-outbox";
 import { resetSlackApiMockState } from "../msw/handlers/slack-api";
-import { deliverAssistantMessagesForTest } from "../fixtures/agent-runner";
+import { createModelStream } from "../fixtures/model-stream";
 import {
   agentDispatchTestDestination as destination,
+  createAgentDispatchModelHarness as createModelHarness,
   createAgentDispatchTestRecord as createDispatch,
-  createAgentDispatchTestRuntime as createDispatchRuntime,
   createAgentDispatchWorkerContext as createContext,
 } from "../fixtures/agent-dispatch";
 
@@ -57,33 +54,29 @@ describe("agent dispatch conversation work", () => {
       undefined,
       input,
     );
-    const run = vi.fn(async (request) => {
-      expect(request.instruction.text).toBe(input);
-      await request.durability.onInputCommitted?.();
-      const piMessages = await deliverAssistantMessagesForTest(request, [
-        { text: "Done" },
-      ]);
-      return completedAgentRun({
-        text: "Done",
-        piMessages,
-        diagnostics: {
-          assistantMessageCount: 1,
-          modelId: "test-model",
-          outcome: "success",
-          toolCalls: [],
-          toolErrorCount: 0,
-          toolResultCount: 0,
-          usedPrimaryText: true,
-        },
-      });
-    });
-    const runtime = createDispatchRuntime({ agentRunner: { run } });
+    const modelStream = vi.fn(
+      createModelStream([{ type: "text", text: "Done" }]),
+    );
+    const { runtime } = createModelHarness(modelStream);
 
     await runtime.runDispatchTurn(dispatch, {
       ack: vi.fn(async () => {}),
     });
 
-    expect(run).toHaveBeenCalledOnce();
+    expect(slackApiOutbox.messages()).toEqual([
+      expect.objectContaining({
+        params: expect.objectContaining({ text: "Done" }),
+      }),
+    ]);
+    expect(modelStream).toHaveBeenCalledOnce();
+    const instruction = modelStream.mock.calls[0]?.[1].messages.at(-1);
+    if (!instruction) {
+      throw new Error("Expected one model instruction");
+    }
+    expect(getUserMessageInstructionText(instruction)).toMatchInlineSnapshot(`
+      "Post snake_case as written.
+      - Keep this bullet."
+    `);
   });
 
   it("runs enqueued dispatch work through production routing with exact authority", async () => {
@@ -96,46 +89,10 @@ describe("agent dispatch conversation work", () => {
     const queue = createConversationWorkQueueTestAdapter();
     const state = getStateAdapter();
     await state.connect();
-    const run = vi.fn(async (request) => {
-      expect(request).toMatchObject({
-        conversationId: `agent-dispatch:${dispatch.id}`,
-        turnId: `dispatch:${dispatch.id}`,
-        actor: { platform: "system", name: "scheduler" },
-        credentialContext: {
-          actor: { platform: "system", name: "scheduler" },
-        },
-        destination,
-        destinationVisibility: "private",
-        dispatch: {
-          id: dispatch.id,
-          plugin: "scheduler",
-          replyAttribution: {
-            label: "Scheduled task",
-            detail: "Weekly",
-          },
-        },
-        surface: "api",
-        disabledFeatures: ["interactive-auth"],
-      });
-      await request.durability.onInputCommitted?.();
-      const piMessages = await deliverAssistantMessagesForTest(request, [
-        { text: "Scheduled digest" },
-      ]);
-      return completedAgentRun({
-        text: "Scheduled digest",
-        piMessages,
-        diagnostics: {
-          assistantMessageCount: 1,
-          modelId: "test-model",
-          outcome: "success",
-          toolCalls: [],
-          toolErrorCount: 0,
-          toolResultCount: 0,
-          usedPrimaryText: true,
-        },
-      });
-    });
-    const runtime = createDispatchRuntime({ agentRunner: { run } });
+    const { agentRunner, runtime } = createModelHarness(
+      createModelStream([{ type: "text", text: "Scheduled digest" }]),
+    );
+    const run = vi.spyOn(agentRunner, "run");
     const dispatchWorker = createAgentDispatchConversationWorker({
       resumeTurn: vi.fn(),
       runTurn: runtime.runDispatchTurn,
@@ -161,7 +118,6 @@ describe("agent dispatch conversation work", () => {
       state,
     });
 
-    expect(run).toHaveBeenCalledOnce();
     expect(slackWorker).not.toHaveBeenCalled();
     expect(queue.hasQueuedMessages()).toBe(false);
     expect(slackApiOutbox.messages()).toHaveLength(1);
@@ -173,88 +129,26 @@ describe("agent dispatch conversation work", () => {
       resultMessageTs: expect.any(String),
       status: "completed",
     });
-  });
-
-  it("retries a transient runtime failure instead of treating it as terminal", async () => {
-    const dispatch = await createDispatch("runtime-retry");
-    const queue = createConversationWorkQueueTestAdapter();
-    const state = getStateAdapter();
-    await state.connect();
-    let runCount = 0;
-    const agentRunner = {
-      run: vi.fn(async (request) => {
-        runCount += 1;
-        if (runCount === 1) {
-          throw new Error("provider temporarily unavailable");
-        }
-        await request.durability.onInputCommitted?.();
-        const piMessages = await deliverAssistantMessagesForTest(request, [
-          { text: "Recovered scheduled digest" },
-        ]);
-        return completedAgentRun({
-          text: "Recovered scheduled digest",
-          piMessages,
-          diagnostics: {
-            assistantMessageCount: 1,
-            modelId: "test-model",
-            outcome: "success",
-            toolCalls: [],
-            toolErrorCount: 0,
-            toolResultCount: 0,
-            usedPrimaryText: true,
-          },
-        });
-      }),
-    };
-    const runtime = createDispatchRuntime({ agentRunner });
-    const route = createAgentDispatchWorkRouter({
-      dispatchWorker: createAgentDispatchConversationWorker({
-        resumeTurn: vi.fn(),
-        runTurn: runtime.runDispatchTurn,
-      }),
-      fallbackWorker: vi.fn(async () => ({
-        status: "completed" as const,
-      })),
-    });
-
-    await enqueueAgentDispatch(dispatch, { queue, state });
-    await expect(
-      processConversationQueueMessage(queue.takeMessage(), {
-        queue,
-        run: route,
-        state,
-      }),
-    ).resolves.toEqual({ status: "failed" });
-
-    expect(agentRunner.run).toHaveBeenCalledOnce();
-    await expect(getDispatchRecord(dispatch.id)).resolves.toMatchObject({
-      status: "running",
-    });
-    await expect(
-      listTurnSummaries(getDispatchConversationId(dispatch)),
-    ).resolves.toEqual([
-      expect.not.objectContaining({ dispatchOutcome: expect.anything() }),
-    ]);
-
-    await expect(
-      processConversationQueueMessage(queue.takeMessage(), {
-        queue,
-        run: route,
-        state,
-      }),
-    ).resolves.toEqual({ status: "completed" });
-
-    expect(agentRunner.run).toHaveBeenCalledTimes(2);
-    expect(slackApiOutbox.messages()).toEqual([
-      expect.objectContaining({
-        params: expect.objectContaining({
-          channel: destination.channelId,
-          text: "Recovered scheduled digest",
-        }),
-      }),
-    ]);
-    await expect(getDispatchRecord(dispatch.id)).resolves.toMatchObject({
-      status: "completed",
+    expect(run).toHaveBeenCalledOnce();
+    expect(run.mock.calls[0]?.[0]).toMatchObject({
+      conversationId: `agent-dispatch:${dispatch.id}`,
+      turnId: `dispatch:${dispatch.id}`,
+      actor: { platform: "system", name: "scheduler" },
+      credentialContext: {
+        actor: { platform: "system", name: "scheduler" },
+      },
+      destination,
+      destinationVisibility: "private",
+      dispatch: {
+        id: dispatch.id,
+        plugin: "scheduler",
+        replyAttribution: {
+          label: "Scheduled task",
+          detail: "Weekly",
+        },
+      },
+      surface: "api",
+      disabledFeatures: ["interactive-auth"],
     });
   });
 
@@ -367,8 +261,10 @@ describe("agent dispatch conversation work", () => {
       },
     );
     await persistConversationMessages({ conversation, conversationId });
-    const agentRunner = { run: vi.fn() };
-    const runtime = createDispatchRuntime({ agentRunner });
+    const { agentRunner, runtime } = createModelHarness(
+      createModelStream([{ type: "text", text: "Unexpected reply" }]),
+    );
+    const run = vi.spyOn(agentRunner, "run");
     const worker = createAgentDispatchConversationWorker({
       resumeTurn: vi.fn(),
       runTurn: runtime.runDispatchTurn,
@@ -379,7 +275,7 @@ describe("agent dispatch conversation work", () => {
       status: "completed",
     });
 
-    expect(agentRunner.run).not.toHaveBeenCalled();
+    expect(run).not.toHaveBeenCalled();
     expect(ack).toHaveBeenCalledOnce();
     await expect(getDispatchRecord(dispatch.id)).resolves.toMatchObject({
       resultMessageTs: "1700000000.000009",

--- a/scripts/test-architecture-debt.json
+++ b/scripts/test-architecture-debt.json
@@ -1,8 +1,7 @@
 {
   "manufactured-agent-outcome": {
     "packages/junior/tests/integration/agent-continue-slack.test.ts": 3,
-    "packages/junior/tests/integration/agent-dispatch-recovery.test.ts": 3,
-    "packages/junior/tests/integration/agent-dispatch-work.test.ts": 4,
+    "packages/junior/tests/integration/agent-dispatch-recovery.test.ts": 2,
     "packages/junior/tests/integration/agent-invocation-concurrency.test.ts": 4,
     "packages/junior/tests/integration/agent-invocation-work.test.ts": 3,
     "packages/junior/tests/integration/local-agent-runner.test.ts": 18,


### PR DESCRIPTION
Agent dispatch integration tests now run normal completion, exact-input handling, replay protection, and terminal provider failure through the production runner and Pi agent loop. Fixed model output remains at the stream boundary, including a new provider-error response, while Slack uses the existing typed adapter and HTTP outbox.

The duplicate transient runner test is removed because the durable queue suite already owns that retry contract. The pre-cutover resume case remains recorded debt because it must seed legacy stored state. Focused dispatch tests, Junior type checks, and the full repository lint suite pass.

Refs #1425
