### PR TITLE
docs(pi): refresh agent integration skill

### DIFF
--- a/.agents/skills/pi-agent-integration/SKILL.md
+++ b/.agents/skills/pi-agent-integration/SKILL.md
@@ -1,58 +1,58 @@
 ---
 name: pi-agent-integration
-description: Integrate the latest `@earendil-works/pi-agent-core` APIs into an app, library, runtime, or agent harness. Use for Pi `Agent`, `AgentHarness`, streaming bridges, tool execution hooks, `convertToLlm`/`transformContext`, queueing via `steer`/`followUp`, `continue()` semantics, `streamFn`/`streamProxy`, timeout/abort, session, skill, or compaction behavior.
+description: Guides implementation and review of the latest `@earendil-works/pi-agent-core` API. Use when a task mentions Pi `Agent`, agent loops, streaming, tools, queues, continuation, proxying, aborts, sessions, skills, compaction, or the current `AgentHarness` scaffold.
 ---
 
-Implement Pi-agent consumers against the latest published Pi API with stable streaming, correct queue semantics, and minimal wrapper surface area.
+Implement Pi consumers against the latest published API. Keep streaming stable, queue behavior explicit, and wrapper code small.
 
 ## Step 1: Classify the request
 
-Pick the path before editing:
-
 | Request type                                                                      | Read first                                  |
 | --------------------------------------------------------------------------------- | ------------------------------------------- |
-| Wiring or updating `Agent`, loop, provider, stream, or tool APIs                  | `references/api-surface.md`                 |
-| Adding Pi behavior in a consuming app, library, or runtime                        | `references/common-use-cases.md`            |
-| Using Pi's built-in harness, sessions, skills, resources, or compaction           | `references/harness.md`                     |
-| Debugging broken streaming, tools, queues, continuation, proxy, or abort behavior | `references/troubleshooting-workarounds.md` |
+| Wire or update `Agent`, loop, provider, stream, or tool APIs                      | `references/api-surface.md`                 |
+| Add Pi behavior in an app, library, runtime, or adapter                           | `references/common-use-cases.md`            |
+| Use `AgentHarness`, sessions, skills, resources, compaction, or execution helpers | `references/harness.md`                     |
+| Debug streaming, tools, queues, continuation, proxy, abort, or harness failures   | `references/troubleshooting-workarounds.md` |
 
-If a task spans multiple categories, load only the relevant references above. Keep guidance Pi-specific unless the user explicitly asks about a consuming product.
+Load each reference that the task needs. Keep guidance Pi-specific unless the user asks about a consuming product.
 
 ## Step 2: Apply integration guardrails
 
-1. Treat npm `latest` for `@earendil-works/pi-agent-core` as the source of truth before relying on a contract.
-2. Use `Agent` when event handling must be awaited as part of run settlement; use low-level `agentLoop` only when an observational event stream is enough.
-3. Stream user-visible text only from `message_update` where `assistantMessageEvent.type === "text_delta"`.
-4. Preserve assistant message boundaries deliberately when forwarding multi-message output.
-5. Do not call `prompt()` or `continue()` while an agent is active; queue mid-run input with `steer()` or `followUp()`.
-6. Treat normal `continue()` as a resume from a non-empty `user` or `toolResult` tail. An `assistant` tail can only drain queued steering/follow-up messages, otherwise it throws.
-7. Keep `streamFn`, `convertToLlm`, `transformContext`, `getApiKey`, queue providers, and loop hooks no-throw for expected request/runtime failures; return safe values or encode failures in protocol events.
-8. Keep tool calls, tool progress, tool results, thinking deltas, and provider payloads internal unless the product UX explicitly exposes them.
-9. Prefer Pi's built-in harness when sessions, skills, prompt templates, resources, filesystem/shell environment, compaction, or tree navigation are required.
+1. Check npm `latest` for `@earendil-works/pi-agent-core` before relying on a contract. Treat the published package as authoritative. Treat upstream `main` as unreleased evidence.
+2. Pass a `streamFn` when constructing `Agent`. Also pass it as the last argument to low-level loop functions.
+3. Use `Agent` when event handling must finish before run settlement. Use `agentLoop` only when an observational event stream is enough.
+4. Stream user-visible text only from `message_update` when `assistantMessageEvent.type === "text_delta"`.
+5. Preserve assistant message boundaries when forwarding multi-message output.
+6. Do not call `prompt()`, `continue()`, or `reset()` while an agent is active. Queue mid-run input with `steer()` or `followUp()`.
+7. Continue a normal run only from a non-empty `user` or `toolResult` tail. An `assistant` tail can only drain queued steering or follow-up messages.
+8. Keep `streamFn`, `convertToLlm`, `transformContext`, `getApiKey`, queue providers, and loop hooks no-throw for expected failures. Return safe values or encode the failure in stream events.
+9. Keep tool calls, progress, results, thinking deltas, and provider payloads internal unless the product exposes them on purpose.
+10. In `0.84.1`, do not recommend `AgentHarness` run, queue, hook, or navigation paths for production use. They are scaffold APIs and most reject with `HarnessNotImplemented`. Use bare `Agent`, session APIs, and standalone helpers until the published implementation is complete.
 
 ## Step 3: Implement with minimal surface
 
-1. Prefer Pi options over custom wrapper state machines: `streamFn`, `getApiKey`, `sessionId`, `thinkingBudgets`, `transport`, `maxRetryDelayMs`, `onPayload`, `onResponse`, `beforeToolCall`, `afterToolCall`, `prepareNextTurn`, `toolExecution`, `steeringMode`, and `followUpMode`.
-2. Mutate `Agent` state through `agent.state` properties and `reset()`; do not invent setter wrappers unless the consumer API needs them.
-3. Use `transformContext` for message-level pruning/injection and `convertToLlm` for provider-compatible role conversion/filtering.
-4. Keep queue modes explicit (`"one-at-a-time"` or `"all"`) when ordering or batching matters.
-5. For server-proxied model access, use `streamFn` with `streamProxy`-style behavior instead of provider logic scattered through consumers.
-6. For tool policy, use `toolExecution`, per-tool `executionMode`, `beforeToolCall`, `afterToolCall`, thrown tool errors, and `terminate` before adding a custom tool runner.
-7. Keep timeout/abort paths observable and make sure streams/iterables settle cleanly.
+1. Prefer Pi options over wrapper state machines: `streamFn`, `getApiKey`, `sessionId`, `thinkingBudgets`, `transport`, `maxRetryDelayMs`, `onPayload`, `onResponse`, `beforeToolCall`, `afterToolCall`, `shouldStopAfterTurn`, `prepareNextTurnWithContext`, `toolExecution`, `steeringMode`, and `followUpMode`.
+2. Mutate `Agent` through `agent.state` and public runtime options. Call `reset()` only when idle.
+3. Use `transformContext` for message-level pruning or injection. Use `convertToLlm` for provider-compatible role conversion and filtering.
+4. Set queue modes to `"one-at-a-time"` or `"all"` when ordering or batching matters.
+5. Use `streamFn` with `streamProxy`-style behavior for server-proxied model access.
+6. Use `toolExecution`, per-tool `executionMode`, `beforeToolCall`, `afterToolCall`, thrown tool errors, and `terminate` before adding a custom tool runner.
+7. Keep timeout and abort paths observable. Make sure streams and iterables settle.
 
 ## Step 4: Verify behavior
 
-1. Verify the event-to-stream bridge emits only text deltas, preserves intended boundaries, and closes on success, error, and abort.
-2. Verify `prompt()`/`continue()` race handling and queued `steer()`/`followUp()` behavior.
-3. Verify `continue()` preconditions for empty history, `user` tail, `toolResult` tail, and `assistant` tail with and without queued messages.
-4. Verify custom message types remain in agent state while `convertToLlm` emits only provider-compatible messages.
-5. Verify `streamFn` encodes expected provider failures instead of throwing/rejecting.
-6. Verify tool execution ordering under default parallel mode, sequential overrides, hook blocking/patching, progress updates, and `terminate` behavior.
-7. Verify `Agent.subscribe()` listener settlement and `waitForIdle()` behavior when listeners perform async work.
-8. Verify `AgentHarness` session, resource, hook, compaction, and abort behavior when the harness path is used.
+1. Verify the event bridge emits only text deltas, preserves intended boundaries, and closes on success, error, and abort.
+2. Verify active-run handling for `prompt()`, `continue()`, and `reset()`. Verify queued `steer()` and `followUp()` behavior.
+3. Verify `continue()` with empty history and with `user`, `toolResult`, and `assistant` tails.
+4. Verify custom messages remain in agent state while `convertToLlm` emits only provider-compatible messages.
+5. Verify `streamFn` encodes expected provider failures instead of throwing or rejecting.
+6. Verify parallel and sequential tool ordering, hook blocking and patches, progress updates, usage, added tools, and termination.
+7. Verify `Agent.subscribe()` listener settlement and `waitForIdle()` with async listeners.
+8. When reviewing the `AgentHarness` scaffold, verify implemented status in the published source before recommending any method.
 
