### PR TITLE
test(slack): run processing reactions through real agent

### DIFF
--- a/packages/junior/tests/integration/slack/processing-reaction-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/processing-reaction-behavior.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { createTestChatRuntime } from "../../fixtures/chat-runtime";
 import {
   createTestMessage,
@@ -6,22 +6,14 @@ import {
   createTestDestination,
 } from "../../fixtures/slack-harness";
 import { slackApiOutbox } from "../../fixtures/slack-api-outbox";
-import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 import {
-  deliverAssistantMessagesForTest,
+  createModelAgentRunner,
+  createModelAgentRunnerForRun,
+  neverRunAgentRunner,
 } from "../../fixtures/agent-runner";
-
-function successDiagnostics(toolCalls: string[] = []) {
-  return {
-    assistantMessageCount: 1,
-    modelId: "fake-agent-model",
-    outcome: "success" as const,
-    toolCalls,
-    toolErrorCount: 0,
-    toolResultCount: toolCalls.length,
-    usedPrimaryText: true,
-  };
-}
+import { createModelStream } from "../../fixtures/model-stream";
+import { NO_REPLY_MARKER } from "@/chat/no-reply";
+import { getConversationEventStore } from "@/chat/db";
 
 function reactionCall(name: string, timestamp: string) {
   return expect.objectContaining({
@@ -38,19 +30,11 @@ describe("Slack behavior: processing reaction", () => {
     const { slackRuntime } = createTestChatRuntime({
       services: {
         replyExecutor: {
-          agentRunner: {
-            run: async (request) => {
-              expect(slackApiOutbox.reactionAdds()).toHaveLength(1);
-              expect(slackApiOutbox.reactionRemovals()).toHaveLength(0);
-              await deliverAssistantMessagesForTest(request, [
-                { text: "Done." },
-              ]);
-              return completedAgentRun({
-                text: "Done.",
-                diagnostics: successDiagnostics(),
-              });
-            },
-          },
+          agentRunner: createModelAgentRunnerForRun(() => {
+            expect(slackApiOutbox.reactionAdds()).toHaveLength(1);
+            expect(slackApiOutbox.reactionRemovals()).toHaveLength(0);
+            return createModelStream([{ type: "text", text: "Done." }]);
+          }),
         },
       },
     });
@@ -101,11 +85,7 @@ describe("Slack behavior: processing reaction", () => {
           },
         },
         replyExecutor: {
-          agentRunner: {
-            run: async () => {
-              throw new Error("assistant should not run for skipped message");
-            },
-          },
+          agentRunner: neverRunAgentRunner(),
         },
       },
     });
@@ -153,16 +133,11 @@ describe("Slack behavior: processing reaction", () => {
           },
         },
         replyExecutor: {
-          agentRunner: {
-            run: async () => {
-              expect(slackApiOutbox.reactionAdds()).toHaveLength(1);
-              expect(slackApiOutbox.reactionRemovals()).toHaveLength(0);
-              return completedAgentRun({
-                text: "Done.",
-                diagnostics: successDiagnostics(),
-              });
-            },
-          },
+          agentRunner: createModelAgentRunnerForRun(() => {
+            expect(slackApiOutbox.reactionAdds()).toHaveLength(1);
+            expect(slackApiOutbox.reactionRemovals()).toHaveLength(0);
+            return createModelStream([{ type: "text", text: "Done." }]);
+          }),
         },
       },
     });
