### PR TITLE
test(slack): run attachment ingress through real agent

### DIFF
--- a/packages/junior/tests/integration/slack/attachment-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/attachment-behavior.test.ts
@@ -5,10 +5,8 @@ import {
   createTestThread,
   createTestDestination,
 } from "../../fixtures/slack-harness";
-import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
-import {
-  deliverAssistantMessagesForTest,
-} from "../../fixtures/agent-runner";
+import { createModelAgentRunnerForRun } from "../../fixtures/agent-runner";
+import { createModelStream } from "../../fixtures/model-stream";
 
 const ORIGINAL_ENV = { ...process.env };
 
@@ -64,39 +62,26 @@ describe("Slack behavior: attachment handling", () => {
           completeText: completeTextMock,
         },
         replyExecutor: {
-          agentRunner: {
-            run: async (request) => {
-              const _prompt = request.instruction.text;
-              const context = request;
-
-              const attachments = context?.instruction.attachments ?? [];
-              capturedAttachmentCounts.push(attachments.length);
-              if (attachments[0]) {
-                capturedAttachmentMediaTypes.push(attachments[0].mediaType);
-              }
-
-              await deliverAssistantMessagesForTest(request, [
-                { text: "Image received. The chart trend is upward." },
-              ]);
-              return completedAgentRun({
+          agentRunner: createModelAgentRunnerForRun((request) => {
+            const attachments = request.instruction.attachments ?? [];
+            capturedAttachmentCounts.push(attachments.length);
+            if (attachments[0]) {
+              capturedAttachmentMediaTypes.push(attachments[0].mediaType);
+            }
+            return createModelStream([
+              {
+                type: "text",
                 text: "Image received. The chart trend is upward.",
-                diagnostics: {
-                  assistantMessageCount: 1,
-                  modelId: "fake-agent-model",
-                  outcome: "success" as const,
-                  toolCalls: [],
-                  toolErrorCount: 0,
-                  toolResultCount: 0,
-                  usedPrimaryText: true,
-                },
-              });
-            },
-          },
+              },
+            ]);
+          }),
         },
       },
     });
 