-## Step 5: Version discipline
+## Step 5: Keep version discipline
 
-1. Target the latest published Pi package only.
-2. Re-check the latest package metadata and declarations before material API updates.
-3. Do not add backward-compatibility shims or old package-name guidance unless the user explicitly asks for a migration.
+1. Target npm `latest` only.
+2. Re-check package metadata, declarations, implementation, README, and changelog before a material API update.
+3. Do not present unreleased `main` behavior as published behavior.
+4. Do not add compatibility shims or old package guidance unless the user asks for a migration.

--- a/.agents/skills/pi-agent-integration/SOURCES.md
+++ b/.agents/skills/pi-agent-integration/SOURCES.md
@@ -1,81 +1,101 @@
 # Sources
 
-Retrieved: 2026-06-01
+Retrieved: 2026-08-12
+Published baseline: `@earendil-works/pi-agent-core@0.84.1`
+Upstream review commit: `9795d602306ef68a97585909e8e79f92a389057b`
 Skill class: `integration-documentation`
 Primary execution shape: `reference-backed-expert`
-Scope: Pi package documentation only; no consuming-product-specific contracts.
+Scope: Pi package guidance only. Consuming-product contracts remain out of scope.
 
 ## Source inventory
 
-| Source                                                               | Trust tier | Confidence | Contribution                                                                                | Usage constraints                         |
-| -------------------------------------------------------------------- | ---------- | ---------- | ------------------------------------------------------------------------------------------- | ----------------------------------------- |
-| npm metadata for `@earendil-works/pi-agent-core`                     | canonical  | high       | Confirmed latest package name, latest version, repository, dist-tags                        | Re-check before future material API edits |
-| `@earendil-works/pi-agent-core@0.78.0/package.json`                  | canonical  | high       | Runtime engine, exports, repository, dependency baseline                                    | Published package snapshot                |
-| `@earendil-works/pi-agent-core@0.78.0/README.md`                     | canonical  | high       | Public API intent, event flow, tool execution, continuation, proxy, low-level loop guidance | Published package snapshot                |
-| `@earendil-works/pi-agent-core@0.78.0/dist/agent.d.ts`               | canonical  | high       | `AgentOptions`, `Agent` methods, state, queue, lifecycle surface                            | Declaration source of truth               |
-| `@earendil-works/pi-agent-core@0.78.0/dist/agent.js`                 | canonical  | high       | Runtime semantics for `continue()`, queue draining, listener settlement, state updates      | Used where README/types were ambiguous    |
-| `@earendil-works/pi-agent-core@0.78.0/dist/types.d.ts`               | canonical  | high       | `StreamFn`, message pipeline, tool hooks, queue mode, tool execution, event types           | Declaration source of truth               |
-| `@earendil-works/pi-agent-core@0.78.0/dist/agent-loop.d.ts`          | canonical  | high       | Low-level loop signatures and continuation caveat                                           | Declaration source of truth               |
-| `@earendil-works/pi-agent-core@0.78.0/dist/agent-loop.js`            | canonical  | high       | Low-level loop ordering, `shouldStopAfterTurn`, `prepareNextTurn`, tool execution internals | Used where README/types were ambiguous    |
-| `@earendil-works/pi-agent-core@0.78.0/dist/proxy.d.ts`               | canonical  | high       | `streamProxy` events and serializable proxy options                                         | Declaration source of truth               |
-| `@earendil-works/pi-agent-core@0.78.0/dist/harness/*.d.ts`           | canonical  | high       | `AgentHarness`, session, skill, prompt-template, compaction, environment contracts          | Declaration source of truth               |
-| `.agents/skills/skill-writer/SKILL.md`                               | canonical  | high       | Required workflow for skill synthesis, authoring, and validation                            | Skill-authoring process source            |
-| `.agents/skills/skill-writer/references/mode-selection.md`           | canonical  | high       | Classified this as `integration-documentation`                                              | Process guidance                          |
-| `.agents/skills/skill-writer/references/execution-shapes.md`         | canonical  | high       | Selected `reference-backed-expert` shape                                                    | Process guidance                          |
-| `.agents/skills/skill-writer/references/synthesis-path.md`           | canonical  | high       | Required source inventory, decisions, coverage, gaps                                        | Process guidance                          |
-| `.agents/skills/skill-writer/references/authoring-path.md`           | canonical  | high       | Runtime authoring and precision-pass rules                                                  | Process guidance                          |
-| `.agents/skills/skill-writer/references/reference-architecture.md`   | canonical  | high       | Added focused `references/harness.md` as a routed lookup leaf                               | Process guidance                          |
-| `.agents/skills/skill-writer/references/spec-template.md`            | canonical  | high       | Added `SPEC.md` for material scope/reference changes                                        | Process guidance                          |
-| `.agents/skills/skill-writer/references/description-optimization.md` | canonical  | high       | Trigger quality pass                                                                        | Process guidance                          |
-| `.agents/skills/skill-writer/references/registration-validation.md`  | canonical  | high       | Validation expectations                                                                     | Process guidance                          |
+| Source                                                                 | Trust      | Contribution                                                                                  | Constraint                                                |
+| ---------------------------------------------------------------------- | ---------- | --------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
+| npm metadata for `@earendil-works/pi-agent-core`                       | canonical  | Confirmed `latest` `0.84.1`, package identity, repository, engine, and publish dates          | Re-check before each material update                      |
+| Published `0.84.1/package.json` and `README.md`                        | canonical  | Confirmed exports, required `streamFn`, main `Agent` API, loop use, tools, and event flow     | Published contract and public intent                      |
+| Published `0.84.1/dist/agent.d.ts` and `agent.js`                      | canonical  | Confirmed options, state, active-run guards, continuation, queues, and listener settlement    | Implementation resolves declaration ambiguity             |
+| Published `0.84.1/dist/types.d.ts` and `agent-loop.*`                  | canonical  | Confirmed stream shape, turn hooks, loop signatures, tools, usage, added tools, and events    | Published contract and behavior                           |
+| Published `0.84.1/dist/proxy.*`                                        | canonical  | Confirmed proxy options and published finalized-event behavior                                | Published package contains the noted metadata defect      |
+| Published `0.84.1/dist/harness/*`                                      | canonical  | Confirmed session v4 exports, scaffold types, and which `AgentHarness` methods are unfinished | Check implementation, not declarations alone              |
+| Upstream `packages/agent/CHANGELOG.md` at review commit                | primary    | Captured breaking changes from `0.78.0` through `0.84.1` and the unreleased proxy fix         | Unreleased entries are evidence, not published contract   |
+| Upstream `packages/agent/src` and `packages/agent/docs/harness.md`     | primary    | Compared implemented scaffold behavior with intended lane-based harness design                | Design text cannot imply current runtime readiness        |
+| Local Pi catalog and consumers                                         | supporting | Confirmed this repo pins `0.82.1` and already uses `prepareNextTurnWithContext`               | Product dependency upgrades are outside this skill update |
+| Local `skill-writer` workflow, repository instructions, and validators | canonical  | Required material synthesis, precision, trigger, source, and validation passes                | Authoring-process source                                  |
 
 ## Decisions
 
-| Decision                                                         | Status   | Evidence                                                                           |
-| ---------------------------------------------------------------- | -------- | ---------------------------------------------------------------------------------- |
-| Keep the skill Pi-only                                           | adopted  | User direction on 2026-06-01                                                       |
-| Target npm `latest` only                                         | adopted  | User direction + npm metadata                                                      |
-| Use `@earendil-works/pi-agent-core` as the only package identity | adopted  | Latest package metadata                                                            |
-| Remove consuming-product-specific source references              | adopted  | User direction + portability goal                                                  |
-| Add a routed harness reference                                   | adopted  | Latest package exports substantial `AgentHarness`, session, skill, compaction APIs |
-| Keep `SKILL.md` as router/guardrail layer                        | adopted  | `skill-writer` reference architecture                                              |
-| Add `SPEC.md`                                                    | adopted  | Material scope and reference architecture change                                   |
-| Add backward compatibility or old package migration guidance     | rejected | Latest-only user direction                                                         |
+| Decision                                                                    | Status   | Evidence                                                        |
+| --------------------------------------------------------------------------- | -------- | --------------------------------------------------------------- |
+| Keep the skill Pi-only                                                      | adopted  | Existing scope and user request                                 |
+| Target npm `latest` as the runtime contract                                 | adopted  | Existing policy and npm metadata                                |
+| Treat upstream `main` as unreleased evidence                                | adopted  | Published package differs from the upstream unreleased section  |
+| Keep the reference-backed shape and replace existing leaves                 | adopted  | Routes remain distinct; no new lookup need exists               |
+| Require explicit `streamFn` in current integrations                         | adopted  | Published declarations and README                               |
+| Prefer `prepareNextTurnWithContext` for context-aware `Agent` work          | adopted  | Published `AgentOptions`                                        |
+| Guard `reset()` with idle state                                             | adopted  | `0.84.1` implementation and changelog                           |
+| Include tool usage, added tools, late-update, and blocked termination rules | adopted  | Published types, implementation, and changelog                  |
+| Replace legacy harness guidance with session v4 and scaffold readiness      | adopted  | `0.84.0` breaking change and `0.84.1` implementation            |
+| Recommend bare `Agent` plus direct session/helpers for production work      | adopted  | Most current `AgentHarness` operations reject as unimplemented  |
+| Add old-package migration or compatibility wrappers by default              | rejected | Latest-only scope                                               |
+| Upgrade this repo's Pi dependency as part of the skill refresh              | rejected | Separate product change that needs its own implementation tests |
+
+## Source adaptation
+
+| Item              | Decision                                                                                                    |
+| ----------------- | ----------------------------------------------------------------------------------------------------------- |
+| Source intent     | Pi docs and types describe execution, sessions, and the intended lane-based harness.                        |
+| Local target      | Cause agents to use only published, implemented behavior and choose the smallest stable Pi surface.         |
+| Fidelity boundary | Keep current names, signatures, ordering, failure rules, and readiness exact.                               |
+| Local replacement | Replace long design prose with routed tables, guardrails, use cases, and failure fixes.                     |
+| Omitted material  | Omit legacy migration detail, unfinished harness internals, provider catalogs, and product-specific policy. |
+| Rights            | Pi is MIT licensed. This skill paraphrases public facts and does not copy substantial source text.          |
 
 ## Coverage matrix
 