@@ -199,19 +174,11 @@ describe("Slack behavior: processing reaction", () => {
     const { slackRuntime } = createTestChatRuntime({
       services: {
         replyExecutor: {
-          agentRunner: {
-            run: async (request) => {
-              expect(slackApiOutbox.reactionAdds()).toHaveLength(0);
-              expect(slackApiOutbox.reactionRemovals()).toHaveLength(0);
-              await deliverAssistantMessagesForTest(request, [
-                { text: "Done." },
-              ]);
-              return completedAgentRun({
-                text: "Done.",
-                diagnostics: successDiagnostics(),
-              });
-            },
-          },
+          agentRunner: createModelAgentRunnerForRun(() => {
+            expect(slackApiOutbox.reactionAdds()).toHaveLength(0);
+            expect(slackApiOutbox.reactionRemovals()).toHaveLength(0);
+            return createModelStream([{ type: "text", text: "Done." }]);
+          }),
         },
       },
     });
@@ -255,23 +222,16 @@ describe("Slack behavior: processing reaction", () => {
     const { slackRuntime } = createTestChatRuntime({
       services: {
         replyExecutor: {
-          agentRunner: {
-            run: async (request) => {
-              const _prompt = request.instruction.text;
-              const context = request;
-
-              await context.onEvent?.({
-                type: "tool_started",
-                params: { emoji: ":eyes:" },
-                toolCallId: "tool-call-eyes",
-                toolName: "addReaction",
-              });
-              return completedAgentRun({
-                text: "Done.",
-                diagnostics: successDiagnostics(["addReaction"]),
-              });
-            },
-          },
+          agentRunner: createModelAgentRunner(
+            createModelStream([
+              {
+                type: "toolCall",
+                name: "addReaction",
+                arguments: { emoji: ":eyes:" },
+              },
+              { type: "text", text: "Done." },
+            ]),
+          ),
         },
       },
     });
@@ -295,36 +255,27 @@ describe("Slack behavior: processing reaction", () => {
       { destination: createTestDestination(thread) },
     );
 
-    expect(slackApiOutbox.reactionAdds()).toHaveLength(1);
+    expect(slackApiOutbox.reactionAdds()).toEqual([
+      reactionCall("eyes", "1700007201.000000"),
+      reactionCall("eyes", "1700007201.000000"),
+    ]);
     expect(slackApiOutbox.reactionRemovals()).toHaveLength(0);
   });
 
   it("clears eyes and marks complete for reaction-only no-reply turns", async () => {
-    const turnLifecycle = {
-      complete: vi.fn(),
-      fail: vi.fn(),
-      start: vi.fn(),
-    };
     const { slackRuntime } = createTestChatRuntime({
       services: {
         replyExecutor: {
-          turnLifecycle,
-          agentRunner: {
-            run: async (request) => {
-              const context = request;
-
-              await context.onEvent?.({
-                type: "tool_started",
-                params: { emoji: ":heart:" },
-                toolCallId: "tool-call-heart",
-                toolName: "addReaction",
-              });
-              return completedAgentRun({
-                text: "",
-                diagnostics: successDiagnostics(["addReaction"]),
-              });
-            },
-          },
+          agentRunner: createModelAgentRunner(
+            createModelStream([
+              {
+                type: "toolCall",
+                name: "addReaction",
+                arguments: { emoji: ":heart:" },
+              },
+              { type: "text", text: NO_REPLY_MARKER },
+            ]),
+          ),
         },
       },
     });
@@ -350,17 +301,19 @@ describe("Slack behavior: processing reaction", () => {
 
     expect(slackApiOutbox.reactionAdds()).toEqual([
       reactionCall("eyes", "1700007301.000000"),
+      reactionCall("heart", "1700007301.000000"),
       reactionCall("white_check_mark", "1700007301.000000"),
     ]);
     expect(slackApiOutbox.reactionRemovals()).toEqual([
       reactionCall("eyes", "1700007301.000000"),
     ]);
     expect(thread.posts).toHaveLength(0);
-    expect(turnLifecycle.complete).toHaveBeenCalledWith(
-      expect.objectContaining({
-        conversationId: thread.id,
-        outcome: "no_reply",
-      }),
-    );
+    const lifecycleEvents = (
+      await getConversationEventStore().loadHistory(thread.id)
+    ).filter((event) => event.data.type.startsWith("turn_"));
+    expect(lifecycleEvents.at(-1)?.data).toMatchObject({
+      type: "turn_completed",
+      outcome: "no_reply",
+    });
   });
 });

--- a/scripts/test-architecture-debt.json
+++ b/scripts/test-architecture-debt.json
@@ -3,7 +3,6 @@
     "packages/junior/tests/integration/slack/bot-handlers.test.ts": 29,
     "packages/junior/tests/integration/slack/conversation-turn-steering-behavior.test.ts": 7,
     "packages/junior/tests/integration/slack/message-content-behavior.test.ts": 2,
-    "packages/junior/tests/integration/slack/processing-reaction-behavior.test.ts": 6,
     "packages/junior/tests/integration/slack/subscribed-message-behavior.test.ts": 3
   }
 }


### PR DESCRIPTION
Processing-reaction integration tests now run through the real Pi agent and Slack reaction tool. They cover automatic processing reactions, subscribed-message decisions, synthetic notifications, explicit `eyes` retention, and reaction-only silence with fixed model output.

The no-reply case now checks the stored turn lifecycle instead of replacing the lifecycle service. This removes six manufactured agent outcomes while preserving the existing Slack contracts. The focused suite, package typecheck, architecture check, and full pre-push lint pass.
