### PR TITLE
fix(chat): keep Slack loading_messages carousel stable on mid-turn progress

### DIFF
--- a/packages/junior/src/chat/slack/assistant-thread/status-scheduler.ts
+++ b/packages/junior/src/chat/slack/assistant-thread/status-scheduler.ts
@@ -94,7 +94,16 @@ export function createAssistantStatusScheduler(args: {
 
   const getLoadingMessagesForVisibleStatus = (
     visible: string,
-  ): string[] | undefined => (visible ? [visible] : undefined);
+  ): string[] | undefined => {
+    if (!visible) {
+      return undefined;
+    }
+    if (!loadingMessages?.length) {
+      return [visible];
+    }
+    const fillers = loadingMessages.filter((message) => message !== visible);
+    return [visible, ...fillers].slice(0, loadingMessages.length);
+  };
 
   const getInitialStatusText = (): string => {
     if (loadingMessages?.length) {

--- a/packages/junior/tests/integration/agent-continue-slack.test.ts
+++ b/packages/junior/tests/integration/agent-continue-slack.test.ts
@@ -536,13 +536,13 @@ describe("paused turn Slack integration", () => {
 
     const activeStatuses = slackApiOutbox
       .calls("assistant.threads.setStatus")
-      .map((call) => call.params)
+      .map(
+        (call) =>
+          call.params as { status?: unknown; loading_messages?: string[] },
+      )
       .filter((params) => params.status !== "");
-    expect(activeStatuses[0]).toEqual(
-      expect.objectContaining({
-        loading_messages: ["Reviewing results"],
-      }),
-    );
+    expect(activeStatuses[0]?.loading_messages?.[0]).toBe("Reviewing results");
+    expect(activeStatuses[0]?.loading_messages?.length).toBeGreaterThan(1);
   });
 
   it("terminalizes startup failures before the visible failure path runs", async () => {

--- a/packages/junior/tests/unit/progress-reporter.test.ts
+++ b/packages/junior/tests/unit/progress-reporter.test.ts
@@ -399,7 +399,78 @@ describe("createAssistantStatusScheduler", () => {
     ]);
   });
 
-  it("replaces generic loading messages when explicit progress matches the visible text", async () => {
+  it("keeps the loading_messages carousel size stable across a mid-turn progress update", async () => {
+    const scheduler = createFakeScheduler();
+    const calls: Array<{ text: string; loadingMessages?: string[] }> = [];
+    const baseCarousel = [
+      "Consulting the orb",
+      "Bribing the gremlins",
+      "Shuffling the papers dramatically",
+    ];
+    const reporter = createAssistantStatusScheduler({
+      sendStatus: async (text, loadingMessages) => {
+        calls.push({ text, loadingMessages });
+      },
+      loadingMessages: baseCarousel,
+      now: scheduler.now,
+      setTimer: scheduler.setTimer,
+      clearTimer: scheduler.clearTimer,
+      random: () => 0,
+    });
+
+    reporter.update();
+    await flushAsyncWork();
+
+    reporter.update(makeAssistantStatus("searching", "sources"));
+    scheduler.advance(1200);
+    await flushAsyncWork();
+
+    // Slack rotates loading_messages as a carousel; shrinking that array on a
+    // mid-turn update (instead of keeping its size stable) is what produced
+    // the flicker in issue #445. The base carousel is shuffled before it
+    // reaches the scheduler, so assert the invariant rather than one exact
+    // fill order.
+    const initialCarousel = calls[0]?.loadingMessages ?? [];
+    expect(initialCarousel).toHaveLength(baseCarousel.length);
+
+    const mergedCarousel = calls[1]?.loadingMessages ?? [];
+    expect(calls[1]?.text).toBe(secondSearchingStatus);
+    expect(mergedCarousel).toHaveLength(baseCarousel.length);
+    expect(mergedCarousel[0]).toBe(secondSearchingStatus);
+    expect(new Set(mergedCarousel).size).toBe(mergedCarousel.length);
+    expect(
+      mergedCarousel
+        .slice(1)
+        .every((message) => initialCarousel.includes(message)),
+    ).toBe(true);
+  });
+
+  it("falls back to a single-element loading message array without a base carousel", async () => {
+    const scheduler = createFakeScheduler();
+    const calls: Array<{ text: string; loadingMessages?: string[] }> = [];
+    const reporter = createAssistantStatusScheduler({
+      sendStatus: async (text, loadingMessages) => {
+        calls.push({ text, loadingMessages });
+      },
+      loadingMessages: [],
+      now: scheduler.now,
+      setTimer: scheduler.setTimer,
+      clearTimer: scheduler.clearTimer,
+      random: () => 0,
+    });
+
+    reporter.update(makeAssistantStatus("searching", "sources"));
+    await flushAsyncWork();
+
+    expect(calls).toEqual([
+      {
+        text: secondSearchingStatus,
+        loadingMessages: [secondSearchingStatus],
+      },
+    ]);
+  });
+
+  it("skips a redundant resend when explicit progress already matches the visible carousel", async () => {
     const scheduler = createFakeScheduler();
     const calls: Array<{ text: string; loadingMessages?: string[] }> = [];
     const reporter = createAssistantStatusScheduler({
@@ -419,14 +490,14 @@ describe("createAssistantStatusScheduler", () => {
     reporter.update(makeAssistantStatus("reviewing"));
     await flushAsyncWork();
 
+    // The merged carousel for the explicit update is identical to the one
+    // already on screen (same visible text, same base carousel), so no
+    // second Slack write is sent — resending it would only recreate the
+    // flicker this scheduler exists to avoid.
     expect(calls).toEqual([
       {
         text: secondReviewingStatus,
         loadingMessages: [secondReviewingStatus, "Consulting the orb"],
-      },
-      {
-        text: secondReviewingStatus,
-        loadingMessages: [secondReviewingStatus],
       },
     ]);
   });


### PR DESCRIPTION
## Summary
- `getLoadingMessagesForVisibleStatus` always returned a single-element array whenever an explicit progress update fired mid-turn, so the `loading_messages` carousel sent to Slack shrank abruptly and the loading indicator flickered.
- Merge the progress text with the base carousel (`loadingMessages` from the closure) so the array size stays stable across updates instead of always collapsing to one element.

Fixes #445

## Test plan
- [x] `pnpm --filter @sentry/junior exec tsc --noEmit`
- [x] `pnpm --filter @sentry/junior exec oxlint` on the changed files
- [x] `pnpm --filter @sentry/junior test` (full package suite green)
- [x] Added unit coverage for `createAssistantStatusScheduler`: carousel stays a stable size across a mid-turn progress update, and falls back to a single-element array when there is no base carousel
- [x] Fixed an existing unit test that asserted the old shrinking behavior as correct; it now documents that a redundant resend is skipped when the merged carousel already matches what's on screen
- [x] Updated an integration assertion in `agent-continue-slack.test.ts` that required `loading_messages` to be exactly length 1; it now checks the first element and that the length is greater than 1 (that test uses non-deterministic shuffle, so the full array can't be asserted)
- [x] Confirmed the new unit tests fail without the fix and pass with it (via `git stash`)