-| Dimension                                   | Coverage status | Evidence                                                                                |
-| ------------------------------------------- | --------------- | --------------------------------------------------------------------------------------- |
-| API surface and behavior contracts          | covered         | `agent.d.ts`, `agent.js`, `types.d.ts`, `agent-loop.d.ts`, `agent-loop.js`, `README.md` |
-| Config/runtime options                      | covered         | `AgentOptions`, `AgentLoopConfig`, `AgentHarnessOptions`, package metadata              |
-| Common downstream use cases                 | covered         | `README.md`, declarations, runtime implementation                                       |
-| Known issues/failure modes with workarounds | covered         | `agent.js`, `agent-loop.js`, type contracts                                             |
-| Version/migration variance                  | constrained     | Latest-only package targeting; migration intentionally omitted                          |
-| Harness/session/skill/compaction surface    | covered         | `dist/harness/*.d.ts`                                                                   |
+| Dimension                          | Status  | Evidence                                                                                   |
+| ---------------------------------- | ------- | ------------------------------------------------------------------------------------------ |
+| API surface and behavior           | covered | Published README, declarations, and implementation                                         |
+| Config and runtime options         | covered | `AgentOptions`, `AgentLoopConfig`, proxy types, scaffold options, and session types        |
+| Downstream use cases               | covered | Ten focused use cases across streaming, proxy, auth, context, queues, tools, and sessions  |
+| Failure modes and workarounds      | covered | Published implementation, changelog fixes, and more than eight troubleshooting entries     |
+| Version variance                   | covered | Diff from `0.78.0`, changelog through `0.84.1`, local `0.82.1`, and unreleased `main` note |
+| Harness, session, helper readiness | covered | Published harness declarations and implementation plus upstream design comparison          |
+| Trigger precision                  | covered | Should-trigger and should-not-trigger sets below                                           |
 
-## Trigger quality notes
+## Trigger quality
 
 Should trigger:
 
 - "integrate pi-agent-core Agent into my app"
-- "stream Pi Agent text deltas into our SDK"
-- "how should I use AgentHarness sessions and skills"
-- "fix continue() throwing in pi-agent-core"
-- "wire streamProxy for Pi"
+- "wire Pi text streaming"
+- "why does Pi continue() reject?"
+- "update our Pi tool hooks"
+- "use Pi sessions or AgentHarness"
+- "proxy Pi model calls"
+- "review whether our Pi integration is current"
 
 Should not trigger:
 
-- "write a generic OpenAI API streaming adapter"
-- "document a consuming app's chat runtime behavior"
-- "create a new Codex skill unrelated to Pi"
+- "write a generic OpenAI streaming adapter"
+- "create an unrelated Codex skill"
 - "debug a React component"
-- "explain TypeBox generally"
+- "explain TypeBox"
+- "change product chat policy without touching Pi"
+
+The description now names concrete Pi APIs and tasks. It keeps generic SDK, skill-authoring, and consuming-product work out of scope.
 
 ## Open gaps
 
-- Re-run npm package retrieval before the next material update; the skill intentionally follows `latest`.
-- Add concrete code examples only after collecting stable upstream examples or tests from the Pi repository. The current runtime guidance is source-backed but example-light.
+- Upstream `main` contains an unreleased fix for `streamProxy()` finalized tool-call metadata. Re-check npm after the next release.
+- `AgentHarness` is a moving scaffold. Re-audit declarations and implementation before any harness guidance change.
+- This repo still pins Pi `0.82.1`. A dependency upgrade is a separate product change and was not made here.
+
+## Validation record
+
+- Agent Skills quick validator: pass with no warnings on 2026-08-12.
+- `pnpm skills:check`: pass for all 17 repository skill directories on 2026-08-12.
+- Manual published-package audit: complete for manifest, README, core declarations, core implementation, proxy, harness, sessions, changelog, and current upstream source.
 
 ## Stopping rationale
 
-Further retrieval is low-yield for this pass because published package metadata, README, declarations, and implementation files cover the latest API contracts needed by this Pi-only integration skill.
+The source mix covers the published contract, implementation edge behavior, breaking changes, current upstream differences, local consumption, and authoring rules. More retrieval is low value until Pi publishes a new release or completes more harness paths.

--- a/.agents/skills/pi-agent-integration/SPEC.md
+++ b/.agents/skills/pi-agent-integration/SPEC.md
@@ -2,83 +2,88 @@
 
 ## Intent
 
-This skill helps agents integrate the latest `@earendil-works/pi-agent-core` APIs into apps, libraries, runtimes, and harnesses without inventing avoidable wrapper behavior.
+This skill helps agents implement and review the latest published `@earendil-works/pi-agent-core` API without adding avoidable wrapper behavior.
 
-It is an integration-documentation skill, not product documentation for any consuming app.
+It is Pi integration guidance. It is not product documentation for a consuming app. It must distinguish declared API shape, implemented behavior, and unreleased upstream design.
 
 ## Scope
 
 In scope:
 
-- Pi `Agent` setup, streaming, queueing, continuation, abort, and state behavior.
-- Pi low-level loop APIs.
-- Pi `streamFn` and `streamProxy` integration.
-- Pi tool execution, hooks, queue modes, and termination behavior.
-- Pi `AgentHarness`, sessions, resources, skills, prompt templates, compaction, and environment interfaces.
-- Troubleshooting based on published Pi package contracts.
+- Pi `Agent` setup, streaming, queueing, continuation, abort, state, and turn hooks.
+- Low-level agent loop APIs.
+- `streamFn`, `streamProxy`, provider request hooks, and failure contracts.
+- Tool execution, progress, result metadata, ordering, and termination.
+- Current `AgentHarness` readiness and declared surface.
+- Session, repository, environment, skill, prompt-template, compaction, search, and helper APIs.
+- Known published defects and source-backed workarounds.
 
 Out of scope:
 
-- Consuming-product-specific runtime policies, chat behavior, telemetry, or storage contracts.
-- Legacy package migrations unless explicitly requested by the user.
+- Consuming-product runtime policy, chat behavior, telemetry, or storage contracts.
+- Legacy migration guidance unless the user asks for it.
 - Provider-specific model recommendations outside the Pi API surface.
+- Treating unreleased design documents or `main` behavior as a published contract.
 
 ## Users And Trigger Context
 
-- Primary users: agents implementing or reviewing Pi integrations.
-- Common user requests: "integrate pi-agent-core", "wire Agent streaming", "debug continue()", "use AgentHarness", "fix Pi tool execution", "proxy Pi model calls".
-- Should not trigger for generic LLM SDK usage, unrelated skill authoring, or product-specific behavior that does not mention or clearly depend on Pi.
+- Primary users: agents that implement, debug, or review Pi integrations.
+- Common requests: integrate Pi, wire `Agent`, stream text, debug `continue()`, execute tools, proxy model calls, add sessions, or assess `AgentHarness`.
+- Should not trigger for generic LLM SDK use or product-specific behavior that does not clearly depend on Pi.
 
 ## Runtime Contract
 
-- Required first actions: classify the request and load only the routed reference files needed.
-- Required outputs: implementation guidance, code edits, or review findings grounded in latest Pi package contracts.
-- Non-negotiable constraints: keep guidance Pi-only, target npm `latest`, and do not add compatibility shims unless requested.
-- Expected bundled files loaded at runtime: `SKILL.md` plus one or more direct `references/*.md` files.
+- First action: classify the request and load only the routed references it needs.
+- Required output: guidance, edits, or findings grounded in npm `latest` and published implementation behavior.
+- Required distinction: published contract, current implementation readiness, and unreleased upstream evidence.
+- Non-negotiable constraints: keep guidance Pi-only, target npm `latest`, and avoid compatibility shims unless requested.
+- Expected files: `SKILL.md` plus one or more direct `references/*.md` leaves.
 
 ## Source And Evidence Model
 
 Authoritative sources:
 
 - npm metadata for `@earendil-works/pi-agent-core`
