### PR TITLE
fix(junior-github): validate bot identity env vars in beforeToolExecute

### DIFF
--- a/packages/junior-github/src/plugin.ts
+++ b/packages/junior-github/src/plugin.ts
@@ -854,11 +854,8 @@ export function githubPlugin(
         if (ctx.tool.name !== "bash") {
           return;
         }
-        const botName = readEnv(botNameEnv);
-        const botEmail = readEnv(botEmailEnv);
-        if (!botName || !botEmail) {
-          return;
-        }
+        const botName = requireEnv(botNameEnv);
+        const botEmail = requireEnv(botEmailEnv);
         ctx.env.set("GIT_AUTHOR_NAME", botName);
         ctx.env.set("GIT_AUTHOR_EMAIL", botEmail);
         ctx.env.set("JUNIOR_GIT_AUTHOR_NAME", botName);

--- a/packages/junior-github/tests/github-plugin.test.ts
+++ b/packages/junior-github/tests/github-plugin.test.ts
@@ -2951,6 +2951,23 @@ Conversation: \`local:test:old-conversation\`
     );
   });
 
+  it("throws GitHubPluginSetupError when bot identity environment variables are missing", () => {
+    delete process.env.GITHUB_APP_BOT_NAME;
+    delete process.env.GITHUB_APP_BOT_EMAIL;
+
+    const plugin = githubPlugin();
+    const before = beforeToolContext({
+      email: "david@example.com",
+      fullName: "David Cramer",
+      userId: "U039RR91S",
+      userName: "dcramer",
+    });
+
+    expect(() => {
+      plugin.hooks?.beforeToolExecute?.(before.ctx as never);
+    }).toThrow("Missing GITHUB_APP_BOT_NAME");
+  });
+
   it("injects Junior author and committer identity", () => {
     process.env.GITHUB_APP_BOT_NAME = "sentry-junior[bot]";
     process.env.GITHUB_APP_BOT_EMAIL = "bot@example.com";


### PR DESCRIPTION
## Description

Fixes #1546.

When `GITHUB_APP_BOT_NAME` or `GITHUB_APP_BOT_EMAIL` was unset, `beforeToolExecute` in `@sentry/junior-github` silently returned early, leaving Git committer and author environment variables unpopulated. Downstream git commits then failed cryptically inside the `prepare-commit-msg` git hook with an internal configuration error.

### Changes
1. In `packages/junior-github/src/plugin.ts` (`beforeToolExecute`):
   - Replaces `readEnv` with `requireEnv` for `botNameEnv` and `botEmailEnv`.
   - Missing configuration now immediately surfaces an actionable `GitHubPluginSetupError("Missing GITHUB_APP_BOT_NAME")` early before any broken tool execution.
2. In `packages/junior-github/tests/github-plugin.test.ts`:
   - Added unit test asserting `GitHubPluginSetupError` is thrown when bot identity environment variables are missing.

## Testing
- Unit tests in `packages/junior-github/tests/github-plugin.test.ts` pass cleanly.
