### PR TITLE
test(slack): run normal completions through real agent

### DIFF
--- a/packages/junior/tests/fixtures/title-model.ts
+++ b/packages/junior/tests/fixtures/title-model.ts
@@ -10,7 +10,7 @@ type TitleModelFixtureOptions = {
   waitFor?: Promise<unknown>;
 };
 
-/** Return fixed title text from the external model edge. */
+/** Return fixed title text from the model service. */
 export function mockTitleModel(
   text: string,
   options: TitleModelFixtureOptions = {},

--- a/packages/junior/tests/fixtures/title-model.ts
+++ b/packages/junior/tests/fixtures/title-model.ts
@@ -1,0 +1,69 @@
+import { http, HttpResponse } from "msw";
+import { mswServer } from "../msw/server";
+
+export type TitleModelRequest = {
+  messages?: unknown[];
+};
+
+type TitleModelFixtureOptions = {
+  onRequest?: (request: TitleModelRequest) => void;
+  waitFor?: Promise<unknown>;
+};
+
+/** Return fixed title text from the external model edge. */
+export function mockTitleModel(
+  text: string,
+  options: TitleModelFixtureOptions = {},
+): void {
+  mswServer.use(
+    http.post(
+      "https://ai-gateway.vercel.sh/v1/messages",
+      async ({ request }) => {
+        const modelRequest = (await request.json()) as TitleModelRequest;
+        options.onRequest?.(modelRequest);
+        await options.waitFor;
+        const events = [
+          {
+            type: "message_start",
+            message: {
+              id: "msg_title_fixture",
+              type: "message",
+              role: "assistant",
+              model: "title-fixture",
+              content: [],
+              stop_reason: null,
+              stop_sequence: null,
+              usage: { input_tokens: 1, output_tokens: 0 },
+            },
+          },
+          {
+            type: "content_block_start",
+            index: 0,
+            content_block: { type: "text", text: "" },
+          },
+          {
+            type: "content_block_delta",
+            index: 0,
+            delta: { type: "text_delta", text },
+          },
+          { type: "content_block_stop", index: 0 },
+          {
+            type: "message_delta",
+            delta: { stop_reason: "end_turn", stop_sequence: null },
+            usage: { output_tokens: 1 },
+          },
+          { type: "message_stop" },
+        ];
+        const body = events
+          .map(
+            (event) =>
+              `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`,
+          )
+          .join("");
+        return HttpResponse.text(body, {
+          headers: { "content-type": "text/event-stream" },
+        });
+      },
+    ),
+  );
+}

--- a/packages/junior/tests/fixtures/turn-router-model.ts
+++ b/packages/junior/tests/fixtures/turn-router-model.ts
@@ -1,0 +1,33 @@
+import { http, HttpResponse } from "msw";
+import { mswServer } from "../msw/server";
+
+/** Return a fixed route decision from the external model edge. */
+export function mockTurnRouterModel(): void {
+  mswServer.use(
+    http.post("https://ai-gateway.vercel.sh/v3/ai/language-model", () =>
+      HttpResponse.json({
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({
+              reasoning_level: "medium",
+              profile: "standard",
+              confidence: 0.9,
+              reason: "Representative integration test request",
+            }),
+          },
+        ],
+        finishReason: { unified: "stop", raw: "stop" },
+        usage: {
+          inputTokens: {
+            total: 1,
+            noCache: 1,
+            cacheRead: 0,
+            cacheWrite: 0,
+          },
+          outputTokens: { total: 1, text: 1, reasoning: 0 },
+        },
+      }),
+    ),
+  );
+}

--- a/packages/junior/tests/fixtures/turn-router-model.ts
+++ b/packages/junior/tests/fixtures/turn-router-model.ts
@@ -1,7 +1,7 @@
 import { http, HttpResponse } from "msw";
 import { mswServer } from "../msw/server";
 
-/** Return a fixed route decision from the external model edge. */
+/** Return a fixed route decision from the model service. */
 export function mockTurnRouterModel(): void {
   mswServer.use(
     http.post("https://ai-gateway.vercel.sh/v3/ai/language-model", () =>

--- a/packages/junior/tests/integration/slack/assistant-thread-contract.test.ts
+++ b/packages/junior/tests/integration/slack/assistant-thread-contract.test.ts
@@ -16,8 +16,7 @@ import type { StreamFn } from "@earendil-works/pi-agent-core";
 import { createModelAgentRunner } from "../../fixtures/agent-runner";
 import { createModelStream } from "../../fixtures/model-stream";
 import { mockTitleModel } from "../../fixtures/title-model";
-import { http, HttpResponse } from "msw";
-import { mswServer } from "../../msw/server";
+import { mockTurnRouterModel } from "../../fixtures/turn-router-model";
 
 const SIGNING_SECRET = "test-signing-secret";
 const BOT_USER_ID = "U0BOT";
@@ -57,36 +56,6 @@ function createChannelMentionRequest(
       text,
       ...(options?.threadTs ? { threadTs: options.threadTs } : {}),
     }),
-  );
-}
-
-function mockTurnRouterModel(): void {
-  mswServer.use(
-    http.post("https://ai-gateway.vercel.sh/v3/ai/language-model", () =>
-      HttpResponse.json({
-        content: [
-          {
-            type: "text",
-            text: JSON.stringify({
-              reasoning_level: "medium",
-              profile: "standard",
-              confidence: 0.9,
-              reason: "Representative integration test request",
-            }),
-          },
-        ],
-        finishReason: { unified: "stop", raw: "stop" },
-        usage: {
-          inputTokens: {
-            total: 1,
-            noCache: 1,
-            cacheRead: 0,
-            cacheWrite: 0,
-          },
-          outputTokens: { total: 1, text: 1, reasoning: 0 },
-        },
-      }),
-    ),
   );
 }
 

