### PR TITLE
test: run child agent invocation through real loop

### DIFF
--- a/packages/junior/tests/fixtures/agent-dispatch.ts
+++ b/packages/junior/tests/fixtures/agent-dispatch.ts
@@ -6,15 +6,14 @@ import {
 } from "@sentry/junior-plugin-api";
 import { createOrGetDispatch } from "@/chat/agent-dispatch/store";
 import { buildAgentDispatchInboundMessage } from "@/chat/agent-dispatch/work";
-import { executeAgentRun } from "@/chat/agent";
 import type { ConversationWorkerContext } from "@/chat/task-execution/worker";
 import { createSlackRuntime } from "@/chat/app/factory";
 import { createJuniorSlackAdapter } from "@/chat/slack/adapter";
 import type { CredentialSubject } from "@/chat/credentials/context";
 import type { JuniorRuntimeServiceOverrides } from "@/chat/app/services";
-import { createAgentRunner } from "@/chat/runtime/agent-runner";
 import type { StreamFn } from "@earendil-works/pi-agent-core";
 import { vi } from "vitest";
+import { createModelAgentRunner } from "./agent-runner";
 
 /** Build a rollout-compatible signed dispatch callback request. */
 export function createSignedDispatchCallbackRequest(
@@ -59,7 +58,7 @@ export function createAgentDispatchTestRuntime(
 
 /** Build a dispatch harness that fakes only model output. */
 export function createAgentDispatchModelHarness(streamFn: StreamFn) {
-  const agentRunner = createAgentRunner(executeAgentRun, { streamFn });
+  const agentRunner = createModelAgentRunner(streamFn);
   return {
     agentRunner,
     runtime: createAgentDispatchTestRuntime({ agentRunner }),

--- a/packages/junior/tests/fixtures/agent-runner.ts
+++ b/packages/junior/tests/fixtures/agent-runner.ts
@@ -1,4 +1,8 @@
-import type { AgentRunner } from "@/chat/runtime/agent-runner";
+import {
+  createAgentRunner,
+  type AgentRunner,
+} from "@/chat/runtime/agent-runner";
+import type { StreamFn } from "@earendil-works/pi-agent-core";
 import type { AssistantMessage } from "@earendil-works/pi-ai";
 import { fauxAssistantMessage } from "@earendil-works/pi-ai/providers/faux";
 import type { AgentRunResult } from "@/chat/services/turn-result";
@@ -23,6 +27,17 @@ export const realAgentRunner: AgentRunner = {
     return await executeAgentRun(run);
   },
 };
+
+/** Run the real agent while replacing only model output. */
+export function createModelAgentRunner(streamFn: StreamFn): AgentRunner {
+  return createAgentRunner(
+    async (run, boundStreamFn) => {
+      const { executeAgentRun } = await import("@/chat/agent");
+      return await executeAgentRun(run, boundStreamFn);
+    },
+    { streamFn },
+  );
+}
 
 /**
  * Guard runner for paths that must never reach agent execution; failing loud

--- a/packages/junior/tests/integration/agent-invocation-work.test.ts
+++ b/packages/junior/tests/integration/agent-invocation-work.test.ts
@@ -19,6 +19,7 @@ import { createSpawnAgentTool } from "@/chat/tools/runtime/spawn-agent";
 import type { AgentRun } from "@/chat/agent/types";
 import { migrateSchema } from "@/chat/conversations/sql/migrations";
 import { createSqlStore } from "@/chat/conversations/sql/store";
+import { loadProjection } from "@/chat/conversations/projection";
 import { disconnectStateAdapter, getStateAdapter } from "@/chat/state/adapter";
 import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 import { processConversationQueueMessage } from "@/chat/task-execution/vercel-callback";
@@ -31,6 +32,8 @@ import {
 } from "@/chat/task-execution/turn-cursor";
 import { createConversationWorkQueueTestAdapter } from "../fixtures/conversation-work";
 import { createConfiguredJuniorSqlFixture } from "../fixtures/sql";
+import { createModelAgentRunner } from "../fixtures/agent-runner";
+import { createModelStream } from "../fixtures/model-stream";
 
 const parentConversationId = "local:test:parent-agent";
 const destination = {
@@ -179,12 +182,12 @@ describe("agent invocation conversation work", () => {
       const request = {
         conversationId: parentConversationId,
         turnId: "parent-turn",
-        instruction: { text: "Delegate the investigation.", },
+        instruction: { text: "Delegate the investigation." },
         actor: { platform: "local", userId: "local-user" },
         credentialContext: {
           actor: { type: "user", userId: "local-user" },
         },
-          destination,
+        destination,
         destinationVisibility: "private",
         source: createLocalSource(parentConversationId),
       } satisfies AgentRun;
@@ -258,40 +261,17 @@ describe("agent invocation conversation work", () => {
           state,
         },
       );
-      const run = vi.fn(async (request) => {
-        expect(request).toMatchObject({
-          conversationId: created.childConversationId,
-          instruction: { text: invocationInput.input },
-          disabledFeatures: ["handoff", "interactive-auth", "subagents"],
-          reasoning: "medium",
-          actor: invocationInput.actor,
-          destination,
-          destinationVisibility: "private",
-          source: invocationInput.source,
-          surface: "internal",
-          runId: created.invocationId,
-        });
-        await request.durability.onInputCommitted?.();
-        return completedAgentRun({
-          diagnostics: {
-            assistantMessageCount: 1,
-            modelId: "test-model",
-            outcome: "success",
-            toolCalls: [],
-            toolErrorCount: 0,
-            toolResultCount: 0,
-            usedPrimaryText: true,
-          },
-          text: "Durable child result",
-        });
-      });
+      const agentRunner = createModelAgentRunner(
+        createModelStream([{ type: "text", text: "Durable child result" }]),
+      );
+      const run = vi.spyOn(agentRunner, "run");
       const fallbackWorker = vi.fn(async () => ({
         status: "completed" as const,
       }));
       const route = routeAgentInvocationWork({
         fallbackWorker,
         invocationWorker: createAgentInvocationWorker({
-          agentRunner: { run },
+          agentRunner,
         }),
       });
       const queueMessage = queue.takeMessage();
@@ -313,8 +293,6 @@ describe("agent invocation conversation work", () => {
         }),
       ).resolves.toMatchObject({ status: "no_work" });
 
-      expect(run).toHaveBeenCalledOnce();
-      expect(fallbackWorker).not.toHaveBeenCalled();
       await expect(
         getAgentInvocation(created.invocationId),
       ).resolves.toMatchObject({
@@ -333,6 +311,35 @@ describe("agent invocation conversation work", () => {
       await expect(getAgentInvocation(created.invocationId)).resolves.toEqual(
         completed,
       );
+      await expect(
+        loadProjection({ conversationId: created.childConversationId }),
+      ).resolves.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            role: "assistant",
+            content: expect.arrayContaining([
+              expect.objectContaining({
+                type: "text",
+                text: "Durable child result",
+              }),
+            ]),
+          }),
+        ]),
+      );
+      expect(run).toHaveBeenCalledOnce();
+      expect(run.mock.calls[0]?.[0]).toMatchObject({
+        conversationId: created.childConversationId,
+        instruction: { text: invocationInput.input },
+        disabledFeatures: ["handoff", "interactive-auth", "subagents"],
+        reasoning: "medium",
+        actor: invocationInput.actor,
+        destination,
+        destinationVisibility: "private",
+        source: invocationInput.source,
+        surface: "internal",
+        runId: created.invocationId,
+      });
+      expect(fallbackWorker).not.toHaveBeenCalled();
     } finally {
       await fixture.close();
     }
@@ -363,7 +370,11 @@ describe("agent invocation conversation work", () => {
             runCount += 1;
             await request.durability.onInputCommitted?.();
             if (runCount === 1) {
-              return { resumeVersion: 1, status: "suspended" as const, reason: "timeout" as const };
+              return {
+                resumeVersion: 1,
+                status: "suspended" as const,
+                reason: "timeout" as const,
+              };
             }
             return completedAgentRun({
               diagnostics: {

--- a/scripts/test-architecture-debt.json
+++ b/scripts/test-architecture-debt.json
@@ -3,7 +3,7 @@
     "packages/junior/tests/integration/agent-continue-slack.test.ts": 3,
     "packages/junior/tests/integration/agent-dispatch-recovery.test.ts": 2,
     "packages/junior/tests/integration/agent-invocation-concurrency.test.ts": 4,
-    "packages/junior/tests/integration/agent-invocation-work.test.ts": 3,
+    "packages/junior/tests/integration/agent-invocation-work.test.ts": 2,
     "packages/junior/tests/integration/local-agent-runner.test.ts": 18,
     "packages/junior/tests/integration/mcp-oauth-callback.test.ts": 2,
     "packages/junior/tests/integration/oauth-callback.test.ts": 3,


### PR DESCRIPTION
Child agent invocation integration coverage now enqueues and executes normal child work through the production runner and real Pi agent loop with fixed model output. The test proves the terminal child result, saved assistant history, execution authority, and replay protection, while dispatch tests now reuse the same shared model-backed runner.

The yielded child resume case remains explicit debt for a later timeout and resume slice. This change lowers the invocation work exception from three references to two; focused integration tests, Junior type checks, and the full repository lint suite pass.

Refs #1425