-- latest published package README
-- latest published package declarations
-- latest published package implementation files when declarations are ambiguous
+- latest published package manifest, README, declarations, and implementation
 
-Useful improvement sources:
+Useful supporting sources:
 
-- upstream Pi repository tests and changelog, when available
-- concrete failure reports from Pi integrations
-- validation results from skill updates
+- upstream changelog, tests, source, and design documents
+- in-repo Pi consumers and validation results
+- issue and pull request history for defects and migration changes
 
-Data that must not be stored:
+Use upstream `main` to find future changes and known defects. Do not use it to override the published contract.
 
-- secrets
-- customer data
-- private application URLs or identifiers
-- consuming-product-specific internal contracts unless the user explicitly asks for that scope
+Do not store secrets, customer data, private application identifiers, or unrelated consuming-product contracts.
 
 ## Reference Architecture
 
-- `SKILL.md` contains routing, guardrails, minimal implementation rules, verification, and version discipline.
-- `references/` contains focused lookup leaves for API surface, common use cases, harness use, and troubleshooting.
-- `SOURCES.md` contains source inventory, decisions, coverage, trigger quality notes, and gaps.
+- `SKILL.md` contains routing, universal guardrails, implementation rules, verification, and version discipline.
+- `references/api-surface.md` contains core `Agent`, loop, tool, stream, and proxy contracts.
+- `references/common-use-cases.md` contains consumer task guidance.
+- `references/harness.md` contains current harness readiness, sessions, and helper guidance.
+- `references/troubleshooting-workarounds.md` contains failure diagnosis and workarounds.
+- `SOURCES.md` contains provenance, decisions, coverage, triggers, and open gaps.
 - `scripts/` and `assets/` are unused.
 
 ## Validation
 
-- Lightweight validation: run the skill structural validator after artifact changes.
-- Deeper validation: manually confirm every runtime reference is directly routed from `SKILL.md`, avoids host-specific paths, and changes an agent decision or verification step.
-- Acceptance gates: package identity is current, no consuming-product-specific guidance remains, latest-only stance is explicit, and `continue()`/stream/tool/harness contracts match published Pi sources.
+- Run the repository skill validator after artifact changes.
+- Confirm each runtime reference is routed directly from `SKILL.md`.
+- Confirm files use skill-root-relative paths and contain no host-specific paths.
+- Confirm the package identity, npm latest version, Node engine, exports, public types, and implementation status.
+- Confirm streaming, continuation, queues, tools, loop signatures, proxy limitations, and harness readiness against the published package.
+- Confirm trigger language covers Pi tasks and rejects generic SDK or unrelated product tasks.
 
 ## Known Limitations
 
-- The skill intentionally follows npm `latest`; it may need refresh when Pi publishes a new latest version.
-- The skill is intentionally example-light until stable upstream examples or tests are captured as evidence.
+- The skill follows npm `latest` and can become stale after any Pi release.
+- `AgentHarness` is changing quickly. Every harness task needs a fresh implementation check.
+- Upstream fixes can exist on `main` before npm publishes them.
 
 ## Maintenance Notes
 
-- Update `SKILL.md` when trigger scope, routing, guardrails, or verification gates change.
-- Update `references/*.md` when the Pi API behavior changes.
-- Update `SOURCES.md` when source baselines, decisions, coverage, or gaps change.
-- Update `SPEC.md` when scope, evidence policy, reference architecture, or validation expectations change.
+- Update `SKILL.md` when triggers, universal guardrails, or readiness defaults change.
+- Update the focused reference that owns an API or failure change.
+- Update `SOURCES.md` for each package baseline, major decision, known gap, and validation result.
+- Update this specification when scope, evidence rules, reference architecture, or acceptance gates change.

--- a/.agents/skills/pi-agent-integration/references/api-surface.md
+++ b/.agents/skills/pi-agent-integration/references/api-surface.md
@@ -3,100 +3,92 @@
 Open this when wiring or updating Pi `Agent`, low-level loop, provider, stream, or tool APIs.
 
 Primary package: `@earendil-works/pi-agent-core`
-Current source baseline: npm `latest` at last synthesis was `0.78.0`.
+Published baseline: npm `latest` `0.84.1`
 
 ## Package facts
 
-| Area         | Latest contract                                                       |
-| ------------ | --------------------------------------------------------------------- |
-| Package      | `@earendil-works/pi-agent-core`                                       |
-| Runtime      | Node `>=22.19.0`                                                      |
-| Repository   | `github.com/earendil-works/pi`, `packages/agent`                      |
-| Main imports | `@earendil-works/pi-agent-core`, `@earendil-works/pi-agent-core/node` |
-| Model layer  | Built on `@earendil-works/pi-ai`                                      |
-
-## Top-level exports
-
-- Core execution: `Agent`, `agentLoop`, `agentLoopContinue`, `runAgentLoop`, `runAgentLoopContinue`.
-- Provider proxy: `streamProxy`, `ProxyAssistantMessageEvent`, `ProxyStreamOptions`.
-- Core types: `AgentMessage`, `AgentTool`, `AgentToolResult`, `AgentEvent`, `AgentState`, `AgentContext`, `AgentLoopConfig`, `StreamFn`, `QueueMode`, `ToolExecutionMode`, `ThinkingLevel`.
-- Harness layer: `AgentHarness`, session repositories, skill loading helpers, prompt-template helpers, compaction helpers, message helpers, and harness types.
-- Node entry: `NodeExecutionEnv` from `@earendil-works/pi-agent-core/node`.
+| Area         | Current contract                                                                                                 |
+| ------------ | ---------------------------------------------------------------------------------------------------------------- |
+| Runtime      | Node `>=22.19.0`                                                                                                 |
+| Repository   | `github.com/earendil-works/pi`, package directory `packages/agent`                                               |
+| Imports      | Root package, `/node` for `NodeExecutionEnv`, and `/session/testing` for session backend conformance tests       |
+| Model layer  | `@earendil-works/pi-ai`; a bound `Models.streamSimple` satisfies `StreamFn`                                      |
+| Main exports | Core agent and loops, proxy helpers, harness and session APIs, compaction helpers, search helpers, and telemetry |
 
 ## `Agent` options
 
-| Option                               | Use                                                                                                                                      |
-| ------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| `initialState`                       | Seed `systemPrompt`, `model`, `thinkingLevel`, `tools`, and `messages`.                                                                  |
-| `convertToLlm(messages)`             | Convert/filter `AgentMessage[]` to provider-compatible LLM messages. Must not throw/reject for expected cases.                           |
-| `transformContext(messages, signal)` | Prune or inject context before conversion. Must not throw/reject for expected cases.                                                     |
-| `streamFn`                           | Replace provider streaming, usually for proxying or tracing. Must return a stream and encode expected failures in stream events/results. |
-| `getApiKey(provider)`                | Resolve short-lived provider credentials per LLM call. Return `undefined` rather than throwing for missing expected auth.                |
-| `onPayload`, `onResponse`            | Observe or patch provider payload/response through `pi-ai` stream options.                                                               |
-| `beforeToolCall`, `afterToolCall`    | Block, inspect, patch, or terminate tool results at Pi's tool boundary. Honor `AbortSignal`.                                             |
-| `prepareNextTurn`                    | Replace context/model/thinking state before another provider request in the current run.                                                 |
-| `steeringMode`, `followUpMode`       | Drain queued messages as `"one-at-a-time"` or `"all"`. Defaults are one-at-a-time.                                                       |
-| `sessionId`                          | Forward provider cache/session identity.                                                                                                 |
-| `thinkingBudgets`                    | Override per-thinking-level token budgets.                                                                                               |
-| `transport`                          | Select preferred provider transport.                                                                                                     |
-| `maxRetryDelayMs`                    | Bound provider-requested retry delays.                                                                                                   |
-| `toolExecution`                      | Execute tool batches as `"parallel"` by default or `"sequential"`.                                                                       |
+| Option                               | Use                                                                                                                        |
+| ------------------------------------ | -------------------------------------------------------------------------------------------------------------------------- |
+| `streamFn`                           | Required provider stream function. Return a stream and encode expected failures in its events and final result.            |
+| `initialState`                       | Seed `systemPrompt`, `model`, `thinkingLevel`, `tools`, and `messages`.                                                    |
+| `convertToLlm(messages)`             | Convert or filter `AgentMessage[]` to provider messages. Keep expected failures no-throw.                                  |
+| `transformContext(messages, signal)` | Prune or inject context before conversion. Keep expected failures no-throw.                                                |
+| `getApiKey(provider)`                | Resolve credentials for each model call. Return `undefined` for an expected missing credential.                            |
+| `onPayload`, `onResponse`            | Observe or patch provider payloads and responses through `pi-ai` stream options.                                           |
+| `beforeToolCall`, `afterToolCall`    | Block, inspect, patch, or terminate tool results. Honor the `AbortSignal`.                                                 |
+| `shouldStopAfterTurn`                | Stop after a complete turn and before queues or another model call. Receives turn context and the run signal.              |
+| `prepareNextTurn`                    | Return a next-turn update. This compatibility-shaped `Agent` hook receives only the run signal.                            |
+| `prepareNextTurnWithContext`         | Return a next-turn context, model, or thinking update with the completed-turn context and run signal. Prefer this variant. |
+| `steeringMode`, `followUpMode`       | Drain queues as `"one-at-a-time"` or `"all"`. Both default to one-at-a-time.                                               |
+| Other request options                | `sessionId`, `thinkingBudgets`, `transport`, `maxRetryDelayMs`, and `toolExecution`.                                       |
 
