### PR TITLE
test: run child agent resume through real loop

### DIFF
--- a/packages/junior/tests/integration/agent-invocation-work.test.ts
+++ b/packages/junior/tests/integration/agent-invocation-work.test.ts
@@ -21,7 +21,6 @@ import { migrateSchema } from "@/chat/conversations/sql/migrations";
 import { createSqlStore } from "@/chat/conversations/sql/store";
 import { loadProjection } from "@/chat/conversations/projection";
 import { disconnectStateAdapter, getStateAdapter } from "@/chat/state/adapter";
-import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 import { processConversationQueueMessage } from "@/chat/task-execution/vercel-callback";
 import { recoverPendingAgentInvocationMailboxAppends } from "@/chat/agent-dispatch/heartbeat";
 import { CONVERSATION_WORK_MAX_DELIVERY_ATTEMPTS } from "@/chat/task-execution/store";
@@ -363,33 +362,15 @@ describe("agent invocation conversation work", () => {
           state,
         },
       );
-      let runCount = 0;
+      const agentRunner = createModelAgentRunner(
+        createModelStream([
+          { type: "toolCall", name: "systemTime", arguments: {} },
+          { type: "text", text: "Resumed child result" },
+        ]),
+      );
+      const run = vi.spyOn(agentRunner, "run");
       const invocationWorker = createAgentInvocationWorker({
-        agentRunner: {
-          run: vi.fn(async (request) => {
-            runCount += 1;
-            await request.durability.onInputCommitted?.();
-            if (runCount === 1) {
-              return {
-                resumeVersion: 1,
-                status: "suspended" as const,
-                reason: "timeout" as const,
-              };
-            }
-            return completedAgentRun({
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "test-model",
-                outcome: "success",
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-              text: "Resumed child result",
-            });
-          }),
-        },
+        agentRunner,
       });
       const route = routeAgentInvocationWork({
         fallbackWorker: vi.fn(async () => ({ status: "completed" as const })),
@@ -401,12 +382,28 @@ describe("agent invocation conversation work", () => {
           conversationStore,
           queue,
           run: route,
+          softYieldAfterMs: 0,
           state,
         }),
       ).resolves.toMatchObject({ status: "yielded" });
       await expect(
         getAgentInvocation(created.invocationId),
       ).resolves.toMatchObject({ status: "awaiting_resume" });
+      await expect(
+        getTurnRecord(
+          created.childConversationId,
+          getAgentInvocationTurnId(created.invocationId),
+        ),
+      ).resolves.toMatchObject({
+        state: "paused",
+        resumeReason: "yield",
+        piMessages: expect.arrayContaining([
+          expect.objectContaining({
+            role: "toolResult",
+            toolName: "systemTime",
+          }),
+        ]),
+      });
 
       await expect(
         processConversationQueueMessage(queue.takeMessage(), {
@@ -416,13 +413,35 @@ describe("agent invocation conversation work", () => {
           state,
         }),
       ).resolves.toMatchObject({ status: "completed" });
-      expect(runCount).toBe(2);
+      expect(run).toHaveBeenCalledTimes(2);
       await expect(
         getAgentInvocation(created.invocationId),
       ).resolves.toMatchObject({
         result: "Resumed child result",
         status: "completed",
       });
+      const projection = await loadProjection({
+        conversationId: created.childConversationId,
+      });
+      expect(
+        projection.filter(
+          (message) =>
+            message.role === "toolResult" && message.toolName === "systemTime",
+        ),
+      ).toHaveLength(1);
+      expect(projection).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            role: "assistant",
+            content: expect.arrayContaining([
+              expect.objectContaining({
+                type: "text",
+                text: "Resumed child result",
+              }),
+            ]),
+          }),
+        ]),
+      );
     } finally {
       await fixture.close();
     }

--- a/scripts/test-architecture-debt.json
+++ b/scripts/test-architecture-debt.json
@@ -3,7 +3,6 @@
     "packages/junior/tests/integration/agent-continue-slack.test.ts": 3,
     "packages/junior/tests/integration/agent-dispatch-recovery.test.ts": 2,
     "packages/junior/tests/integration/agent-invocation-concurrency.test.ts": 4,
-    "packages/junior/tests/integration/agent-invocation-work.test.ts": 2,
     "packages/junior/tests/integration/local-agent-runner.test.ts": 18,
     "packages/junior/tests/integration/mcp-oauth-callback.test.ts": 2,
     "packages/junior/tests/integration/oauth-callback.test.ts": 3,


### PR DESCRIPTION
Child agent invocation resume coverage now runs the real agent with fixed model output. The first worker slice calls the real `systemTime` tool and pauses after its result is stored. The next queue wake resumes the same turn, stores the final response, and proves the tool work is not repeated.

This removes the manufactured agent outcome and its temporary test architecture exception, so the automated check prevents that weaker pattern from returning. The focused integration test, package typecheck, test architecture check, and full pre-push checks pass.
