### PR TITLE
test: run OAuth Slack resume through real agent

### DIFF
--- a/packages/junior/tests/component/runtime/slack-resume.test.ts
+++ b/packages/junior/tests/component/runtime/slack-resume.test.ts
@@ -1,0 +1,281 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createSlackSource } from "@sentry/junior-plugin-api";
+import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
+import { disconnectStateAdapter } from "@/chat/state/adapter";
+import { getCapturedSlackApiCalls } from "../../msw/handlers/slack-api";
+
+const ORIGINAL_STATE_ADAPTER = process.env.JUNIOR_STATE_ADAPTER;
+const TEST_SLACK_DESTINATION = {
+  platform: "slack",
+  teamId: "T123",
+  channelId: "C123",
+} as const;
+
+function testSlackSource(threadTs: string) {
+  return createSlackSource({
+    teamId: TEST_SLACK_DESTINATION.teamId,
+    channelId: TEST_SLACK_DESTINATION.channelId,
+    threadTs,
+    visibility: "private",
+  });
+}
+
+function makeDiagnostics() {
+  return {
+    assistantMessageCount: 0,
+    modelId: "fake-agent-model",
+    outcome: "execution_failure" as const,
+    toolCalls: [],
+    toolErrorCount: 0,
+    toolResultCount: 0,
+    usedPrimaryText: false,
+  };
+}
+
+describe("Slack resume result handling", () => {
+  beforeEach(async () => {
+    process.env.JUNIOR_STATE_ADAPTER = "memory";
+    vi.resetModules();
+    await disconnectStateAdapter();
+  });
+
+  afterEach(async () => {
+    await disconnectStateAdapter();
+    if (ORIGINAL_STATE_ADAPTER === undefined) {
+      delete process.env.JUNIOR_STATE_ADAPTER;
+    } else {
+      process.env.JUNIOR_STATE_ADAPTER = ORIGINAL_STATE_ADAPTER;
+    }
+  });
+
+  it("posts the safe fallback when failure-state persistence fails", async () => {
+    const { resumeSlackTurn } = await import("@/chat/runtime/slack-resume");
+    const { getConversationEventStore } = await import("@/chat/db");
+    const conversationId = "slack:T123:C123:1700000000.009";
+    const turnId = "turn_1700000000_009";
+
+    await expect(
+      resumeSlackTurn({
+        messageText: "Resume the failed turn",
+        channelId: "C123",
+        threadTs: "1700000000.009",
+        inputMessageIds: ["msg.9"],
+        conversationId,
+        turnId,
+        replyContext: {
+          credentialContext: {
+            actor: { type: "user", userId: "U123" },
+          },
+          destination: TEST_SLACK_DESTINATION,
+          source: testSlackSource("1700000000.009"),
+          actor: { platform: "slack", teamId: "T123", userId: "U123" },
+        },
+        agentRunner: {
+          run: async () => {
+            throw new Error("resume failed");
+          },
+        },
+        onFailure: async () => {
+          throw new Error("failure state unavailable");
+        },
+      }),
+    ).rejects.toThrow("failure state unavailable");
+
+    expect(getCapturedSlackApiCalls("chat.postMessage")).toEqual([
+      expect.objectContaining({
+        params: expect.objectContaining({
+          channel: "C123",
+          thread_ts: "1700000000.009",
+          text: expect.stringContaining(
+            "I ran into an internal error while processing that. Reference: `event_id=",
+          ),
+        }),
+      }),
+    ]);
+
+    const lifecycle = (
+      await getConversationEventStore().loadHistory(conversationId)
+    ).filter((event) => event.data.type.startsWith("turn_"));
+    expect(lifecycle.map((event) => event.data)).toEqual([
+      expect.objectContaining({
+        type: "turn_started",
+        turnId,
+        inputMessageIds: ["msg.9"],
+        surface: "slack",
+      }),
+      expect.objectContaining({
+        type: "turn_failed",
+        turnId,
+        failureCode: "persistence_failed",
+        eventId: expect.stringMatching(/^[a-f0-9]{32}$/i),
+      }),
+    ]);
+  });
+
+  it("posts an auth pause notice with the conversation footer", async () => {
+    const { resumeSlackTurn } = await import("@/chat/runtime/slack-resume");
+
+    await resumeSlackTurn({
+      messageText: "continue this turn",
+      conversationId: "conversation-auth-pause",
+      turnId: "turn-auth-pause",
+      channelId: "C123",
+      threadTs: "1700000000.008",
+      initialText: "",
+      replyContext: {
+        credentialContext: {
+          actor: { type: "user", userId: "U123" },
+        },
+        destination: TEST_SLACK_DESTINATION,
+        source: testSlackSource("1700000000.008"),
+        actor: { platform: "slack", teamId: "T123", userId: "U123" },
+      },
+      agentRunner: {
+        run: async () => ({
+          status: "awaiting_auth" as const,
+          providerDisplayName: "Eval Auth",
+        }),
+      },
+      onAuthPause: async () => undefined,
+    });
+
+    expect(getCapturedSlackApiCalls("chat.postMessage")).toEqual([
+      expect.objectContaining({
+        params: expect.objectContaining({
+          channel: "C123",
+          thread_ts: "1700000000.008",
+          text: "<@U123> I'll need you to authorize Eval Auth. I sent you a link.",
+          blocks: expect.any(Array),
+        }),
+      }),
+    ]);
+    expect(
+      JSON.stringify(
+        getCapturedSlackApiCalls("chat.postMessage")[0]?.params.blocks,
+      ),
+    ).toContain("conversation-auth-pause");
+  });
+
+  it("replaces an execution-failure result before Slack planning", async () => {
+    const { resumeSlackTurn } = await import("@/chat/runtime/slack-resume");
+
+    await resumeSlackTurn({
+      messageText: "Continue the original request",
+      conversationId: "slack:C123:1700000000.006",
+      turnId: "turn-resume-execution-failure",
+      channelId: "C123",
+      threadTs: "1700000000.006",
+      initialText: "Connected. Continuing...",
+      replyContext: {
+        credentialContext: {
+          actor: { type: "user", userId: "U123" },
+        },
+        destination: TEST_SLACK_DESTINATION,
+        source: testSlackSource("1700000000.006"),
+        actor: { platform: "slack", teamId: "T123", userId: "U123" },
+      },
+      agentRunner: {
+        run: async () =>
+          completedAgentRun({ text: "", diagnostics: makeDiagnostics() }),
+      },
+    });
+
+    expect(getCapturedSlackApiCalls("chat.postMessage").at(-1)?.params).toEqual(
+      expect.objectContaining({
+        channel: "C123",
+        thread_ts: "1700000000.006",
+        text: expect.stringContaining(
+          "I ran into an internal error while processing that. Reference: `event_id=",
+        ),
+      }),
+    );
+  });
+
+  it("releases the thread lock before scheduling a suspended continuation", async () => {
+    const { resumeSlackTurn } = await import("@/chat/runtime/slack-resume");
+    const { getStateAdapter } = await import("@/chat/state/adapter");
+    const onSuspend = vi.fn(async () => {
+      const stateAdapter = getStateAdapter();
+      await stateAdapter.connect();
+      const lock = await stateAdapter.acquireLock(
+        "slack:C123:1700000000.013",
+        60_000,
+      );
+      expect(lock).not.toBeNull();
+      if (lock) {
+        await stateAdapter.releaseLock(lock);
+      }
+    });
+
+    await resumeSlackTurn({
+      messageText: "continue this turn",
+      conversationId: "slack:C123:1700000000.013",
+      turnId: "turn-resume-lock-release",
+      channelId: "C123",
+      threadTs: "1700000000.013",
+      replyContext: {
+        credentialContext: {
+          actor: { type: "user", userId: "U123" },
+        },
+        destination: TEST_SLACK_DESTINATION,
+        source: testSlackSource("1700000000.013"),
+        actor: { platform: "slack", teamId: "T123", userId: "U123" },
+      },
+      agentRunner: {
+        run: async () => ({
+          status: "suspended" as const,
+          reason: "timeout" as const,
+          resumeVersion: 3,
+        }),
+      },
+      onSuspend,
+    });
+
+    expect(onSuspend).toHaveBeenCalledOnce();
+    expect(onSuspend).toHaveBeenCalledWith(3);
+    expect(getCapturedSlackApiCalls("chat.postMessage")).toEqual([]);
+  });
+
+  it("runs failure handling when suspended continuation scheduling fails", async () => {
+    const { resumeSlackTurn } = await import("@/chat/runtime/slack-resume");
+    const onFailure = vi.fn(async () => undefined);
+
+    await resumeSlackTurn({
+      messageText: "continue this turn",
+      conversationId: "slack:C123:1700000000.014",
+      turnId: "turn-resume-suspend-fail",
+      channelId: "C123",
+      threadTs: "1700000000.014",
+      replyContext: {
+        credentialContext: {
+          actor: { type: "user", userId: "U123" },
+        },
+        destination: TEST_SLACK_DESTINATION,
+        source: testSlackSource("1700000000.014"),
+        actor: { platform: "slack", teamId: "T123", userId: "U123" },
+      },
+      agentRunner: {
+        run: async () => ({
+          status: "suspended" as const,
+          reason: "timeout" as const,
+          resumeVersion: 3,
+        }),
+      },
+      onSuspend: async () => {
+        throw new Error("continuation scheduling failed");
+      },
+      onFailure,
+    });
+
+    expect(onFailure).toHaveBeenCalledOnce();
+    expect(
+      getCapturedSlackApiCalls("chat.postMessage").map(
+        (call) => call.params.text,
+      ),
+    ).toEqual([
+      expect.stringContaining(
+        "I ran into an internal error while processing that. Reference: `event_id=",
+      ),
+    ]);
+  });
+});

