### PR TITLE
test(slack): run assistant-thread contracts through real agent

### DIFF
--- a/packages/junior/tests/integration/slack/assistant-thread-contract.test.ts
+++ b/packages/junior/tests/integration/slack/assistant-thread-contract.test.ts
@@ -8,14 +8,15 @@ import { slackApiOutbox } from "../../fixtures/slack-api-outbox";
 import { createSlackWebhookTestClient } from "../../fixtures/slack/webhook-client";
 import { createSlackRuntime } from "@/chat/app/factory";
 import { JuniorChat } from "@/chat/ingress/junior-chat";
-import type { AgentRunner } from "@/chat/runtime/agent-runner";
 import { createJuniorSlackAdapter } from "@/chat/slack/adapter";
-import type { ConversationMemoryDeps } from "@/chat/services/conversation-memory";
 import { resetConversationTitleStateForTests } from "@/chat/services/conversation-title";
 import { handleChatSdkPlatformWebhook } from "@/handlers/webhooks";
-import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 import { resetAssistantTitleProjectionForTests } from "@/chat/slack/assistant-thread/title";
-import * as piClient from "@/chat/pi/client";
+import type { StreamFn } from "@earendil-works/pi-agent-core";
+import { createModelAgentRunner } from "../../fixtures/agent-runner";
+import { createModelStream } from "../../fixtures/model-stream";
+import { http, HttpResponse } from "msw";
+import { mswServer } from "../../msw/server";
 
 const SIGNING_SECRET = "test-signing-secret";
 const BOT_USER_ID = "U0BOT";
@@ -23,6 +24,7 @@ const DM_CHANNEL_ID = "D12345";
 const DM_THREAD_TS = "1700000000.000001";
 const CHANNEL_ID = "C12345";
 const CHANNEL_ROOT_TS = "1700000200.000200";
+const ORIGINAL_AI_GATEWAY_API_KEY = process.env.AI_GATEWAY_API_KEY;
 const slackWebhookClient = createSlackWebhookTestClient({
   signingSecret: SIGNING_SECRET,
 });
@@ -57,34 +59,96 @@ function createChannelMentionRequest(
   );
 }
 
-function makeDiagnostics() {
-  return {
-    assistantMessageCount: 1,
-    modelId: "fake-agent-model",
-    outcome: "success" as const,
-    toolCalls: [],
-    toolErrorCount: 0,
-    toolResultCount: 0,
-    usedPrimaryText: true,
-  };
+function mockTurnRouterModel(): void {
+  mswServer.use(
+    http.post("https://ai-gateway.vercel.sh/v3/ai/language-model", () =>
+      HttpResponse.json({
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({
+              reasoning_level: "medium",
+              profile: "standard",
+              confidence: 0.9,
+              reason: "Representative integration test request",
+            }),
+          },
+        ],
+        finishReason: { unified: "stop", raw: "stop" },
+        usage: {
+          inputTokens: {
+            total: 1,
+            noCache: 1,
+            cacheRead: 0,
+            cacheWrite: 0,
+          },
+          outputTokens: { total: 1, text: 1, reasoning: 0 },
+        },
+      }),
+    ),
+  );
 }
 