-    const thread = await createTestThread({ id: "slack:C0BEHAVIOR:1700004000.000" });
+    const thread = await createTestThread({
+      id: "slack:C0BEHAVIOR:1700004000.000",
+    });
     const message = createTestMessage({
       id: "m-attachment-1",
       text: "<@U0APP> summarize this chart",
@@ -131,8 +116,8 @@ describe("Slack behavior: attachment handling", () => {
     const completeTextMock = vi.fn(async () => {
       throw new Error("vision unavailable");
     });
-    const executeAgentRun = vi.fn(async (request) => {
-      const attachments = request?.instruction?.attachments ?? [];
+    const streamForRun = vi.fn((request) => {
+      const attachments = request.instruction.attachments ?? [];
       expect(attachments).toEqual([
         expect.objectContaining({
           filename: "error.png",
@@ -142,23 +127,12 @@ describe("Slack behavior: attachment handling", () => {
           ),
         }),
       ]);
-      await deliverAssistantMessagesForTest(request, [
+      return createModelStream([
         {
+          type: "text",
           text: "I couldn’t inspect the attached image. Please try uploading it again.",
         },
       ]);
-      return completedAgentRun({
-        text: "I couldn’t inspect the attached image. Please try uploading it again.",
-        diagnostics: {
-          assistantMessageCount: 1,
-          modelId: "fake-agent-model",
-          outcome: "success" as const,
-          toolCalls: [],
-          toolErrorCount: 0,
-          toolResultCount: 0,
-          usedPrimaryText: true,
-        },
-      });
     });
 
     const { slackRuntime } = await createRuntime({
@@ -167,12 +141,14 @@ describe("Slack behavior: attachment handling", () => {
           completeText: completeTextMock,
         },
         replyExecutor: {
-          agentRunner: { run: executeAgentRun },
+          agentRunner: createModelAgentRunnerForRun(streamForRun),
         },
       },
     });
 
-    const thread = await createTestThread({ id: "slack:C0BEHAVIOR:1700004001.000" });
+    const thread = await createTestThread({
+      id: "slack:C0BEHAVIOR:1700004001.000",
+    });
     const message = createTestMessage({
       id: "m-attachment-2",
       text: "<@U0APP> what does this screenshot mean?",
@@ -196,7 +172,7 @@ describe("Slack behavior: attachment handling", () => {
 
     expect(attachmentFetch).toHaveBeenCalledTimes(1);
     expect(completeTextMock).toHaveBeenCalledTimes(1);
-    expect(executeAgentRun).toHaveBeenCalledTimes(1);
+    expect(streamForRun).toHaveBeenCalledTimes(1);
     expect(thread.posts).toHaveLength(1);
     expect(toPostedText(thread.posts[0])).toContain(
       "I couldn’t inspect the attached image.",

--- a/packages/junior/tests/integration/slack/attachment-media-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/attachment-media-behavior.test.ts
@@ -5,11 +5,8 @@ import {
   createTestThread,
   createTestDestination,
 } from "../../fixtures/slack-harness";
-import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
-import type { AgentRunner } from "@/chat/runtime/agent-runner";
-import {
-  deliverAssistantMessagesForTest,
-} from "../../fixtures/agent-runner";
+import { createModelAgentRunnerForRun } from "../../fixtures/agent-runner";
+import { createModelStream } from "../../fixtures/model-stream";
 
 const ORIGINAL_ENV = { ...process.env };
 
@@ -73,34 +70,18 @@ describe("Slack behavior: mixed attachment media", () => {
             completeText: completeTextMock,
           },
           replyExecutor: {
-            agentRunner: {
-              run: async (request) => {
-                const _prompt = request.instruction.text;
-                const context = {
-                  ...request,
-                };
-
-                const attachments = context?.instruction.attachments ?? [];
-                capturedAttachmentMediaTypes.push(
-                  attachments.map((attachment) => attachment.mediaType),
-                );
-                capturedAttachmentNames.push(
-                  attachments.map((attachment) => attachment.filename ?? ""),
-                );
-                return completedAgentRun({
-                  text: "Processed attachments.",
-                  diagnostics: {
-                    assistantMessageCount: 1,
-                    modelId: "fake-agent-model",
-                    outcome: "success" as const,
-                    toolCalls: [],
-                    toolErrorCount: 0,
-                    toolResultCount: 0,
-                    usedPrimaryText: true,
-                  },
-                });
-              },
-            },
+            agentRunner: createModelAgentRunnerForRun((request) => {
+              const attachments = request.instruction.attachments ?? [];
+              capturedAttachmentMediaTypes.push(
+                attachments.map((attachment) => attachment.mediaType),
+              );
+              capturedAttachmentNames.push(
+                attachments.map((attachment) => attachment.filename ?? ""),
+              );
+              return createModelStream([
+                { type: "text", text: "Processed attachments." },
+              ]);
+            }),
           },
         },
       },
@@ -174,40 +155,28 @@ describe("Slack behavior: mixed attachment media", () => {
     const { slackRuntime } = await createRuntime({
       services: {
         replyExecutor: {
-          agentRunner: {
-            run: async (request) => {
-              const _prompt = request.instruction.text;
-              const context = request;
-
-              const attachments = context?.instruction.attachments ?? [];
-              capturedAttachmentMediaTypes.push(
-                attachments.map((attachment) => attachment.mediaType),
-              );
-              capturedAttachmentNames.push(
-                attachments.map((attachment) => attachment.filename ?? ""),
-              );
-              capturedOmittedImageCounts.push(
-                context?.instruction.omittedImageAttachmentCount ?? 0,
-              );
-              return completedAgentRun({
-                text: "Processed attachments.",
-                diagnostics: {
-                  assistantMessageCount: 1,
-                  modelId: "fake-agent-model",
-                  outcome: "success" as const,
-                  toolCalls: [],
-                  toolErrorCount: 0,
-                  toolResultCount: 0,
-                  usedPrimaryText: true,
-                },
-              });
-            },
-          },
+          agentRunner: createModelAgentRunnerForRun((request) => {
+            const attachments = request.instruction.attachments ?? [];
+            capturedAttachmentMediaTypes.push(
+              attachments.map((attachment) => attachment.mediaType),
+            );
+            capturedAttachmentNames.push(
+              attachments.map((attachment) => attachment.filename ?? ""),
+            );
+            capturedOmittedImageCounts.push(
+              request.instruction.omittedImageAttachmentCount ?? 0,
+            );
+            return createModelStream([
+              { type: "text", text: "Processed attachments." },
+            ]);
+          }),
         },
       },
     });
 
-    const thread = await createTestThread({ id: "slack:C0BEHAVIOR:1700004011.000" });
+    const thread = await createTestThread({
+      id: "slack:C0BEHAVIOR:1700004011.000",
+    });
     const message = createTestMessage({
       id: "m-attachment-mixed-2",
       text: "<@U0APP> summarize these files",
@@ -244,44 +213,29 @@ describe("Slack behavior: mixed attachment media", () => {
   it("still runs the assistant when only images are attached and vision is disabled", async () => {
     const imageFetch = vi.fn(async () => Buffer.from("image-bytes"));
     const capturedOmittedImageCounts: number[] = [];
-    const executeAgentRun = vi.fn<AgentRunner["run"]>(async (request) => {
-      await deliverAssistantMessagesForTest(request, [
+    const streamForRun = vi.fn((request) => {
+      capturedOmittedImageCounts.push(
+        request.instruction.omittedImageAttachmentCount ?? 0,
+      );
+      return createModelStream([
         {
+          type: "text",
           text: "I can’t inspect the attached image in this runtime, but I do see that an image was included.",
         },
       ]);
-      return completedAgentRun({
-        text: "I can’t inspect the attached image in this runtime, but I do see that an image was included.",
-        diagnostics: {
-          assistantMessageCount: 1,
-          modelId: "fake-agent-model",
-          outcome: "success" as const,
-          toolCalls: [],
-          toolErrorCount: 0,
-          toolResultCount: 0,
-          usedPrimaryText: true,
-        },
-      });
     });
 
     const { slackRuntime } = await createRuntime({
       services: {
         replyExecutor: {
-          agentRunner: {
-            run: async (request) => {
-              const context = request;
-
-              capturedOmittedImageCounts.push(
-                context?.instruction.omittedImageAttachmentCount ?? 0,
-              );
-              return executeAgentRun(request);
-            },
-          },
+          agentRunner: createModelAgentRunnerForRun(streamForRun),
         },
       },
     });
 
-    const thread = await createTestThread({ id: "slack:C0BEHAVIOR:1700004012.000" });
+    const thread = await createTestThread({
+      id: "slack:C0BEHAVIOR:1700004012.000",
+    });
     const message = createTestMessage({
       id: "m-attachment-mixed-3",
       text: "<@U0APP> what about this image?",
@@ -304,7 +258,7 @@ describe("Slack behavior: mixed attachment media", () => {
     });
 
     expect(imageFetch).not.toHaveBeenCalled();
-    expect(executeAgentRun).toHaveBeenCalledTimes(1);
+    expect(streamForRun).toHaveBeenCalledTimes(1);
     expect(capturedOmittedImageCounts).toEqual([1]);
     expect(thread.posts).toHaveLength(1);
     expect(toPostedText(thread.posts[0])).toContain(

--- a/packages/junior/tests/integration/slack/message-im-attachment-contract.test.ts
+++ b/packages/junior/tests/integration/slack/message-im-attachment-contract.test.ts
@@ -6,7 +6,8 @@ import { slackEventsApiEnvelope } from "../../fixtures/slack/factories/events";
 import { createSlackWebhookTestClient } from "../../fixtures/slack/webhook-client";
 import { mswServer } from "../../msw/server";
 import type { AgentRunner } from "@/chat/runtime/agent-runner";
-import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
+import { createModelAgentRunnerForRun } from "../../fixtures/agent-runner";
+import { createModelStream } from "../../fixtures/model-stream";
 
 const SIGNING_SECRET = "test-signing-secret";
 const BOT_USER_ID = "U0BOT";
@@ -16,18 +17,6 @@ const ORIGINAL_ENV = { ...process.env };
 const slackWebhookClient = createSlackWebhookTestClient({
   signingSecret: SIGNING_SECRET,
 });
-
-function makeDiagnostics() {
-  return {
-    assistantMessageCount: 1,
-    modelId: "fake-agent-model",
-    outcome: "success" as const,
-    toolCalls: [],
-    toolErrorCount: 0,
-    toolResultCount: 0,
-    usedPrimaryText: true,
-  };
-}
 
 async function createDirectMessageBot(args: {
   completeText: () => Promise<{ text: string; message: never }>;
@@ -103,24 +92,18 @@ describe("Slack contract: message.im attachment ingress", () => {
         text: "Screenshot shows the current incident chart.",
         message: {} as never,
       }),
-      agentRunner: {
-        run: async (request) => {
-          const _prompt = request.instruction.text;
-          const context = request;
-
-          const attachments = context?.instruction.attachments ?? [];
-          capturedAttachmentMediaTypes.push(
-            attachments.map((attachment) => attachment.mediaType),
-          );
-          capturedAttachmentNames.push(
-            attachments.map((attachment) => attachment.filename ?? ""),
-          );
-          return completedAgentRun({
-            text: "Processed screenshot.",
-            diagnostics: makeDiagnostics(),
-          });
-        },
-      },
+      agentRunner: createModelAgentRunnerForRun((request) => {
+        const attachments = request.instruction.attachments ?? [];
+        capturedAttachmentMediaTypes.push(
+          attachments.map((attachment) => attachment.mediaType),
+        );
+        capturedAttachmentNames.push(
+          attachments.map((attachment) => attachment.filename ?? ""),
+        );
+        return createModelStream([
+          { type: "text", text: "Processed screenshot." },
+        ]);
+      }),
     });
     const waitUntil = slackWebhookClient.waitUntil();
 

--- a/scripts/test-architecture-debt.json
+++ b/scripts/test-architecture-debt.json
@@ -1,15 +1,12 @@
 {
   "manufactured-agent-outcome": {
     "packages/junior/tests/integration/slack/assistant-thread-contract.test.ts": 2,
-    "packages/junior/tests/integration/slack/attachment-behavior.test.ts": 3,
-    "packages/junior/tests/integration/slack/attachment-media-behavior.test.ts": 4,
     "packages/junior/tests/integration/slack/bot-handlers.test.ts": 29,
     "packages/junior/tests/integration/slack/bot-image-hydration.test.ts": 2,
     "packages/junior/tests/integration/slack/conversation-turn-steering-behavior.test.ts": 7,
     "packages/junior/tests/integration/slack/message-changed-behavior.test.ts": 2,
     "packages/junior/tests/integration/slack/message-changed-reply-contract.test.ts": 4,
     "packages/junior/tests/integration/slack/message-content-behavior.test.ts": 2,
-    "packages/junior/tests/integration/slack/message-im-attachment-contract.test.ts": 2,
     "packages/junior/tests/integration/slack/new-mention-behavior.test.ts": 2,
     "packages/junior/tests/integration/slack/processing-reaction-behavior.test.ts": 6,
     "packages/junior/tests/integration/slack/provider-default-config-behavior.test.ts": 2,


### PR DESCRIPTION
Slack attachment integration tests now run through the real agent and reply delivery path while replacing only model output. The existing cases still cover Slack file ingress, attachment hydration, vision failure, mixed-file filtering, and disabled vision behavior; the matching test architecture debt entries are removed. This makes failures reflect production wiring instead of custom runners that manufactured successful outcomes.
