### PR TITLE
test(slack): run edited replies through real agent

### DIFF
--- a/packages/junior/tests/integration/slack/message-changed-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/message-changed-behavior.test.ts
@@ -1,24 +1,13 @@
-import {
-  createTestDestination,
-  TEST_SLACK_TEAM_ID,
-} from "../../fixtures/slack-harness";
 import { http, HttpResponse } from "msw";
 import { afterEach, describe, expect, it } from "vitest";
 import { createMemoryState } from "@chat-adapter/state-memory";
-import type { SlackAdapter } from "@chat-adapter/slack";
 import type { Message } from "chat";
 import { slackEventsApiEnvelope } from "../../fixtures/slack/factories/events";
-import { slackApiOutbox } from "../../fixtures/slack-api-outbox";
 import { createSlackWebhookTestClient } from "../../fixtures/slack/webhook-client";
 import { mswServer } from "../../msw/server";
-import { createSlackRuntime } from "@/chat/app/factory";
 import { JuniorChat } from "@/chat/ingress/junior-chat";
 import { createJuniorSlackAdapter } from "@/chat/slack/adapter";
 import { handleChatSdkPlatformWebhook } from "@/handlers/webhooks";
-import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
-import {
-  deliverAssistantMessagesForTest,
-} from "../../fixtures/agent-runner";
 
 const SIGNING_SECRET = "test-signing-secret";
 const BOT_USER_ID = "U0BOT";
@@ -26,18 +15,6 @@ const ORIGINAL_ENV = { ...process.env };
 const slackWebhookClient = createSlackWebhookTestClient({
   signingSecret: SIGNING_SECRET,
 });
