### PR TITLE
test: harden agent integration boundaries

### DIFF
--- a/packages/junior/src/chat/runtime/agent-runner.ts
+++ b/packages/junior/src/chat/runtime/agent-runner.ts
@@ -8,6 +8,8 @@ import { isExperimentalFeatureEnabled } from "@/chat/experimental";
 import type { AgentRunOutcome } from "@/chat/runtime/agent-run-outcome";
 import type { SandboxEgressTracePropagationConfig } from "@/chat/sandbox/egress/tracing";
 
+const AGENT_ABORT_SETTLE_GRACE_MS = 5_000;
+
 /** Run one agent-run slice behind runtime-owned orchestration boundaries. */
 export interface AgentRunner {
   run(run: AgentRun): Promise<AgentRunOutcome>;
@@ -15,10 +17,7 @@ export interface AgentRunner {
 
 /** Compose the agent executor with stable host dependencies. */
 export function createAgentRunner(
-  execute: (
-    run: AgentRun,
-    streamFn?: StreamFn,
-  ) => Promise<AgentRunOutcome>,
+  execute: (run: AgentRun, streamFn?: StreamFn) => Promise<AgentRunOutcome>,
   options?: {
     bindSpawnAgent?: (run: AgentRun) => SpawnAgent | undefined;
     streamFn?: StreamFn;
@@ -57,4 +56,64 @@ export function createAgentRunner(
       return await execute(nextRun, streamFn);
     },
   };
+}
+
+async function waitForAgentSettlement(
+  runPromise: Promise<AgentRunOutcome>,
+): Promise<void> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const settleGrace = new Promise<void>((resolve) => {
+    timeoutId = setTimeout(resolve, AGENT_ABORT_SETTLE_GRACE_MS);
+    timeoutId.unref?.();
+  });
+  await Promise.race([
+    runPromise.then(
+      () => undefined,
+      () => undefined,
+    ),
+    settleGrace,
+  ]);
+  if (timeoutId) {
+    clearTimeout(timeoutId);
+  }
+}
+
+/** Abort a timed-out agent run and wait briefly for its work to settle. */
+export async function runAgentWithTimeout(
+  agentRunner: AgentRunner,
+  run: AgentRun,
+  timeoutMs: number | undefined,
+): Promise<AgentRunOutcome> {
+  if (typeof timeoutMs !== "number") {
+    return await agentRunner.run(run);
+  }
+
+  const timeoutError = new Error(
+    `executeAgentRun timed out after ${timeoutMs}ms`,
+  );
+  const abortController = new AbortController();
+  const signal = run.signal
+    ? AbortSignal.any([run.signal, abortController.signal])
+    : abortController.signal;
+  const runPromise = agentRunner.run({ ...run, signal });
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(() => {
+      abortController.abort(timeoutError);
+      reject(timeoutError);
+    }, timeoutMs);
+  });
+
+  try {
+    return await Promise.race([runPromise, timeoutPromise]);
+  } catch (error) {
+    if (abortController.signal.aborted) {
+      await waitForAgentSettlement(runPromise);
+    }
+    throw error;
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+  }
 }

