### PR TITLE
test: run dispatch recovery through real agent

### DIFF
--- a/packages/junior/tests/integration/agent-dispatch-recovery.test.ts
+++ b/packages/junior/tests/integration/agent-dispatch-recovery.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { createLocalSource } from "@sentry/junior-plugin-api";
+import { createSlackSource } from "@sentry/junior-plugin-api";
 import {
   getDispatchConversationId,
   getDispatchInputMessageId,
@@ -19,12 +19,10 @@ import {
 } from "@/chat/agent-dispatch/work";
 import { disconnectStateAdapter, getStateAdapter } from "@/chat/state/adapter";
 import { JUNIOR_THREAD_STATE_TTL_MS } from "@/chat/state/ttl";
-import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 import { createConversationWorkQueueTestAdapter } from "../fixtures/conversation-work";
 import { processConversationQueueMessage } from "@/chat/task-execution/vercel-callback";
 import { runNextPausedTurn } from "@/chat/task-execution/paused-turn";
 import { wakePausedTurn } from "@/chat/task-execution/turn-wake";
-import { saveTurnCheckpoint } from "@/chat/task-execution/checkpoint";
 import {
   getTurnRecord,
   listTurnSummaries,
@@ -38,7 +36,7 @@ import { coerceThreadConversationState } from "@/chat/state/conversation";
 import { slackApiOutbox } from "../fixtures/slack-api-outbox";
 import { resetSlackApiMockState } from "../msw/handlers/slack-api";
 import { turnCursorKey } from "@/chat/task-execution/turn-cursor-keys";
-import { deliverAssistantMessagesForTest } from "../fixtures/agent-runner";
+import { createModelAgentRunner } from "../fixtures/agent-runner";
 import { createModelStream } from "../fixtures/model-stream";
 import {
   createAgentDispatchModelHarness as createModelHarness,
@@ -127,85 +125,23 @@ describe("agent dispatch recovery", () => {
           signature: "v1=test",
         },
       },
-      createLocalSource("local:cli:dispatch-origin"),
+      createSlackSource({
+        teamId: "T123",
+        channelId: "C123",
+        visibility: "private",
+      }),
       { label: "Scheduled task", detail: "Weekly" },
     );
     const queue = createConversationWorkQueueTestAdapter();
     const state = getStateAdapter();
     await state.connect();
-    let runCount = 0;
-    const agentRunner = {
-      run: vi.fn(async (request) => {
-        runCount += 1;
-        if (runCount === 1) {
-          await request.durability.onInputCommitted?.();
-          const session = await saveTurnCheckpoint({
-            mode: "paused",
-            reason: "yield",
-            actor: dispatch.actor,
-            conversationId: request.conversationId,
-            sliceId: 3,
-            destination: dispatch.destination,
-            dispatchId: dispatch.id,
-            errorMessage: "Conversation worker yielded",
-            messages: [
-              {
-                role: "user",
-                content: [{ type: "text", text: dispatch.input }],
-                timestamp: dispatch.createdAtMs,
-              },
-            ],
-            turnId: request.turnId,
-            source: dispatch.source,
-            surface: "api",
-          });
-          if (!session) {
-            throw new Error("Expected a durable yielded dispatch session");
-          }
-          return {
-            status: "suspended" as const,
-            reason: "yield" as const,
-            resumeVersion: session.version,
-          };
-        }
-
-        expect(request).toMatchObject({
-          actor: dispatch.actor,
-          credentialContext: {
-            actor: dispatch.actor,
-            subject: dispatch.credentialSubject,
-          },
-          dispatch: {
-            id: dispatch.id,
-            plugin: dispatch.plugin,
-            replyAttribution: dispatch.replyAttribution,
-          },
-          source: createLocalSource("local:cli:dispatch-origin"),
-          surface: "api",
-        });
-        expect(request.instruction.text).toBe(dispatch.input);
-        expect(request.instruction.context).toBeUndefined();
-        expect(JSON.stringify(request.history)).not.toContain(
-          "expose system credentials",
-        );
-        const piMessages = await deliverAssistantMessagesForTest(request, [
-          { text: "Resumed scheduled digest" },
-        ]);
-        return completedAgentRun({
-          text: "Resumed scheduled digest",
-          piMessages,
-          diagnostics: {
-            assistantMessageCount: 1,
-            modelId: "test-model",
-            outcome: "success",
-            toolCalls: [],
-            toolErrorCount: 0,
-            toolResultCount: 0,
-            usedPrimaryText: true,
-          },
-        });
-      }),
-    };
+    const agentRunner = createModelAgentRunner(
+      createModelStream([
+        { type: "toolCall", name: "systemTime", arguments: {} },
+        { type: "text", text: "Resumed scheduled digest" },
+      ]),
+    );
+    const runAgent = vi.spyOn(agentRunner, "run");
     const runtime = createDispatchRuntime({
       agentRunner,
       wakePausedTurn: async (request) => {
@@ -245,6 +181,8 @@ describe("agent dispatch recovery", () => {
       await processConversationQueueMessage(queue.takeMessage(), {
         queue,
         run: route,
+        // Pause the first slice after the tool result is saved.
+        softYieldAfterMs: deliveries === 1 ? 0 : undefined,
         state,
       });
       if (deliveries === 1) {
@@ -282,14 +220,13 @@ describe("agent dispatch recovery", () => {
           storedSession as Record<string, unknown>;
         await state.set(
           sessionKey,
-          preCutoverSession,
+          // Older records can lack dispatchId and already be on slice 3.
+          { ...preCutoverSession, sliceId: 3 },
           JUNIOR_THREAD_STATE_TTL_MS,
         );
       }
     }
 
-    expect(slackWorker).not.toHaveBeenCalled();
-    expect(agentRunner.run).toHaveBeenCalledTimes(2);
     expect(slackApiOutbox.messages()).toHaveLength(1);
     expect(slackApiOutbox.messages()[0]?.params).toMatchObject({
       text: "Resumed scheduled digest\n\nScheduled task · Weekly",
@@ -317,6 +254,28 @@ describe("agent dispatch recovery", () => {
       resultMessageTs: expect.any(String),
       status: "completed",
     });
+    expect(slackWorker).not.toHaveBeenCalled();
+    expect(runAgent).toHaveBeenCalledTimes(2);
+    const resumedRun = runAgent.mock.calls[1]?.[0];
+    expect(resumedRun).toMatchObject({
+      actor: dispatch.actor,
+      credentialContext: {
+        actor: dispatch.actor,
+        subject: dispatch.credentialSubject,
+      },
+      dispatch: {
+        id: dispatch.id,
+        plugin: dispatch.plugin,
+        replyAttribution: dispatch.replyAttribution,
+      },
+      source: dispatch.source,
+      surface: "api",
+    });
+    expect(resumedRun?.instruction.text).toBe(dispatch.input);
+    expect(resumedRun?.instruction.context).toBeUndefined();
+    expect(JSON.stringify(resumedRun?.history)).not.toContain(
+      "expose system credentials",
+    );
   });
 
   it("repairs a pending mailbox append without owning execution recovery", async () => {

--- a/scripts/test-architecture-debt.json
+++ b/scripts/test-architecture-debt.json
@@ -1,7 +1,6 @@
 {
   "manufactured-agent-outcome": {
     "packages/junior/tests/integration/agent-continue-slack.test.ts": 3,
-    "packages/junior/tests/integration/agent-dispatch-recovery.test.ts": 2,
     "packages/junior/tests/integration/local-agent-runner.test.ts": 18,
     "packages/junior/tests/integration/mcp-oauth-callback.test.ts": 2,
     "packages/junior/tests/integration/oauth-callback.test.ts": 3,


### PR DESCRIPTION
Dispatch recovery now proves a pre-cutover paused turn through the real agent and durable worker. A fixed model stream calls the real `systemTime` tool, the worker pauses after saving its result, the test rewrites the saved record into the older shape, and the next queue wake resumes the turn and delivers the Slack reply.

The former fake runner also hid an invalid local-source and Slack-destination pair, so the fixture now matches a production scheduled dispatch. This removes two manufactured outcome debt entries without changing production code. The related integration suites, typecheck, architecture checks, lint, formatting, and full pre-push checks pass.

Refs #1425