-function makeCompletedReply(text: string) {
-  return completedAgentRun({
-    text,
-    diagnostics: makeDiagnostics(),
-  });
+function mockTitleModel(text: string, waitFor?: Promise<unknown>): void {
+  mswServer.use(
+    http.post("https://ai-gateway.vercel.sh/v1/messages", async () => {
+      await waitFor;
+      const events = [
+        {
+          type: "message_start",
+          message: {
+            id: "msg_title_fixture",
+            type: "message",
+            role: "assistant",
+            model: "title-fixture",
+            content: [],
+            stop_reason: null,
+            stop_sequence: null,
+            usage: { input_tokens: 1, output_tokens: 0 },
+          },
+        },
+        {
+          type: "content_block_start",
+          index: 0,
+          content_block: { type: "text", text: "" },
+        },
+        {
+          type: "content_block_delta",
+          index: 0,
+          delta: { type: "text_delta", text },
+        },
+        { type: "content_block_stop", index: 0 },
+        {
+          type: "message_delta",
+          delta: { stop_reason: "end_turn", stop_sequence: null },
+          usage: { output_tokens: 1 },
+        },
+        { type: "message_stop" },
+      ];
+      const body = events
+        .map(
+          (event) => `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`,
+        )
+        .join("");
+      return HttpResponse.text(body, {
+        headers: { "content-type": "text/event-stream" },
+      });
+    }),
+  );
 }
 
-async function createDirectMessageBot(args: {
-  completeText?: ConversationMemoryDeps["completeText"];
-  agentRunner: AgentRunner;
-}) {
-  if (args.completeText) {
-    vi.spyOn(piClient, "completeText").mockImplementation(
-      args.completeText as typeof piClient.completeText,
-    );
-  }
+function progressThenReply(): StreamFn {
+  return createModelStream([
+    {
+      type: "toolCall",
+      name: "reportProgress",
+      arguments: { message: "Running bash" },
+    },
+    { type: "text", text: "Done." },
+  ]);
+}
+
+async function createDirectMessageBot(modelStream: StreamFn) {
   const bot = new JuniorChat<{ slack: SlackAdapter }>({
     userName: "junior",
     adapters: {
@@ -100,7 +164,7 @@ async function createDirectMessageBot(args: {
     getSlackAdapter: () => bot.getAdapter("slack"),
     services: {
       replyExecutor: {
-        agentRunner: args.agentRunner,
+        agentRunner: createModelAgentRunner(modelStream),
       },
     },
   });
@@ -114,7 +178,7 @@ async function createDirectMessageBot(args: {
   return bot;
 }
 
-async function createMentionBot(args: { agentRunner: AgentRunner }) {
+async function createMentionBot(modelStream: StreamFn) {
   const bot = new JuniorChat<{ slack: SlackAdapter }>({
     userName: "junior",
     adapters: {
@@ -130,7 +194,7 @@ async function createMentionBot(args: { agentRunner: AgentRunner }) {
     getSlackAdapter: () => bot.getAdapter("slack"),
     services: {
       replyExecutor: {
-        agentRunner: args.agentRunner,
+        agentRunner: createModelAgentRunner(modelStream),
       },
     },
   });
@@ -146,6 +210,9 @@ async function createMentionBot(args: { agentRunner: AgentRunner }) {
 
 describe("Slack contract: assistant-thread delivery", () => {
   beforeEach(async () => {
+    process.env.AI_GATEWAY_API_KEY = "test-gateway-key";
+    mockTurnRouterModel();
+    mockTitleModel("Run a command");
     resetSlackApiMockState();
     resetConversationTitleStateForTests();
     resetAssistantTitleProjectionForTests();
@@ -155,6 +222,11 @@ describe("Slack contract: assistant-thread delivery", () => {
   });
 
   afterEach(async () => {
+    if (ORIGINAL_AI_GATEWAY_API_KEY === undefined) {
+      delete process.env.AI_GATEWAY_API_KEY;
+    } else {
+      process.env.AI_GATEWAY_API_KEY = ORIGINAL_AI_GATEWAY_API_KEY;
+    }
     resetSlackApiMockState();
     resetConversationTitleStateForTests();
     resetAssistantTitleProjectionForTests();
@@ -163,17 +235,7 @@ describe("Slack contract: assistant-thread delivery", () => {
   });
 
   it("does not post assistant status when the DM message omits thread_ts", async () => {
-    const bot = await createDirectMessageBot({
-      agentRunner: {
-        run: async (request) => {
-          const _prompt = request.instruction.text;
-          const context = request;
-
-          await context?.onEvent?.({ type: "status", text: "running bash" });
-          return makeCompletedReply("Done.");
-        },
-      },
-    });
+    const bot = await createDirectMessageBot(progressThenReply());
     const waitUntil = slackWebhookClient.waitUntil();
 
     const response = await handleChatSdkPlatformWebhook(
@@ -190,17 +252,7 @@ describe("Slack contract: assistant-thread delivery", () => {
   });
 
   it("posts assistant status with a raw DM channel id when thread_ts is present", async () => {
-    const bot = await createDirectMessageBot({
-      agentRunner: {
-        run: async (request) => {
-          const _prompt = request.instruction.text;
-          const context = request;
-
-          await context?.onEvent?.({ type: "status", text: "running bash" });
-          return makeCompletedReply("Done.");
-        },
-      },
-    });
+    const bot = await createDirectMessageBot(progressThenReply());
     const waitUntil = slackWebhookClient.waitUntil();
 
     const response = await handleChatSdkPlatformWebhook(
@@ -236,17 +288,7 @@ describe("Slack contract: assistant-thread delivery", () => {
   });
 
   it("posts assistant status for the first channel-thread reply before Slack adds thread_ts", async () => {
-    const bot = await createMentionBot({
-      agentRunner: {
-        run: async (request) => {
-          const _prompt = request.instruction.text;
-          const context = request;
-
-          await context?.onEvent?.({ type: "status", text: "running bash" });
-          return makeCompletedReply("Done.");
-        },
-      },
-    });
+    const bot = await createMentionBot(progressThenReply());
     const waitUntil = slackWebhookClient.waitUntil();
 
     const response = await handleChatSdkPlatformWebhook(
@@ -280,17 +322,12 @@ describe("Slack contract: assistant-thread delivery", () => {
   });
 
   it("posts assistant titles with a raw DM channel id when thread_ts is present", async () => {
-    const bot = await createDirectMessageBot({
-      completeText: async () =>
-        ({
-          text: "Debugging Node.js Memory Leaks",
-          message: { role: "assistant", content: "" },
-        }) as any,
-      agentRunner: {
-        run: async () =>
-          makeCompletedReply("Here is how to debug memory leaks."),
-      },
-    });
+    mockTitleModel("Debugging Node.js Memory Leaks");
+    const bot = await createDirectMessageBot(
+      createModelStream([
+        { type: "text", text: "Here is how to debug memory leaks." },
+      ]),
+    );
     const waitUntil = slackWebhookClient.waitUntil();
 
     const response = await handleChatSdkPlatformWebhook(
@@ -318,21 +355,15 @@ describe("Slack contract: assistant-thread delivery", () => {
 
   it("lets the awaited webhook turn task finish before slow title generation", async () => {
     let resolveTitle: (() => void) | undefined;
-    const bot = await createDirectMessageBot({
-      completeText: async () =>
-        await new Promise((resolve) => {
-          resolveTitle = () => {
-            resolve({
-              text: "Debugging Node.js Memory Leaks",
-              message: { role: "assistant", content: "" },
-            } as any);
-          };
-        }),
-      agentRunner: {
-        run: async () =>
-          makeCompletedReply("Here is how to debug memory leaks."),
-      },
+    const titleGate = new Promise<void>((resolve) => {
+      resolveTitle = resolve;
     });
+    mockTitleModel("Debugging Node.js Memory Leaks", titleGate);
+    const bot = await createDirectMessageBot(
+      createModelStream([
+        { type: "text", text: "Here is how to debug memory leaks." },
+      ]),
+    );
     const waitUntil = slackWebhookClient.waitUntil();
 
     const response = await handleChatSdkPlatformWebhook(
@@ -374,17 +405,12 @@ describe("Slack contract: assistant-thread delivery", () => {
   });
 
   it("does not post assistant titles when the DM message omits thread_ts", async () => {
-    const bot = await createDirectMessageBot({
-      completeText: async () =>
-        ({
-          text: "Debugging Node.js Memory Leaks",
-          message: { role: "assistant", content: "" },
-        }) as any,
-      agentRunner: {
-        run: async () =>
-          makeCompletedReply("Here is how to debug memory leaks."),
-      },
-    });
+    mockTitleModel("Debugging Node.js Memory Leaks");
+    const bot = await createDirectMessageBot(
+      createModelStream([
+        { type: "text", text: "Here is how to debug memory leaks." },
+      ]),
+    );
     const waitUntil = slackWebhookClient.waitUntil();
 
     const response = await handleChatSdkPlatformWebhook(

--- a/scripts/test-architecture-debt.json
+++ b/scripts/test-architecture-debt.json
@@ -1,6 +1,5 @@
 {
   "manufactured-agent-outcome": {
-    "packages/junior/tests/integration/slack/assistant-thread-contract.test.ts": 2,
     "packages/junior/tests/integration/slack/bot-handlers.test.ts": 29,
     "packages/junior/tests/integration/slack/conversation-turn-steering-behavior.test.ts": 7,
     "packages/junior/tests/integration/slack/message-content-behavior.test.ts": 2,


### PR DESCRIPTION
Assistant-thread integration tests now run Junior through the real Pi agent loop with fixed model output and external AI Gateway responses. The cases continue to cover direct-message and channel status updates, title projection, and slow title generation without manufactured agent outcomes or Junior-owned module spies.

This removes the file's test architecture debt exception. Slack uses the shared typed fixtures, and the focused six-case suite, package typecheck, test architecture check, and full pre-push lint pass.