--- a/packages/junior/tests/integration/slack/assistant-thread-contract.test.ts
+++ b/packages/junior/tests/integration/slack/assistant-thread-contract.test.ts
@@ -15,6 +15,7 @@ import { resetAssistantTitleProjectionForTests } from "@/chat/slack/assistant-th
 import type { StreamFn } from "@earendil-works/pi-agent-core";
 import { createModelAgentRunner } from "../../fixtures/agent-runner";
 import { createModelStream } from "../../fixtures/model-stream";
+import { mockTitleModel } from "../../fixtures/title-model";
 import { http, HttpResponse } from "msw";
 import { mswServer } from "../../msw/server";
 
@@ -86,54 +87,6 @@ function mockTurnRouterModel(): void {
         },
       }),
     ),
-  );
-}
-
-function mockTitleModel(text: string, waitFor?: Promise<unknown>): void {
-  mswServer.use(
-    http.post("https://ai-gateway.vercel.sh/v1/messages", async () => {
-      await waitFor;
-      const events = [
-        {
-          type: "message_start",
-          message: {
-            id: "msg_title_fixture",
-            type: "message",
-            role: "assistant",
-            model: "title-fixture",
-            content: [],
-            stop_reason: null,
-            stop_sequence: null,
-            usage: { input_tokens: 1, output_tokens: 0 },
-          },
-        },
-        {
-          type: "content_block_start",
-          index: 0,
-          content_block: { type: "text", text: "" },
-        },
-        {
-          type: "content_block_delta",
-          index: 0,
-          delta: { type: "text_delta", text },
-        },
-        { type: "content_block_stop", index: 0 },
-        {
-          type: "message_delta",
-          delta: { stop_reason: "end_turn", stop_sequence: null },
-          usage: { output_tokens: 1 },
-        },
-        { type: "message_stop" },
-      ];
-      const body = events
-        .map(
-          (event) => `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`,
-        )
-        .join("");
-      return HttpResponse.text(body, {
-        headers: { "content-type": "text/event-stream" },
-      });
-    }),
   );
 }
 
