### PR TITLE
test(slack): keep failure coverage at owning boundaries

### DIFF
--- a/packages/junior/tests/component/runtime/slack-resume.test.ts
+++ b/packages/junior/tests/component/runtime/slack-resume.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createSlackSource } from "@sentry/junior-plugin-api";
 import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 import { disconnectStateAdapter } from "@/chat/state/adapter";
+import { deliverAssistantMessagesForTest } from "../../fixtures/agent-runner";
 import { getCapturedSlackApiCalls } from "../../msw/handlers/slack-api";
 
 const ORIGINAL_STATE_ADAPTER = process.env.JUNIOR_STATE_ADAPTER;
@@ -30,6 +31,21 @@ function makeDiagnostics() {
     toolResultCount: 0,
     usedPrimaryText: false,
   };
+}
+
+function successfulAgentRun(text: string) {
+  return completedAgentRun({
+    text,
+    diagnostics: {
+      assistantMessageCount: 1,
+      modelId: "fake-agent-model",
+      outcome: "success",
+      toolCalls: [],
+      toolErrorCount: 0,
+      toolResultCount: 0,
+      usedPrimaryText: true,
+    },
+  });
 }
 
 describe("Slack resume result handling", () => {
@@ -87,7 +103,7 @@ describe("Slack resume result handling", () => {
           channel: "C123",
           thread_ts: "1700000000.009",
           text: expect.stringContaining(
-            "I ran into an internal error while processing that. Reference: `event_id=",
+            "I ran into an internal error while processing that.",
           ),
         }),
       }),
@@ -107,7 +123,6 @@ describe("Slack resume result handling", () => {
         type: "turn_failed",
         turnId,
         failureCode: "persistence_failed",
-        eventId: expect.stringMatching(/^[a-f0-9]{32}$/i),
       }),
     ]);
   });
@@ -185,10 +200,52 @@ describe("Slack resume result handling", () => {
         channel: "C123",
         thread_ts: "1700000000.006",
         text: expect.stringContaining(
-          "I ran into an internal error while processing that. Reference: `event_id=",
+          "I ran into an internal error while processing that.",
         ),
       }),
     );
+  });
+
+  it("keeps the delivered reply when the result commit fails", async () => {
+    const { resumeSlackTurn } = await import("@/chat/runtime/slack-resume");
+    const onFailure = vi.fn(async () => undefined);
+
+    await expect(
+      resumeSlackTurn({
+        messageText: "continue this turn",
+        conversationId: "slack:C123:1700000000.011",
+        turnId: "turn-resume-commit-fail",
+        channelId: "C123",
+        threadTs: "1700000000.011",
+        replyContext: {
+          credentialContext: {
+            actor: { type: "user", userId: "U123" },
+          },
+          destination: TEST_SLACK_DESTINATION,
+          source: testSlackSource("1700000000.011"),
+          actor: { platform: "slack", teamId: "T123", userId: "U123" },
+        },
+        agentRunner: {
+          run: async (run) => {
+            await deliverAssistantMessagesForTest(run, [
+              { text: "Final resumed answer" },
+            ]);
+            return successfulAgentRun("Final resumed answer");
+          },
+        },
+        commitResult: async () => {
+          throw new Error("state write failed");
+        },
+        onFailure,
+      }),
+    ).rejects.toThrow("state write failed");
+
+    expect(onFailure).not.toHaveBeenCalled();
+    expect(
+      getCapturedSlackApiCalls("chat.postMessage").map(
+        (call) => call.params.text,
+      ),
+    ).toEqual([expect.stringContaining("Final resumed answer")]);
   });
 
   it("releases the thread lock before scheduling a suspended continuation", async () => {
@@ -274,7 +331,7 @@ describe("Slack resume result handling", () => {
       ),
     ).toEqual([
       expect.stringContaining(
-        "I ran into an internal error while processing that. Reference: `event_id=",
+        "I ran into an internal error while processing that.",
       ),
     ]);
   });

--- a/packages/junior/tests/integration/oauth-resume-slack.test.ts
+++ b/packages/junior/tests/integration/oauth-resume-slack.test.ts
@@ -148,7 +148,7 @@ describe("oauth resume slack integration", () => {
       ),
     ).toEqual([
       expect.stringContaining(
-        "I ran into an internal error while processing that. Reference: `event_id=",
+        "I ran into an internal error while processing that.",
       ),
     ]);
   });
@@ -221,7 +221,7 @@ describe("oauth resume slack integration", () => {
     ).toEqual([
       "Connected. Continuing...",
       expect.stringContaining(
-        "I ran into an internal error while processing that. Reference: `event_id=",
+        "I ran into an internal error while processing that.",
       ),
     ]);
   });
