### PR TITLE
test(local): remove scripted agent runner

### DIFF
--- a/packages/junior/tests/fixtures/agent-runner.ts
+++ b/packages/junior/tests/fixtures/agent-runner.ts
@@ -5,9 +5,7 @@ import {
 import type { StreamFn } from "@earendil-works/pi-agent-core";
 import type { AssistantMessage } from "@earendil-works/pi-ai";
 import { fauxAssistantMessage } from "@earendil-works/pi-ai/providers/faux";
-import type { AgentRunResult } from "@/chat/services/turn-result";
 import { getAssistantReplyText } from "@/chat/services/assistant-reply";
-import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 import type { PiMessage } from "@/chat/pi/messages";
 import { isAssistantMessage } from "@/chat/pi/transcript";
 import type { AgentRun } from "@/chat/agent/types";
@@ -85,21 +83,4 @@ export async function deliverAssistantMessagesForTest(
     await run.delivery(message);
   }
   return history;
-}
-
-/** Script completed assistant messages through the production delivery port. */
-export function scriptedAssistantMessageRunner(args: {
-  messages: Array<{ text: string }>;
-  result: AgentRunResult;
-}): AgentRunner {
-  return {
-    run: async (run) => {
-      await deliverAssistantMessagesForTest(
-        run,
-        args.messages,
-        args.result.piMessages,
-      );
-      return completedAgentRun(args.result);
-    },
-  };
 }

--- a/packages/junior/tests/integration/local-agent-runner.test.ts
+++ b/packages/junior/tests/integration/local-agent-runner.test.ts
@@ -31,11 +31,11 @@ import { coerceThreadConversationState } from "@/chat/state/conversation";
 import { hydrateConversationMessages } from "@/chat/conversations/messages";
 import { setPlugins } from "@/chat/plugins/agent-hooks";
 import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
+import { NO_REPLY_MARKER } from "@/chat/no-reply";
 import { createProviderError } from "@/chat/services/provider-error";
 import {
   createModelAgentRunnerForRun,
   neverRunAgentRunner,
-  scriptedAssistantMessageRunner,
 } from "../fixtures/agent-runner";
 import { createModelStream } from "../fixtures/model-stream";
 import { getConversationEventStore } from "@/chat/db";