--- a/packages/junior/src/chat/runtime/slack-resume.ts
+++ b/packages/junior/src/chat/runtime/slack-resume.ts
@@ -21,7 +21,10 @@ import {
 import type { AgentRunResult } from "@/chat/services/turn-result";
 import { getAssistantReplyText } from "@/chat/services/assistant-reply";
 import type { AssistantMessage } from "@earendil-works/pi-ai";
-import type { AgentRunner } from "@/chat/runtime/agent-runner";
+import {
+  runAgentWithTimeout,
+  type AgentRunner,
+} from "@/chat/runtime/agent-runner";
 import { scheduleSessionCompletedPluginTasks } from "@/chat/plugins/task-runner";
 import {
   buildTurnFailureResponse,
@@ -389,8 +392,7 @@ function createResumeReplyContext(
             ...(args.threadTs ? { threadTs: args.threadTs } : {}),
           }
         : source,
-    deadlineAtMs:
-      replyContext.deadlineAtMs ?? requestDeadline?.deadlineAtMs,
+    deadlineAtMs: replyContext.deadlineAtMs ?? requestDeadline?.deadlineAtMs,
     environment: {
       ...replyContext.environment,
       locationConfiguration: persistedLocationConfiguration,
@@ -584,8 +586,7 @@ async function resumeSlackTurnInContext(
           slackMessageTs = await sendSlackReply({
             channelId: runArgs.channelId,
             conversationId: runArgs.conversationId,
-            replyAttribution:
-              runArgs.replyContext?.dispatch?.replyAttribution,
+            replyAttribution: runArgs.replyContext?.dispatch?.replyAttribution,
             text,
             threadTs: runArgs.threadTs,
           });
@@ -687,25 +688,12 @@ async function resumeSlackTurnInContext(
         surface: "slack",
       });
     }
-    const replyPromise = runArgs.agentRunner.run(replyContext);
     const replyTimeoutMs = resolveReplyTimeoutMs(runArgs.replyTimeoutMs);
-    const outcome =
-      typeof replyTimeoutMs === "number"
-        ? await Promise.race([
-            replyPromise,
-            new Promise<never>((_, reject) =>
-              setTimeout(
-                () =>
-                  reject(
-                    new Error(
-                      `executeAgentRun timed out after ${replyTimeoutMs}ms`,
-                    ),
-                  ),
-                replyTimeoutMs,
-              ),
-            ),
-          ])
-        : await replyPromise;
+    const outcome = await runAgentWithTimeout(
+      runArgs.agentRunner,
+      replyContext,
+      replyTimeoutMs,
+    );
     if (outcome.status !== "completed") {
       // Expected pauses defer their handlers until the lock is released,
       // mirroring the failure path below.

--- a/packages/junior/tests/integration/oauth-resume-slack.test.ts
+++ b/packages/junior/tests/integration/oauth-resume-slack.test.ts
@@ -155,7 +155,20 @@ describe("oauth resume slack integration", () => {
 
   it("posts a failure reply when resumed generation times out", async () => {
     const { resumeSlackTurn } = await import("@/chat/runtime/slack-resume");
-    const onFailure = vi.fn(async () => undefined);
+    const runEvents: string[] = [];
+    let observedSignal: AbortSignal | undefined;
+    const realAgentRunner = createModelAgentRunner(
+      createModelStream([
+        {
+          type: "text",
+          text: "This reply should not finish.",
+          waitFor: new Promise<never>(() => undefined),
+        },
+      ]),
+    );
+    const onFailure = vi.fn(async () => {
+      runEvents.push("failure handled");
+    });
 
     await resumeSlackTurn({
       messageText: "What budget deadline did I mention earlier?",
@@ -172,19 +185,34 @@ describe("oauth resume slack integration", () => {
         source: testSlackSource("1700000000.010"),
         actor: { platform: "slack", teamId: "T123", userId: "U123" },
       },
-      agentRunner: createModelAgentRunner(
-        createModelStream([
-          {
-            type: "text",
-            text: "This reply should not finish.",
-            waitFor: new Promise<never>(() => undefined),
-          },
-        ]),
-      ),
+      agentRunner: {
+        run: async (run) => {
+          observedSignal = run.signal;
+          run.signal?.addEventListener(
+            "abort",
+            () => runEvents.push("agent aborted"),
+            { once: true },
+          );
+          try {
+            return await realAgentRunner.run(run);
+          } finally {
+            runEvents.push("agent settled");
+          }
+        },
+      },
       replyTimeoutMs: 10,
       onFailure,
     });
 
+    expect(observedSignal?.aborted).toBe(true);
+    expect(observedSignal?.reason).toEqual(
+      new Error("executeAgentRun timed out after 10ms"),
+    );
+    expect(runEvents).toEqual([
+      "agent aborted",
+      "agent settled",
+      "failure handled",
+    ]);
     expect(onFailure).toHaveBeenCalledOnce();
     expect(
       getCapturedSlackApiCalls("chat.postMessage").map(

--- a/scripts/check-test-architecture.mjs
+++ b/scripts/check-test-architecture.mjs
@@ -26,7 +26,8 @@ const RULES = [
     id: "manufactured-agent-outcome",
     message:
       "integration tests must run the real agent instead of manufacturing agent outcomes",
-    pattern: /\bcompletedAgentRun\b/g,
+    pattern:
+      /\bcompletedAgentRun\b|\breturn\s*\(?\s*\{\s*status:\s*["'](?:completed|awaiting_auth|suspended)["']/g,
   },
   {
     allowsDebt: true,
@@ -157,9 +158,7 @@ function main() {
     readDebt(root),
   );
   if (errors.length === 0) {
-    console.log(
-      "Tests do not add to known test architecture debt.",
-    );
+    console.log("Tests do not add to known test architecture debt.");
     return;
   }
   console.error(["Test architecture check failed:", ...errors].join("\n"));

--- a/scripts/check-test-architecture.test.mjs
+++ b/scripts/check-test-architecture.test.mjs
@@ -56,12 +56,28 @@ test("rejects manufactured agent outcomes", () => {
   assert.deepEqual(
     checkIntegrationTestArchitecture([
       integrationTest(
-        'import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";',
+        [
+          'import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";',
+          'return { status: "awaiting_auth", providerDisplayName: "GitHub" };',
+          'return ({ status: "suspended", reason: "timeout", resumeVersion: 2 });',
+          'return { status: "completed", result };',
+        ].join("\n"),
       ),
     ]),
     [
-      `${TEST_PATH}: integration tests must run the real agent instead of manufacturing agent outcomes (1 found, 0 allowed)`,
+      `${TEST_PATH}: integration tests must run the real agent instead of manufacturing agent outcomes (4 found, 0 allowed)`,
     ],
+  );
+});
+
+test("allows assertions about real agent outcomes", () => {
+  assert.deepEqual(
+    checkIntegrationTestArchitecture([
+      integrationTest(
+        'await expect(run).resolves.toEqual({ status: "completed" });',
+      ),
+    ]),
+    [],
   );
 });
 

--- a/scripts/test-architecture-debt.json
+++ b/scripts/test-architecture-debt.json
@@ -1,22 +1,23 @@
 {
   "manufactured-agent-outcome": {
-    "packages/junior/tests/integration/local-agent-runner.test.ts": 18,
+    "packages/junior/tests/integration/api-turn-work.test.ts": 1,
+    "packages/junior/tests/integration/local-agent-runner.test.ts": 19,
     "packages/junior/tests/integration/mcp-oauth-callback.test.ts": 2,
-    "packages/junior/tests/integration/oauth-callback.test.ts": 3,
+    "packages/junior/tests/integration/oauth-callback.test.ts": 4,
     "packages/junior/tests/integration/slack/assistant-thread-contract.test.ts": 2,
     "packages/junior/tests/integration/slack/attachment-behavior.test.ts": 3,
     "packages/junior/tests/integration/slack/attachment-media-behavior.test.ts": 4,
-    "packages/junior/tests/integration/slack/bot-handlers.test.ts": 24,
+    "packages/junior/tests/integration/slack/bot-handlers.test.ts": 29,
     "packages/junior/tests/integration/slack/bot-image-hydration.test.ts": 2,
     "packages/junior/tests/integration/slack/conversation-turn-steering-behavior.test.ts": 7,
     "packages/junior/tests/integration/slack/message-changed-behavior.test.ts": 2,
-    "packages/junior/tests/integration/slack/message-changed-reply-contract.test.ts": 3,
+    "packages/junior/tests/integration/slack/message-changed-reply-contract.test.ts": 4,
     "packages/junior/tests/integration/slack/message-content-behavior.test.ts": 2,
     "packages/junior/tests/integration/slack/message-im-attachment-contract.test.ts": 2,
     "packages/junior/tests/integration/slack/new-mention-behavior.test.ts": 2,
     "packages/junior/tests/integration/slack/processing-reaction-behavior.test.ts": 6,
     "packages/junior/tests/integration/slack/provider-default-config-behavior.test.ts": 2,
-    "packages/junior/tests/integration/slack/subscribed-message-behavior.test.ts": 2,
+    "packages/junior/tests/integration/slack/subscribed-message-behavior.test.ts": 3,
     "packages/junior/tests/integration/slack/thread-continuity-behavior.test.ts": 2
   },
   "scripted-agent-runner": {


### PR DESCRIPTION
Integration test enforcement now catches agent outcomes returned directly as `completed`, `awaiting_auth`, or `suspended`, instead of counting only the existing helper names. The debt file now records the corrected baseline of 112 references, so new direct outcome fakes cannot pass unnoticed. This is a count correction, not added test debt.

Timed Slack resume runs now receive an abort signal and wait briefly for the real agent to settle before failure handling starts. The OAuth resume integration test checks the abort, settlement, and failure order through the real agent with fixed model output. The seven migrated integration suites pass together, and the full repository lint passed before push.

Refs #1425.
