### PR TITLE
ref(slack): move Turn orchestration to provider layer

### DIFF
--- a/packages/junior-evals/src/behavior-harness.ts
+++ b/packages/junior-evals/src/behavior-harness.ts
@@ -18,7 +18,7 @@ import {
 import { createSlackRuntime } from "@/chat/app/factory";
 import { botConfig } from "@/chat/config";
 import { getConversationEventStore, getDb } from "@/chat/db";
-import type { AssistantLifecycleEvent } from "@/chat/runtime/slack-runtime";
+import type { AssistantLifecycleEvent } from "@/chat/providers/slack/runtime";
 import type { JuniorRuntimeServiceOverrides } from "@/chat/app/services";
 import { createUserTokenStore } from "@/chat/capabilities/factory";
 import { parseOAuthStatePayload } from "@/chat/oauth-flow";

--- a/packages/junior/.dependency-cruiser.mjs
+++ b/packages/junior/.dependency-cruiser.mjs
@@ -25,6 +25,18 @@ export default {
       },
     },
     {
+      name: "no-native-runtime-to-providers",
+      comment:
+        "The native agent runtime and shared services must not depend on provider layers.",
+      severity: "error",
+      from: {
+        path: "^src/chat/(agent|runtime|services)/",
+      },
+      to: {
+        path: "^src/chat/providers/",
+      },
+    },
+    {
       name: "no-chat-services-to-slack",
       comment:
         "Service modules must depend on small injected ports, not Slack infrastructure; Slack timestamp value objects are the only exception.",

--- a/packages/junior/src/chat/README.md
+++ b/packages/junior/src/chat/README.md
@@ -13,7 +13,8 @@ file.
    destinationless child work.
 3. A worker acquires the conversation lease, drains pending input, and restores
    persisted conversation state.
-4. `runtime/` prepares and orchestrates the run; `agent/` owns Pi execution.
+4. `runtime/` prepares and orchestrates the native run; `agent/` owns Pi
+   execution. `providers/` adds source-specific ingress and delivery behavior.
 5. Tools, plugins, credentials, sandbox, and MCP operate within harness-owned
    actor and destination context.
 6. `agent/` emits every completed, tool-free visible assistant message through
@@ -35,7 +36,9 @@ with `publishExternally: false`. Continues keep the conversation destination
 - `app/`: composition root only.
 - `ingress/`: source parsing, classification, and routing.
 - `task-execution/`: mailbox, queue, lease, checkpoint, worker, and recovery.
-- `runtime/`: turn orchestration and provider-neutral delivery callbacks.
+- `runtime/`: native Turn orchestration and provider-neutral delivery ports.
+- `providers/`: source provider layers around the native runtime. Slack owns
+  its provider runtime in `providers/slack/`.
 - `api-turns/`: mailbox enqueue and worker consumer for dashboard/API turns
   that stay in the conversation log (`publishExternally: false`), including
   continues of Slack-rooted conversations by verified participants.
@@ -52,7 +55,8 @@ with `publishExternally: false`. Continues keep the conversation destination
 - `attachments/`: provider-neutral attachment metadata, object storage, and garbage collection.
 - `artifacts/`: content-addressed public artifacts, SQL metadata, and their unauthenticated read path.
 - `state/` and `conversations/`: persistence by concern.
-- `slack/` and `local/`: platform adapters.
+- `slack/`: low-level Slack transport, message projection, and formatting.
+- `local/`: local CLI adapter.
 - `plugins/`, `credentials/`, `sandbox/`, and `mcp/`: external capability
   boundaries.
 - `tool-support/action-review.ts`: effective approval modes, authoritative
@@ -61,9 +65,11 @@ with `publishExternally: false`. Continues keep the conversation destination
   Codex-derived policy and structured model reviewer for actions that enter
   review.
 
-Provider modules must not import runtime orchestration. Runtime and service
-modules depend on small injected ports rather than provider implementations or
-the production singleton.
+Provider layers may call the native runtime through provider-neutral contracts.
+The native runtime must not import a provider layer. Low-level provider
+adapters must not orchestrate native Turns. Runtime and service modules depend
+on small injected ports rather than provider implementations or the production
+singleton.
 
 ## Vocabulary
 

--- a/packages/junior/src/chat/app/factory.ts
+++ b/packages/junior/src/chat/app/factory.ts
@@ -3,12 +3,12 @@ import type { Message } from "chat";
 import {
   createSlackTurnRuntime,
   type AssistantLifecycleEvent,
-} from "@/chat/runtime/slack-runtime";
+} from "@/chat/providers/slack/runtime";
 import { createJuniorRuntimeServices } from "@/chat/app/services";
 import type { JuniorRuntimeServiceOverrides } from "@/chat/app/services";
 import { coerceThreadConversationState } from "@/chat/state/conversation";
 import { logException, logWarn, withSpan } from "@/chat/logging";