@@ -165,44 +165,6 @@ async function persistRunningSessionForFakeReply(
 }
 
 describe("local agent runner", () => {
-  it("delivers and persists completed assistant messages in order", async () => {
-    const conversationId = normalizeLocalConversationId({
-      alias: "assistant-messages",
-      cwd: "/tmp/local-agent-runner-assistant-messages",
-    });
-    expect(conversationId).toBeDefined();
-    const delivered: LocalAgentReply[] = [];
-
-    await runLocalAgentTurn(
-      {
-        conversationId: conversationId!,
-        message: "check this",
-      },
-      {
-        deliverReply: async (reply) => {
-          delivered.push(reply);
-        },
-        agentRunner: scriptedAssistantMessageRunner({
-          messages: [{ text: "Checking now." }, { text: "Done." }],
-          result: successReply("Done."),
-        }),
-      },
-    );
-
-    expect(delivered).toEqual([{ text: "Checking now." }, { text: "Done." }]);
-    const state = await getPersistedThreadState(conversationId!);
-    const conversation = coerceThreadConversationState(state);
-    await hydrateConversationMessages({
-      conversation,
-      conversationId: conversationId!,
-    });
-    expect(
-      conversation.messages
-        .filter((message) => message.role === "assistant")
-        .map((message) => message.text),
-    ).toEqual(["Checking now.", "Done."]);
-  });
-
   it("runs a local message without Slack actor or destination state", async () => {
     const conversationId = normalizeLocalConversationId({
       alias: "demo",
@@ -398,9 +360,9 @@ describe("local agent runner", () => {
     await runLocalAgentTurn(
       { conversationId: conversationId!, message: "react only" },
       {
-        agentRunner: {
-          run: async () => completedAgentRun(successReply("")),
-        },
+        agentRunner: createModelAgentRunnerForRun(() =>
+          createModelStream([{ type: "text", text: NO_REPLY_MARKER }]),
+        ),
         deliverReply,
       },
     );
@@ -418,51 +380,12 @@ describe("local agent runner", () => {
     expect(JSON.stringify(conversation.messages)).not.toContain(
       "[no visible reply]",
     );
-    expect(await loadLifecycleEvents(conversationId!)).toEqual([
-      expect.objectContaining({
-        data: expect.objectContaining({ type: "turn_started" }),
-      }),
-      expect.objectContaining({
-        data: expect.objectContaining({
-          type: "turn_completed",
-          outcome: "no_reply",
-        }),
-      }),
-    ]);
-  });
-
-  it("records success when a completed message precedes intentional silence", async () => {
-    const conversationId = normalizeLocalConversationId({
-      alias: "message-then-no-reply",
-      cwd: "/tmp/local-agent-runner-message-then-no-reply",
+    const lifecycle = await loadLifecycleEvents(conversationId!);
+    expect(lifecycle[0]?.data).toMatchObject({ type: "turn_started" });
+    expect(lifecycle.at(-1)?.data).toMatchObject({
+      type: "turn_completed",
+      outcome: "no_reply",
     });
-    const delivered: LocalAgentReply[] = [];
-
-    await runLocalAgentTurn(
-      { conversationId: conversationId!, message: "check, then react" },
-      {
-        agentRunner: scriptedAssistantMessageRunner({
-          messages: [{ text: "Checked it." }],
-          result: successReply(""),
-        }),
-        deliverReply: async (reply) => {
-          delivered.push(reply);
-        },
-      },
-    );
-
-    expect(delivered).toEqual([{ text: "Checked it." }]);
-    expect(await loadLifecycleEvents(conversationId!)).toEqual([
-      expect.objectContaining({
-        data: expect.objectContaining({ type: "turn_started" }),
-      }),
-      expect.objectContaining({
-        data: expect.objectContaining({
-          type: "turn_completed",
-          outcome: "success",
-        }),
-      }),
-    ]);
   });
 
   it("records a delivered sanitized model failure without raw error data", async () => {

--- a/scripts/test-architecture-debt.json
+++ b/scripts/test-architecture-debt.json
@@ -1,6 +1,6 @@
 {
   "manufactured-agent-outcome": {
-    "packages/junior/tests/integration/local-agent-runner.test.ts": 11,
+    "packages/junior/tests/integration/local-agent-runner.test.ts": 10,
     "packages/junior/tests/integration/slack/assistant-thread-contract.test.ts": 2,
     "packages/junior/tests/integration/slack/attachment-behavior.test.ts": 3,
     "packages/junior/tests/integration/slack/attachment-media-behavior.test.ts": 4,
@@ -16,8 +16,5 @@
     "packages/junior/tests/integration/slack/provider-default-config-behavior.test.ts": 2,
     "packages/junior/tests/integration/slack/subscribed-message-behavior.test.ts": 3,
     "packages/junior/tests/integration/slack/thread-continuity-behavior.test.ts": 2
-  },
-  "scripted-agent-runner": {
-    "packages/junior/tests/integration/local-agent-runner.test.ts": 3
   }
 }


### PR DESCRIPTION
The local no-reply integration case now sends the reserved no-reply response through the real agent with fixed model output. This exercises real routing and completion while keeping the assertion focused on the durable start and terminal no-reply states.

Two scripted cases are removed because a normal local turn cannot emit multiple completed replies without queued input, or emit a completed reply and then continue to intentional silence. With those false cases gone, the unused scripted runner and its remaining debt exception are also removed. No product code changes in this PR.

All 18 local-agent integration cases pass. Type checks, lint, dependency rules, test-architecture checks, and the full push policy gate also pass.
