### PR TITLE
test(local): run delivery rollback through real agent

### DIFF
--- a/packages/junior/tests/integration/local-agent-runner.test.ts
+++ b/packages/junior/tests/integration/local-agent-runner.test.ts
@@ -1007,15 +1007,18 @@ describe("local agent runner", () => {
     const eventId = "33333333333333333333333333333333";
     const capture = vi.fn().mockReturnValue(eventId);
 
-    const generateReply = vi.fn<AgentRunner["run"]>(async (request) => {
-      const context = request;
-      await context.durability?.onSandboxRefChanged?.({
-        id: "sandbox-undelivered",
-        profileHash: "profile-undelivered",
-      });
-      await deliverAssistantText(request, "not delivered");
-      return completedAgentRun(successReply("not delivered"));
-    });
+    const realAgentRunner = createModelAgentRunnerForRun(() =>
+      createModelStream([{ type: "text", text: "not delivered" }]),
+    );
+    const agentRunner: AgentRunner = {
+      run: async (request) => {
+        await request.durability?.onSandboxRefChanged?.({
+          id: "sandbox-undelivered",
+          profileHash: "profile-undelivered",
+        });
+        return await realAgentRunner.run(request);
+      },
+    };
 
     await expect(
       runLocalAgentTurn(
@@ -1027,14 +1030,28 @@ describe("local agent runner", () => {
           deliverReply: async () => {
             throw new Error(rawDeliveryError);
           },
-          agentRunner: { run: generateReply },
+          agentRunner,
           logException: capture,
         },
       ),
     ).rejects.toThrow(rawDeliveryError);
 
-    expect(await loadProjection({ conversationId: conversationId! })).toEqual(
-      [],
+    const projection = await loadProjection({
+      conversationId: conversationId!,
+    });
+    expect(projection).toEqual([
+      expect.objectContaining({
+        role: "user",
+        content: expect.arrayContaining([
+          expect.objectContaining({
+            type: "text",
+            text: expect.stringContaining("hello"),
+          }),
+        ]),
+      }),
+    ]);
+    expect(projection.some((message) => message.role === "assistant")).toBe(
+      false,
     );
     const state = await getPersistedThreadState(conversationId!);
     expect(getPersistedSandboxState(state)).toBeUndefined();

--- a/scripts/test-architecture-debt.json
+++ b/scripts/test-architecture-debt.json
@@ -1,6 +1,6 @@
 {
   "manufactured-agent-outcome": {
-    "packages/junior/tests/integration/local-agent-runner.test.ts": 4,
+    "packages/junior/tests/integration/local-agent-runner.test.ts": 3,
     "packages/junior/tests/integration/slack/assistant-thread-contract.test.ts": 2,
     "packages/junior/tests/integration/slack/attachment-behavior.test.ts": 3,
     "packages/junior/tests/integration/slack/attachment-media-behavior.test.ts": 4,


### PR DESCRIPTION
The local delivery-failure integration test now sends a fixed reply through the real agent before the local output sink rejects it. The test still confirms that the temporary sandbox reference is restored, the visible conversation keeps only the user message, and the failed turn records the delivery error.

Real execution also corrects the durable Pi assertion: Junior keeps the accepted user input but does not commit the rejected assistant output. This removes one manufactured agent outcome and lowers the local test debt from four cases to three.