-
-function makeDiagnostics() {
-  return {
-    assistantMessageCount: 1,
-    modelId: "fake-agent-model",
-    outcome: "success" as const,
-    toolCalls: [],
-    toolErrorCount: 0,
-    toolResultCount: 0,
-    usedPrimaryText: true,
-  };
-}
 
 describe("Slack behavior: message_changed webhook ingress", () => {
   afterEach(() => {
@@ -141,7 +118,7 @@ describe("Slack behavior: message_changed webhook ingress", () => {
     expect((editedMessage.raw as { ts?: string }).ts).toBe("1700000100.000100");
   });
 
-  it("preserves edited-message image attachments through to the agent context", async () => {
+  it("preserves edited-message image attachments through the webhook and adapter path", async () => {
     mswServer.use(
       http.get("https://files.slack.com/private/edited.png", async () => {
         return new HttpResponse(Buffer.from("image-bytes"), {
@@ -241,112 +218,6 @@ describe("Slack behavior: message_changed webhook ingress", () => {
     ]);
     const imageData = await editedMessage?.attachments[0]?.fetchData?.();
     expect(imageData?.toString()).toBe("image-bytes");
-  });
-
-  it("posts a finalized reply back into the edited DM thread", async () => {
-    const state = createMemoryState();
-    await state.connect();
-    const bot = new JuniorChat<{ slack: SlackAdapter }>({
-      userName: "junior",
-      adapters: {
-        slack: createJuniorSlackAdapter({
-          botToken: "xoxb-test",
-          botUserId: BOT_USER_ID,
-          signingSecret: SIGNING_SECRET,
-        }),
-      },
-      state,
-    });
-    const slackRuntime = createSlackRuntime({
-      getSlackAdapter: () => bot.getAdapter("slack"),
-      services: {
-        replyExecutor: {
-          lookupSlackUser: async () => ({
-            email: "david@example.com",
-            fullName: "David Cramer",
-            userName: "dcramer",
-          }),
-          agentRunner: {
-            run: async (request) => {
-              const _prompt = request.instruction.text;
-              const context = request;
-
-              expect(context?.actor).toEqual({
-                email: "david@example.com",
-                fullName: "David Cramer",
-                platform: "slack",
-                teamId: TEST_SLACK_TEAM_ID,
-                userId: "U123",
-                userName: "dcramer",
-              });
-              await deliverAssistantMessagesForTest(request, [
-                { text: "Hello world" },
-              ]);
-              return completedAgentRun({
-                text: "Hello world",
-                diagnostics: makeDiagnostics(),
-              });
-            },
-          },
-        },
-      },
-    });
-    const waitUntil = slackWebhookClient.waitUntil();
-
-    bot.onDirectMessage((thread, message) =>
-      slackRuntime.handleNewMention(thread, message, {
-        destination: createTestDestination(thread),
-      }),
-    );
-
-    const editedPayload = {
-      ...slackEventsApiEnvelope({
-        eventType: "message",
-        channel: "D12345",
-        ts: "1700000100.000100",
-        text: "hello there",
-      }),
-      event: {
-        type: "message",
-        subtype: "message_changed",
-        channel: "D12345",
-        hidden: true,
-        message: {
-          type: "message",
-          user: "U123",
-          text: `<@${BOT_USER_ID}> hello there`,
-          ts: "1700000100.000100",
-        },
-        previous_message: {
-          type: "message",
-          user: "U123",
-          text: "hello there",
-          ts: "1700000100.000100",
-        },
-      },
-    };
-
-    const response = await handleChatSdkPlatformWebhook(
-      slackWebhookClient.event(editedPayload),
-      "slack",
-      waitUntil.fn,
-      bot,
-    );
-    await waitUntil.flush();
-
-    expect(response.status).toBe(200);
-    const postCalls = slackApiOutbox.messages();
-
-    expect(postCalls).toHaveLength(1);
-    expect(postCalls[0]).toEqual(
-      expect.objectContaining({
-        params: expect.objectContaining({
-          channel: "D12345",
-          thread_ts: "1700000100.000100",
-          text: "Hello world",
-        }),
-      }),
-    );
   });
 
   it("rejects forged edited mentions before any bot handler runs", async () => {

--- a/packages/junior/tests/integration/slack/message-changed-reply-contract.test.ts
+++ b/packages/junior/tests/integration/slack/message-changed-reply-contract.test.ts
@@ -10,10 +10,9 @@ import { JuniorChat } from "@/chat/ingress/junior-chat";
 import type { AgentRunner } from "@/chat/runtime/agent-runner";
 import { createJuniorSlackAdapter } from "@/chat/slack/adapter";
 import { handleChatSdkPlatformWebhook } from "@/handlers/webhooks";
-import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
-import { deliverAssistantMessagesForTest } from "../../fixtures/agent-runner";
+import { createModelAgentRunner } from "../../fixtures/agent-runner";
+import { createModelStream } from "../../fixtures/model-stream";
 import { queueSlackApiError } from "../../msw/handlers/slack-api";
-import { RetryableDeliveryError } from "@/chat/agent/types";
 import type { PausedTurnRequest } from "@/chat/task-execution/turn-wake";
 
 const SIGNING_SECRET = "test-signing-secret";
@@ -21,18 +20,6 @@ const BOT_USER_ID = "U0BOT";
 const slackWebhookClient = createSlackWebhookTestClient({
   signingSecret: SIGNING_SECRET,
 });
-
-function makeDiagnostics() {
-  return {
-    assistantMessageCount: 1,
-    modelId: "fake-agent-model",
-    outcome: "success" as const,
-    toolCalls: [],
-    toolErrorCount: 0,
-    toolResultCount: 0,
-    usedPrimaryText: true,
-  };
-}
 
 function createEditedMentionRequest(args: {
   messageTs: string;
@@ -106,18 +93,9 @@ async function createEditedDmBot(args: {
 describe("Slack contract: edited-message reply delivery", () => {
   it("posts the finalized reply into the edited DM thread with chat.postMessage", async () => {
     const bot = await createEditedDmBot({
-      agentRunner: {
-        run: async (request) => {
-          const _prompt = request.instruction.text;
-          await deliverAssistantMessagesForTest(request, [
-            { text: "Hello world" },
-          ]);
-          return completedAgentRun({
-            text: "Hello world",
-            diagnostics: makeDiagnostics(),
-          });
-        },
-      },
+      agentRunner: createModelAgentRunner(
+        createModelStream([{ type: "text", text: "Hello world" }]),
+      ),
     });
     const waitUntil = slackWebhookClient.waitUntil();
 
@@ -151,15 +129,9 @@ describe("Slack contract: edited-message reply delivery", () => {
       (_, i) => `line ${i + 1}`,
     ).join("\n");
     const bot = await createEditedDmBot({
-      agentRunner: {
-        run: async (request) => {
-          await deliverAssistantMessagesForTest(request, [{ text: longReply }]);
-          return completedAgentRun({
-            text: longReply,
-            diagnostics: makeDiagnostics(),
-          });
-        },
-      },
+      agentRunner: createModelAgentRunner(
+        createModelStream([{ type: "text", text: longReply }]),
+      ),
     });
     const waitUntil = slackWebhookClient.waitUntil();
 
@@ -197,14 +169,9 @@ describe("Slack contract: edited-message reply delivery", () => {
     }
     const wakePausedTurn = vi.fn().mockResolvedValue(undefined);
     const bot = await createEditedDmBot({
-      agentRunner: {
-        run: async (request) => {
-          await expect(
-            deliverAssistantMessagesForTest(request, [{ text: "Hello world" }]),
-          ).rejects.toBeInstanceOf(RetryableDeliveryError);
-          return { status: "suspended", reason: "retry", resumeVersion: 2 };
-        },
-      },
+      agentRunner: createModelAgentRunner(
+        createModelStream([{ type: "text", text: "Hello world" }]),
+      ),
       wakePausedTurn,
     });
     const waitUntil = slackWebhookClient.waitUntil();

--- a/scripts/test-architecture-debt.json
+++ b/scripts/test-architecture-debt.json
@@ -3,8 +3,6 @@
     "packages/junior/tests/integration/slack/assistant-thread-contract.test.ts": 2,
     "packages/junior/tests/integration/slack/bot-handlers.test.ts": 29,
     "packages/junior/tests/integration/slack/conversation-turn-steering-behavior.test.ts": 7,
-    "packages/junior/tests/integration/slack/message-changed-behavior.test.ts": 2,
-    "packages/junior/tests/integration/slack/message-changed-reply-contract.test.ts": 4,
     "packages/junior/tests/integration/slack/message-content-behavior.test.ts": 2,
     "packages/junior/tests/integration/slack/new-mention-behavior.test.ts": 2,
     "packages/junior/tests/integration/slack/processing-reaction-behavior.test.ts": 6,


### PR DESCRIPTION
Edited Slack message delivery tests now use the real agent loop with fixed model output for normal replies, overflow posts, and transient Slack failures. The ingress suite keeps payload parsing, attachment, and signature contracts, while the delivery suite is the single owner of reply-thread behavior. This removes duplicate coverage and clears both matching test architecture debt entries.
