### PR TITLE
test: run Slack continuation through real agent

### DIFF
--- a/packages/junior/tests/component/task-execution/paused-turn.test.ts
+++ b/packages/junior/tests/component/task-execution/paused-turn.test.ts
@@ -2,7 +2,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createSlackSource } from "@sentry/junior-plugin-api";
 import { getConversationStore } from "@/chat/db";
 import { disconnectStateAdapter } from "@/chat/state/adapter";
-import { persistThreadStateById } from "@/chat/runtime/thread-state";
+import {
+  getPersistedThreadState,
+  persistThreadStateById,
+} from "@/chat/runtime/thread-state";
 import {
   getTurnRecord,
   upsertTurnRecord,
@@ -223,14 +226,107 @@ describe("paused turn runner callbacks", () => {
             if (!prepared || !prepared.replyContext) {
               throw new Error("Expected prepared paused-turn reply context");
             }
-            seenPublishExternally =
-              prepared.replyContext.publishExternally;
+            seenPublishExternally = prepared.replyContext.publishExternally;
             return true;
           },
         },
       ),
     ).resolves.toBe(true);
     expect(seenPublishExternally).toBe(true);
+  });
+
+  it("requests another wake when a high-slice continuation suspends", async () => {
+    const conversationId = "slack:C123:1712345.0002";
+    const sessionId = "turn_msg_2";
+    const sessionRecord = await upsertTurnRecord({
+      conversationId,
+      turnId: sessionId,
+      sliceId: 5,
+      state: "paused",
+      destination: SLACK_DESTINATION,
+      source: createSlackSource({
+        teamId: SLACK_DESTINATION.teamId,
+        channelId: SLACK_DESTINATION.channelId,
+        threadTs: "1712345.0002",
+        visibility: "private",
+      }),
+      piMessages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "hello" }],
+          timestamp: 1,
+        },
+      ],
+      resumeReason: "timeout",
+      resumedFromSliceId: 4,
+      errorMessage: "Agent turn timed out",
+      actor: {
+        platform: "slack",
+        teamId: SLACK_DESTINATION.teamId,
+        userId: "U123",
+        userName: "testuser",
+        fullName: "Test User",
+        email: "testuser@example.com",
+      },
+    });
+    await seedConversationRouting({
+      conversationId,
+      threadTs: "1712345.0002",
+    });
+    await persistThreadStateById(conversationId, {
+      conversation: {
+        schemaVersion: 1,
+        compactions: [],
+        messages: [
+          {
+            id: "msg.2",
+            role: "user",
+            text: "resume this request",
+            createdAtMs: 1,
+            author: { userId: "U123" },
+          },
+        ],
+        processing: { activeTurnId: sessionId },
+        vision: { byFileId: {} },
+      },
+    });
+
+    const wakePausedTurn = vi.fn(async () => {});
+    const { runPausedTurn } = await import("@/chat/task-execution/paused-turn");
+    await expect(
+      runPausedTurn(
+        {
+          conversationId,
+          destination: SLACK_DESTINATION,
+          turnId: sessionId,
+          expectedVersion: sessionRecord.version,
+        },
+        {
+          agentRunner: agentRunnerShouldNotRun,
+          wakePausedTurn,
+          resumeTurn: async (args) => {
+            const prepared = await args.beforeStart?.();
+            if (!prepared) {
+              throw new Error("Expected the continuation to prepare");
+            }
+            const runArgs = { ...args, ...prepared };
+            await runArgs.onSuspend?.(sessionRecord.version + 1);
+            return true;
+          },
+        },
+      ),
+    ).resolves.toBe(true);
+    expect(wakePausedTurn).toHaveBeenCalledWith({
+      conversationId,
+      destination: SLACK_DESTINATION,
+      turnId: sessionId,
+      expectedVersion: sessionRecord.version + 1,
+    });
+    const persisted = await getPersistedThreadState(conversationId);
+    const conversation = (persisted.conversation ?? {}) as {
+      processing?: { activeTurnId?: string };
+    };
+    expect(conversation.processing?.activeTurnId).toBe(sessionId);
   });
 
   it("fails before continuing when sql conversation source is missing", async () => {

--- a/packages/junior/tests/integration/agent-continue-slack-file-delivery.test.ts
+++ b/packages/junior/tests/integration/agent-continue-slack-file-delivery.test.ts
@@ -1,0 +1,266 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createSlackSource } from "@sentry/junior-plugin-api";
+import {
+  SLACK_DESTINATION,
+  createConversationWorkQueueTestAdapter,
+  type ConversationWorkQueueTestAdapter,
+} from "../fixtures/conversation-work";
+import { slackApiOutbox } from "../fixtures/slack-api-outbox";
+import { resetSlackApiMockState } from "../msw/handlers/slack-api";
+import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
+import { hydrateConversationMessages } from "@/chat/conversations/messages";
+import { coerceThreadConversationState } from "@/chat/state/conversation";
+import type { AgentRun } from "@/chat/agent/types";
+import type { AgentRunner } from "@/chat/runtime/agent-runner";
+import type { SandboxWorkspace } from "@/chat/sandbox/workspace";
+import { createTools } from "@/chat/tools";
+import type { ToolRuntimeContext } from "@/chat/tools/types";
+import { deliverAssistantMessagesForTest } from "../fixtures/agent-runner";
+
+const ORIGINAL_ENV = { ...process.env };
+
+function slackSource(threadTs: string) {
+  return createSlackSource({
+    teamId: SLACK_DESTINATION.teamId,
+    channelId: SLACK_DESTINATION.channelId,
+    threadTs,
+    visibility: "private",
+  });
+}
+
+function createSandbox(files: Record<string, Buffer>): SandboxWorkspace {
+  return {
+    readFileToBuffer: async ({ path }) => files[path] ?? null,
+    runCommand: async () => ({
+      exitCode: 0,
+      stdout: "image/png\n",
+      stderr: "",
+    }),
+    writeFiles: async () => undefined,
+  };
+}
+
+function createToolContext(
+  request: AgentRun,
+  workspace: SandboxWorkspace,
+): ToolRuntimeContext {
+  if (
+    request.source.platform !== "slack" ||
+    request.destination.platform !== "slack"
+  ) {
+    throw new Error("test requires Slack tool context");
+  }
+
+  return {
+    configuration: request.environment?.configuration,
+    conversationId: request.conversationId,
+    destination: request.destination,
+    egress: {} as ToolRuntimeContext["egress"],
+    actor: request.actor?.platform === "slack" ? request.actor : undefined,
+    workspace,
+    source: request.source,
+    surface: request.surface,
+    userText: request.instruction.text,
+  };
+}
+
+type StateAdapterModule = typeof import("@/chat/state/adapter");
+type ThreadStateModule = typeof import("@/chat/runtime/thread-state");
+type PausedTurnModule = typeof import("@/chat/task-execution/paused-turn");
+type RequestDeadlineModule = typeof import("@/chat/runtime/request-deadline");
+type TurnSessionStoreModule =
+  typeof import("@/chat/task-execution/turn-cursor");
+type TurnWakeModule = typeof import("@/chat/task-execution/turn-wake");
+
+let stateAdapterModule: StateAdapterModule;
+let threadStateModule: ThreadStateModule;
+let pausedTurnModule: PausedTurnModule;
+let requestDeadlineModule: RequestDeadlineModule;
+let turnSessionStoreModule: TurnSessionStoreModule;
+let turnWakeModule: TurnWakeModule;
+let queue: ConversationWorkQueueTestAdapter;
+let agentRunner: AgentRunner;
+
+function continueAgentRun(args: {
+  conversationId: string;
+  sessionId: string;
+  expectedVersion: number;
+}): Promise<boolean> {
+  return requestDeadlineModule.runWithTurnRequestDeadline(() =>
+    pausedTurnModule.runPausedTurn(
+      {
+        conversationId: args.conversationId,
+        destination: SLACK_DESTINATION,
+        expectedVersion: args.expectedVersion,
+        turnId: args.sessionId,
+      },
+      {
+        agentRunner,
+        wakePausedTurn: (request) =>
+          turnWakeModule.wakePausedTurn(request, { queue }),
+      },
+    ),
+  );
+}
+
+describe("paused turn Slack file delivery", () => {
+  beforeEach(async () => {
+    queue = createConversationWorkQueueTestAdapter();
+    resetSlackApiMockState();
+    process.env = {
+      ...ORIGINAL_ENV,
+      JUNIOR_STATE_ADAPTER: "memory",
+      JUNIOR_BASE_URL: "https://junior.example.com",
+      JUNIOR_SECRET: "resume-secret",
+      SLACK_BOT_TOKEN: process.env.SLACK_BOT_TOKEN ?? "xoxb-test-token",
+    };
+
+    vi.resetModules();
+    stateAdapterModule = await import("@/chat/state/adapter");
+    threadStateModule = await import("@/chat/runtime/thread-state");
+    pausedTurnModule = await import("@/chat/task-execution/paused-turn");
+    requestDeadlineModule = await import("@/chat/runtime/request-deadline");
+    turnSessionStoreModule = await import("@/chat/task-execution/turn-cursor");
+    turnWakeModule = await import("@/chat/task-execution/turn-wake");
+
+    await stateAdapterModule.disconnectStateAdapter();
+    await stateAdapterModule.getStateAdapter().connect();
+  });
+
+  afterEach(async () => {
+    await stateAdapterModule.disconnectStateAdapter();
+    process.env = { ...ORIGINAL_ENV };
+    vi.restoreAllMocks();
+  });
+
+  it("posts resumed replies through the shared delivery path", async () => {
+    const conversationId = "slack:C123:1712345.0003";
+    const sessionId = "turn_msg_3";
+    const sessionRecord = await turnSessionStoreModule.upsertTurnRecord({
+      conversationId,
+      turnId: sessionId,
+      sliceId: 2,
+      state: "paused",
+      destination: SLACK_DESTINATION,
+      source: slackSource("1712345.0003"),
+      piMessages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "hello" }],
+          timestamp: 1,
+        },
+      ],
+      resumeReason: "timeout",
+      resumedFromSliceId: 1,
+      errorMessage: "Agent turn timed out",
+      actor: {
+        platform: "slack",
+        teamId: SLACK_DESTINATION.teamId,
+        userId: "U123",
+        userName: "testuser",
+        fullName: "Test User",
+        email: "testuser@example.com",
+      },
+    });
+
+    agentRunner = {
+      run: async (request) => {
+        const tools = createTools(
+          [],
+          {},
+          createToolContext(
+            request,
+            createSandbox({
+              "/tmp/resumed-image.png": Buffer.from("resumed image"),
+            }),
+          ),
+        );
+        const sendFiles = tools.sendFiles;
+        if (!sendFiles?.execute) {
+          throw new Error("sendFiles tool missing from resumed Slack context");
+        }
+        await sendFiles.execute(
+          { files: [{ path: "/tmp/resumed-image.png" }] },
+          {} as never,
+        );
+
+        await deliverAssistantMessagesForTest(request, [
+          { text: "Final resumed answer." },
+        ]);
+        return completedAgentRun({
+          text: "Final resumed answer.",
+          diagnostics: {
+            assistantMessageCount: 1,
+            modelId: "fake-agent-model",
+            outcome: "success",
+            toolCalls: [],
+            toolErrorCount: 0,
+            toolResultCount: 0,
+            usedPrimaryText: true,
+          },
+        });
+      },
+    };
+
+    await threadStateModule.persistThreadStateById(conversationId, {
+      conversation: {
+        schemaVersion: 1,
+        compactions: [],
+        messages: [
+          {
+            id: "msg.3",
+            role: "user",
+            text: "resume this request",
+            createdAtMs: 1,
+            author: { userId: "U123", userName: "alice" },
+          },
+        ],
+        processing: { activeTurnId: sessionId },
+        vision: { byFileId: {} },
+      },
+    });
+
+    const continued = await continueAgentRun({
+      conversationId,
+      sessionId,
+      expectedVersion: sessionRecord.version,
+    });
+
+    expect(continued).toBe(true);
+    expect(slackApiOutbox.messages()).toEqual([
+      expect.objectContaining({
+        params: expect.objectContaining({
+          channel: "C123",
+          thread_ts: "1712345.0003",
+          text: "Final resumed answer.",
+        }),
+      }),
+    ]);
+    expect(slackApiOutbox.calls("files.getUploadURLExternal")).toHaveLength(1);
+    expect(slackApiOutbox.fileUploads()).toHaveLength(1);
+    expect(
+      slackApiOutbox.calls("files.completeUploadExternal")[0]?.params,
+    ).toMatchObject({
+      channel_id: "C123",
+      thread_ts: "1712345.0003",
+    });
+    expect(slackApiOutbox.calls("files.completeUploadExternal")).toHaveLength(
+      1,
+    );
+
+    const persisted =
+      await threadStateModule.getPersistedThreadState(conversationId);
+    const processing = (
+      (persisted.conversation ?? {}) as {
+        processing?: { activeTurnId?: string };
+      }
+    ).processing;
+    expect(processing?.activeTurnId).toBeUndefined();
+    const conversation = coerceThreadConversationState({});
+    await hydrateConversationMessages({ conversation, conversationId });
+    expect(conversation.messages.at(-1)).toMatchObject({
+      role: "assistant",
+      text: "Final resumed answer.",
+    });
+  });
+});

