### PR TITLE
test(slack): run new mention paths through real agent

### DIFF
--- a/packages/junior/tests/integration/slack/new-mention-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/new-mention-behavior.test.ts
@@ -9,15 +9,15 @@ import {
   createTestMessage,
   createTestThread,
 } from "../../fixtures/slack-harness";
-import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
-import type { AgentRunner } from "@/chat/runtime/agent-runner";
 import { hydrateConversationMessages } from "@/chat/conversations/messages";
 import { coerceThreadConversationState } from "@/chat/state/conversation";
 import {
-  deliverAssistantMessagesForTest,
+  createModelAgentRunner,
+  createModelAgentRunnerForRun,
 } from "../../fixtures/agent-runner";
+import { createModelStream } from "../../fixtures/model-stream";
 
-interface FakeReplyCall {
+interface CapturedRun {
   prompt: string;
   piMessages?: unknown[];
 }
@@ -37,88 +37,22 @@ function toPostedText(value: unknown): string {
   return String(value);
 }
 
-async function completedReply(
-  request: Parameters<AgentRunner["run"]>[0],
-  text: string,
-  toolCalls: string[] = [],
-) {
-  await deliverAssistantMessagesForTest(request, [{ text }]);
-  return completedAgentRun({
-    text,
-    diagnostics: {
-      assistantMessageCount: 1,
-      modelId: "fake-agent-model",
-      outcome: "success" as const,
-      toolCalls,
-      toolErrorCount: 0,
-      toolResultCount: toolCalls.length,
-      usedPrimaryText: true,
-    },
-  });
-}
-
 describe("Slack behavior: new mention", () => {
-  it("handles a mention with real runtime wiring and fake agent response", async () => {
-    const fakeReplyCalls: FakeReplyCall[] = [];
-
-    const { slackRuntime } = createTestChatRuntime({
-      services: {
-        replyExecutor: {
-          agentRunner: {
-            run: async (request) => {
-              const prompt = request.instruction.text;
-
-              fakeReplyCalls.push({ prompt });
-              return await completedReply(
-                request,
-                "Acknowledged. Rollback is complete and error rates are stable.",
-              );
-            },
-          },
-        },
-      },
-    });
-
-    const thread = await createTestThread({
-      id: "slack:C0BEHAVIOR:1700001234.000",
-    });
-    const message = createTestMessage({
-      id: "m-behavior-1",
-      text: "<@U0APP> give me a status update",
-      isMention: true,
-      threadId: thread.id,
-      author: {
-        userId: "U0TESTER",
-        userName: "tester",
-      },
-    });
-
-    await slackRuntime.handleNewMention(thread, message, {
-      destination: createTestDestination(thread),
-    });
-
-    expect(fakeReplyCalls).toHaveLength(1);
-    expect(fakeReplyCalls[0]?.prompt).toContain("give me a status update");
-    expect(thread.subscribeCalls).toBe(1);
-    expect(thread.posts).toHaveLength(1);
-    expect(toPostedText(thread.posts[0])).toContain("Rollback is complete");
-  });
-
   it("includes queued SDK messages in the assistant prompt", async () => {
-    const fakeReplyCalls: FakeReplyCall[] = [];
+    const agentRuns: CapturedRun[] = [];
 
     const { slackRuntime } = createTestChatRuntime({
       services: {
         replyExecutor: {
-          agentRunner: {
-            run: async (request) => {
-              const prompt = request.instruction.text;
-              const context = request;
-
-              fakeReplyCalls.push({ prompt, piMessages: context.history ? [...context.history] : undefined });
-              return await completedReply(request, "Handled both updates.");
-            },
-          },
+          agentRunner: createModelAgentRunnerForRun((request) => {
+            agentRuns.push({
+              prompt: request.instruction.text,
+              piMessages: request.history ? [...request.history] : undefined,
+            });
+            return createModelStream([
+              { type: "text", text: "Handled both updates." },
+            ]);
+          }),
         },
       },
     });
@@ -149,10 +83,10 @@ describe("Slack behavior: new mention", () => {
       },
     });
 
-    expect(fakeReplyCalls).toHaveLength(1);
-    expect(fakeReplyCalls[0]?.prompt).toContain("latest request");
-    expect(fakeReplyCalls[0]?.prompt).not.toContain("first queued request");
-    expect(JSON.stringify(fakeReplyCalls[0]?.piMessages)).toContain(
+    expect(agentRuns).toHaveLength(1);
+    expect(agentRuns[0]?.prompt).toContain("latest request");
+    expect(agentRuns[0]?.prompt).not.toContain("first queued request");
+    expect(JSON.stringify(agentRuns[0]?.piMessages)).toContain(
       "first queued request",
     );
     const conversation = coerceThreadConversationState(await thread.getState());
@@ -175,7 +109,7 @@ describe("Slack behavior: new mention", () => {
   });
 
   it("forwards queued SDK message attachments to the assistant context", async () => {
-    const fakeReplyCalls: Array<{
+    const agentRuns: Array<{
       attachmentText?: string;
       filenames: string[];
       inboundAttachmentCount?: number;
@@ -186,27 +120,22 @@ describe("Slack behavior: new mention", () => {
     const { slackRuntime } = createTestChatRuntime({
       services: {
         replyExecutor: {
-          agentRunner: {
-            run: async (request) => {
-              const prompt = request.instruction.text;
-              const context = request;
-
-              const attachments = context?.instruction.attachments ?? [];
-              fakeReplyCalls.push({
-                prompt,
-                inboundAttachmentCount: context?.instruction.inboundAttachmentCount,
-                filenames: attachments.map(
-                  (attachment) => attachment.filename ?? "",
-                ),
-                attachmentText: attachments[0]?.data?.toString("utf8"),
-                piMessages: context?.history ? [...context.history] : undefined,
-              });
-              return await completedReply(
-                request,
-                "Handled queued attachment.",
-              );
-            },
-          },
+          agentRunner: createModelAgentRunnerForRun((request) => {
+            const attachments = request.instruction.attachments ?? [];
+            agentRuns.push({
+              prompt: request.instruction.text,
+              inboundAttachmentCount:
+                request.instruction.inboundAttachmentCount,
+              filenames: attachments.map(
+                (attachment) => attachment.filename ?? "",
+              ),
+              attachmentText: attachments[0]?.data?.toString("utf8"),
+              piMessages: request.history ? [...request.history] : undefined,
+            });
+            return createModelStream([
+              { type: "text", text: "Handled queued attachment." },
+            ]);
+          }),
         },
       },
     });
@@ -243,7 +172,7 @@ describe("Slack behavior: new mention", () => {
       },
     });
 
-    expect(fakeReplyCalls).toEqual([
+    expect(agentRuns).toEqual([
       expect.objectContaining({
         prompt: "then answer now",
         inboundAttachmentCount: 1,
@@ -251,7 +180,7 @@ describe("Slack behavior: new mention", () => {
         attachmentText: "queued attachment notes",
       }),
     ]);
-    expect(JSON.stringify(fakeReplyCalls[0]?.piMessages)).toContain(
+    expect(JSON.stringify(agentRuns[0]?.piMessages)).toContain(
       "review this file first",
     );
     expect(thread.posts).toHaveLength(1);
@@ -260,59 +189,17 @@ describe("Slack behavior: new mention", () => {
     );
   });
 
-  it("clears assistant status after successful reply", async () => {
-    const slackAdapter = new FakeSlackAdapter();
-    const { slackRuntime } = createTestChatRuntime({
-      slackAdapter,
-      services: {
-        replyExecutor: {
-          agentRunner: {
-            run: async (request) => {
-              const _prompt = request.instruction.text;
-              const context = request;
-
-              await context?.onEvent?.({ type: "status", text: "running bash" });
-              return await completedReply(request, "Done.", ["bash"]);
-            },
-          },
-        },
-      },
-    });
-
-    const thread = await createTestThread({
-      id: "slack:C0STATUS:1700002000.000",
-    });
-    await slackRuntime.handleNewMention(
-      thread,
-      createTestMessage({
-        id: "m-status-clear",
-        text: "<@U0APP> run a command",
-        isMention: true,
-        threadId: thread.id,
-      }),
-      { destination: createTestDestination(thread) },
-    );
-
-    expect(slackAdapter.statusCalls.length).toBeGreaterThan(0);
-    expect(slackAdapter.statusCalls.at(-1)).toEqual({
-      channelId: "C0STATUS",
-      threadTs: "1700002000.000",
-      text: "",
-      loadingMessages: undefined,
-    });
-  });
-
   it("clears assistant status after agent error", async () => {
     const slackAdapter = new FakeSlackAdapter();
     const { slackRuntime } = createTestChatRuntime({
       slackAdapter,
       services: {
         replyExecutor: {
-          agentRunner: {
-            run: async () => {
-              throw new Error("model exploded");
-            },
-          },
+          agentRunner: createModelAgentRunner(
+            createModelStream([
+              { type: "error", errorMessage: "model exploded" },
+            ]),
+          ),
         },
       },
     });

--- a/packages/junior/tests/integration/slack/provider-default-config-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/provider-default-config-behavior.test.ts
@@ -1,13 +1,16 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { createTestChatRuntime } from "../../fixtures/chat-runtime";
 import {
   createTestMessage,
   createTestThread,
   createTestDestination,
 } from "../../fixtures/slack-harness";
-import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 import { getLocationConfigurationService } from "@/chat/runtime/thread-state";
-import { deliverAssistantMessagesForTest } from "../../fixtures/agent-runner";
+import {
+  createModelAgentRunnerForRun,
+  neverRunAgentRunner,
+} from "../../fixtures/agent-runner";
+import { createModelStream } from "../../fixtures/model-stream";
 
 function toPostedText(value: unknown): string {
   if (typeof value === "string") {
@@ -24,11 +27,10 @@ function toPostedText(value: unknown): string {
 
 describe("Slack behavior: provider default configuration", () => {
   it("sets an explicit default GitHub repo without starting an agent turn", async () => {
-    const executeAgentRun = vi.fn();
     const { slackRuntime } = createTestChatRuntime({
       services: {
         replyExecutor: {
-          agentRunner: { run: executeAgentRun },
+          agentRunner: neverRunAgentRunner(),
         },
       },
     });
@@ -47,7 +49,6 @@ describe("Slack behavior: provider default configuration", () => {
       { destination: createTestDestination(thread) },
     );
 
-    expect(executeAgentRun).not.toHaveBeenCalled();
     expect(thread.posts).toHaveLength(1);
     expect(toPostedText(thread.posts[0])).toContain("getsentry/junior");
     await expect(
@@ -62,27 +63,16 @@ describe("Slack behavior: provider default configuration", () => {
   });
 
   it("does not intercept combined repo setup and agent work", async () => {
-    const executeAgentRun = vi.fn(async (request) => {
-      await deliverAssistantMessagesForTest(request, [
-        { text: "Created the issue." },
-      ]);
-      return completedAgentRun({
-        text: "Created the issue.",
-        diagnostics: {
-          assistantMessageCount: 1,
-          modelId: "test-model",
-          outcome: "success" as const,
-          toolCalls: [],
-          toolErrorCount: 0,
-          toolResultCount: 0,
-          usedPrimaryText: true,
-        },
-      });
-    });
+    let agentRunCount = 0;
     const { slackRuntime } = createTestChatRuntime({
       services: {
         replyExecutor: {
-          agentRunner: { run: executeAgentRun },
+          agentRunner: createModelAgentRunnerForRun(() => {
+            agentRunCount += 1;
+            return createModelStream([
+              { type: "text", text: "Created the issue." },
+            ]);
+          }),
         },
       },
     });
@@ -101,7 +91,7 @@ describe("Slack behavior: provider default configuration", () => {
       { destination: createTestDestination(thread) },
     );
 
-    expect(executeAgentRun).toHaveBeenCalledOnce();
+    expect(agentRunCount).toBe(1);
     expect(toPostedText(thread.posts[0])).toContain("Created the issue.");
     await expect(
       getLocationConfigurationService(createTestDestination(thread)).get(

--- a/scripts/test-architecture-debt.json
+++ b/scripts/test-architecture-debt.json
@@ -4,9 +4,7 @@
     "packages/junior/tests/integration/slack/bot-handlers.test.ts": 29,
     "packages/junior/tests/integration/slack/conversation-turn-steering-behavior.test.ts": 7,
     "packages/junior/tests/integration/slack/message-content-behavior.test.ts": 2,
-    "packages/junior/tests/integration/slack/new-mention-behavior.test.ts": 2,
     "packages/junior/tests/integration/slack/processing-reaction-behavior.test.ts": 6,
-    "packages/junior/tests/integration/slack/provider-default-config-behavior.test.ts": 2,
     "packages/junior/tests/integration/slack/subscribed-message-behavior.test.ts": 3
   }
 }


### PR DESCRIPTION
Slack new-mention tests now use the real agent loop for queued messages, queued attachments, provider default fallthrough, and model-error cleanup. Generic reply and successful status cases were removed because finalized reply and assistant status suites already own those contracts. This keeps the entry-path suite focused and clears both matching test architecture debt entries.