-## `Agent` runtime surface
+`Agent` requires an options object and `streamFn` in the public type contract. The runtime fallback for older compiled consumers is not a latest-API integration path. The public mutable stream property is `agent.streamFunction`.
 
-- Prompting: `prompt(string, images?)`, `prompt(AgentMessage)`, `prompt(AgentMessage[])`.
-- Continuation: `continue()`.
-- Queueing: `steer(message)`, `followUp(message)`, `clearSteeringQueue()`, `clearFollowUpQueue()`, `clearAllQueues()`, `hasQueuedMessages()`.
-- Lifecycle: `abort()`, `waitForIdle()`, `subscribe(listener)`, `signal`.
-- State: mutate `agent.state.systemPrompt`, `agent.state.model`, `agent.state.thinkingLevel`, `agent.state.tools`, and `agent.state.messages`; use `reset()` to clear transcript/runtime/queues.
-- Runtime state: `agent.state.isStreaming`, `agent.state.streamingMessage`, `agent.state.pendingToolCalls`, `agent.state.errorMessage`.
+## Runtime surface
 
-## Events and streaming
+- Prompt with `prompt(string, images?)`, `prompt(AgentMessage)`, or `prompt(AgentMessage[])`.
+- Continue with `continue()`.
+- Queue with `steer()`, `followUp()`, queue clear methods, and `hasQueuedMessages()`.
+- Control a run with `abort()`, `waitForIdle()`, `subscribe()`, and `signal`.
+- Mutate `agent.state.systemPrompt`, `model`, `thinkingLevel`, `tools`, and `messages`.
+- Inspect `isStreaming`, `streamingMessage`, `pendingToolCalls`, and `errorMessage`.
+- Call `reset()` only when idle. It clears messages, runtime state, and both queues. It rejects during an active run.
 
-- Lifecycle events: `agent_start`, `turn_start`, `turn_end`, `agent_end`.
-- Message events: `message_start`, `message_update`, `message_end`.
-- Tool events: `tool_execution_start`, `tool_execution_update`, `tool_execution_end`.
-- `message_update` is assistant-only but includes text, thinking, and tool-call deltas. Forward user-visible text only when `assistantMessageEvent.type === "text_delta"`.
-- `Agent.subscribe()` awaits listener promises in registration order. `agent_end` is the final event, but `prompt()`, `continue()`, and `waitForIdle()` settle only after awaited `agent_end` listeners finish.
+## Events and message flow
 
-## Message pipeline
+- Lifecycle: `agent_start`, `turn_start`, `turn_end`, `agent_end`.
+- Messages: `message_start`, `message_update`, `message_end`.
+- Tools: `tool_execution_start`, `tool_execution_update`, `tool_execution_end`.
+- Forward visible text only from `message_update` plus `text_delta`.
+- `Agent.subscribe()` awaits listeners in registration order. A run settles after awaited `agent_end` listeners finish.
 
-`AgentMessage[]` -> `transformContext()` -> `AgentMessage[]` -> `convertToLlm()` -> LLM `Message[]`.
+Message flow is `AgentMessage[] -> transformContext() -> convertToLlm() -> pi-ai Message[]`.
 
-- Keep app-specific/custom messages in agent state when useful.
-- Filter or map custom messages in `convertToLlm`.
-- For low-level continuation, the last message must convert to `user` or `toolResult`; Pi can only check raw assistant tails before conversion.
+Keep custom messages in state when useful. Filter or map them in `convertToLlm`. For low-level continuation, conversion must leave a final `user` or `toolResult` message.
 
-## Continue and queue semantics
+## Continue and queues
 
-- `prompt()` throws while a run is active.
-- `continue()` throws while a run is active.
-- `continue()` throws on empty history.
-- `continue()` normally resumes from a `user` or `toolResult` tail.
-- If the tail is `assistant`, `continue()` drains queued steering first, then queued follow-ups; if neither exists, it throws.
-- `steer()` injects queued messages after the current assistant turn and tool batch finish.
-- `followUp()` runs only after the agent would otherwise stop.
+- `prompt()` and `continue()` reject while a run is active.
+- `continue()` rejects on empty history.
+- A `user` or `toolResult` tail starts normal continuation.
+- An `assistant` tail drains steering first, then follow-ups. It rejects if both queues are empty.
+- Steering runs after the current assistant turn and tool batch.
+- Follow-ups run only after the agent would otherwise stop.
 
-## Tool execution
+## Tools
 
-- Default batch mode is `parallel`: tool preflight is sequential, allowed tools execute concurrently, `tool_execution_end` follows completion order, and tool-result messages/`turn_end.toolResults` follow assistant source order.
-- Global `toolExecution: "sequential"` executes one call at a time.
-- A per-tool `executionMode: "sequential"` forces the whole batch sequential.
-- `beforeToolCall` runs after tool-start emission and argument validation; returning `{ block: true }` produces an error tool result.
-- `afterToolCall` can replace `content`, `details`, `isError`, or `terminate`; `content` and `details` are full replacements, not deep merges.
-- Tool `execute()` should throw on failure rather than returning failure text as successful content.
-- `terminate: true` skips the automatic follow-up LLM call only when every finalized result in the batch terminates.
+- Default batch mode is `parallel`. Preflight is sequential. Allowed tools run concurrently.
+- `tool_execution_end` follows completion order. Tool-result messages and `turn_end.toolResults` follow assistant source order.
+- Global `toolExecution: "sequential"` or any per-tool `executionMode: "sequential"` makes the full batch sequential.
+- `beforeToolCall` runs after start emission and argument validation. A blocked result can include `reason` and `terminate`.
+- `afterToolCall` can replace `content`, `details`, `isError`, `usage`, or `terminate`. These values are replacements, not deep merges.
+- `AgentToolResult` can include `usage`, `addedToolNames`, and `terminate`.
+- Throw from `execute()` on failure. Late progress callbacks after settlement are ignored.
+- Early termination happens only when every finalized result in the batch terminates.
 
-## Low-level loop API
+## Low-level loops
 
-- Use `agentLoop(prompts, context, config, signal?, streamFn?)` to start with prompt messages.
-- Use `agentLoopContinue(context, config, signal?, streamFn?)` to continue existing context.
-- Raw loop streams preserve event order but do not wait for async event handling to settle before producer phases continue.
-- Use `Agent` instead when event processing must be a barrier before tool preflight or run settlement.
-- `AgentLoopConfig` adds low-level-only hooks such as `shouldStopAfterTurn`, `getSteeringMessages`, and `getFollowUpMessages`.
+- Start with `agentLoop(prompts, context, config, signal, streamFn)`.
+- Continue with `agentLoopContinue(context, config, signal, streamFn)`.
+- The `runAgentLoop` variants also require an event sink before `signal` and `streamFn`.
+- Pass `undefined` in the signal position when no signal exists. The final `streamFn` argument is required.
+- Low-level-only queue providers are `getSteeringMessages` and `getFollowUpMessages`.
+- `shouldStopAfterTurn` and `prepareNextTurn` exist on both the low-level config and the `Agent` wrapper.
+- Raw streams preserve event order but do not await consumer event handling between producer phases.
 
-## Proxy and stream functions
+## Proxy streams
 
-- `streamFn` has the same shape as `pi-ai` `streamSimple`.
-- Expected provider/request/runtime failures must be encoded in the returned stream with protocol events and a final assistant message with `stopReason: "error"` or `"aborted"`.
-- `streamProxy(model, context, options)` proxies through a server with `authToken`, `proxyUrl`, local `signal`, and serializable stream options.
+- `StreamFn` structurally matches `Models.streamSimple`.
+- Encode expected failures with protocol events and a final assistant message whose `stopReason` is `"error"` or `"aborted"`.
+- `streamProxy(model, context, options)` accepts `authToken`, `proxyUrl`, a local `signal`, and serializable stream options, including OpenAI-compatible `samplingParams`.
+- Check `references/troubleshooting-workarounds.md` for the published `0.84.1` finalized tool-call metadata defect.

--- a/.agents/skills/pi-agent-integration/references/common-use-cases.md
+++ b/.agents/skills/pi-agent-integration/references/common-use-cases.md
@@ -1,8 +1,14 @@
 # Common Use Cases
 