@@ -371,42 +371,6 @@ describe("oauth resume slack integration", () => {
     expect(postCalls[1]?.params.text).toContain(
       getSlackInterruptionMarker().trim(),
     );
-    expect(postCalls[1]?.params.text).not.toContain("event_id=");
-  });
-
-  it("keeps the delivered resume reply when post-delivery commit fails", async () => {
-    const { resumeSlackTurn } = await import("@/chat/runtime/slack-resume");
-    const onFailure = vi.fn(async () => undefined);
-
-    await expect(
-      resumeSlackTurn({
-        messageText: "continue this turn",
-        conversationId: "slack:C123:1700000000.011",
-        turnId: "turn-resume-commit-fail",
-        channelId: "C123",
-        threadTs: "1700000000.011",
-        replyContext: {
-          credentialContext: {
-            actor: { type: "user", userId: "U123" },
-          },
-          destination: TEST_SLACK_DESTINATION,
-          source: testSlackSource("1700000000.011"),
-          actor: { platform: "slack", teamId: "T123", userId: "U123" },
-        },
-        agentRunner: modelReply("Final resumed answer"),
-        commitResult: async () => {
-          throw new Error("state write failed");
-        },
-        onFailure,
-      }),
-    ).rejects.toThrow("state write failed");
-
-    expect(onFailure).not.toHaveBeenCalled();
-    expect(
-      getCapturedSlackApiCalls("chat.postMessage").map(
-        (call) => call.params.text,
-      ),
-    ).toEqual([expect.stringContaining("Final resumed answer")]);
   });
 
   it("schedules plugin tasks after a successful resumed turn", async () => {

--- a/packages/junior/tests/integration/slack/bot-handlers.test.ts
+++ b/packages/junior/tests/integration/slack/bot-handlers.test.ts
@@ -1,11 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  fauxAssistantMessage,
-  fauxText,
-  fauxThinking,
-} from "@earendil-works/pi-ai/providers/faux";
 import { createSlackSource, type Destination } from "@sentry/junior-plugin-api";
-import { executeAgentRun } from "@/chat/agent";
 import type { JuniorRuntimeServiceOverrides } from "@/chat/app/services";
 import { disconnectStateAdapter, getStateAdapter } from "@/chat/state/adapter";
 import { acquireActiveLock } from "@/chat/state/locks";
@@ -14,7 +8,6 @@ import { instructionActors } from "@/chat/conversations/provenance";
 import {
   loadProjection,
   loadConversationProjection,
-  recordTurnRoute,
 } from "@/chat/conversations/projection";
 import { projectConversationReportEventPage } from "@/api/conversations/events";
 import { getConversationEventStore } from "@/chat/db";
@@ -486,7 +479,6 @@ describe("bot handlers (integration)", () => {
       expect.objectContaining({
         type: "turn_failed",
         turnId: "turn_msg-err",
-        eventId: expect.stringMatching(/^[a-f0-9]{32}$/i),
         failureCode: "model_execution_failed",
       }),
     ]);
@@ -564,150 +556,7 @@ describe("bot handlers (integration)", () => {
       expect.objectContaining({
         type: "turn_failed",
         turnId: sessionId,
-        eventId: expect.stringMatching(/^[a-f0-9]{32}$/i),
         failureCode: "delivery_failed",
-      }),
-    ]);
-  });
-
-  it("commits real agent history before the Slack reply when later state persistence fails", async () => {
-    const conversationId = "slack:C0POSTDELIVERY:1700000000.000";
-    const sessionId = "turn_msg-post-delivery";
-    const finalText = "Delivered before the state store failed.";
-    const { slackRuntime } = createTestChatRuntime({
-      services: {
-        replyExecutor: {
-          agentRunner: {
-            run: async (request) => {
-              await recordTurnRoute({
-                conversationId,
-                turnId: request.turnId,
-                modelProfile: "standard",
-                modelId: "test/model",
-                reasoningLevel: "medium",
-                source: "configured",
-              });
-              const modelStream = createModelStream([
-                {
-                  type: "message",
-                  message: fauxAssistantMessage([
-                    fauxThinking("Check the final answer."),
-                    fauxText(finalText),
-                  ]),
-                },
-              ]);
-              return executeAgentRun(request, modelStream);
-            },
-          },
-        },
-        visionContext: {
-          listThreadReplies: async () => [],
-        },
-      },
-    });
-    const thread = await createTestThread({ id: conversationId });
-    const originalPost = thread.post.bind(thread);
-    const { getStateAdapter } = await import("@/chat/state/adapter");
-    const stateAdapter = getStateAdapter();
-    const originalSet = stateAdapter.set.bind(stateAdapter);
-    let replyPosted = false;
-    let postDeliveryStateAttempted = false;
-    thread.post = (async (message: unknown) => {
-      const sent = await originalPost(
-        message as Parameters<typeof originalPost>[0],
-      );
-      replyPosted = true;
-      return sent;
-    }) as typeof thread.post;
-    stateAdapter.set = (async (key, value, ttlMs) => {
-      if (
-        replyPosted &&
-        typeof key === "string" &&
-        key.startsWith(`thread-state:${conversationId}`)
-      ) {
-        postDeliveryStateAttempted = true;
-        throw new Error("state store unavailable");
-      }
-      return originalSet(key, value, ttlMs);
-    }) as typeof stateAdapter.set;
-
-    // The user already saw the answer: post-delivery persistence failures are
-    // logged, the turn stays successful, and no fallback failure reply posts.
-    await expect(
-      slackRuntime.handleNewMention(
-        thread,
-        createTestMessage({
-          id: "msg-post-delivery",
-          threadId: conversationId,
-          text: "please answer",
-          isMention: true,
-        }),
-        { destination: createTestDestination(thread) },
-      ),
-    ).resolves.toBeUndefined();
-
-    expect(postIncludes(thread, finalText)).toBe(true);
-    expect(postDeliveryStateAttempted).toBe(true);
-    expect(
-      postIncludes(
-        thread,
-        "I ran into an internal error while processing that.",
-      ),
-    ).toBe(false);
-
-    const conversation = await loadVisibleConversation(thread);
-    expect(conversation.messages).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          role: "assistant",
-          text: finalText,
-        }),
-        expect.objectContaining({
-          id: "msg-post-delivery",
-          meta: expect.objectContaining({ replied: true }),
-        }),
-      ]),
-    );
-    await expect(
-      getTurnRecord(conversationId, sessionId),
-    ).resolves.toMatchObject({ state: "completed" });
-    await expect(loadProjection({ conversationId })).resolves.toEqual(
-      expect.arrayContaining([expect.objectContaining({ role: "assistant" })]),
-    );
-    const report = projectConversationReportEventPage({
-      canExposePayload: true,
-      events: await getConversationEventStore().loadHistory(conversationId),
-    });
-    expect(
-      report
-        .filter(
-          (event) =>
-            event.data.type === "assistant_message" ||
-            (event.data.type === "message" && event.data.role === "assistant"),
-        )
-        .map((event) => event.data),
-    ).toMatchObject([
-      {
-        type: "assistant_message",
-        parts: [{ type: "reasoning", text: "Check the final answer." }],
-      },
-      {
-        type: "message",
-        role: "assistant",
-        text: finalText,
-      },
-    ]);
-    const lifecycle = await loadTurnLifecycleEvents(conversationId);
-    expect(lifecycle.map((event) => event.data)).toEqual([
-      expect.objectContaining({
-        type: "turn_started",
-        turnId: sessionId,
-      }),
-      expect.objectContaining({
-        type: "turn_failed",
-        turnId: sessionId,
-        eventId: expect.stringMatching(/^[a-f0-9]{32}$/i),
-        failureCode: "persistence_failed",
       }),
     ]);
   });

