### PR TITLE
test(local): use real runtime boundaries

### DIFF
--- a/packages/junior/src/chat/local/runner.ts
+++ b/packages/junior/src/chat/local/runner.ts
@@ -48,10 +48,7 @@ import {
 } from "@/chat/conversations/projection";
 import { credentialContextForActor } from "@/chat/credentials/context";
 import { getConversationEventStore, getConversationStore } from "@/chat/db";
-import {
-  ConversationTurnLifecycleService,
-  type ConversationTurnLifecycle,
-} from "@/chat/conversations/turn-lifecycle";
+import { ConversationTurnLifecycleService } from "@/chat/conversations/turn-lifecycle";
 import type { ConversationTurnFailureCode } from "@/chat/conversations/history";
 import { persistConversationMessages } from "@/chat/conversations/messages";
 import { persistWithRetry } from "@/chat/services/persist-retry";
@@ -95,17 +92,8 @@ export interface LocalAgentTurnDeps {
     cancel: () => void;
     wait: () => Promise<void>;
   };
-  /** Post-delivery checkpoint write. */
-  saveTurnCheckpoint?: typeof saveTurnCheckpoint;
   deliverReply: (reply: LocalAgentReply) => Promise<void>;
   sandboxEgressSignals?: SandboxEgressSignalTransport;
-  /** Pre-agent durable Pi projection boundary. */
-  loadPiMessages?: typeof loadLocalPiMessages;
-  /** Injectable failure capture boundary for deterministic runtime integration tests. */
-  logException?: typeof logException;
-  /** Canonical lifecycle writer; defaults to the production SQL service. */
-  turnLifecycle?: ConversationTurnLifecycle;
-  now?: () => number;
   onStatus?: (status: string) => void | Promise<void>;
   onToolInvocation?: (invocation: LocalToolInvocation) => void | Promise<void>;
   onToolResult?: (result: LocalToolResult) => void | Promise<void>;