--- a/packages/junior/tests/integration/agent-continue-slack.test.ts
+++ b/packages/junior/tests/integration/agent-continue-slack.test.ts
@@ -7,16 +7,12 @@ import {
 } from "../fixtures/conversation-work";
 import { slackApiOutbox } from "../fixtures/slack-api-outbox";
 import { resetSlackApiMockState } from "../msw/handlers/slack-api";
-import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 import { hydrateConversationMessages } from "@/chat/conversations/messages";
 import { coerceThreadConversationState } from "@/chat/state/conversation";
 import type { AgentRun } from "@/chat/agent/types";
-import type { SandboxWorkspace } from "@/chat/sandbox/workspace";
-import { createTools } from "@/chat/tools";
-import type { ToolRuntimeContext } from "@/chat/tools/types";
-import { deliverAssistantMessagesForTest } from "../fixtures/agent-runner";
-
-const executeAgentRunMock = vi.fn();
+import type { AgentRunner } from "@/chat/runtime/agent-runner";
+import { createModelAgentRunnerForRun } from "../fixtures/agent-runner";
+import { createModelStream } from "../fixtures/model-stream";
 
 const ORIGINAL_ENV = { ...process.env };
 const TEST_USAGE = {
@@ -44,58 +40,6 @@ function slackSource(threadTs: string) {
   });
 }
 