@@ -358,7 +311,7 @@ describe("Slack contract: assistant-thread delivery", () => {
     const titleGate = new Promise<void>((resolve) => {
       resolveTitle = resolve;
     });
-    mockTitleModel("Debugging Node.js Memory Leaks", titleGate);
+    mockTitleModel("Debugging Node.js Memory Leaks", { waitFor: titleGate });
     const bot = await createDirectMessageBot(
       createModelStream([
         { type: "text", text: "Here is how to debug memory leaks." },

--- a/packages/junior/tests/integration/slack/bot-handlers.test.ts
+++ b/packages/junior/tests/integration/slack/bot-handlers.test.ts
@@ -44,13 +44,19 @@ import {
 import { createTestChatRuntime } from "../../fixtures/chat-runtime";
 import { resetConversationTitleStateForTests } from "@/chat/services/conversation-title";
 import { resetAssistantTitleProjectionForTests } from "@/chat/slack/assistant-thread/title";
-import * as piClient from "@/chat/pi/client";
 import {
+  createModelAgentRunner,
+  createModelAgentRunnerForRun,
   deliverAssistantMessagesForTest,
 } from "../../fixtures/agent-runner";
 import { createModelStream } from "../../fixtures/model-stream";
+import {
+  mockTitleModel,
+  type TitleModelRequest,
+} from "../../fixtures/title-model";
 
 const emptyThreadReplies = async () => [];
+const ORIGINAL_AI_GATEWAY_API_KEY = process.env.AI_GATEWAY_API_KEY;
 
 function postIncludes(thread: { posts: unknown[] }, text: string): boolean {
   return thread.posts.some((post) => {
@@ -108,14 +114,6 @@ function expectBlocksIncludeConversationId(
 ): void {
   expect(params.blocks).toBeDefined();
   expect(JSON.stringify(params.blocks)).toContain(conversationId);
-}
-
-function mockTitleCompleteText(
-  impl: (...args: any[]) => Promise<any> | any,
-) {
-  return vi
-    .spyOn(piClient, "completeText")
-    .mockImplementation(async (...args) => await impl(...args));
 }
 
 function createRuntime(
@@ -226,6 +224,11 @@ describe("bot handlers (integration)", () => {
   });
 
   afterEach(async () => {
+    if (ORIGINAL_AI_GATEWAY_API_KEY === undefined) {
+      delete process.env.AI_GATEWAY_API_KEY;
+    } else {
+      process.env.AI_GATEWAY_API_KEY = ORIGINAL_AI_GATEWAY_API_KEY;
+    }
     resetSlackApiMockState();
     resetConversationTitleStateForTests();
     resetAssistantTitleProjectionForTests();
@@ -1044,7 +1047,11 @@ describe("bot handlers (integration)", () => {
           wakePausedTurn,
           agentRunner: {
             run: async () => {
-              return { status: "suspended", reason: "timeout", resumeVersion: 3 };
+              return {
+                status: "suspended",
+                reason: "timeout",
+                resumeVersion: 3,
+              };
             },
           },
         },
@@ -1096,7 +1103,11 @@ describe("bot handlers (integration)", () => {
           wakePausedTurn,
           agentRunner: {
             run: async () => {
-              return { status: "suspended", reason: "timeout", resumeVersion: 4 };
+              return {
+                status: "suspended",
+                reason: "timeout",
+                resumeVersion: 4,
+              };
             },
           },
         },
@@ -1141,7 +1152,11 @@ describe("bot handlers (integration)", () => {
           wakePausedTurn,
           agentRunner: {
             run: async () => {
-              return { status: "suspended", reason: "timeout", resumeVersion: 3 };
+              return {
+                status: "suspended",
+                reason: "timeout",
+                resumeVersion: 3,
+              };
             },
           },
         },
@@ -1548,7 +1563,9 @@ describe("bot handlers (integration)", () => {
         replyExecutor: {
           agentRunner: {
             run: async (request) => {
-              capturedInput = { piMessages: request.history ? [...request.history] : undefined };
+              capturedInput = {
+                piMessages: request.history ? [...request.history] : undefined,
+              };
               const runActor = request.actor;
               capturedActorUserId =
                 runActor && "userId" in runActor ? runActor.userId : undefined;
@@ -2196,26 +2213,9 @@ describe("bot handlers (integration)", () => {
       slackAdapter: fakeAdapter,
       services: {
         replyExecutor: {
-          agentRunner: {
-            run: async (request) => {
-              const _prompt = request.instruction.text;
-              const context = request;
-
-              await context?.onEvent?.({ type: "status", text: "reading channel messages" });
-              return completedAgentRun({
-                text: "Done.",
-                diagnostics: {
-                  assistantMessageCount: 1,
-                  modelId: "test-model",
-                  outcome: "success" as const,
-                  toolCalls: [],
-                  toolErrorCount: 0,
-                  toolResultCount: 0,
-                  usedPrimaryText: true,
-                },
-              });
-            },
-          },
+          agentRunner: createModelAgentRunner(
+            createModelStream([{ type: "text", text: "Done." }]),
+          ),
         },
       },
     });
@@ -2248,81 +2248,6 @@ describe("bot handlers (integration)", () => {
       text: "",
       loadingMessages: undefined,
     });
-  });
-
-  it("does not block assistant reply generation on slow assistant status writes", async () => {
-    const fakeAdapter = new FakeSlackAdapter();
-    let releaseFirstStatus: (() => void) | undefined;
-    let statusCallCount = 0;
-    fakeAdapter.setAssistantStatus = async () => {
-      statusCallCount += 1;
-      if (statusCallCount !== 1) {
-        return;
-      }
-      await new Promise<void>((resolve) => {
-        releaseFirstStatus = resolve;
-      });
-    };
-
-    let replyStarted = false;
-    const { slackRuntime } = createRuntime({
-      slackAdapter: fakeAdapter,
-      services: {
-        conversationMemory: {
-          completeText: async () => ({ text: "Status thread" }) as never,
-        },
-        replyExecutor: {
-          agentRunner: {
-            run: async (request) => {
-              replyStarted = true;
-              await deliverAssistantMessagesForTest(request, [
-                { text: "Reply lands after the pending status is drained." },
-              ]);
-              return completedAgentRun({
-                text: "Still replied while status was pending.",
-                diagnostics: {
-                  assistantMessageCount: 1,
-                  modelId: "test-model",
-                  outcome: "success" as const,
-                  toolCalls: [],
-                  toolErrorCount: 0,
-                  toolResultCount: 0,
-                  usedPrimaryText: true,
-                },
-              });
-            },
-          },
-        },
-      },
-    });
-
-    let settled = false;
-    const thread = await createTestThread({
-      id: "slack:D0STATUSBLOCK:1700000000.000",
-    });
-    const turnPromise = slackRuntime
-      .handleNewMention(
-        thread,
-        createTestMessage({
-          id: "msg-status-block",
-          threadId: "slack:D0STATUSBLOCK:1700000000.000",
-          text: "show the channel",
-          isMention: true,
-        }),
-        { destination: createTestDestination(thread) },
-      )
-      .then(() => {
-        settled = true;
-      });
-
-    await vi.waitFor(() => {
-      expect(replyStarted).toBe(true);
-    });
-
-    expect(settled).toBe(false);
-
-    releaseFirstStatus!();
-    await turnPromise;
   });
 
   it("posts a completed message even while the initial assistant status write is pending", async () => {
@@ -2360,26 +2285,17 @@ describe("bot handlers (integration)", () => {
           completeText: async () => ({ text: "Status thread" }) as never,
         },
         replyExecutor: {
-          agentRunner: {
-            run: async (request) => {
-              replyStarted = true;
-              await deliverAssistantMessagesForTest(request, [
-                { text: "Reply lands after the pending status is drained." },
-              ]);
-              return completedAgentRun({
+          agentRunner: createModelAgentRunner(
+            createModelStream([
+              {
+                type: "text",
                 text: "Reply lands after the pending status is drained.",
-                diagnostics: {
-                  assistantMessageCount: 1,
-                  modelId: "test-model",
-                  outcome: "success" as const,
-                  toolCalls: [],
-                  toolErrorCount: 0,
-                  toolResultCount: 0,
-                  usedPrimaryText: true,
+                onRequest: () => {
+                  replyStarted = true;
                 },
-              });
-            },
-          },
+              },
+            ]),
+          ),
         },
       },
     });
@@ -2415,98 +2331,25 @@ describe("bot handlers (integration)", () => {
     await turnPromise;
   });
 
-  it("thread title: generates and sets title after first assistant reply", async () => {
+  it("thread title: uses the first human message we know about in the thread", async () => {
+    process.env.AI_GATEWAY_API_KEY = "test-gateway-key";
     const fakeAdapter = new FakeSlackAdapter();
-    mockTitleCompleteText(async () =>
-      ({
-        text: "Debugging Node.js Memory Leaks",
-        message: { role: "assistant", content: "" },
-      }) as any,
-    );
-
-    const { slackRuntime } = createRuntime({
-      slackAdapter: fakeAdapter,
-      services: {
-        replyExecutor: {
-          agentRunner: {
-            run: async () =>
-              completedAgentRun({
-                text: "Here is how to debug memory leaks.",
-                diagnostics: {
-                  assistantMessageCount: 1,
-                  modelId: "test-model",
-                  outcome: "success" as const,
-                  toolCalls: [],
-                  toolErrorCount: 0,
-                  toolResultCount: 0,
-                  usedPrimaryText: true,
-                },
-              }),
-          },
-        },
+    let titleRequest: TitleModelRequest | undefined;
+    mockTitleModel("Production Issue Summary", {
+      onRequest: (request) => {
+        titleRequest = request;
       },
     });
 
-    const thread = await createTestThread({
-      id: "slack:D0TITLE:1700000000.000",
-    });
-
-    await slackRuntime.handleNewMention(
-      thread,
-      createTestMessage({
-        id: "msg-title-1",
-        threadId: "slack:D0TITLE:1700000000.000",
-        text: "How do I debug memory leaks in Node?",
-        isMention: true,
-      }),
-      { destination: createTestDestination(thread) },
-    );
-
-    await new Promise((r) => setTimeout(r, 0));
-
-    const generatedTitleCall = fakeAdapter.titleCalls.find(
-      (c) => c.title !== "Junior",
-    );
-    expect(generatedTitleCall).toBeDefined();
-    expect(generatedTitleCall!.title).toBe("Debugging Node.js Memory Leaks");
-    expect(generatedTitleCall!.channelId).toBe("D0TITLE");
-    expect(generatedTitleCall!.threadTs).toBe("1700000000.000");
-  });
-
-  it("thread title: uses the first human message we know about in the thread", async () => {
-    const fakeAdapter = new FakeSlackAdapter();
-    mockTitleCompleteText(async (params) => {
-      const prompt =
-        typeof params.messages[0]?.content === "string"
-          ? params.messages[0].content
-          : "";
-      return {
-        text: prompt.includes("Original production issue summary")
-          ? "Production Issue Summary"
-          : "Follow-up Clarification",
-        message: { role: "assistant", content: "" },
-      } as any;
-    });
-
     const { slackRuntime } = createRuntime({
       slackAdapter: fakeAdapter,
       services: {
         replyExecutor: {
-          agentRunner: {
-            run: async () =>
-              completedAgentRun({
-                text: "Here is the updated answer.",
-                diagnostics: {
-                  assistantMessageCount: 1,
-                  modelId: "test-model",
-                  outcome: "success" as const,
-                  toolCalls: [],
-                  toolErrorCount: 0,
-                  toolResultCount: 0,
-                  usedPrimaryText: true,
-                },
-              }),
-          },
+          agentRunner: createModelAgentRunner(
+            createModelStream([
+              { type: "text", text: "Here is the updated answer." },
+            ]),
+          ),
         },
       },
     });
@@ -2534,47 +2377,38 @@ describe("bot handlers (integration)", () => {
       { destination: createTestDestination(thread) },
     );
 
-    await new Promise((r) => setTimeout(r, 0));
-
+    await vi.waitFor(() => {
+      expect(
+        fakeAdapter.titleCalls.some((call) => call.title !== "Junior"),
+      ).toBe(true);
+    });
     const generatedTitleCall = fakeAdapter.titleCalls.find(
-      (c) => c.title !== "Junior",
+      (call) => call.title !== "Junior",
     );
     expect(generatedTitleCall).toBeDefined();
     expect(generatedTitleCall!.title).toBe("Production Issue Summary");
+    expect(JSON.stringify(titleRequest)).toContain(
+      "Original production issue summary",
+    );
+    expect(JSON.stringify(titleRequest)).not.toContain(
+      "Can you also include the regression window?",
+    );
   });
 
   it("thread title: still generates for a new thread with starter assistant content", async () => {
+    process.env.AI_GATEWAY_API_KEY = "test-gateway-key";
     const fakeAdapter = new FakeSlackAdapter();
-    mockTitleCompleteText(async () =>
-      ({
-        text: "Today's Date",
-        message: { role: "assistant", content: "" },
-      }) as any,
-    );
+    mockTitleModel("Today's Date");
 
     const { slackRuntime } = createRuntime({
       slackAdapter: fakeAdapter,
       services: {
         replyExecutor: {
-          agentRunner: {
-            run: async (request) => {
-              await deliverAssistantMessagesForTest(request, [
-                { text: "Today is April 16, 2026." },
-              ]);
-              return completedAgentRun({
-                text: "Today is April 16, 2026.",
-                diagnostics: {
-                  assistantMessageCount: 1,
-                  modelId: "test-model",
-                  outcome: "success" as const,
-                  toolCalls: [],
-                  toolErrorCount: 0,
-                  toolResultCount: 0,
-                  usedPrimaryText: true,
-                },
-              });
-            },
-          },
+          agentRunner: createModelAgentRunner(
+            createModelStream([
+              { type: "text", text: "Today is April 16, 2026." },
+            ]),
+          ),
         },
       },
     });
@@ -2607,129 +2441,42 @@ describe("bot handlers (integration)", () => {
       { destination: createTestDestination(thread) },
     );
 
-    await new Promise((r) => setTimeout(r, 0));
-
+    await vi.waitFor(() => {
+      expect(
+        fakeAdapter.titleCalls.some((call) => call.title !== "Junior"),
+      ).toBe(true);
+    });
     const generatedTitleCall = fakeAdapter.titleCalls.find(
-      (c) => c.title !== "Junior",
+      (call) => call.title !== "Junior",
     );
     expect(generatedTitleCall).toBeDefined();
     expect(generatedTitleCall!.title).toBe("Today's Date");
   });
 
-  it("thread title: does not block reply delivery when generation is slow", async () => {
-    const fakeAdapter = new FakeSlackAdapter();
-    let resolveTitle: (() => void) | undefined;
-    mockTitleCompleteText(async () =>
-      await new Promise((resolve) => {
-        resolveTitle = () =>
-          resolve({
-            text: "Today's Date",
-            message: { role: "assistant", content: "" },
-          } as any);
-      }),
-    );
-    const { slackRuntime } = createRuntime({
-      slackAdapter: fakeAdapter,
-      services: {
-        replyExecutor: {
-          agentRunner: {
-            run: async (request) => {
-              await deliverAssistantMessagesForTest(request, [
-                { text: "Today is April 16, 2026." },
-              ]);
-              return completedAgentRun({
-                text: "Today is April 16, 2026.",
-                diagnostics: {
-                  assistantMessageCount: 1,
-                  modelId: "test-model",
-                  outcome: "success" as const,
-                  toolCalls: [],
-                  toolErrorCount: 0,
-                  toolResultCount: 0,
-                  usedPrimaryText: true,
-                },
-              });
-            },
-          },
-        },
-      },
-    });
-
-    const thread = await createTestThread({
-      id: "slack:D0TITLE6:1700000000.000",
-    });
-    let settled = false;
-    const turnPromise = slackRuntime
-      .handleNewMention(
-        thread,
-        createTestMessage({
-          id: "msg-title-6",
-          threadId: "slack:D0TITLE6:1700000000.000",
-          text: "what's today's date",
-          isMention: true,
-        }),
-        { destination: createTestDestination(thread) },
-      )
-      .then(() => {
-        settled = true;
-      });
-
-    await vi.waitFor(() => {
-      expect(postIncludes(thread, "Today is April 16, 2026.")).toBe(true);
-    });
-    await vi.waitFor(() => {
-      expect(settled).toBe(true);
-    });
-    expect(
-      fakeAdapter.titleCalls.some((call) => call.title === "Today's Date"),
-    ).toBe(false);
-
-    resolveTitle!();
-    await turnPromise;
-    await vi.waitFor(() => {
-      expect(
-        fakeAdapter.titleCalls.some((call) => call.title === "Today's Date"),
-      ).toBe(true);
-    });
-  });
-
   it("thread title: preserves artifact updates when title resolves before completion", async () => {
+    process.env.AI_GATEWAY_API_KEY = "test-gateway-key";
     const fakeAdapter = new FakeSlackAdapter();
-    mockTitleCompleteText(async () =>
-      ({
-        text: "Today's Date",
-        message: { role: "assistant", content: "" },
-      }) as any,
-    );
+    mockTitleModel("Today's Date");
 
     const { slackRuntime } = createRuntime({
       slackAdapter: fakeAdapter,
       services: {
         replyExecutor: {
-          agentRunner: {
-            run: async (request) => {
-              const _text = request.instruction.text;
-              await vi.waitFor(() => {
-                expect(
-                  fakeAdapter.titleCalls.some(
-                    (call) => call.title === "Today's Date",
-                  ),
-                ).toBe(true);
-              });
-              return completedAgentRun({
+          agentRunner: createModelAgentRunner(
+            createModelStream([
+              {
+                type: "text",
                 text: "Today is April 16, 2026.",
-                diagnostics: {
-                  assistantMessageCount: 1,
-                  modelId: "test-model",
-                  outcome: "success" as const,
-                  toolCalls: [],
-                  toolErrorCount: 0,
-                  toolResultCount: 0,
-                  usedPrimaryText: true,
-                },
-              });
-            },
-          },
+                waitFor: vi.waitFor(() => {
+                  expect(
+                    fakeAdapter.titleCalls.some(
+                      (call) => call.title === "Today's Date",
+                    ),
+                  ).toBe(true);
+                }),
+              },
+            ]),
+          ),
         },
       },
     });
@@ -2753,35 +2500,20 @@ describe("bot handlers (integration)", () => {
   });
 
   it("thread title: does not generate title on subsequent replies", async () => {
+    process.env.AI_GATEWAY_API_KEY = "test-gateway-key";
     const fakeAdapter = new FakeSlackAdapter();
     let turnCount = 0;
-    mockTitleCompleteText(async () =>
-      ({
-        text: "Some Title",
-        message: { role: "assistant", content: "" },
-      }) as any,
-    );
+    mockTitleModel("Some Title");
     const { slackRuntime } = createRuntime({
       slackAdapter: fakeAdapter,
       services: {
         replyExecutor: {
-          agentRunner: {
-            run: async () => {
-              turnCount += 1;
-              return completedAgentRun({
-                text: `reply-${turnCount}`,
-                diagnostics: {
-                  assistantMessageCount: 1,
-                  modelId: "test-model",
-                  outcome: "success" as const,
-                  toolCalls: [],
-                  toolErrorCount: 0,
-                  toolResultCount: 0,
-                  usedPrimaryText: true,
-                },
-              });
-            },
-          },
+          agentRunner: createModelAgentRunnerForRun(() => {
+            turnCount += 1;
+            return createModelStream([
+              { type: "text", text: `reply-${turnCount}` },
+            ]);
+          }),
         },
       },
     });
@@ -2800,10 +2532,13 @@ describe("bot handlers (integration)", () => {
       }),
       { destination: createTestDestination(thread) },
     );
-    await new Promise((r) => setTimeout(r, 0));
-
+    await vi.waitFor(() => {
+      expect(
+        fakeAdapter.titleCalls.filter((call) => call.title !== "Junior"),
+      ).toHaveLength(1);
+    });
     const titleCallsAfterFirst = fakeAdapter.titleCalls.filter(
-      (c) => c.title !== "Junior",
+      (call) => call.title !== "Junior",
     ).length;
     expect(titleCallsAfterFirst).toBe(1);
 
@@ -2820,12 +2555,13 @@ describe("bot handlers (integration)", () => {
     await new Promise((r) => setTimeout(r, 0));
 
     const titleCallsAfterSecond = fakeAdapter.titleCalls.filter(
-      (c) => c.title !== "Junior",
+      (call) => call.title !== "Junior",
     ).length;
     expect(titleCallsAfterSecond).toBe(1);
   });
 
   it("thread title: ignores Slack permission errors when setting title", async () => {
+    process.env.AI_GATEWAY_API_KEY = "test-gateway-key";
     const fakeAdapter = new FakeSlackAdapter();
     fakeAdapter.setAssistantTitle = async () => {
       const error = new Error(
@@ -2836,35 +2572,16 @@ describe("bot handlers (integration)", () => {
       error.data = { error: "no_permission" };
       throw error;
     };
-    mockTitleCompleteText(async () =>
-      ({
-        text: "Permission Safe Title",
-        message: { role: "assistant", content: "" },
-      }) as any,
-    );
+    mockTitleModel("Permission Safe Title");
     const { slackRuntime } = createRuntime({
       slackAdapter: fakeAdapter,
       services: {
         replyExecutor: {
-          agentRunner: {
-            run: async (request) => {
-              await deliverAssistantMessagesForTest(request, [
-                { text: "This reply should still succeed." },
-              ]);
-              return completedAgentRun({
-                text: "This reply should still succeed.",
-                diagnostics: {
-                  assistantMessageCount: 1,
-                  modelId: "test-model",
-                  outcome: "success" as const,
-                  toolCalls: [],
-                  toolErrorCount: 0,
-                  toolResultCount: 0,
-                  usedPrimaryText: true,
-                },
-              });
-            },
-          },
+          agentRunner: createModelAgentRunner(
+            createModelStream([
+              { type: "text", text: "This reply should still succeed." },
+            ]),
+          ),
         },
       },
     });
@@ -2890,6 +2607,7 @@ describe("bot handlers (integration)", () => {
   });
 
   it("thread title: does not regenerate after stable Slack permission failures", async () => {
+    process.env.AI_GATEWAY_API_KEY = "test-gateway-key";
     const fakeAdapter = new FakeSlackAdapter();
     fakeAdapter.setAssistantTitle = async () => {
       const error = new Error(
@@ -2902,32 +2620,20 @@ describe("bot handlers (integration)", () => {
     };
 
     let titleGenerationCount = 0;
-    mockTitleCompleteText(async () => {
-      titleGenerationCount += 1;
-      return {
-        text: "Stable Permission Title",
-        message: { role: "assistant", content: "" },
-      } as any;
+    mockTitleModel("Stable Permission Title", {
+      onRequest: () => {
+        titleGenerationCount += 1;
+      },
     });
     const { slackRuntime } = createRuntime({
       slackAdapter: fakeAdapter,
       services: {
         replyExecutor: {
-          agentRunner: {
-            run: async () =>
-              completedAgentRun({
-                text: "Reply still succeeds.",
-                diagnostics: {
-                  assistantMessageCount: 1,
-                  modelId: "test-model",
-                  outcome: "success" as const,
-                  toolCalls: [],
-                  toolErrorCount: 0,
-                  toolResultCount: 0,
-                  usedPrimaryText: true,
-                },
-              }),
-          },
+          agentRunner: createModelAgentRunner(
+            createModelStream([
+              { type: "text", text: "Reply still succeeds." },
+            ]),
+          ),
         },
       },
     });
@@ -2965,26 +2671,10 @@ describe("bot handlers (integration)", () => {
     const { slackRuntime } = createRuntime({
       services: {
         replyExecutor: {
-          agentRunner: {
-            run: async (request) => {
-              const _prompt = request.instruction.text;
-              const context = request;
-
-              capturedContexts.push(context?.instruction.context);
-              return completedAgentRun({
-                text: "First reply.",
-                diagnostics: {
-                  assistantMessageCount: 1,
-                  modelId: "test-model",
-                  outcome: "success" as const,
-                  toolCalls: [],
-                  toolErrorCount: 0,
-                  toolResultCount: 0,
-                  usedPrimaryText: true,
-                },
-              });
-            },
-          },
+          agentRunner: createModelAgentRunnerForRun((run) => {
+            capturedContexts.push(run.instruction.context);
+            return createModelStream([{ type: "text", text: "First reply." }]);
+          }),
         },
       },
     });
@@ -3011,26 +2701,12 @@ describe("bot handlers (integration)", () => {
     const { slackRuntime } = createRuntime({
       services: {
         replyExecutor: {
-          agentRunner: {
-            run: async (request) => {
-              const _prompt = request.instruction.text;
-              const context = request;
-
-              capturedContexts.push(context?.instruction.context);
-              return completedAgentRun({
-                text: "Follow-up reply.",
-                diagnostics: {
-                  assistantMessageCount: 1,
-                  modelId: "test-model",
-                  outcome: "success" as const,
-                  toolCalls: [],
-                  toolErrorCount: 0,
-                  toolResultCount: 0,
-                  usedPrimaryText: true,
-                },
-              });
-            },
-          },
+          agentRunner: createModelAgentRunnerForRun((run) => {
+            capturedContexts.push(run.instruction.context);
+            return createModelStream([
+              { type: "text", text: "Follow-up reply." },
+            ]);
+          }),
         },
       },
     });
@@ -3119,26 +2795,12 @@ describe("bot handlers (integration)", () => {
             }) as any,
         },
         replyExecutor: {
-          agentRunner: {
-            run: async (request) => {
-              const _prompt = request.instruction.text;
-              const context = request;
-
-              capturedContexts.push(context?.instruction.context);
-              return completedAgentRun({
-                text: "Responding to first message only.",
-                diagnostics: {
-                  assistantMessageCount: 1,
-                  modelId: "test-model",
-                  outcome: "success" as const,
-                  toolCalls: [],
-                  toolErrorCount: 0,
-                  toolResultCount: 0,
-                  usedPrimaryText: true,
-                },
-              });
-            },
-          },
+          agentRunner: createModelAgentRunnerForRun((run) => {
+            capturedContexts.push(run.instruction.context);
+            return createModelStream([
+              { type: "text", text: "Responding to first message only." },
+            ]);
+          }),
         },
       },
     });
@@ -3182,23 +2844,12 @@ describe("bot handlers (integration)", () => {
     const { slackRuntime } = createRuntime({
       services: {
         replyExecutor: {
-          agentRunner: {
-            run: async () => {
-              turnCount += 1;
-              return completedAgentRun({
-                text: `reply-${turnCount}`,
-                diagnostics: {
-                  assistantMessageCount: 1,
-                  modelId: "test-model",
-                  outcome: "success" as const,
-                  toolCalls: [],
-                  toolErrorCount: 0,
-                  toolResultCount: 0,
-                  usedPrimaryText: true,
-                },
-              });
-            },
-          },
+          agentRunner: createModelAgentRunnerForRun(() => {
+            turnCount += 1;
+            return createModelStream([
+              { type: "text", text: `reply-${turnCount}` },
+            ]);
+          }),
         },
       },
     });

--- a/packages/junior/tests/integration/slack/bot-handlers.test.ts
+++ b/packages/junior/tests/integration/slack/bot-handlers.test.ts
@@ -50,10 +50,12 @@ import {
   deliverAssistantMessagesForTest,
 } from "../../fixtures/agent-runner";
 import { createModelStream } from "../../fixtures/model-stream";
+import { deferred } from "../../fixtures/conversation-work";
 import {
   mockTitleModel,
   type TitleModelRequest,
 } from "../../fixtures/title-model";
+import { mockTurnRouterModel } from "../../fixtures/turn-router-model";
 
 const emptyThreadReplies = async () => [];
 const ORIGINAL_AI_GATEWAY_API_KEY = process.env.AI_GATEWAY_API_KEY;
@@ -218,6 +220,9 @@ function turnPiMessages(text: string) {
 
 describe("bot handlers (integration)", () => {
   beforeEach(async () => {
+    process.env.AI_GATEWAY_API_KEY = "test-gateway-key";
+    mockTurnRouterModel();
+    mockTitleModel("Test conversation");
     resetConversationTitleStateForTests();
     resetAssistantTitleProjectionForTests();
     await disconnectStateAdapter();
@@ -2332,7 +2337,6 @@ describe("bot handlers (integration)", () => {
   });
 
   it("thread title: uses the first human message we know about in the thread", async () => {
-    process.env.AI_GATEWAY_API_KEY = "test-gateway-key";
     const fakeAdapter = new FakeSlackAdapter();
     let titleRequest: TitleModelRequest | undefined;
     mockTitleModel("Production Issue Summary", {
@@ -2396,7 +2400,6 @@ describe("bot handlers (integration)", () => {
   });
 
   it("thread title: still generates for a new thread with starter assistant content", async () => {
-    process.env.AI_GATEWAY_API_KEY = "test-gateway-key";
     const fakeAdapter = new FakeSlackAdapter();
     mockTitleModel("Today's Date");
 
@@ -2454,8 +2457,15 @@ describe("bot handlers (integration)", () => {
   });
 
   it("thread title: preserves artifact updates when title resolves before completion", async () => {
-    process.env.AI_GATEWAY_API_KEY = "test-gateway-key";
     const fakeAdapter = new FakeSlackAdapter();
+    const titleReady = deferred();
+    const recordTitle = fakeAdapter.setAssistantTitle.bind(fakeAdapter);
+    fakeAdapter.setAssistantTitle = async (channelId, threadTs, title) => {
+      await recordTitle(channelId, threadTs, title);
+      if (title === "Today's Date") {
+        titleReady.resolve();
+      }
+    };
     mockTitleModel("Today's Date");
 
     const { slackRuntime } = createRuntime({
@@ -2467,13 +2477,7 @@ describe("bot handlers (integration)", () => {
               {
                 type: "text",
                 text: "Today is April 16, 2026.",
-                waitFor: vi.waitFor(() => {
-                  expect(
-                    fakeAdapter.titleCalls.some(
-                      (call) => call.title === "Today's Date",
-                    ),
-                  ).toBe(true);
-                }),
+                waitFor: titleReady.promise,
               },
             ]),
           ),
@@ -2500,7 +2504,6 @@ describe("bot handlers (integration)", () => {
   });
 
   it("thread title: does not generate title on subsequent replies", async () => {
-    process.env.AI_GATEWAY_API_KEY = "test-gateway-key";
     const fakeAdapter = new FakeSlackAdapter();
     let turnCount = 0;
     mockTitleModel("Some Title");
@@ -2561,7 +2564,6 @@ describe("bot handlers (integration)", () => {
   });
 
   it("thread title: ignores Slack permission errors when setting title", async () => {
-    process.env.AI_GATEWAY_API_KEY = "test-gateway-key";
     const fakeAdapter = new FakeSlackAdapter();
     fakeAdapter.setAssistantTitle = async () => {
       const error = new Error(
@@ -2607,7 +2609,6 @@ describe("bot handlers (integration)", () => {
   });
 
   it("thread title: does not regenerate after stable Slack permission failures", async () => {
-    process.env.AI_GATEWAY_API_KEY = "test-gateway-key";
     const fakeAdapter = new FakeSlackAdapter();
     fakeAdapter.setAssistantTitle = async () => {
       const error = new Error(

--- a/scripts/test-architecture-debt.json
+++ b/scripts/test-architecture-debt.json
@@ -1,5 +1,5 @@
 {
   "manufactured-agent-outcome": {
-    "packages/junior/tests/integration/slack/bot-handlers.test.ts": 29
+    "packages/junior/tests/integration/slack/bot-handlers.test.ts": 14
   }
 }


### PR DESCRIPTION
Slack bot-handler integration tests for assistant status, thread titles, and conversation context now run normal completions through the real agent with fixed model output. The change removes three lower-fidelity duplicate tests and reduces recorded manufactured-result exceptions from 29 to 14.

Title and turn-routing responses now come from typed fixtures at the external model gateway, shared with the assistant-thread contract tests. The migrated tests neither replace Junior modules nor reach live model services, and title ordering uses an untimed completion gate. Auth parking, timeouts, retries, and other special results remain recorded for separate work because they are not normal model completions.
