### PR TITLE
fix(chat): serialize conversation writes

### DIFF
--- a/packages/junior/src/chat/conversations/README.md
+++ b/packages/junior/src/chat/conversations/README.md
@@ -77,6 +77,12 @@ older source-thread context; it does not replace Pi history.
 - Restore transcripts and agent history directly from conversation events.
 - Keep imports and migrations idempotent and preserve conversation IDs.
 
+## SQL Write Lock
+
+All metadata and event writes for one conversation use the
+`junior_conversation:<conversationId>` advisory lock. They cannot lock shared SQL
+rows in opposite order because their transactions do not overlap.
+
 Reporting APIs project an authorized, redacted contract from the event stream.
 Raw event payloads are internal and must not become dashboard or external API
 payloads. Reporting keeps destination-visible `message` events separate from

--- a/packages/junior/src/chat/conversations/sql/event-lock.ts
+++ b/packages/junior/src/chat/conversations/sql/event-lock.ts
@@ -6,8 +6,8 @@ export async function withConversationEventLock<T>(
   conversationId: string,
   callback: () => Promise<T>,
 ): Promise<T> {
-  return executor.withLock(
-    `junior_conversation:event:${conversationId}`,
-    callback,
-  );
+  // Event writes and metadata writes touch the same conversation and identity
+  // rows. Use the mutation lock so their transactions cannot deadlock by
+  // acquiring those rows in different orders.
+  return executor.withLock(`junior_conversation:${conversationId}`, callback);
 }

--- a/packages/junior/src/chat/conversations/sql/event-lock.ts
+++ b/packages/junior/src/chat/conversations/sql/event-lock.ts
@@ -1,13 +1,10 @@
 import type { JuniorSqlDatabase } from "@/db/db";
 
-/** Serialize all event sequence allocation and visible projection writes. */
+/** Serialize event sequence allocation with other conversation writes. */
 export async function withConversationEventLock<T>(
   executor: JuniorSqlDatabase,
   conversationId: string,
   callback: () => Promise<T>,
 ): Promise<T> {
-  // Event writes and metadata writes touch the same conversation and identity
-  // rows. Use the mutation lock so their transactions cannot deadlock by
-  // acquiring those rows in different orders.
   return executor.withLock(`junior_conversation:${conversationId}`, callback);
 }

--- a/packages/junior/tests/component/conversations/retention.test.ts
+++ b/packages/junior/tests/component/conversations/retention.test.ts
@@ -351,7 +351,7 @@ describe("retention purge job", () => {
       withLock: async (name, callback) => {
         if (
           !childWriteCompleted &&
-          name === "junior_conversation:event:racing-child"
+          name === "junior_conversation:racing-child"
         ) {
           await fixture.sql
             .db()


### PR DESCRIPTION
Conversation event writes now use the same per-conversation advisory lock as metadata writes. This prevents PostgreSQL deadlocks when transcript persistence overlaps background title or activity persistence, so affected Slack mentions reach agent execution instead of the fallback error reply.

The change keeps event ordering and actor identity resolution unchanged. The owning conversation README now records the shared lock invariant, and the retention race fixture observes the canonical lock key.

The previously failing Slack scenario passed ten consecutive runs. The full Junior suite passed with 2,600 tests, type checks passed, and the push checks passed.