@@ -193,20 +181,16 @@ async function runLocalAgentTurnInContext(
   if (!text) {
     throw new Error("Local agent message must not be empty");
   }
-  if (!deps.deliverReply) {
-    throw new Error("Local reply delivery is required");
-  }
   const destination = localDestination(input.conversationId);
   const source = createLocalSource(destination.conversationId);
-  const lifecycle =
-    deps.turnLifecycle ??
-    new ConversationTurnLifecycleService(getConversationEventStore());
+  const lifecycle = new ConversationTurnLifecycleService(
+    getConversationEventStore(),
+  );
 
-  const now = deps.now ?? (() => Date.now());
   await getConversationStore().recordActivity({
     conversationId: input.conversationId,
     destination,
-    nowMs: now(),
+    nowMs: Date.now(),
     source: "local",
   });
   const persisted = await getPersistedThreadState(input.conversationId);
@@ -220,7 +204,7 @@ async function runLocalAgentTurnInContext(
 
   const turnId = localTurnId();
   const userMessageId = `${turnId}:user`;
-  const startedAtMs = now();
+  const startedAtMs = Date.now();
   upsertConversationMessage(conversation, {
     id: userMessageId,
     role: "user",
@@ -244,7 +228,7 @@ async function runLocalAgentTurnInContext(
   });
   await lifecycle.start({
     conversationId: input.conversationId,
-    createdAtMs: now(),
+    createdAtMs: Date.now(),
     inputMessageIds: [userMessageId],
     surface: "internal",
     turnId,
@@ -312,7 +296,7 @@ async function runLocalAgentTurnInContext(
   };
   try {
     await persistThreadStateById(input.conversationId, { conversation });
-    const piMessages = await (deps.loadPiMessages ?? loadLocalPiMessages)({
+    const piMessages = await loadLocalPiMessages({
       conversationId: input.conversationId,
     });
     failureCode = "agent_run_failed";
@@ -416,7 +400,7 @@ async function runLocalAgentTurnInContext(
       // Resuming after authorization starts the next durable session slice.
       completionSliceId += 1;
       outcome = await runAgent(
-        await (deps.loadPiMessages ?? loadLocalPiMessages)({
+        await loadLocalPiMessages({
           conversationId: input.conversationId,
         }),
       );
@@ -431,7 +415,7 @@ async function runLocalAgentTurnInContext(
     modelFailureCaptureAttempted = reply.diagnostics.outcome !== "success";
     const finalized = finalizeFailedTurnReplyWithEvent({
       reply,
-      logException: deps.logException ?? logException,
+      logException,
     });
     reply = finalized.reply;
     modelFailureEventId = finalized.eventId;
@@ -452,7 +436,7 @@ async function runLocalAgentTurnInContext(
       modelFailureCaptureAttempted && failureCode === "agent_run_failed"
         ? modelFailureEventId
         : captureLocalBoundaryFailure({
-            capture: deps.logException ?? logException,
+            capture: logException,
             conversationId: input.conversationId,
             error,
             failureCode,
@@ -461,7 +445,7 @@ async function runLocalAgentTurnInContext(
     try {
       markTurnFailed({
         conversation,
-        nowMs: now(),
+        nowMs: Date.now(),
         sessionId: turnId,
         userMessageId,
         markConversationMessage,
@@ -472,7 +456,7 @@ async function runLocalAgentTurnInContext(
       });
     } catch (persistenceError) {
       const persistenceEventId = captureLocalBoundaryFailure({
-        capture: deps.logException ?? logException,
+        capture: logException,
         conversationId: input.conversationId,
         error: persistenceError,
         failureCode: "persistence_failed",
@@ -480,7 +464,7 @@ async function runLocalAgentTurnInContext(
       });
       await lifecycle.fail({
         conversationId: input.conversationId,
-        createdAtMs: now(),
+        createdAtMs: Date.now(),
         ...(persistenceEventId ? { eventId: persistenceEventId } : {}),
         failureCode: "persistence_failed",
         turnId,
@@ -492,7 +476,7 @@ async function runLocalAgentTurnInContext(
     }
     await lifecycle.fail({
       conversationId: input.conversationId,
-      createdAtMs: now(),
+      createdAtMs: Date.now(),
       ...(failureEventId ? { eventId: failureEventId } : {}),
       failureCode,
       turnId,
@@ -510,7 +494,7 @@ async function runLocalAgentTurnInContext(
       // Destination acceptance is the completion boundary: this first commits
       // the final assistant messages to the event log and marks the session
       // record completed only after the CLI sink accepted the reply.
-      await (deps.saveTurnCheckpoint ?? saveTurnCheckpoint)({
+      await saveTurnCheckpoint({
         mode: "completed",
         conversationId: input.conversationId,
         turnId,
@@ -526,7 +510,7 @@ async function runLocalAgentTurnInContext(
     }
   } catch (error) {
     const persistenceEventId = captureLocalBoundaryFailure({
-      capture: deps.logException ?? logException,
+      capture: logException,
       conversationId: input.conversationId,
       error,
       failureCode: "persistence_failed",
@@ -534,7 +518,7 @@ async function runLocalAgentTurnInContext(
     });
     await lifecycle.fail({
       conversationId: input.conversationId,
-      createdAtMs: now(),
+      createdAtMs: Date.now(),
       ...(persistenceEventId ? { eventId: persistenceEventId } : {}),
       failureCode: "persistence_failed",
       turnId,
@@ -545,14 +529,14 @@ async function runLocalAgentTurnInContext(
   if (reply.diagnostics.outcome === "success") {
     await lifecycle.complete({
       conversationId: input.conversationId,
-      createdAtMs: now(),
+      createdAtMs: Date.now(),
       outcome: assistantMessageDelivered ? "success" : "no_reply",
       turnId,
     });
   } else {
     await lifecycle.fail({
       conversationId: input.conversationId,
-      createdAtMs: now(),
+      createdAtMs: Date.now(),
       ...(modelFailureEventId ? { eventId: modelFailureEventId } : {}),
       failureCode: "model_execution_failed",
       turnId,

--- a/packages/junior/tests/integration/local-agent-runner.test.ts
+++ b/packages/junior/tests/integration/local-agent-runner.test.ts
@@ -5,7 +5,6 @@ import {
   type PluginRunContext,
 } from "@sentry/junior-plugin-api";
 import { normalizeLocalConversationId } from "@/chat/local/conversation";
-import { getLogContextAttributes } from "@/chat/logging";
 import {
   runLocalAgentTurn,
   type LocalAgentReply,
@@ -394,24 +393,17 @@ describe("local agent runner", () => {
         deliverReply: async (reply) => {
           delivered.push(reply);
         },
-        logException: vi
-          .fn()
-          .mockReturnValue("0123456789abcdef0123456789abcdef"),
       },
     );
 
     expect(delivered).toHaveLength(1);
     expect(delivered[0]?.text).toContain("temporary connection problem");
-    expect(delivered[0]?.text).toContain(
-      "event_id=0123456789abcdef0123456789abcdef",
-    );
     expect(delivered[0]?.text).not.toContain("raw-error-sentinel");
     const lifecycle = await loadLifecycleEvents(conversationId!);
-    expect(lifecycle.at(-1)?.data).toEqual({
+    expect(lifecycle.at(-1)?.data).toMatchObject({
       type: "turn_failed",
       turnId: expect.stringMatching(/^local-turn-/),
       failureCode: "model_execution_failed",
-      eventId: "0123456789abcdef0123456789abcdef",
     });
     expect(JSON.stringify(lifecycle)).not.toContain("raw-error-sentinel");
     expect(JSON.stringify(lifecycle)).not.toContain("provider.invalid");
@@ -423,18 +415,6 @@ describe("local agent runner", () => {
       cwd: "/tmp/local-agent-runner-throw",
     });
     const rawError = "raw-run-error-sentinel token=secret";
-    const eventId = "11111111111111111111111111111111";
-    let capturedLogContext: ReturnType<typeof getLogContextAttributes>;
-    const capture = vi.fn(
-      (
-        _error: unknown,
-        _eventName: string,
-        _attributes?: Record<string, unknown>,
-      ) => {
-        capturedLogContext = getLogContextAttributes();
-        return eventId;
-      },
-    );
     const cancelAuthorization = vi.fn();
 
     await expect(
@@ -447,13 +427,10 @@ describe("local agent runner", () => {
             deliver: vi.fn(),
             wait: vi.fn(),
           },
-          agentRunner: {
-            run: async () => {
-              throw new Error(rawError);
-            },
-          },
+          agentRunner: createModelAgentRunnerForRun(() => {
+            throw new Error(rawError);
+          }),
           deliverReply: async () => undefined,
-          logException: capture,
         },
       ),
     ).rejects.toThrow(rawError);
@@ -462,103 +439,8 @@ describe("local agent runner", () => {
     expect(lifecycle.at(-1)?.data).toMatchObject({
       type: "turn_failed",
       failureCode: "agent_run_failed",
-      eventId,
-    });
-    expect(capture).toHaveBeenCalledOnce();
-    expect(capture.mock.calls[0]?.[2]).toEqual({
-      "app.ai.failure_code": "agent_run_failed",
-    });
-    expect(capturedLogContext!).toMatchObject({
-      "app.run.id": expect.stringMatching(/^local-run-[0-9a-f-]{36}$/),
-      "gen_ai.conversation.id": conversationId,
     });
     expect(cancelAuthorization).toHaveBeenCalledOnce();
-    expect(JSON.stringify(lifecycle)).not.toContain(rawError);
-  });
-
-  it("retains the model incident when post-delivery persistence fails", async () => {
-    const conversationId = normalizeLocalConversationId({
-      alias: "model-persistence-failure",
-      cwd: "/tmp/local-agent-model-persistence-failure",
-    });
-    const modelEventId = "22222222222222222222222222222222";
-    const persistenceEventId = "55555555555555555555555555555555";
-    const capture = vi
-      .fn()
-      .mockReturnValueOnce(modelEventId)
-      .mockReturnValueOnce(persistenceEventId);
-    const rawModelError = "raw-model-error-sentinel";
-
-    await expect(
-      runLocalAgentTurn(
-        { conversationId: conversationId!, message: "please try" },
-        {
-          agentRunner: createModelAgentRunnerForRun(() =>
-            createModelStream([{ type: "error", errorMessage: rawModelError }]),
-          ),
-          saveTurnCheckpoint: async () => {
-            throw new Error("session-persistence-error-sentinel");
-          },
-          deliverReply: async () => undefined,
-          logException: capture,
-        },
-      ),
-    ).rejects.toThrow("session-persistence-error-sentinel");
-
-    expect(capture).toHaveBeenCalledTimes(2);
-    const lifecycle = await loadLifecycleEvents(conversationId!);
-    expect(lifecycle.at(-1)?.data).toMatchObject({
-      type: "turn_failed",
-      eventId: persistenceEventId,
-      failureCode: "persistence_failed",
-    });
-    const visible = coerceThreadConversationState(
-      await getPersistedThreadState(conversationId!),
-    );
-    await hydrateConversationMessages({
-      conversation: visible,
-      conversationId: conversationId!,
-    });
-    expect(JSON.stringify(visible.messages)).toContain(modelEventId);
-    expect(JSON.stringify(visible.messages)).not.toContain(persistenceEventId);
-    expect(JSON.stringify(lifecycle)).not.toContain(rawModelError);
-    expect(JSON.stringify(lifecycle)).not.toContain(
-      "session-persistence-error-sentinel",
-    );
-  });
-
-  it("captures post-delivery persistence failure when no model incident exists", async () => {
-    const conversationId = normalizeLocalConversationId({
-      alias: "success-persistence-failure",
-      cwd: "/tmp/local-agent-success-persistence-failure",
-    });
-    const eventId = "44444444444444444444444444444444";
-    const capture = vi.fn().mockReturnValue(eventId);
-    const rawError = "raw-session-persistence-error-sentinel";
-
-    await expect(
-      runLocalAgentTurn(
-        { conversationId: conversationId!, message: "please try" },
-        {
-          agentRunner: createModelAgentRunnerForRun(() =>
-            createModelStream([{ type: "text", text: "delivered" }]),
-          ),
-          saveTurnCheckpoint: async () => {
-            throw new Error(rawError);
-          },
-          deliverReply: async () => undefined,
-          logException: capture,
-        },
-      ),
-    ).rejects.toThrow(rawError);
-
-    expect(capture).toHaveBeenCalledOnce();
-    const lifecycle = await loadLifecycleEvents(conversationId!);
-    expect(lifecycle.at(-1)?.data).toMatchObject({
-      type: "turn_failed",
-      eventId,
-      failureCode: "persistence_failed",
-    });
     expect(JSON.stringify(lifecycle)).not.toContain(rawError);
   });
 
@@ -764,74 +646,7 @@ describe("local agent runner", () => {
     ]);
   });
 
-  it("requires local delivery before running a turn", async () => {
-    const conversationId = normalizeLocalConversationId({
-      alias: "missing-delivery",
-      cwd: "/tmp/local-agent-runner-three",
-    });
-    expect(conversationId).toBeDefined();
-
-    await expect(
-      runLocalAgentTurn(
-        {
-          conversationId: conversationId!,
-          message: "hello",
-        },
-        {
-          agentRunner: neverRunAgentRunner(),
-        } as unknown as Parameters<typeof runLocalAgentTurn>[1],
-      ),
-    ).rejects.toThrow("Local reply delivery is required");
-
-    const state = await getPersistedThreadState(conversationId!);
-    const conversation = coerceThreadConversationState(state);
-    expect(conversation.messages).toEqual([]);
-  });
-
-  it("does not advertise an active turn when lifecycle start persistence fails", async () => {
-    const conversationId = normalizeLocalConversationId({
-      alias: "start-failure",
-      cwd: "/tmp/local-agent-runner-start-failure",
-    });
-    const agentRunner = { run: vi.fn<AgentRunner["run"]>() };
-    const startError = new Error("lifecycle store unavailable");
-    const turnLifecycle: NonNullable<LocalAgentTurnDeps["turnLifecycle"]> = {
-      start: vi.fn().mockRejectedValue(startError),
-      complete: vi.fn(),
-      fail: vi.fn(),
-    };
-
-    await expect(
-      runLocalAgentTurn(
-        { conversationId: conversationId!, message: "durable input" },
-        {
-          agentRunner,
-          deliverReply: async () => undefined,
-          turnLifecycle,
-        },
-      ),
-    ).rejects.toBe(startError);
-
-    expect(agentRunner.run).not.toHaveBeenCalled();
-    expect(turnLifecycle.complete).not.toHaveBeenCalled();
-    expect(turnLifecycle.fail).not.toHaveBeenCalled();
-    const state = await getPersistedThreadState(conversationId!);
-    const conversation = coerceThreadConversationState(state);
-    expect(conversation.processing.activeTurnId).toBeUndefined();
-    await hydrateConversationMessages({
-      conversation,
-      conversationId: conversationId!,
-    });
-    expect(conversation.messages).toEqual([
-      expect.objectContaining({ role: "user", text: "durable input" }),
-    ]);
-  });
-
   it("rejects malformed local conversation ids before generation", async () => {
-    const generateReply = vi.fn<AgentRunner["run"]>(async () => {
-      throw new Error("generation should not run");
-    });
-
     await expect(
       runLocalAgentTurn(
         {
@@ -840,42 +655,10 @@ describe("local agent runner", () => {
         },
         {
           deliverReply: async () => undefined,
-          agentRunner: { run: generateReply },
+          agentRunner: neverRunAgentRunner(),
         },
       ),
     ).rejects.toThrow("Invalid local conversation id");
-  });
-
-  it("uses durable Pi projection for follow-up local turns", async () => {
-    const conversationId = normalizeLocalConversationId({
-      alias: "pi-history",
-      cwd: "/tmp/local-agent-runner-four",
-    });
-    expect(conversationId).toBeDefined();
-    const projectedMessage = userPiMessage("projected history");
-    await commitMessages({
-      conversationId: conversationId!,
-      messages: [projectedMessage],
-    });
-
-    const agentRuns: CapturedAgentRun[] = [];
-    const agentRunner = createModelAgentRunnerForRun((run) => {
-      agentRuns.push(run);
-      return createModelStream([{ type: "text", text: "uses projection" }]);
-    });
-
-    await runLocalAgentTurn(
-      {
-        conversationId: conversationId!,
-        message: "follow up",
-      },
-      {
-        deliverReply: async () => undefined,
-        agentRunner,
-      },
-    );
-
-    expect(agentRuns[0]?.history).toEqual([projectedMessage]);
   });
 
   it("commits generated Pi history after successful local delivery", async () => {
@@ -1036,8 +819,6 @@ describe("local agent runner", () => {
     });
     expect(conversationId).toBeDefined();
     const rawDeliveryError = "raw-delivery-error-sentinel stdout closed";
-    const eventId = "33333333333333333333333333333333";
-    const capture = vi.fn().mockReturnValue(eventId);
 
     const realAgentRunner = createModelAgentRunnerForRun(() =>
       createModelStream([{ type: "text", text: "not delivered" }]),
@@ -1063,7 +844,6 @@ describe("local agent runner", () => {
             throw new Error(rawDeliveryError);
           },
           agentRunner,
-          logException: capture,
         },
       ),
     ).rejects.toThrow(rawDeliveryError);
@@ -1099,9 +879,7 @@ describe("local agent runner", () => {
     expect(lifecycle.at(-1)?.data).toMatchObject({
       type: "turn_failed",
       failureCode: "delivery_failed",
-      eventId,
     });
-    expect(capture).toHaveBeenCalledOnce();
     expect(JSON.stringify(lifecycle)).not.toContain(rawDeliveryError);
   });
 });

--- a/scripts/file-length-exceptions.mjs
+++ b/scripts/file-length-exceptions.mjs
@@ -56,8 +56,6 @@ export const fileLengthExceptions = {
     "Existing broad conversation work suite; split by behavior.",
   "packages/junior/tests/component/task-execution/slack-conversation-work.test.ts":
     "Existing broad Slack conversation work suite; split by behavior.",
-  "packages/junior/tests/integration/local-agent-runner.test.ts":
-    "Existing broad local runner suite; split by behavior.",
   "packages/junior/tests/component/auth/mcp-auth-runtime-slack.test.ts":
     "Existing broad MCP auth suite; split by behavior.",
   "packages/junior/tests/component/runtime/agent-run-provider-retry.test.ts":


### PR DESCRIPTION
Local CLI turns now create their lifecycle writer and use the canonical history, checkpoint, logging, and clock paths directly. This removes internal test-only controls from `LocalAgentTurnDeps`, so the integration suite no longer replaces Junior-owned persistence and lifecycle behavior.

The suite drops manufactured lifecycle and checkpoint failures, an unreachable missing-dependency case, duplicate history coverage, and assertions about telemetry identifiers. Lower-level tests still own storage and lifecycle failure contracts, while the local suite keeps real coverage for model failure, delivery failure, OAuth resume, tools, history, and durable outcomes. All 2,664 Junior tests and the repository policy checks pass.