--- a/packages/junior/tests/integration/oauth-resume-slack.test.ts
+++ b/packages/junior/tests/integration/oauth-resume-slack.test.ts
@@ -1,28 +1,20 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createSlackSource } from "@sentry/junior-plugin-api";
+import { fauxAssistantMessage } from "@earendil-works/pi-ai/providers/faux";
 import {
   getSlackContinuationMarker,
   getSlackInterruptionMarker,
 } from "@/chat/slack/output";
 import { disconnectStateAdapter } from "@/chat/state/adapter";
 import { getCapturedSlackApiCalls } from "../msw/handlers/slack-api";
-import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
-import { scriptedAssistantMessageRunner } from "../fixtures/agent-runner";
+import {
+  createModelAgentRunner,
+  neverRunAgentRunner,
+} from "../fixtures/agent-runner";
+import { createModelStream } from "../fixtures/model-stream";
 
-function makeDiagnostics(
-  outcome: "success" | "execution_failure" | "provider_error" = "success",
-  extras: Record<string, unknown> = {},
-) {
-  return {
-    assistantMessageCount: 1,
-    modelId: "fake-agent-model",
-    outcome,
-    toolCalls: [],
-    toolErrorCount: 0,
-    toolResultCount: 0,
-    usedPrimaryText: true,
-    ...extras,
-  };
+function modelReply(text: string) {
+  return createModelAgentRunner(createModelStream([{ type: "text", text }]));
 }
 
 const TEST_SLACK_DESTINATION = {
@@ -72,27 +64,16 @@ describe("oauth resume slack integration", () => {
       initialText:
         "Your eval-auth MCP access is now connected. Continuing the original request...",
       replyContext: {
-          credentialContext: {
-            actor: { type: "user", userId: "U123" },
-          },
-          destination: TEST_SLACK_DESTINATION,
-          source: testSlackSource("1700000000.001"),
-          actor: { platform: "slack", teamId: "T123", userId: "U123" },
-      },
-      agentRunner: scriptedAssistantMessageRunner({
-        messages: [
-          { text: "The budget deadline you mentioned earlier was Friday." },
-        ],
-        result: {
-          text: "The budget deadline you mentioned earlier was Friday.",
-          diagnostics: makeDiagnostics("success", {
-            durationMs: 842,
-            usage: {
-              totalTokens: 1234,
-            },
-          }),
+        credentialContext: {
+          actor: { type: "user", userId: "U123" },
         },
-      }),
+        destination: TEST_SLACK_DESTINATION,
+        source: testSlackSource("1700000000.001"),
+        actor: { platform: "slack", teamId: "T123", userId: "U123" },
+      },
+      agentRunner: modelReply(
+        "The budget deadline you mentioned earlier was Friday.",
+      ),
       commitResult: async () => {
         expect(
           getCapturedSlackApiCalls("assistant.threads.setStatus").at(-1)
@@ -139,14 +120,7 @@ describe("oauth resume slack integration", () => {
 
   it("validates credentials before starting Slack resume UX", async () => {
     const { resumeSlackTurn } = await import("@/chat/runtime/slack-resume");
-    const agentRunner = {
-      run: vi.fn(async () =>
-        completedAgentRun({
-          text: "should not run",
-          diagnostics: makeDiagnostics(),
-        }),
-      ),
-    };
+    const agentRunner = neverRunAgentRunner();
 
     await resumeSlackTurn({
       messageText: "Continue the original request",
@@ -157,17 +131,16 @@ describe("oauth resume slack integration", () => {
       initialText: "Connected. Continuing...",
       initialStatus: { text: "Continuing request" },
       replyContext: {
-          credentialContext: {
-            actor: { type: "user", userId: "U456" },
-          },
-          destination: TEST_SLACK_DESTINATION,
-          source: testSlackSource("1700000000.011"),
-          actor: { platform: "slack", teamId: "T123", userId: "U123" },
+        credentialContext: {
+          actor: { type: "user", userId: "U456" },
+        },
+        destination: TEST_SLACK_DESTINATION,
+        source: testSlackSource("1700000000.011"),
+        actor: { platform: "slack", teamId: "T123", userId: "U123" },
       },
       agentRunner,
     });
 
-    expect(agentRunner.run).not.toHaveBeenCalled();
     expect(getCapturedSlackApiCalls("assistant.threads.setStatus")).toEqual([]);
     expect(
       getCapturedSlackApiCalls("chat.postMessage").map(
@@ -192,14 +165,22 @@ describe("oauth resume slack integration", () => {
       threadTs: "1700000000.010",
       initialText: "Connected. Continuing...",
       replyContext: {
-          credentialContext: {
-            actor: { type: "user", userId: "U123" },
-          },
-          destination: TEST_SLACK_DESTINATION,
-          source: testSlackSource("1700000000.010"),
-          actor: { platform: "slack", teamId: "T123", userId: "U123" },
+        credentialContext: {
+          actor: { type: "user", userId: "U123" },
+        },
+        destination: TEST_SLACK_DESTINATION,
+        source: testSlackSource("1700000000.010"),
+        actor: { platform: "slack", teamId: "T123", userId: "U123" },
       },
-      agentRunner: { run: () => new Promise<never>(() => {}) },
+      agentRunner: createModelAgentRunner(
+        createModelStream([
+          {
+            type: "text",
+            text: "This reply should not finish.",
+            waitFor: new Promise<never>(() => undefined),
+          },
+        ]),
+      ),
       replyTimeoutMs: 10,
       onFailure,
     });
@@ -217,7 +198,7 @@ describe("oauth resume slack integration", () => {
     ]);
   });
 
-  it("persists resumed assistant messages without canonical user history", async () => {
+  it("persists a resumed assistant message without canonical user history", async () => {
     const { resumeSlackTurn } = await import("@/chat/runtime/slack-resume");
     const { getPersistedThreadState } =
       await import("@/chat/runtime/thread-state");
@@ -236,30 +217,20 @@ describe("oauth resume slack integration", () => {
       conversationId,
       turnId,
       replyContext: {
-          credentialContext: {
-            actor: { type: "user", userId: "U123" },
-          },
-          destination: TEST_SLACK_DESTINATION,
-          dispatch: { id: "resume-binding" },
-          source: testSlackSource(threadTs),
-          actor: { platform: "slack", teamId: "T123", userId: "U123" },
-      },
-      agentRunner: scriptedAssistantMessageRunner({
-        messages: [{ text: "Checking now." }, { text: "Done." }],
-        result: {
-          text: "Done.",
-          diagnostics: makeDiagnostics(),
+        credentialContext: {
+          actor: { type: "user", userId: "U123" },
         },
-      }),
+        destination: TEST_SLACK_DESTINATION,
+        dispatch: { id: "resume-binding" },
+        source: testSlackSource(threadTs),
+        actor: { platform: "slack", teamId: "T123", userId: "U123" },
+      },
+      agentRunner: modelReply("Done."),
     });
 
     const postCalls = getCapturedSlackApiCalls("chat.postMessage");
-    expect(postCalls.map((call) => call.params.text)).toEqual([
-      "Checking now.",
-      "Done.",
-    ]);
+    expect(postCalls.map((call) => call.params.text)).toEqual(["Done."]);
     expectBlocksIncludeConversationId(postCalls[0]!.params, conversationId);
-    expectBlocksIncludeConversationId(postCalls[1]!.params, conversationId);
     const { getConversationStore } = await import("@/chat/db");
     await expect(
       getConversationStore().getConversationIdByProviderConversation({
@@ -277,113 +248,7 @@ describe("oauth resume slack integration", () => {
       conversation.messages
         .filter((message) => message.role === "assistant")
         .map((message) => message.text),
-    ).toEqual(["Checking now.", "Done."]);
-  });
-
-  it("posts the safe fallback when failure-state persistence fails", async () => {
-    const { resumeSlackTurn } = await import("@/chat/runtime/slack-resume");
-    const { getConversationEventStore } = await import("@/chat/db");
-    const conversationId = "slack:T123:C123:1700000000.009";
-    const turnId = "turn_1700000000_009";
-
-    await expect(
-      resumeSlackTurn({
-        messageText: "Resume the failed turn",
-        channelId: "C123",
-        threadTs: "1700000000.009",
-        inputMessageIds: ["msg.9"],
-        conversationId,
-        turnId,
-        replyContext: {
-            credentialContext: {
-              actor: { type: "user", userId: "U123" },
-            },
-            destination: TEST_SLACK_DESTINATION,
-            source: testSlackSource("1700000000.009"),
-            actor: { platform: "slack", teamId: "T123", userId: "U123" },
-        },
-        agentRunner: {
-          run: async () => {
-            throw new Error("resume failed");
-          },
-        },
-        onFailure: async () => {
-          throw new Error("failure state unavailable");
-        },
-      }),
-    ).rejects.toThrow("failure state unavailable");
-
-    expect(getCapturedSlackApiCalls("chat.postMessage")).toEqual([
-      expect.objectContaining({
-        params: expect.objectContaining({
-          channel: "C123",
-          thread_ts: "1700000000.009",
-          text: expect.stringContaining(
-            "I ran into an internal error while processing that. Reference: `event_id=",
-          ),
-        }),
-      }),
-    ]);
-
-    const lifecycle = (
-      await getConversationEventStore().loadHistory(conversationId)
-    ).filter((event) => event.data.type.startsWith("turn_"));
-    expect(lifecycle.map((event) => event.data)).toEqual([
-      expect.objectContaining({
-        type: "turn_started",
-        turnId,
-        inputMessageIds: ["msg.9"],
-        surface: "slack",
-      }),
-      expect.objectContaining({
-        type: "turn_failed",
-        turnId,
-        failureCode: "persistence_failed",
-        eventId: expect.stringMatching(/^[a-f0-9]{32}$/i),
-      }),
-    ]);
-  });
-
-  it("posts resumed auth pause notices with the conversation footer", async () => {
-    const { resumeSlackTurn } = await import("@/chat/runtime/slack-resume");
-
-    await resumeSlackTurn({
-      messageText: "continue this turn",
-      conversationId: "conversation-auth-pause",
-      turnId: "turn-auth-pause",
-      channelId: "C123",
-      threadTs: "1700000000.008",
-      initialText: "",
-      replyContext: {
-          credentialContext: {
-            actor: { type: "user", userId: "U123" },
-          },
-          destination: TEST_SLACK_DESTINATION,
-          source: testSlackSource("1700000000.008"),
-          actor: { platform: "slack", teamId: "T123", userId: "U123" },
-      },
-      agentRunner: {
-        run: async () => ({
-          status: "awaiting_auth" as const,
-          providerDisplayName: "Eval Auth",
-        }),
-      },
-      onAuthPause: async () => undefined,
-    });
-
-    expect(getCapturedSlackApiCalls("chat.postMessage")).toEqual([
-      expect.objectContaining({
-        params: expect.objectContaining({
-          channel: "C123",
-          thread_ts: "1700000000.008",
-          text: "<@U123> I'll need you to authorize Eval Auth. I sent you a link.",
-        }),
-      }),
-    ]);
-    expectBlocksIncludeConversationId(
-      getCapturedSlackApiCalls("chat.postMessage")[0]!.params,
-      "conversation-auth-pause",
-    );
+    ).toEqual(["Done."]);
   });
 
   it("chunks long resumed replies into explicit continuation messages", async () => {
@@ -401,20 +266,14 @@ describe("oauth resume slack integration", () => {
       threadTs: "1700000000.002",
       initialText: "Connected. Continuing...",
       replyContext: {
-          credentialContext: {
-            actor: { type: "user", userId: "U123" },
-          },
-          destination: TEST_SLACK_DESTINATION,
-          source: testSlackSource("1700000000.002"),
-          actor: { platform: "slack", teamId: "T123", userId: "U123" },
-      },
-      agentRunner: scriptedAssistantMessageRunner({
-        messages: [{ text: longReply }],
-        result: {
-          text: longReply,
-          diagnostics: makeDiagnostics(),
+        credentialContext: {
+          actor: { type: "user", userId: "U123" },
         },
-      }),
+        destination: TEST_SLACK_DESTINATION,
+        source: testSlackSource("1700000000.002"),
+        actor: { platform: "slack", teamId: "T123", userId: "U123" },
+      },
+      agentRunner: modelReply(longReply),
     });
 
     const postCalls = getCapturedSlackApiCalls("chat.postMessage");
@@ -454,20 +313,24 @@ describe("oauth resume slack integration", () => {
       threadTs: "1700000000.003",
       initialText: "Connected. Continuing...",
       replyContext: {
-          credentialContext: {
-            actor: { type: "user", userId: "U123" },
+        credentialContext: {
+          actor: { type: "user", userId: "U123" },
+        },
+        destination: TEST_SLACK_DESTINATION,
+        source: testSlackSource("1700000000.003"),
+        actor: { platform: "slack", teamId: "T123", userId: "U123" },
+      },
+      agentRunner: createModelAgentRunner(
+        createModelStream([
+          {
+            type: "message",
+            message: fauxAssistantMessage("Partial output", {
+              stopReason: "error",
+              errorMessage: "The model stream stopped.",
+            }),
           },
-          destination: TEST_SLACK_DESTINATION,
-          source: testSlackSource("1700000000.003"),
-          actor: { platform: "slack", teamId: "T123", userId: "U123" },
-      },
-      agentRunner: {
-        run: async () =>
-          completedAgentRun({
-            text: "Partial output",
-            diagnostics: makeDiagnostics("provider_error"),
-          }),
-      },
+        ]),
+      ),
     });
 
     const postCalls = getCapturedSlackApiCalls("chat.postMessage");
@@ -481,47 +344,6 @@ describe("oauth resume slack integration", () => {
       getSlackInterruptionMarker().trim(),
     );
     expect(postCalls[1]?.params.text).not.toContain("event_id=");
-  });
-
-  it("replaces resumed execution-failure replies before Slack planning", async () => {
-    const { resumeSlackTurn } = await import("@/chat/runtime/slack-resume");
-
-    await resumeSlackTurn({
-      messageText: "Continue the original request",
-      conversationId: "slack:C123:1700000000.006",
-      turnId: "turn-resume-execution-failure",
-      channelId: "C123",
-      threadTs: "1700000000.006",
-      initialText: "Connected. Continuing...",
-      replyContext: {
-          credentialContext: {
-            actor: { type: "user", userId: "U123" },
-          },
-          destination: TEST_SLACK_DESTINATION,
-          source: testSlackSource("1700000000.006"),
-          actor: { platform: "slack", teamId: "T123", userId: "U123" },
-      },
-      agentRunner: {
-        run: async () =>
-          completedAgentRun({
-            text: "",
-            diagnostics: makeDiagnostics("execution_failure", {
-              assistantMessageCount: 0,
-              usedPrimaryText: false,
-            }),
-          }),
-      },
-    });
-
-    const postCalls = getCapturedSlackApiCalls("chat.postMessage");
-    expect(postCalls).toHaveLength(2);
-    expect(postCalls[1]?.params).toMatchObject({
-      channel: "C123",
-      thread_ts: "1700000000.006",
-    });
-    expect(postCalls[1]?.params.text).toContain(
-      "I ran into an internal error while processing that. Reference: `event_id=",
-    );
   });
 
   it("keeps the delivered resume reply when post-delivery commit fails", async () => {
@@ -543,13 +365,7 @@ describe("oauth resume slack integration", () => {
           source: testSlackSource("1700000000.011"),
           actor: { platform: "slack", teamId: "T123", userId: "U123" },
         },
-        agentRunner: scriptedAssistantMessageRunner({
-          messages: [{ text: "Final resumed answer" }],
-          result: {
-            text: "Final resumed answer",
-            diagnostics: makeDiagnostics(),
-          },
-        }),
+        agentRunner: modelReply("Final resumed answer"),
         commitResult: async () => {
           throw new Error("state write failed");
         },
@@ -583,13 +399,7 @@ describe("oauth resume slack integration", () => {
         source: testSlackSource("1700000000.012"),
         actor: { platform: "slack", teamId: "T123", userId: "U123" },
       },
-      agentRunner: scriptedAssistantMessageRunner({
-        messages: [{ text: "Final resumed answer" }],
-        result: {
-          text: "Final resumed answer",
-          diagnostics: makeDiagnostics(),
-        },
-      }),
+      agentRunner: modelReply("Final resumed answer"),
       scheduleSessionCompletedPluginTasks,
     });
 
@@ -597,93 +407,5 @@ describe("oauth resume slack integration", () => {
       conversationId: "slack:C123:1700000000.012",
       sessionId: "turn-resume-plugin-tasks",
     });
-  });
-
-  it("releases the thread lock before scheduling a suspended resume continuation", async () => {
-    const { resumeSlackTurn } = await import("@/chat/runtime/slack-resume");
-    const { getStateAdapter } = await import("@/chat/state/adapter");
-    const onSuspend = vi.fn(async () => {
-      const stateAdapter = getStateAdapter();
-      await stateAdapter.connect();
-      const lock = await stateAdapter.acquireLock(
-        "slack:C123:1700000000.013",
-        60_000,
-      );
-      expect(lock).not.toBeNull();
-      if (lock) {
-        await stateAdapter.releaseLock(lock);
-      }
-    });
-
-    await resumeSlackTurn({
-      messageText: "continue this turn",
-      conversationId: "slack:C123:1700000000.013",
-      turnId: "turn-resume-lock-release",
-      channelId: "C123",
-      threadTs: "1700000000.013",
-      replyContext: {
-        credentialContext: {
-          actor: { type: "user", userId: "U123" },
-        },
-        destination: TEST_SLACK_DESTINATION,
-        source: testSlackSource("1700000000.013"),
-        actor: { platform: "slack", teamId: "T123", userId: "U123" },
-      },
-      agentRunner: {
-        run: async () => ({
-          status: "suspended" as const,
-          reason: "timeout" as const,
-          resumeVersion: 3,
-        }),
-      },
-      onSuspend,
-    });
-
-    expect(onSuspend).toHaveBeenCalledOnce();
-    expect(onSuspend).toHaveBeenCalledWith(3);
-    expect(getCapturedSlackApiCalls("chat.postMessage")).toEqual([]);
-  });
-
-  it("runs failure handling when suspended resume continuation throws", async () => {
-    const { resumeSlackTurn } = await import("@/chat/runtime/slack-resume");
-    const onFailure = vi.fn(async () => undefined);
-
-    await resumeSlackTurn({
-      messageText: "continue this turn",
-      conversationId: "slack:C123:1700000000.014",
-      turnId: "turn-resume-suspend-fail",
-      channelId: "C123",
-      threadTs: "1700000000.014",
-      replyContext: {
-        credentialContext: {
-          actor: { type: "user", userId: "U123" },
-        },
-        destination: TEST_SLACK_DESTINATION,
-        source: testSlackSource("1700000000.014"),
-        actor: { platform: "slack", teamId: "T123", userId: "U123" },
-      },
-      agentRunner: {
-        run: async () => ({
-          status: "suspended" as const,
-          reason: "timeout" as const,
-          resumeVersion: 3,
-        }),
-      },
-      onSuspend: async () => {
-        throw new Error("continuation scheduling failed");
-      },
-      onFailure,
-    });
-
-    expect(onFailure).toHaveBeenCalledOnce();
-    expect(
-      getCapturedSlackApiCalls("chat.postMessage").map(
-        (call) => call.params.text,
-      ),
-    ).toEqual([
-      expect.stringContaining(
-        "I ran into an internal error while processing that. Reference: `event_id=",
-      ),
-    ]);
   });
 });

--- a/scripts/test-architecture-debt.json
+++ b/scripts/test-architecture-debt.json
@@ -3,7 +3,6 @@
     "packages/junior/tests/integration/local-agent-runner.test.ts": 18,
     "packages/junior/tests/integration/mcp-oauth-callback.test.ts": 2,
     "packages/junior/tests/integration/oauth-callback.test.ts": 3,
-    "packages/junior/tests/integration/oauth-resume-slack.test.ts": 4,
     "packages/junior/tests/integration/slack/assistant-thread-contract.test.ts": 2,
     "packages/junior/tests/integration/slack/attachment-behavior.test.ts": 3,
     "packages/junior/tests/integration/slack/attachment-media-behavior.test.ts": 4,
@@ -23,7 +22,6 @@
   "scripted-agent-runner": {
     "packages/junior/tests/integration/api-turn-work.test.ts": 4,
     "packages/junior/tests/integration/local-agent-runner.test.ts": 3,
-    "packages/junior/tests/integration/oauth-resume-slack.test.ts": 6,
     "packages/junior/tests/integration/slack/finalized-reply-behavior.test.ts": 7
   }
 }


### PR DESCRIPTION
OAuth Slack resume tests now run normal replies, long replies, timeouts, partial provider failures, persistence, and post-turn work through the real agent with fixed model output. This exercises the same prompt, Pi loop, delivery, and completion code used in production.

Tests that intentionally supply a completed, paused, suspended, or thrown runner result now live in a component suite where that result is the input contract. The split removes ten test architecture exceptions without changing production behavior.

Refs #1425