-import { createReplyToThread } from "@/chat/runtime/reply-executor";
+import { createSlackTurn } from "@/chat/providers/slack/turn";
 import {
   initializeAssistantThread as initializeAssistantThreadImpl,
   refreshAssistantThreadContext as refreshAssistantThreadContextImpl,
@@ -117,7 +117,7 @@ export function createSlackRuntime(options: CreateSlackRuntimeOptions) {
       );
     },
   });
-  const replyToThread = createReplyToThread({
+  const executeSlackTurn = createSlackTurn({
     getSlackAdapter: options.getSlackAdapter,
     prepareTurnState,
     resolveUserAttachments: services.visionContext.resolveUserAttachments,
@@ -229,7 +229,7 @@ export function createSlackRuntime(options: CreateSlackRuntimeOptions) {
         conversation: preparedState.conversation,
       });
     },
-    replyToThread,
+    executeSlackTurn,
     initializeAssistantThread: async ({
       channelId,
       threadTs,
@@ -260,7 +260,7 @@ export function createSlackRuntime(options: CreateSlackRuntimeOptions) {
     runDispatchTurn: createSlackDispatchTurnRunner({
       getLocationConfiguration: getLocationConfigurationService,
       getSlackAdapter: options.getSlackAdapter,
-      replyToThread,
+      executeSlackTurn,
     }),
   };
 }

--- a/packages/junior/src/chat/app/services.ts
+++ b/packages/junior/src/chat/app/services.ts
@@ -24,7 +24,7 @@ import {
   type SubscribedReplyPolicy,
   type SubscribedReplyPolicyDeps,
 } from "@/chat/services/subscribed-reply-policy";
-import type { ReplyExecutorServices } from "@/chat/runtime/reply-executor";
+import type { SlackTurnServices } from "@/chat/providers/slack/turn";
 import {
   createVisionContextService,
   type VisionContextDeps,
@@ -39,7 +39,7 @@ import { getVercelConversationWorkQueue } from "@/chat/task-execution/vercel-que
 export interface JuniorRuntimeServices {
   conversationMemory: ConversationMemoryService;
   contextCompactor: ContextCompactor;
-  replyExecutor: ReplyExecutorServices;
+  replyExecutor: SlackTurnServices;
   subscribedReplyPolicy: SubscribedReplyPolicy;
   visionContext: VisionContextService;
 }
@@ -47,7 +47,7 @@ export interface JuniorRuntimeServices {
 export interface JuniorRuntimeServiceOverrides {
   conversationMemory?: Partial<ConversationMemoryDeps>;
   contextCompactor?: Partial<ContextCompactorDeps>;
-  replyExecutor?: Partial<ReplyExecutorServices>;
+  replyExecutor?: Partial<SlackTurnServices>;
   subscribedReplyPolicy?: Partial<SubscribedReplyPolicyDeps>;
   sandbox?: {
     tracePropagation?: SandboxEgressTracePropagationConfig;

--- a/packages/junior/src/chat/ingress/slack-webhook.ts
+++ b/packages/junior/src/chat/ingress/slack-webhook.ts
@@ -6,7 +6,7 @@ import {
   type SlashCommandEvent,
   type StateAdapter,
 } from "chat";
-import type { SlackTurnRuntime } from "@/chat/runtime/slack-runtime";
+import type { SlackTurnRuntime } from "@/chat/providers/slack/runtime";
 import type { ConversationStore } from "@/chat/conversations/store";
 import { getConversationStore } from "@/chat/db";
 import type { ConversationWorkQueue } from "@/chat/task-execution/queue";

--- a/packages/junior/src/chat/providers/README.md
+++ b/packages/junior/src/chat/providers/README.md
@@ -1,0 +1,11 @@
+# Chat Providers
+
+Provider layers add source-specific input, policy, progress, delivery, and
+error behavior around the native agent runtime.
+
+Each provider has a concrete directory. Do not add a provider registry or a
+generic adapter framework. A provider may call provider-neutral runtime
+contracts. The native runtime must not import a provider layer.
+
+`slack/` owns Slack Turn routing and execution composition. Low-level Slack
+transport, message projection, and formatting remain in `../slack/`.

--- a/packages/junior/src/chat/providers/slack/runtime.ts
+++ b/packages/junior/src/chat/providers/slack/runtime.ts
@@ -1,5 +1,5 @@
 /**
- * Slack event runtime.
+ * Slack provider runtime.
  *
  * This module owns inbound Slack routing decisions for mentions, subscribed
  * messages, assistant lifecycle events, and retryable turn pauses. It should
@@ -170,7 +170,7 @@ export interface SlackTurnRuntimeDependencies<TPreparedState> {
     thread: Thread;
   }) => Promise<void>;
   prepareTurnState: (args: PrepareTurnStateInput) => Promise<TPreparedState>;
-  replyToThread: (
+  executeSlackTurn: (
     thread: Thread,
     message: Message,
     options: {
@@ -780,7 +780,7 @@ export function createSlackTurnRuntime<
               }),
             stripLeadingBotMention: deps.stripLeadingBotMention,
           });
-          await deps.replyToThread(thread, message, {
+          await deps.executeSlackTurn(thread, message, {
             explicitMention: true,
             beforeFirstResponsePost: hooks.beforeFirstResponsePost,
             conversationId: hooks.conversationId,
@@ -921,7 +921,7 @@ export function createSlackTurnRuntime<
         });
         await deps.withSpan("chat.turn", "chat.turn", turnContext, async () => {
           // This path can compact context and run router/vision model calls
-          // before replyToThread() opens the main reply span.
+          // before executeSlackTurn() opens the main reply span.
           const content = parseContent(message);
           const strippedUserText = deps.stripLeadingBotMention(
             stripLeadingSteeringOverride(content.topLevelText),
@@ -1121,7 +1121,7 @@ export function createSlackTurnRuntime<
             hooks,
           );
 
-          await deps.replyToThread(thread, message, {
+          await deps.executeSlackTurn(thread, message, {
             explicitMention: Boolean(message.isMention),
             conversationId: hooks.conversationId,
             destination: hooks.destination,

--- a/packages/junior/src/chat/providers/slack/turn.ts
+++ b/packages/junior/src/chat/providers/slack/turn.ts
@@ -1,10 +1,10 @@
 /**
- * Slack reply execution boundary.
+ * Add Slack provider behavior around one native agent Turn.
  *
- * This module bridges prepared Slack thread state into the agent runner
- * and commits the resulting Slack-visible delivery/state updates. It is where
- * queued messages, compaction, status updates, and Slack posting meet; agent
- * internals stay behind the runner seam.
+ * This module prepares Slack input and owns Slack status, delivery, and saved
+ * Slack state. Native execution concerns that remain here must move behind a
+ * provider-neutral runtime contract. Agent execution stays behind
+ * `AgentRunner`.
  */
 import type { Message, Thread } from "chat";
 import type { SlackAdapter } from "@chat-adapter/slack";
@@ -358,7 +358,7 @@ async function loadPiMessagesForTurn(args: {
   return {};
 }
 
-export interface ReplyExecutorServices {
+export interface SlackTurnServices {
   agentRunner: AgentRunner;
   contextCompactor: ContextCompactor;
   getPausedTurnRequest: (args: {
@@ -374,7 +374,7 @@ export interface ReplyExecutorServices {
   }) => Promise<void>;
 }
 
-interface ReplyExecutorDeps {
+interface SlackTurnDeps {
   getSlackAdapter: () => SlackAdapter;
   resolveUserAttachments: (
     attachments: Message["attachments"] | undefined,
@@ -395,17 +395,17 @@ interface ReplyExecutorDeps {
     }>
   >;
   prepareTurnState: (args: PrepareTurnStateInput) => Promise<PreparedTurnState>;
-  services: ReplyExecutorServices;
+  services: SlackTurnServices;
 }
 
-/** Build the shared reply handler that prepares, advances, and commits a turn. */
-/** Slack reply executor publishes unless a caller opts out. */
+/** Return whether the Slack caller should publish destination output. */
 function shouldPublishExternally(publishExternally?: boolean): boolean {
   return publishExternally !== false;
 }
 
-export function createReplyToThread(deps: ReplyExecutorDeps) {
-  return async function replyToThread(
+/** Build the Slack caller that prepares input and delivers output for a Turn. */
+export function createSlackTurn(deps: SlackTurnDeps) {
+  return async function executeSlackTurn(
     thread: Thread,
     message: Message,
     options: {
@@ -605,7 +605,9 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
           } catch (error) {
             logException(error, "slack.auth_pause.notice_post.failed", {
               "app.slack.reply_stage": "thread_reply_auth_pause_notice",
-              ...(messageTs ? { "messaging.message.id": messageTs } : undefined),
+              ...(messageTs
+                ? { "messaging.message.id": messageTs }
+                : undefined),
               ...getSlackErrorObservabilityAttributes(error),
             });
           }
@@ -785,7 +787,9 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
               logException(error, "agent.continue.schedule.failed", {
                 "app.ai.resume_session_version": pausedTurn.expectedVersion,
                 "app.ai.resume_session_id": pausedTurn.turnId,
-                ...(messageTs ? { "messaging.message.id": messageTs } : undefined),
+                ...(messageTs
+                  ? { "messaging.message.id": messageTs }
+                  : undefined),
               });
               throw error;
             }
@@ -1069,7 +1073,9 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
             }
             const eventId = logException(error, "slack.thread.post.failed", {
               "app.slack.reply_stage": "thread_reply",
-              ...(messageTs ? { "messaging.message.id": messageTs } : undefined),
+              ...(messageTs
+                ? { "messaging.message.id": messageTs }
+                : undefined),
               ...getSlackErrorObservabilityAttributes(error),
             });
             throw new ConversationTurnBoundaryError({
@@ -1451,7 +1457,9 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
               shouldPersistFailureState = false;
             } catch (scheduleError) {
               logException(scheduleError, "agent.continue.schedule.failed", {
-                ...(messageTs ? { "messaging.message.id": messageTs } : undefined),
+                ...(messageTs
+                  ? { "messaging.message.id": messageTs }
+                  : undefined),
                 "app.ai.resume_session_version": outcome.resumeVersion,
               });
               shouldPersistFailureState = true;
@@ -1570,7 +1578,9 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
               await deps.services.turnLifecycle.fail({
                 conversationId,
                 createdAtMs: Date.now(),
-                ...(persistenceEventId ? { eventId: persistenceEventId } : undefined),
+                ...(persistenceEventId
+                  ? { eventId: persistenceEventId }
+                  : undefined),
                 failureCode: "persistence_failed",
                 turnId,
               });

--- a/packages/junior/src/chat/slack/README.md
+++ b/packages/junior/src/chat/slack/README.md
@@ -1,8 +1,8 @@
 # Slack Adapter
 
-Slack code owns Slack ingress context, assistant-thread status, outbound
-formatting, and Slack API error mapping. It does not own agent decisions or
-runtime orchestration.
+Low-level Slack code owns Slack ingress data, assistant-thread status, outbound
+formatting, and Slack API error mapping. The Slack provider layer in
+`../providers/slack/` combines these capabilities with the native agent runtime.
 
 ## Ingress And Context
 
@@ -67,7 +67,9 @@ status rendering.
 
 ## Boundaries
 
-- Slack modules must not import runtime modules.
+- Low-level Slack modules must not import runtime modules.
+- The Slack provider layer may call provider-neutral runtime contracts. It must
+  not replace the native agent loop.
 - Shared services receive small Slack ports instead of SDK clients.
 - Slack SDK types stay inside the adapter.
 - Do not add bespoke `chat.update` streaming loops unless Slack imposes a hard

--- a/packages/junior/src/chat/slack/dispatch-turn.ts
+++ b/packages/junior/src/chat/slack/dispatch-turn.ts
@@ -13,23 +13,21 @@ import {
 } from "@/chat/agent-dispatch/store";
 import { buildDispatchRoutingContext } from "@/chat/agent-dispatch/work";
 
-interface DispatchReplyToThread {
-  (
-    thread: ThreadImpl,
-    message: Message,
-    options: {
-      ack?: () => Promise<void>;
-      conversationId?: string;
-      destination: DispatchRecord["destination"];
-      execution: DispatchTurnContext;
-      publishExternally?: boolean;
-      onTurnDeliveryAccepted?: (messageId?: string) => void;
-      onTurnOutcome?: (result: DispatchTurnResult) => void;
-      shouldYield?: () => boolean;
-      skipBackfill?: boolean;
-    },
-  ): Promise<void>;
-}
+type ExecuteSlackTurn = (
+  thread: ThreadImpl,
+  message: Message,
+  options: {
+    ack?: () => Promise<void>;
+    conversationId?: string;
+    destination: DispatchRecord["destination"];
+    execution: DispatchTurnContext;
+    publishExternally?: boolean;
+    onTurnDeliveryAccepted?: (messageId?: string) => void;
+    onTurnOutcome?: (result: DispatchTurnResult) => void;
+    shouldYield?: () => boolean;
+    skipBackfill?: boolean;
+  },
+) => Promise<void>;
 
 /** Build the Slack provider adapter for agent-dispatched conversation turns. */
 export function createSlackDispatchTurnRunner(options: {
@@ -37,7 +35,7 @@ export function createSlackDispatchTurnRunner(options: {
     destination: DispatchRecord["destination"],
   ) => DispatchTurnContext["locationConfiguration"];
   getSlackAdapter: () => SlackAdapter;
-  replyToThread: DispatchReplyToThread;
+  executeSlackTurn: ExecuteSlackTurn;
 }) {
   return async function runSlackDispatchTurn(
     dispatch: DispatchRecord,
@@ -90,7 +88,7 @@ export function createSlackDispatchTurnRunner(options: {
     let errorMessage: string | undefined;
     let resultMessageTs: string | undefined;
     const routing = buildDispatchRoutingContext(dispatch);
-    await options.replyToThread(thread, message, {
+    await options.executeSlackTurn(thread, message, {
       ack: hooks.ack,
       conversationId,
       destination: dispatch.destination,

--- a/packages/junior/src/chat/task-execution/slack-work.ts
+++ b/packages/junior/src/chat/task-execution/slack-work.ts
@@ -11,7 +11,7 @@ import { z } from "zod";
 import type {
   SlackTurnOptions,
   SteeringCandidateMessage,
-} from "@/chat/runtime/slack-runtime";
+} from "@/chat/providers/slack/runtime";
 import {
   isCooperativeTurnYieldError,
   isTurnInputDeferredError,

--- a/packages/junior/tests/unit/slack/slack-runtime.test.ts
+++ b/packages/junior/tests/unit/slack/slack-runtime.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   createSlackTurnRuntime,
   type SlackTurnRuntimeDependencies,
-} from "@/chat/runtime/slack-runtime";
+} from "@/chat/providers/slack/runtime";
 import type { SubscribedReplyDecision } from "@/chat/services/subscribed-reply-policy";
 import {
   createTestThread,
@@ -37,7 +37,7 @@ function createMockDeps(
     prepareTurnState: vi
       .fn()
       .mockResolvedValue({ prepared: true } satisfies TestState),
-    replyToThread: vi.fn().mockResolvedValue(undefined),
+    executeSlackTurn: vi.fn().mockResolvedValue(undefined),
     decideSubscribedReply: vi.fn().mockResolvedValue({
       shouldReply: true,
       reason: "test",
@@ -51,7 +51,7 @@ function createMockDeps(
 
 describe("createSlackTurnRuntime", () => {
   describe("handleNewMention", () => {
-    it("subscribes thread and calls replyToThread with explicitMention: true", async () => {
+    it("subscribes thread and calls executeSlackTurn with explicitMention: true", async () => {
       const deps = createMockDeps();
       const runtime = createSlackTurnRuntime<TestState>(deps);
       const thread = await createTestThread({});
@@ -62,7 +62,7 @@ describe("createSlackTurnRuntime", () => {
       });
 
       expect(thread.subscribeCalls).toBe(1);
-      expect(deps.replyToThread).toHaveBeenCalledWith(
+      expect(deps.executeSlackTurn).toHaveBeenCalledWith(
         thread,
         message,
         expect.objectContaining({
@@ -100,7 +100,7 @@ describe("createSlackTurnRuntime", () => {
         },
       });
 
-      expect(deps.replyToThread).toHaveBeenCalledWith(
+      expect(deps.executeSlackTurn).toHaveBeenCalledWith(
         thread,
         latest,
         expect.objectContaining({
@@ -139,7 +139,7 @@ describe("createSlackTurnRuntime", () => {
       "$name",
       async ({ ackBeforeFailure, isFinalAttempt, shouldPostFallback }) => {
         const deps = createMockDeps({
-          replyToThread: vi.fn(async (_thread, _message, hooks) => {
+          executeSlackTurn: vi.fn(async (_thread, _message, hooks) => {
             if (ackBeforeFailure) {
               await hooks.ack?.();
             }
@@ -215,7 +215,7 @@ describe("createSlackTurnRuntime", () => {
             },
           }),
         );
-        expect(deps.replyToThread).not.toHaveBeenCalled();
+        expect(deps.executeSlackTurn).not.toHaveBeenCalled();
       } finally {
         setExperimentalFeatures({
           "passive-routing": true,

--- a/scripts/file-length-exceptions.mjs
+++ b/scripts/file-length-exceptions.mjs
@@ -28,10 +28,10 @@ export const fileLengthExceptions = {
     "Existing plugin hook runtime; split by hook phase.",
   "packages/junior/src/chat/plugins/manifest.ts":
     "Existing manifest parser; split parsing from validation.",
-  "packages/junior/src/chat/runtime/reply-executor.ts":
-    "Existing reply lifecycle; split only at a clear lifecycle boundary.",
-  "packages/junior/src/chat/runtime/slack-runtime.ts":
-    "Existing Slack runtime; split by runtime phase.",
+  "packages/junior/src/chat/providers/slack/turn.ts":
+    "Existing mixed Slack Turn behavior; shrink as native execution moves to the runtime.",
+  "packages/junior/src/chat/providers/slack/runtime.ts":
+    "Existing Slack provider routing; split only at a clear provider behavior boundary.",
   "packages/junior/src/chat/task-execution/turn-cursor.ts":
     "Turn cursor storage behind checkpoint; split by persistence concern.",
   "packages/junior/src/chat/task-execution/state.ts":


### PR DESCRIPTION
This is the first small slice of #1563. It moves the current Slack Turn
orchestration out of the native runtime namespace without changing product
behavior.

## What changed

- Move Slack event routing from `chat/runtime/slack-runtime.ts` to
  `chat/providers/slack/runtime.ts`.
- Move the existing reply executor to `chat/providers/slack/turn.ts` and name
  its entry point `createSlackTurn`.
- Name the dispatch capability `executeSlackTurn`.
- Document `chat/providers/slack` as the concrete provider layer and
  `chat/slack` as the low-level Slack adapter.
- Add a dependency rule that prevents the native agent runtime and shared
  services from importing provider layers.

## Deliberate boundary

This pull request adds no provider registry, generic adapter framework, or new
interface hierarchy. It changes ownership and names only.

It does not extract native Turn execution. It does not change the Conversation
API, IDs, mailbox routing, recovery, local CLI, dispatch behavior, Slack reply
behavior, or child-agent behavior.

The existing `replyExecutor` service override remains because it currently
contains native agent services as well as Slack services. A later slice will
separate those dependencies when Slack calls the provider-neutral Turn
contract.

Part of #1563.