-function makeDiagnostics() {
-  return {
-    assistantMessageCount: 1,
-    modelId: "fake-agent-model",
-    outcome: "success" as const,
-    toolCalls: [],
-    toolErrorCount: 0,
-    toolResultCount: 0,
-    usedPrimaryText: true,
-  };
-}
-
-function createSandbox(files: Record<string, Buffer>): SandboxWorkspace {
-  return {
-    readFileToBuffer: async ({ path }) => files[path] ?? null,
-    runCommand: async () => ({
-      exitCode: 0,
-      stdout: "image/png\n",
-      stderr: "",
-    }),
-    writeFiles: async () => undefined,
-  };
-}
-
-/** Build a Slack tool context from the resumed request to exercise continuation file sends. */
-function createToolContext(
-  request: AgentRun,
-  workspace: SandboxWorkspace,
-): ToolRuntimeContext {
-  if (
-    request.source.platform !== "slack" ||
-    request.destination.platform !== "slack"
-  ) {
-    throw new Error("test requires Slack tool context");
-  }
-
-  return {
-    configuration: request.environment?.configuration,
-    conversationId: request.conversationId,
-    destination: request.destination,
-    egress: {} as ToolRuntimeContext["egress"],
-    actor:
-      request.actor?.platform === "slack"
-        ? request.actor
-        : undefined,
-    workspace,
-    source: request.source,
-    surface: request.surface,
-    userText: request.instruction.text,
-  };
-}
-
 type StateAdapterModule = typeof import("@/chat/state/adapter");
 type ThreadStateModule = typeof import("@/chat/runtime/thread-state");
 type PausedTurnModule = typeof import("@/chat/task-execution/paused-turn");