--- a/packages/junior/tests/integration/slack/finalized-reply-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/finalized-reply-behavior.test.ts
@@ -208,7 +208,6 @@ describe("Slack behavior: finalized thread replies", () => {
     expect(postedText).toContain(partialStart);
     expect(postedText).toContain(partialEnd);
     expect(postedText).toContain(getSlackInterruptionMarker().trim());
-    expect(postedText).not.toContain("event_id=");
     const lifecycle = await loadTurnLifecycleEvents(thread.id);
     expect(lifecycle.map((event) => event.data)).toEqual([
       expect.objectContaining({
@@ -220,7 +219,6 @@ describe("Slack behavior: finalized thread replies", () => {
       expect.objectContaining({
         type: "turn_failed",
         turnId: "turn_m-final-8",
-        eventId: expect.stringMatching(/^[a-f0-9]{32}$/i),
         failureCode: "model_execution_failed",
       }),
     ]);


### PR DESCRIPTION
Slack and OAuth integration tests now assert visible replies, failure codes, and durable state without coupling product coverage to Sentry event IDs. The full Slack integration test no longer mutates the state adapter to manufacture a post-delivery failure.

The fixed ordering contract now lives in the Slack resume component test: once Slack accepts the reply, a later result commit failure propagates without posting a second failure reply. Durable session and dispatch tests continue to own recovery after an accepted delivery, so this keeps the behavior covered at the boundary that controls it.
