### PR TITLE
docs(testing): Limit integration fakes to Slack and LLMs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ Use **pnpm**: `pnpm install`, `pnpm dev`, `pnpm test`, `pnpm typecheck`, `pnpm s
 
 ## Testing And Validation
 
-- Follow `policies/testing.md` and `policies/evals.md`. Product/runtime behavior belongs in integration tests through real Junior wiring; agent interpretation and reply quality belong in evals; unit tests are reserved for isolated deterministic logic.
+- Follow `policies/testing.md` and `policies/evals.md`. Product/runtime behavior belongs in integration tests through real Junior wiring (fake only Slack and LLMs via shared harnesses); agent interpretation and reply quality belong in evals; unit tests are reserved for isolated deterministic logic.
 - Before adding a test, search every test layer for the behavior and extend its primary owning scenario. A source change does not automatically require a new test, and equal- or higher-fidelity existing coverage is sufficient.
 - Do not repeat the same behavioral assertion at multiple layers or add one test per implementation branch. Add cross-layer coverage only for a distinct contract or failure boundary, and use representative cases unless exhaustive inputs protect a local deterministic invariant.
 - Test harness mechanics live in `packages/junior/tests/README.md` and `packages/junior-evals/README.md`.

--- a/packages/junior/tests/README.md
+++ b/packages/junior/tests/README.md
@@ -13,14 +13,16 @@ documents the package-local harness and commands.
 - `msw/`: shared outbound HTTP interception and captured request helpers.
 - `fixtures/slack/`: canonical Slack payload and identifier factories.
 
-Integration tests may fake an external boundary through the shared harnesses,
-but may not mock Junior-owned `@/` modules. `pnpm test-architecture:check`
+Integration tests compose real Junior wiring. They may fake only Slack and LLMs,
+and only through the shared harnesses (Slack MSW/outbox fixtures and
+`fixtures/model-stream.ts`). They must not mock Junior-owned `@/` modules or
+other external edges such as `@vercel/sandbox`. `pnpm test-architecture:check`
 also blocks Pi agent mocks, manufactured agent outcomes, scripted agent runners,
 and unsafe Slack double casts. These rules have no exceptions. Rewrite a test
 through real wiring or remove it when stronger coverage owns the behavior.
 
-A test that needs internal module replacement belongs in `component/` unless it
-is rewritten to use real wiring.
+A test that needs internal module replacement, or a non-Slack/non-LLM external
+fake, belongs in `component/` unless it is rewritten to use real wiring.
 
 Use `../../junior-evals/README.md` for model-dependent behavior and
 `../../docs/src/content/docs/contribute/local-agent-validation.md` for local

--- a/policies/testing.md
+++ b/policies/testing.md
@@ -9,7 +9,7 @@ refactors should not churn brittle unit tests.
 ## Policy
 
 - Prefer integration tests for product and runtime behavior when the contract
-  can be proven through real wiring with only the allowed fake edge.
+  can be proven through real wiring with only Slack and LLM fakes.
 - Prefer evals for agent-facing behavior that depends on model reading,
   continuity, routing, or reply quality. Assert through normalized session,
   tool, and artifact surfaces. Fixed persistence belongs in integration tests.
@@ -42,7 +42,10 @@ refactors should not churn brittle unit tests.
   stack mocks across persistence, runtime, delivery, and reply execution to fake
   a product workflow.
 - Integration tests must not mock Junior-owned modules. Compose real Junior
-  wiring and fake only the external edge named by the test harness.
+  wiring. Fake only Slack and LLMs, and only through the shared harnesses (Slack
+  MSW/outbox fixtures and model-stream). Do not mock other external edges such
+  as `@vercel/sandbox`, provider SDKs, or other live infrastructure the product
+  calls. Put those fakes in component tests when the contract needs them.
 - Prefer existing harnesses, shared fixtures, memory adapters, MSW handlers, and
   outboxes over ad hoc mocks or local payload schemas.
 - Assert user-visible outcomes and external contracts before implementation

--- a/scripts/check-test-architecture.mjs
+++ b/scripts/check-test-architecture.mjs
@@ -10,13 +10,10 @@ const DASHBOARD_E2E_ROOT = "packages/junior-dashboard/e2e/";
 
 const RULES = [
   {
-    message: "integration tests must not mock Junior-owned @/ modules",
-    pattern: /\bvi\.(?:doMock|mock)\(\s*["']@\//g,
-  },
-  {
-    message: "integration tests must not mock Pi's agent",
-    pattern:
-      /\bvi\.(?:doMock|mock)\(\s*["']@earendil-works\/pi-agent-core["']/g,
+    // Slack and LLM fakes go through shared harnesses, not vi.mock.
+    message:
+      "integration tests must not use vi.mock or vi.doMock; fake only Slack and LLMs through shared harnesses",
+    pattern: /\bvi\.(?:doMock|mock)\s*\(/g,
   },
   {
     message:

--- a/scripts/check-test-architecture.test.mjs
+++ b/scripts/check-test-architecture.test.mjs
@@ -16,28 +16,30 @@ test("rejects a new integration test that mocks a Junior module", () => {
       integrationTest('vi.mock("@/chat/runtime", () => ({}));'),
     ]),
     [
-      `${TEST_PATH}: integration tests must not mock Junior-owned @/ modules (1 found, 0 allowed)`,
+      `${TEST_PATH}: integration tests must not use vi.mock or vi.doMock; fake only Slack and LLMs through shared harnesses (1 found, 0 allowed)`,
     ],
   );
 });
 
-test("rejects dynamic mocks of Junior modules", () => {
+test("rejects dynamic mocks", () => {
   assert.deepEqual(
     checkIntegrationTestArchitecture([
       integrationTest("vi.doMock(\n  '@/chat/runtime',\n  () => ({}),\n);"),
     ]),
     [
-      `${TEST_PATH}: integration tests must not mock Junior-owned @/ modules (1 found, 0 allowed)`,
+      `${TEST_PATH}: integration tests must not use vi.mock or vi.doMock; fake only Slack and LLMs through shared harnesses (1 found, 0 allowed)`,
     ],
   );
 });
 
-test("allows external mocks", () => {
+test("rejects external package mocks", () => {
   assert.deepEqual(
     checkIntegrationTestArchitecture([
-      integrationTest('vi.mock("external-provider", () => ({}));'),
+      integrationTest('vi.mock("@vercel/sandbox", () => ({}));'),
     ]),
-    [],
+    [
+      `${TEST_PATH}: integration tests must not use vi.mock or vi.doMock; fake only Slack and LLMs through shared harnesses (1 found, 0 allowed)`,
+    ],
   );
 });
 
@@ -47,7 +49,7 @@ test("rejects Pi agent mocks", () => {
       integrationTest('vi.mock("@earendil-works/pi-agent-core", () => ({}));'),
     ]),
     [
-      `${TEST_PATH}: integration tests must not mock Pi's agent (1 found, 0 allowed)`,
+      `${TEST_PATH}: integration tests must not use vi.mock or vi.doMock; fake only Slack and LLMs through shared harnesses (1 found, 0 allowed)`,
     ],
   );
 });


### PR DESCRIPTION
Integration tests now permit fakes only for Slack and LLM boundaries through the shared harnesses. Other external-edge fakes belong in component tests, which keeps runtime integration coverage on real Junior wiring.

The test-architecture check now rejects all `vi.mock` and `vi.doMock` calls in integration tests, so the repository guidance and automated enforcement use the same rule. This policy change is independent of the Workspace snapshot behavior in #1599.