@@ -113,6 +57,8 @@ let turnSessionStoreModule: TurnSessionStoreModule;
 let turnWakeModule: TurnWakeModule;
 let taskExecutionStoreModule: TaskExecutionStoreModule;
 let queue: ConversationWorkQueueTestAdapter;
+let agentRunner: AgentRunner;
+let agentRuns: AgentRun[];
 
 function continueAgentRun(args: {
   conversationId: string;
@@ -130,7 +76,7 @@ function continueAgentRun(args: {
         turnId: args.sessionId,
       },
       {
-        agentRunner: { run: executeAgentRunMock },
+        agentRunner,
         wakePausedTurn: (request) =>
           turnWakeModule.wakePausedTurn(request, {
             queue,
@@ -143,15 +89,12 @@ function continueAgentRun(args: {
 describe("paused turn Slack integration", () => {
   beforeEach(async () => {
     queue = createConversationWorkQueueTestAdapter();
-    executeAgentRunMock.mockReset();
-    executeAgentRunMock.mockImplementation(async (request) => {
-      await deliverAssistantMessagesForTest(request, [
-        { text: "Final resumed answer" },
+    agentRuns = [];
+    agentRunner = createModelAgentRunnerForRun((run) => {
+      agentRuns.push(run);
+      return createModelStream([
+        { type: "text", text: "Final resumed answer" },
       ]);
-      return completedAgentRun({
-        text: "Final resumed answer",
-        diagnostics: makeDiagnostics(),
-      });
     });
     resetSlackApiMockState();
     process.env = {
@@ -256,40 +199,6 @@ describe("paused turn Slack integration", () => {
 
     expect(continued).toBe(true);
 
-    expect(executeAgentRunMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        instruction: expect.objectContaining({
-          text: "resume this request",
-          inboundAttachmentCount: 2,
-          omittedImageAttachmentCount: 1,
-        }),
-          actor: {
-            platform: "slack",
-            teamId: "T123",
-            userId: "U123",
-          },
-          destination: SLACK_DESTINATION,
-          source: storedSource,
-          toolChannelId: "C123",
-        state: expect.objectContaining({
-          sandboxRef: undefined,
-        }),
-      }),
-    );
-    const resumeContext = executeAgentRunMock.mock.calls[0]?.[0] as {
-      deadlineAtMs?: number;
-      environment?: {
-        locationConfiguration?: {
-          resolve: (key: string) => Promise<unknown>;
-        };
-      };
-    };
-    expect(resumeContext.deadlineAtMs).toEqual(expect.any(Number));
-    expect(resumeContext.deadlineAtMs).toBeGreaterThan(Date.now());
-    expect(
-      await resumeContext.environment?.locationConfiguration?.resolve("demo.org"),
-    ).toBe("acme");
-
     expect(slackApiOutbox.calls("assistant.threads.setStatus")).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -318,6 +227,40 @@ describe("paused turn Slack integration", () => {
         }),
       }),
     ]);
+    expect(agentRuns).toHaveLength(1);
+    expect(agentRuns[0]).toMatchObject({
+      instruction: {
+        text: "resume this request",
+        inboundAttachmentCount: 2,
+        omittedImageAttachmentCount: 1,
+      },
+      actor: {
+        platform: "slack",
+        teamId: "T123",
+        userId: "U123",
+      },
+      destination: SLACK_DESTINATION,
+      source: storedSource,
+      toolChannelId: "C123",
+      state: expect.objectContaining({
+        sandboxRef: undefined,
+      }),
+    });
+    const resumeContext = agentRuns[0] as {
+      deadlineAtMs?: number;
+      environment?: {
+        locationConfiguration?: {
+          resolve: (key: string) => Promise<unknown>;
+        };
+      };
+    };
+    expect(resumeContext.deadlineAtMs).toEqual(expect.any(Number));
+    expect(resumeContext.deadlineAtMs).toBeGreaterThan(Date.now());
+    expect(
+      await resumeContext.environment?.locationConfiguration?.resolve(
+        "demo.org",
+      ),
+    ).toBe("acme");
 
     const persisted =
       await threadStateModule.getPersistedThreadState(conversationId);
@@ -343,6 +286,10 @@ describe("paused turn Slack integration", () => {
         turnId: sessionId,
         inputMessageIds: ["msg.1"],
         surface: "slack",
+      }),
+      expect.objectContaining({
+        type: "turn_routed",
+        turnId: sessionId,
       }),
       expect.objectContaining({
         type: "turn_completed",
@@ -419,16 +366,15 @@ describe("paused turn Slack integration", () => {
         }),
       }),
     ]);
-    expect(executeAgentRunMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        instruction: expect.objectContaining({ text: "resume this request" }),
-          actor: {
-            platform: "slack",
-            teamId: "T123",
-            userId: "U123",
-          },
-      }),
-    );
+    expect(agentRuns).toHaveLength(1);
+    expect(agentRuns[0]).toMatchObject({
+      instruction: { text: "resume this request" },
+      actor: {
+        platform: "slack",
+        teamId: "T123",
+        userId: "U123",
+      },
+    });
   });
 
   it("restores explicit progress from the active turn", async () => {
@@ -599,94 +545,6 @@ describe("paused turn Slack integration", () => {
     );
   });
 
-  it("schedules another continuation for high slice ids", async () => {
-    const conversationId = "slack:C123:1712345.0002";
-    const sessionId = "turn_msg_2";
-    const sessionRecord = await turnSessionStoreModule.upsertTurnRecord({
-      conversationId,
-      turnId: sessionId,
-      sliceId: 5,
-      state: "paused",
-      destination: SLACK_DESTINATION,
-      source: slackSource("1712345.0002"),
-      piMessages: [
-        {
-          role: "user",
-          content: [{ type: "text", text: "hello" }],
-          timestamp: 1,
-        },
-      ],
-      resumeReason: "timeout",
-      resumedFromSliceId: 4,
-      errorMessage: "Agent turn timed out",
-      actor: {
-        platform: "slack",
-        teamId: SLACK_DESTINATION.teamId,
-        userId: "U123",
-        userName: "testuser",
-        fullName: "Test User",
-        email: "testuser@example.com",
-      },
-    });
-
-    await threadStateModule.persistThreadStateById(conversationId, {
-      conversation: {
-        schemaVersion: 1,
-        compactions: [],
-        messages: [
-          {
-            id: "msg.2",
-            role: "user",
-            text: "resume this request",
-            createdAtMs: 1,
-            author: {
-              userId: "U123",
-            },
-          },
-        ],
-        processing: {
-          activeTurnId: sessionId,
-        },
-        vision: {
-          byFileId: {},
-        },
-      },
-    });
-
-    // retry (not timeout): leased timeout hands the lease back via yield error.
-    // This case covers the onSuspend → wake path for another continuation.
-    executeAgentRunMock.mockResolvedValueOnce({
-      status: "suspended",
-      reason: "retry",
-      resumeVersion: sessionRecord.version + 1,
-    });
-
-    const continued = await continueAgentRun({
-      conversationId,
-      sessionId,
-      expectedVersion: sessionRecord.version,
-    });
-
-    expect(continued).toBe(true);
-
-    expect(slackApiOutbox.messages()).toEqual([]);
-    expect(queue.sentRecords()).toEqual([
-      {
-        conversationId,
-        idempotencyKey: expect.stringContaining(
-          `agent-continue:${conversationId}:${sessionId}:`,
-        ),
-      },
-    ]);
-
-    const persisted =
-      await threadStateModule.getPersistedThreadState(conversationId);
-    const conversation = (persisted.conversation ?? {}) as {
-      processing?: { activeTurnId?: string };
-    };
-    expect(conversation.processing?.activeTurnId).toBe(sessionId);
-  });
-
   it("terminalizes startup failures before the visible failure path runs", async () => {
     const conversationId = "slack:C123:1712345.0007";
     const sessionId = "turn_msg_7";
@@ -739,7 +597,6 @@ describe("paused turn Slack integration", () => {
 
     // Missing author id is fail-closed without throwing out of beforeStart.
     expect(continued).toBe(false);
-    expect(executeAgentRunMock).not.toHaveBeenCalled();
     await expect(
       turnSessionStoreModule.getTurnRecord(conversationId, sessionId),
     ).resolves.toMatchObject({
@@ -757,6 +614,7 @@ describe("paused turn Slack integration", () => {
         }),
       }),
     ]);
+    expect(agentRuns).toEqual([]);
   });
 
   it("resumes resource-event turns with the rebuilt system actor", async () => {
@@ -815,16 +673,15 @@ describe("paused turn Slack integration", () => {
     });
 
     expect(continued).toBe(true);
-    expect(executeAgentRunMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-          actor: { platform: "system", name: "resource-event" },
-          credentialContext: {
-            actor: { platform: "system", name: "resource-event" },
-          },
-          destination: SLACK_DESTINATION,
-          source: storedSource,
-      }),
-    );
+    expect(agentRuns).toHaveLength(1);
+    expect(agentRuns[0]).toMatchObject({
+      actor: { platform: "system", name: "resource-event" },
+      credentialContext: {
+        actor: { platform: "system", name: "resource-event" },
+      },
+      destination: SLACK_DESTINATION,
+      source: storedSource,
+    });
   });
 
   it("rebuilds the resume actor from the message author when redis has no actor", async () => {
@@ -883,15 +740,14 @@ describe("paused turn Slack integration", () => {
     });
 
     expect(continued).toBe(true);
-    expect(executeAgentRunMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-          actor: {
-            platform: "slack",
-            teamId: "T123",
-            userId: "U123",
-          },
-      }),
-    );
+    expect(agentRuns).toHaveLength(1);
+    expect(agentRuns[0]).toMatchObject({
+      actor: {
+        platform: "slack",
+        teamId: "T123",
+        userId: "U123",
+      },
+    });
   });
 
   it("recovers the resume actor from the durable conversation record", async () => {
@@ -962,17 +818,6 @@ describe("paused turn Slack integration", () => {
     });
 
     expect(continued).toBe(true);
-    expect(executeAgentRunMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        instruction: expect.objectContaining({ text: "resume this request" }),
-          actor: expect.objectContaining({
-            userId: "U123",
-            userName: "testuser",
-            fullName: "Test User",
-            email: "testuser@example.com",
-        }),
-      }),
-    );
     expect(slackApiOutbox.messages()).toEqual([
       expect.objectContaining({
         params: expect.objectContaining({
@@ -982,136 +827,15 @@ describe("paused turn Slack integration", () => {
         }),
       }),
     ]);
-  });
-
-  it("posts resumed replies through the shared delivery path", async () => {
-    const conversationId = "slack:C123:1712345.0003";
-    const sessionId = "turn_msg_3";
-    const sessionRecord = await turnSessionStoreModule.upsertTurnRecord({
-      conversationId,
-      turnId: sessionId,
-      sliceId: 2,
-      state: "paused",
-      destination: SLACK_DESTINATION,
-      source: slackSource("1712345.0003"),
-      piMessages: [
-        {
-          role: "user",
-          content: [{ type: "text", text: "hello" }],
-          timestamp: 1,
-        },
-      ],
-      resumeReason: "timeout",
-      resumedFromSliceId: 1,
-      errorMessage: "Agent turn timed out",
-      actor: {
-        platform: "slack",
-        teamId: SLACK_DESTINATION.teamId,
+    expect(agentRuns).toHaveLength(1);
+    expect(agentRuns[0]).toMatchObject({
+      instruction: { text: "resume this request" },
+      actor: expect.objectContaining({
         userId: "U123",
         userName: "testuser",
         fullName: "Test User",
         email: "testuser@example.com",
-      },
-    });
-
-    executeAgentRunMock.mockImplementationOnce(async (request) => {
-      const tools = createTools(
-        [],
-        {},
-        createToolContext(
-          request as AgentRun,
-          createSandbox({
-            "/tmp/resumed-image.png": Buffer.from("resumed image"),
-          }),
-        ),
-      );
-      const sendFiles = tools.sendFiles;
-      if (!sendFiles?.execute) {
-        throw new Error("sendFiles tool missing from resumed Slack context");
-      }
-      await sendFiles.execute(
-        {
-          files: [{ path: "/tmp/resumed-image.png" }],
-        },
-        {} as never,
-      );
-
-      await deliverAssistantMessagesForTest(request, [
-        { text: "Final resumed answer." },
-      ]);
-      return completedAgentRun({
-        text: "Final resumed answer.",
-        diagnostics: makeDiagnostics(),
-      });
-    });
-
-    await threadStateModule.persistThreadStateById(conversationId, {
-      conversation: {
-        schemaVersion: 1,
-        compactions: [],
-        messages: [
-          {
-            id: "msg.3",
-            role: "user",
-            text: "resume this request",
-            createdAtMs: 1,
-            author: {
-              userId: "U123",
-              userName: "alice",
-            },
-          },
-        ],
-        processing: {
-          activeTurnId: sessionId,
-        },
-        vision: {
-          byFileId: {},
-        },
-      },
-    });
-
-    const continued = await continueAgentRun({
-      conversationId,
-      sessionId,
-      expectedVersion: sessionRecord.version,
-    });
-
-    expect(continued).toBe(true);
-
-    expect(slackApiOutbox.messages()).toEqual([
-      expect.objectContaining({
-        params: expect.objectContaining({
-          channel: "C123",
-          thread_ts: "1712345.0003",
-          text: "Final resumed answer.",
-        }),
       }),
-    ]);
-    expect(slackApiOutbox.calls("files.getUploadURLExternal")).toHaveLength(1);
-    expect(slackApiOutbox.fileUploads()).toHaveLength(1);
-    expect(
-      slackApiOutbox.calls("files.completeUploadExternal")[0]?.params,
-    ).toMatchObject({
-      channel_id: "C123",
-      thread_ts: "1712345.0003",
-    });
-    expect(slackApiOutbox.calls("files.completeUploadExternal")).toHaveLength(
-      1,
-    );
-
-    const persisted =
-      await threadStateModule.getPersistedThreadState(conversationId);
-    const processing = (
-      (persisted.conversation ?? {}) as {
-        processing?: { activeTurnId?: string };
-      }
-    ).processing;
-    expect(processing?.activeTurnId).toBeUndefined();
-    const conversation = coerceThreadConversationState({});
-    await hydrateConversationMessages({ conversation, conversationId });
-    expect(conversation.messages.at(-1)).toMatchObject({
-      role: "assistant",
-      text: "Final resumed answer.",
     });
   });
 });

--- a/scripts/file-length-exceptions.mjs
+++ b/scripts/file-length-exceptions.mjs
@@ -56,8 +56,6 @@ export const fileLengthExceptions = {
     "Existing broad conversation work suite; split by behavior.",
   "packages/junior/tests/component/task-execution/slack-conversation-work.test.ts":
     "Existing broad Slack conversation work suite; split by behavior.",
-  "packages/junior/tests/integration/agent-continue-slack.test.ts":
-    "Existing broad Slack continuation suite; split by behavior.",
   "packages/junior/tests/integration/local-agent-runner.test.ts":
     "Existing broad local runner suite; split by behavior.",
   "packages/junior/tests/component/auth/mcp-auth-runtime-slack.test.ts":

--- a/scripts/test-architecture-debt.json
+++ b/scripts/test-architecture-debt.json
@@ -1,6 +1,6 @@
 {
   "manufactured-agent-outcome": {
-    "packages/junior/tests/integration/agent-continue-slack.test.ts": 3,
+    "packages/junior/tests/integration/agent-continue-slack-file-delivery.test.ts": 2,
     "packages/junior/tests/integration/local-agent-runner.test.ts": 18,
     "packages/junior/tests/integration/mcp-oauth-callback.test.ts": 2,
     "packages/junior/tests/integration/oauth-callback.test.ts": 3,


### PR DESCRIPTION
Paused Slack continuation now runs the real agent with fixed model output for normal replies, restored progress, missing profile data, resource-event identity, and user identity recovery. Prompt building, model continuation, delivery, persistence, and turn events now use the same code as production; the coverage includes the `turn_routed` event that the former fake runner skipped.

The high-slice wake contract moved to the narrow paused-turn component boundary. Resumed file delivery is isolated in a smaller integration file for the next real-tool migration. This reduces the main suite from 1,117 to 841 lines, removes its file-length exception, and reduces its manufactured outcome debt from three entries to two without changing production code. The related 36 tests, typecheck, lint, architecture and file-length checks, formatting, and full pre-push checks pass.

Refs #1425