-Open this when adding Pi behavior in a consuming app, library, runtime, or adapter.
+Open this when adding Pi behavior in an app, library, runtime, or adapter.
 
-## Stream assistant text into another surface
+## Construct an agent
+
+Pass a `streamFn` explicitly. A bound `Models.streamSimple` is the default direct-provider choice.
+
+Keep model, tools, prompt, thinking level, and transcript in `initialState`. Keep request policy in `AgentOptions` or the matching public runtime properties.
+
+## Stream assistant text
 
 Use `agent.subscribe()` and forward only:
 
@@ -11,67 +17,70 @@ event.type === "message_update" &&
   event.assistantMessageEvent.type === "text_delta";
 ```
 
-Bridge those deltas into the consumer's streaming abstraction. Insert separators only at intentional assistant message boundaries and apply the same normalization to streamed and finalized output.
+Insert separators only at intended assistant message boundaries. Apply the same normalization to streamed and final output.
 
 ## Proxy provider access
 
-Use `streamFn` when model calls must route through a backend, tracing layer, gateway, or policy boundary.
+Use `streamFn` when model calls must pass through a backend, trace layer, gateway, or policy boundary.
 
-- Preserve the `StreamFn` contract: return a stream; do not throw/reject for expected provider failures.
-- Use `streamProxy` when a browser or untrusted client needs server-owned auth.
-- Use `onPayload` and `onResponse` when the consumer needs provider payload/response observation without replacing the stream function.
+- Preserve the `StreamFn` contract. Return a stream and encode expected provider failures.
+- Use `streamProxy` when an untrusted client needs server-owned auth.
+- Use `onPayload` and `onResponse` for observation or patching without replacing the stream function.
+- Do not rely on finalized tool-call metadata through published `0.84.1` `streamProxy`; read the troubleshooting reference.
 
 ## Resolve short-lived credentials
 
-Use `getApiKey(provider)` for per-call provider credentials. Return `undefined` for expected unauthenticated states and let the consumer own visible auth recovery.
+Use `getApiKey(provider)` for each provider call. Return `undefined` for an expected unauthenticated state. Let the consumer own visible auth recovery.
 
-## Add custom app messages
+## Keep custom messages
 
-Extend `CustomAgentMessages` and keep custom entries in `agent.state.messages` when they matter to UI/session state. Use `convertToLlm` to filter UI-only messages or map custom messages to provider-compatible `user`, `assistant`, or `toolResult` messages.
+Extend `CustomAgentMessages` and retain useful custom entries in `agent.state.messages`. Use `convertToLlm` to filter UI-only messages or map custom messages to `user`, `assistant`, or `toolResult`.
 
 ## Prune or augment context
 
-Use `transformContext(messages, signal)` for message-level pruning, compaction insertion, external context injection, and other operations that should happen before provider conversion.
+Use `transformContext(messages, signal)` for pruning, compaction insertion, or external context injection before conversion.
 
-Keep `transformContext` deterministic and no-throw for expected cases. Return the original messages or a conservative safe subset when pruning cannot run.
+Return the original messages or a safe subset when an expected transform cannot run. Do not throw for expected cases.
 
 ## Support steering and follow-ups
 
-Use `steer()` for user input that should influence the next model call after the current assistant turn and tool batch finish. Use `followUp()` for input that should wait until the agent would otherwise stop.
+Use `steer()` for input that should affect the next model call after the current assistant turn and tool batch. Use `followUp()` for input that should wait until the run would otherwise stop.
 
-Set `steeringMode` and `followUpMode` explicitly when queued-message batching affects UX or correctness.
+Set `steeringMode` and `followUpMode` when batching affects behavior.
 
 ## Retry or resume generation
 
-Use `continue()` only when the agent is idle and has a valid transcript.
+Call `continue()` only when the agent is idle and has a valid transcript.
 
-- `user` or `toolResult` tail: normal continuation.
-- `assistant` tail with queued steering/follow-up: drains queued messages as a new prompt path.
-- `assistant` tail without queued messages: throws.
+- A `user` or `toolResult` tail starts normal continuation.
+- An `assistant` tail with queued steering or follow-up input drains the queue.
+- An `assistant` tail without queued input rejects.
 
-For provider retry, trim only retryable trailing assistant error messages and continue from a safe `user` or `toolResult` boundary.
+For provider retry, remove only retryable trailing assistant error messages. Continue from a safe `user` or `toolResult` boundary.
 
-## Bound and abort runs
+## Bound, abort, and reset runs
 
-Race the prompt/continue promise against the consumer timeout. On timeout, call `agent.abort()`, wait for run settlement when possible, and close downstream streams/iterables in `finally`.
+Race the prompt or continuation promise against the consumer timeout. On timeout, call `agent.abort()`, await settlement when possible, and close downstream streams in `finally`.
+
+Call `reset()` only after `waitForIdle()`. It rejects while a run is active.
 
 ## Execute tools through Pi
 
-Prefer Pi's tool execution surface over a custom runner.
+- Use `toolExecution` and per-tool `executionMode` for ordering.
+- Use `beforeToolCall` to block a validated call. Set `terminate` on a blocked result when it should join batch termination.
+- Use `afterToolCall` to replace content, details, error state, usage, or termination.
+- Throw from `execute()` on failure.
+- Use `onUpdate` for progress. Late updates after settlement are ignored.
+- Use `addedToolNames` when a result introduces tools from that transcript point onward.
 
-- Use `toolExecution` for global parallel/sequential policy.
-- Use per-tool `executionMode` for tools that cannot run in a concurrent batch.
-- Use `beforeToolCall` to block or authorize a call after validation.
-- Use `afterToolCall` to patch content/details/error/termination at the final tool boundary.
-- Throw from `execute()` on tool failure; Pi will create an error tool result for the model.
-- Use `onUpdate` for progress, not user-visible final replies.
+## Stop or prepare the next turn
 
-## Stop gracefully between turns
+Use `shouldStopAfterTurn` on `Agent` or `AgentLoopConfig` to stop after a complete turn and before queues are polled.
 
-Use low-level `shouldStopAfterTurn` when the consumer owns the loop and needs to stop after a completed assistant turn before queues are polled.
+Use `Agent.prepareNextTurnWithContext` when the next provider request needs a replacement context, model, or thinking level. Use low-level `prepareNextTurn` for the same turn-context contract in `AgentLoopConfig`.
 
-Use `prepareNextTurn` when the next provider request needs a replacement context, model, or thinking level.
+## Add durable sessions
 
-## Choose `AgentHarness`
+Use `Session` and a `SessionRepo` directly when the app needs a durable tree but can keep orchestration in bare `Agent`. Use `InMemorySessionRepo`, `JsonlSessionRepo`, or a backend that passes the `/session/testing` conformance suite.
 
-Use Pi's `AgentHarness` instead of a custom wrapper when the consumer needs a session tree, skill loading/invocation, prompt templates, resources, filesystem/shell environment, compaction, branch navigation, provider request hooks, or high-level queue UX. Read `references/harness.md`.
+Do not use published `0.84.1` `AgentHarness` operation methods as a production orchestration layer. They are scaffold paths and most reject with `HarnessNotImplemented`.

--- a/.agents/skills/pi-agent-integration/references/harness.md
+++ b/.agents/skills/pi-agent-integration/references/harness.md
@@ -1,96 +1,85 @@
-# AgentHarness
+# AgentHarness and Sessions
 
-Open this when using Pi's built-in harness, sessions, skills, prompt templates, resources, environment, compaction, or tree navigation.
+Open this when using Pi sessions, skills, prompt templates, compaction, execution helpers, or the current `AgentHarness` scaffold.
 
-## When to use it
+## Published readiness
 
-Use `AgentHarness` when the consumer needs more than a single `Agent` transcript:
+Pi `0.84.0` replaced the legacy harness and session APIs with a v4 lane-based session model and an `AgentHarness` v2 scaffold. In published `0.84.1`, the types describe the intended surface, but most operation paths reject with `HarnessNotImplemented`.
 
-- durable session tree and leaf navigation
-- skills or prompt-template invocation
-- app-owned resources included in system prompts
-- active tool subsets
-- filesystem and shell environment abstraction
-- compaction or branch summary operations
-- provider auth/header hooks
-- high-level queued UX with `steer`, `followUp`, and `nextTurn`
+Use these production paths now:
 
-Use bare `Agent` when the consumer already owns these concerns and only needs Pi execution/events/tools.
+- Use bare `Agent` for model turns, tools, queues, events, and aborts.
+- Use `Session`, `SessionTree`, and a `SessionRepo` for durable transcript and tree storage.
+- Use exported skill, prompt-template, compaction, branch-summary, search, environment, and tool helpers directly when they fit.
+- Use `AgentHarness` only for scaffold development or implemented configuration and session access. Verify source before each use.
 
-## Constructor inputs
+Do not restore the removed pre-`0.84` harness API or add compatibility wrappers unless the user asks for a migration.
 
-| Option                         | Purpose                                                                                                                   |
-| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------- |
-| `env`                          | `ExecutionEnv` filesystem/shell capability. Operations return `Result` values rather than throwing for expected failures. |
-| `session`                      | Session tree storage for messages, settings, compactions, labels, and leaf state.                                         |
-| `tools`                        | Available `AgentTool` definitions.                                                                                        |
-| `resources`                    | App-owned skills and prompt templates.                                                                                    |
-| `systemPrompt`                 | Static prompt or async function using env/session/model/thinking/tools/resources.                                         |
-| `getApiKeyAndHeaders(model)`   | Per-request provider auth and headers.                                                                                    |
-| `streamOptions`                | Curated provider options: transport, timeout, retries, headers, metadata, cache retention.                                |
-| `model`, `thinkingLevel`       | Active model and reasoning level.                                                                                         |
-| `activeToolNames`              | Optional initial active tool subset.                                                                                      |
-| `steeringMode`, `followUpMode` | Queue draining policy.                                                                                                    |
+## Create the scaffold
 
-## Main methods
+Call `await AgentHarness.create(options)`. The constructor is private. Creation returns `{ harness, suspended }` and currently rejects with `HarnessNotImplemented("create.restore")` when the session already has durable records.
 
-- Run work: `prompt(text, { images })`, `skill(name, additionalInstructions)`, `promptFromTemplate(name, args)`.
-- Queue work: `steer(text)`, `followUp(text)`, `nextTurn(text)`.
-- Mutate session: `appendMessage(message)`, `compact(customInstructions)`, `navigateTree(targetId, options)`.
-- Update runtime settings: `setModel`, `setThinkingLevel`, `setTools`, `setActiveTools`, `setResources`, `setStreamOptions`, `setSteeringMode`, `setFollowUpMode`.
-- Inspect runtime settings: `getModel`, `getThinkingLevel`, `getTools`, `getActiveTools`, `getResources`, `getStreamOptions`, `getSteeringMode`, `getFollowUpMode`.
-- Lifecycle: `abort()`, `waitForIdle()`, `subscribe(listener)`, `on(type, handler)`.
+| Required or common option | Current purpose                                                                              |
+| ------------------------- | -------------------------------------------------------------------------------------------- |
+| `session`                 | A v4 `Session`, not a legacy session repository wrapper.                                     |
+| `models`                  | Required `pi-ai` `Models` collection for provider calls.                                     |
+| `model`                   | Required initial model.                                                                      |
+| `thinkingLevel`           | Initial thinking level.                                                                      |
+| `tools`, `toolContext`    | Available tools and an optional static or per-turn application context source.               |
+| `activeToolNames`         | Initial active tool subset.                                                                  |
+| `systemPrompt`            | Static string or zero-argument async provider.                                               |
+| `resources`               | Skills and prompt templates.                                                                 |
+| Request policy            | `streamOptions`, `retry`, `compaction`, `toolExecution`, `steeringMode`, and `followUpMode`. |
+| Runtime control           | `drive`, `toProviderMessages`, `entryProjectors`, and telemetry `context`.                   |
 
-## Harness events and hooks
+`env` and `getApiKeyAndHeaders` are not constructor options. Provider auth belongs in the required `Models` collection. `ExecutionEnv` is used by standalone environment and tool helpers.
 
-Harness subscribers receive both core `AgentEvent` values and harness-owned events.
+## Implemented scaffold methods
 
-Use `on(type, handler)` for hook-style events that can return patches:
+Published `0.84.1` implements only a narrow subset:
 
-- `before_agent_start`: replace initial messages or system prompt.
-- `context`: replace context messages before provider conversion.
-- `before_provider_request`: patch stream options.
-- `before_provider_payload`: replace provider payload.
-- `tool_call`: block tool execution with a reason.
-- `tool_result`: patch content, details, error state, or termination.
-- `session_before_compact`: cancel or provide compaction output.
-- `session_before_tree`: cancel or provide branch summary/tree options.
+- `getLeafId()` through the current session.
+- Get and set model, thinking level, active tool names, tools, resources, stream options, retry policy, compaction settings, and queue modes.
+- Read the `session` tree.
+- `close()`.
 
-Observe these events for state and diagnostics:
+The following paths currently reject with `HarnessNotImplemented`:
 
-- `after_provider_response`
-- `session_compact`
-- `session_tree`
-- `model_update`
-- `thinking_level_update`
-- `resources_update`
-- `tools_update`
-- `queue_update`
-- `save_point`
-- `abort`
-- `settled`
+- Runs: `prompt`, `skill`, `promptFromTemplate`, `resume`.
+- Queues and control: `steer`, `followUp`, `nextRun`, `cancelQueued`, `abort`, `waitForIdle`, `runWhenIdle`.
+- History work: `compact`, `navigateTree`, `recordUsage`.
+- Driving and observation: `peekAction`, `executeAction`, `runToCompletion`, `watch`, `watchSession`, `hooks.on`, and `events.on`.
+- Lanes: `lane`, `createLane`, and `lanes`.
 
-## Queue guidance
+Do not describe declared `RunResult`, `QueueResult`, or hook behavior as executable until the published implementation supports it.
 
-- `steer()` targets the active run's next opportunity after the current assistant turn/tool batch.
-- `followUp()` runs after the agent would otherwise stop.
-- `nextTurn()` queues text for the next explicit turn and should be kept distinct from mid-run steering.
-- `queue_update` exposes current queued `steer`, `followUp`, and `nextTurn` messages.
+## Current declared vocabulary
 
-## Session and compaction guidance
+Use these names when reviewing or developing the scaffold:
 
-- Keep app-specific data in session entries or resources when it should survive turns.
-- Use `compact()` for harness-managed history reduction.
-- Use `navigateTree()` when moving the active leaf or summarizing a branch.
-- Treat compaction/tree hooks as policy boundaries; return structured results instead of mutating storage behind the harness.
+- The default lane is `main`. `AgentLane` owns prompts, queues, navigation, model settings, active tools, and a `SessionTree` view.
+- Queue names are `steer`, `followUp`, and `nextRun`. The removed name `nextTurn` is not current.
+- Hook names include `before_run`, `before_resume`, `before_run_end`, `transform_context`, `before_request`, `before_payload`, `after_response`, `before_tool`, `after_tool`, `before_compaction`, and `before_navigation`.
+- Expected operation rejections use typed `Result` values. Harness faults, closure during active work, and unfinished paths can reject with errors.
+
+These names describe the current contract shape. They do not override the readiness limits above.
+
+## Session v4
+
+- `SessionStorage` owns lanes, entries, records, queries, global facts, and statistics.
+- `Session` wraps storage and implements the main `SessionTree`. Use `session.view(lane)` for another lane.
+- `SessionTree` can read entries and facts, query all entries or one branch, and append messages or custom entries.
+- `SessionRepo` defines `create`, `open`, `list`, `delete`, and `fork`.
+- Use `InMemorySessionRepo` for process-local storage.
+- Use `JsonlSessionRepo` for append-only JSONL storage. It needs a filesystem and sessions root. Its create options include `cwd`.
+- Use `@earendil-works/pi-agent-core/session/testing` to run backend conformance checks for a custom repository.
+
+`FileSystem` implementations must include atomic same-filesystem `renameFile()` replacement semantics. `NodeExecutionEnv` from the `/node` entry implements the filesystem and shell environment.
 
 ## Verification
 
-Verify:
-
-1. Hook return patches are applied at the documented boundary.
-2. Session writes flush before relying on persisted state.
-3. Active tool names match the available tool set.
-4. `abort()` clears queued steer/follow-up messages and emits `abort`.
-5. `waitForIdle()` waits for the active run and awaited listeners.
-6. Compaction and tree navigation preserve expected leaf/session state.
+1. Confirm npm `latest` and inspect `dist/harness/agent-harness.js` before using a scaffold method.
+2. Confirm the session is v4 and uses current `Session`, `SessionStorage`, and `SessionRepo` contracts.
+3. Confirm old names such as `nextTurn`, `subscribe`, and legacy hook event names are absent.
+4. Treat `HarnessNotImplemented` as an unavailable feature, not a transient runtime failure.
+5. Test custom session backends with the `/session/testing` conformance export.

--- a/.agents/skills/pi-agent-integration/references/troubleshooting-workarounds.md
+++ b/.agents/skills/pi-agent-integration/references/troubleshooting-workarounds.md
@@ -1,40 +1,44 @@
 # Troubleshooting and Workarounds
 
-Open this when Pi-agent integration behavior is wrong in a consumer.
+Open this when Pi integration behavior is wrong.
 
-| Symptom                                                            | Likely cause                                                                        | Fix                                                                                      |
-| ------------------------------------------------------------------ | ----------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
-| `prompt()` throws "Agent is already processing a prompt..."        | A run is active                                                                     | Queue input with `steer()`/`followUp()` or await `waitForIdle()`                         |
-| `continue()` throws "Agent is already processing..."               | Continuation called during an active run                                            | Await the current prompt/continue or queue input                                         |
-| `continue()` throws "No messages to continue from"                 | Empty transcript                                                                    | Restore or append prior `AgentMessage[]` first                                           |
-| `continue()` throws "Cannot continue from message role: assistant" | Assistant tail with no queued steering/follow-up                                    | Trim to a safe `user`/`toolResult` boundary, queue a message, or start a new prompt      |
-| Low-level continuation reaches a provider role error               | Last custom message converts to `assistant` or an invalid provider role             | Ensure `convertToLlm` leaves a final `user` or `toolResult` message                      |
-| Stream shows no user-visible text                                  | Listener is forwarding the wrong event/delta                                        | Forward only `message_update` + `assistantMessageEvent.type === "text_delta"`            |
-| Thinking or tool-call text leaks to users                          | Consumer renders all assistant deltas                                               | Ignore `thinking_*` and `toolcall_*` deltas unless a deliberate UX exposes them          |
-| Streamed and final text differ                                     | Missing or inconsistent assistant-message boundaries                                | Insert separators intentionally and normalize streamed/final output the same way         |
-| Run settles late after `agent_end`                                 | Async subscribers are still running                                                 | Treat `agent_end` as final event emission, not full idle; await `waitForIdle()`          |
-| Tool preflight sees stale state with low-level loop                | Raw `agentLoop` event handling is observational                                     | Use `Agent` when message event handling must be a barrier before tool preflight          |
-| Provider failures bypass normal event flow                         | `streamFn` throws/rejects for expected failures                                     | Return a stream that encodes `error`/`aborted` and a final assistant message             |
-| Transform/conversion breaks lifecycle                              | `transformContext` or `convertToLlm` throws/rejects                                 | Return original messages, filtered messages, or another safe fallback for expected cases |
-| Missing auth crashes the loop                                      | `getApiKey` throws for expected unauthenticated state                               | Return `undefined` and let the consumer own visible auth recovery                        |
-| Tool results appear out of expected order                          | Default tool mode is parallel                                                       | Account for completion-order `tool_execution_end`; use `sequential` when required        |
-| A sequential-only tool still changes whole batch behavior          | Per-tool `executionMode: "sequential"` forces the whole batch sequential            | Isolate the tool call or accept sequential batch execution                               |
-| Tool failure is treated as success                                 | Tool returned failure text as normal content                                        | Throw from `execute()` so Pi emits an error tool result                                  |
-| `terminate: true` does not stop the next LLM call                  | Mixed batch where not every finalized tool result terminates                        | Ensure every result in the batch sets `terminate: true`, or split the batch              |
-| Queue order surprises                                              | Default queue mode drains one message at a time                                     | Set `steeringMode`/`followUpMode` explicitly                                             |
-| Proxy errors are opaque                                            | Proxy response/event handling hides status/body                                     | Validate proxy status/body in the proxy server and encode visible stream errors          |
-| Harness hook changes are ignored                                   | Handler is attached to the wrong event type or uses `subscribe()` instead of `on()` | Use `harness.on(type, handler)` for patch-returning hooks                                |
-| Harness session state is missing                                   | Work relies on pending writes before they flush                                     | Wait for the harness method/idle boundary before reading persisted session state         |
+| Symptom                                                    | Cause                                                                                | Fix                                                                                               |
+| ---------------------------------------------------------- | ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------- |
+| `Agent` construction or loop call fails type checking      | `streamFn` or its required argument position is missing                              | Pass `streamFn`; pass `undefined` in the low-level signal position when needed                    |
+| `prompt()` says the agent is already processing            | A run is active                                                                      | Queue with `steer()` or `followUp()`, or await `waitForIdle()`                                    |
+| `continue()` says the agent is already processing          | Continuation started during a run                                                    | Await the run or queue input                                                                      |
+| `reset()` says the agent is already processing             | Reset started during a run                                                           | Abort if needed, await `waitForIdle()`, then reset                                                |
+| `continue()` says there are no messages                    | The transcript is empty                                                              | Restore or append prior messages                                                                  |
+| `continue()` rejects an `assistant` tail                   | Both input queues are empty                                                          | Queue a message, trim to a safe `user` or `toolResult` boundary, or start a new prompt            |
+| Low-level continuation reaches a provider role error       | Conversion leaves an invalid final role                                              | Make `convertToLlm` leave a final `user` or `toolResult`                                          |
+| Visible text is missing or thinking/tool text leaks        | The listener forwards the wrong assistant delta                                      | Forward only `message_update` plus `text_delta`                                                   |
+| Streamed and final text differ                             | Message boundaries or normalization differ                                           | Insert boundaries on purpose and use one normalization rule                                       |
+| Run settlement is late after `agent_end`                   | Async subscribers are still running                                                  | Await the prompt or `waitForIdle()`                                                               |
+| Tool preflight sees stale state with a low-level loop      | Raw loop event handling is observational                                             | Use `Agent` when event handling must be a barrier                                                 |
+| Provider failures bypass normal events                     | `streamFn` throws or rejects for an expected failure                                 | Return a stream that encodes `error` or `aborted`                                                 |
+| Transform, conversion, auth, or loop hooks break lifecycle | An expected failure escapes                                                          | Return original or filtered messages, `undefined`, or another safe value                          |
+| Tool results appear in an unexpected order                 | Default tool mode is parallel                                                        | Expect completion-order end events or use sequential mode                                         |
+| One sequential tool serializes every call                  | Any per-tool sequential override affects the full batch                              | Isolate the call or accept sequential batch execution                                             |
+| Tool failure appears successful                            | The tool returned failure text as normal content                                     | Throw from `execute()`                                                                            |
+| A blocked tool does not terminate                          | The block result omitted `terminate`, or another batch result did not terminate      | Set `terminate` on every finalized result that must join early termination                        |
+| `afterToolCall` loses nested fields                        | `content`, `details`, and `usage` are full replacements                              | Return the complete replacement value                                                             |
+| Progress arrives after tool completion                     | The tool calls `onUpdate` after its promise settles                                  | Stop updates before settlement; Pi ignores late callbacks                                         |
+| Added tools are not available from the result point        | `addedToolNames` is missing from `AgentToolResult`                                   | Return the introduced tool names and keep the definitions available                               |
+| `prepareNextTurn` lacks completed-turn context             | The signal-only `Agent` compatibility hook is in use                                 | Use `Agent.prepareNextTurnWithContext`                                                            |
+| `AgentHarness` method rejects with `HarnessNotImplemented` | Published `0.84.1` ships a compile-complete scaffold with unfinished operation paths | Use bare `Agent`, direct session APIs, or standalone helpers                                      |
+| Old harness names do not compile                           | `0.84.0` replaced the legacy harness and session model                               | Use `AgentHarness.create`, `nextRun`, lane/session v4 names, and the current options              |
+| `AgentHarness.create()` rejects with `create.restore`      | The session contains durable records and restore is unfinished                       | Do not use the scaffold to restore that session                                                   |
+| `streamProxy` loses finalized tool-call metadata           | Published `0.84.1` drops some final metadata, including OpenAI Responses namespaces  | Do not depend on it; patch the proxy path locally or wait for the upstream unreleased fix to ship |
 
 ## Debugging checklist
 
-1. Confirm the package name is `@earendil-works/pi-agent-core` and the API was checked against npm `latest`.
-2. Identify whether the consumer uses `Agent`, low-level loop APIs, or `AgentHarness`.
-3. Check active-run state before any `prompt()` or `continue()` call.
-4. Inspect the transcript tail before continuation.
-5. Check whether queued steering/follow-up messages exist when continuing from an assistant tail.
-6. Confirm stream forwarding filters to text deltas only.
-7. Confirm expected provider failures are encoded in the stream rather than thrown.
-8. Confirm transform/conversion/auth hooks return safe values for expected failures.
-9. Confirm tool execution mode and per-tool execution overrides.
-10. Confirm async listeners or harness hooks are not delaying settlement unexpectedly.
+1. Confirm npm `latest`, then inspect the published README, declarations, and implementation.
+2. Identify `Agent`, a low-level loop, direct session APIs, or the `AgentHarness` scaffold.
+3. Confirm a required `streamFn` is present.
+4. Check active-run state before `prompt()`, `continue()`, or `reset()`.
+5. Inspect the transcript tail and queued input before continuation.
+6. Filter visible streaming to text deltas.
+7. Keep expected provider, conversion, transform, auth, and queue failures no-throw.
+8. Confirm tool execution mode, hook replacement semantics, usage, added tools, and termination.
+9. Account for awaited `Agent` listeners during settlement.
+10. For harness work, inspect which methods are implemented in the published package. Do not infer readiness from types or design docs.


### PR DESCRIPTION
Refreshes the Pi integration skill against published `@earendil-works/pi-agent-core@0.84.1`. Core guidance now covers required stream functions, current loop signatures, turn hooks, active-run reset behavior, tool result metadata, and the known published proxy limitation.

The previous skill was based on `0.78.0` and treated the old harness contract as production-ready. This replaces that guidance with the v4 session APIs, clearly marks the current `AgentHarness` operation surface as an unfinished scaffold, and records how to separate published behavior from unreleased upstream changes.
