### PR TITLE
feat(workspaces): Move snapshots to dedicated table

### DIFF
--- a/packages/junior/migrations/0032_workspace_snapshots_table.sql
+++ b/packages/junior/migrations/0032_workspace_snapshots_table.sql
@@ -4,8 +4,6 @@ CREATE TABLE "junior_snapshots" (
 	"profile_hash" text NOT NULL,
 	"status" text NOT NULL,
 	"snapshot_id" text,
-	"runtime" text,
-	"dependency_count" integer,
 	"build_duration_ms" integer,
 	"generated_at" timestamp with time zone,
 	"build_started_at" timestamp with time zone,
@@ -16,13 +14,16 @@ CREATE TABLE "junior_snapshots" (
 	"created_at" timestamp with time zone NOT NULL,
 	"updated_at" timestamp with time zone NOT NULL,
 	CONSTRAINT "junior_snapshots_status_check" CHECK ("junior_snapshots"."status" in ('building', 'failed', 'ready')),
-	CONSTRAINT "junior_snapshots_build_phase_check" CHECK ("junior_snapshots"."build_phase" is null or "junior_snapshots"."build_phase" in ('created', 'dependencies_installed', 'repositories_prepared'))
+	CONSTRAINT "junior_snapshots_build_phase_check" CHECK ("junior_snapshots"."build_phase" is null or "junior_snapshots"."build_phase" in ('created', 'dependencies_installed', 'repositories_prepared')),
+	CONSTRAINT "junior_snapshots_ready_fields_check" CHECK ("junior_snapshots"."status" <> 'ready' or ("junior_snapshots"."snapshot_id" is not null and "junior_snapshots"."build_duration_ms" is not null and "junior_snapshots"."generated_at" is not null)),
+	CONSTRAINT "junior_snapshots_build_fields_check" CHECK ("junior_snapshots"."status" = 'ready' or ("junior_snapshots"."build_started_at" is not null and "junior_snapshots"."build_phase" is not null)),
+	CONSTRAINT "junior_snapshots_build_duration_check" CHECK ("junior_snapshots"."build_duration_ms" is null or "junior_snapshots"."build_duration_ms" >= 0)
 );
 --> statement-breakpoint
 ALTER TABLE "junior_snapshots" ADD CONSTRAINT "junior_snapshots_workspace_id_junior_workspaces_id_fk" FOREIGN KEY ("workspace_id") REFERENCES "public"."junior_workspaces"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 CREATE UNIQUE INDEX "junior_snapshots_snapshot_id_uidx" ON "junior_snapshots" USING btree ("snapshot_id");--> statement-breakpoint
 CREATE INDEX "junior_snapshots_workspace_idx" ON "junior_snapshots" USING btree ("workspace_id");--> statement-breakpoint
-CREATE INDEX "junior_snapshots_profile_status_idx" ON "junior_snapshots" USING btree ("profile_hash","status");--> statement-breakpoint
+CREATE INDEX "junior_snapshots_workspace_profile_status_idx" ON "junior_snapshots" USING btree ("workspace_id","profile_hash","status");--> statement-breakpoint
 CREATE INDEX "junior_snapshots_workspace_status_idx" ON "junior_snapshots" USING btree ("workspace_id","status");--> statement-breakpoint
 -- Move legacy recipe-column snapshot facts into junior_snapshots before drop.
 INSERT INTO "junior_snapshots" (
@@ -31,8 +32,6 @@ INSERT INTO "junior_snapshots" (
 	"profile_hash",
 	"status",
 	"snapshot_id",
-	"runtime",
-	"dependency_count",
 	"build_duration_ms",
 	"generated_at",
 	"build_started_at",
@@ -49,8 +48,6 @@ SELECT
 	"snapshot_profile_hash",
 	'ready',
 	"snapshot_id",
-	'node22',
-	0,
 	"snapshot_build_duration_ms",
 	"snapshot_generated_at",
 	NULL,

--- a/packages/junior/migrations/0032_workspace_snapshots_table.sql
+++ b/packages/junior/migrations/0032_workspace_snapshots_table.sql
@@ -1,0 +1,72 @@
+CREATE TABLE "junior_snapshots" (
+	"id" text PRIMARY KEY NOT NULL,
+	"workspace_id" text NOT NULL,
+	"profile_hash" text NOT NULL,
+	"status" text NOT NULL,
+	"snapshot_id" text,
+	"runtime" text,
+	"dependency_count" integer,
+	"build_duration_ms" integer,
+	"generated_at" timestamp with time zone,
+	"build_started_at" timestamp with time zone,
+	"build_phase" text,
+	"build_sandbox_name" text,
+	"build_command_id" text,
+	"build_error" text,
+	"created_at" timestamp with time zone NOT NULL,
+	"updated_at" timestamp with time zone NOT NULL,
+	CONSTRAINT "junior_snapshots_status_check" CHECK ("junior_snapshots"."status" in ('building', 'failed', 'ready')),
+	CONSTRAINT "junior_snapshots_build_phase_check" CHECK ("junior_snapshots"."build_phase" is null or "junior_snapshots"."build_phase" in ('created', 'dependencies_installed', 'repositories_prepared'))
+);
+--> statement-breakpoint
+ALTER TABLE "junior_snapshots" ADD CONSTRAINT "junior_snapshots_workspace_id_junior_workspaces_id_fk" FOREIGN KEY ("workspace_id") REFERENCES "public"."junior_workspaces"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "junior_snapshots_snapshot_id_uidx" ON "junior_snapshots" USING btree ("snapshot_id");--> statement-breakpoint
+CREATE INDEX "junior_snapshots_workspace_idx" ON "junior_snapshots" USING btree ("workspace_id");--> statement-breakpoint
+CREATE INDEX "junior_snapshots_profile_status_idx" ON "junior_snapshots" USING btree ("profile_hash","status");--> statement-breakpoint
+CREATE INDEX "junior_snapshots_workspace_status_idx" ON "junior_snapshots" USING btree ("workspace_id","status");--> statement-breakpoint
+-- Move legacy recipe-column snapshot facts into junior_snapshots before drop.
+INSERT INTO "junior_snapshots" (
+	"id",
+	"workspace_id",
+	"profile_hash",
+	"status",
+	"snapshot_id",
+	"runtime",
+	"dependency_count",
+	"build_duration_ms",
+	"generated_at",
+	"build_started_at",
+	"build_phase",
+	"build_sandbox_name",
+	"build_command_id",
+	"build_error",
+	"created_at",
+	"updated_at"
+)
+SELECT
+	gen_random_uuid()::text,
+	"id",
+	"snapshot_profile_hash",
+	'ready',
+	"snapshot_id",
+	'node22',
+	0,
+	"snapshot_build_duration_ms",
+	"snapshot_generated_at",
+	NULL,
+	NULL,
+	NULL,
+	NULL,
+	NULL,
+	COALESCE("snapshot_generated_at", "updated_at", "created_at"),
+	COALESCE("snapshot_generated_at", "updated_at", "created_at")
+FROM "junior_workspaces"
+WHERE
+	"snapshot_id" IS NOT NULL
+	AND "snapshot_profile_hash" IS NOT NULL
+	AND "snapshot_generated_at" IS NOT NULL
+	AND "snapshot_build_duration_ms" IS NOT NULL;--> statement-breakpoint
+ALTER TABLE "junior_workspaces" DROP COLUMN "snapshot_id";--> statement-breakpoint
+ALTER TABLE "junior_workspaces" DROP COLUMN "snapshot_generated_at";--> statement-breakpoint
+ALTER TABLE "junior_workspaces" DROP COLUMN "snapshot_build_duration_ms";--> statement-breakpoint
+ALTER TABLE "junior_workspaces" DROP COLUMN "snapshot_profile_hash";

--- a/packages/junior/migrations/meta/0032_snapshot.json
+++ b/packages/junior/migrations/meta/0032_snapshot.json
@@ -2329,18 +2329,6 @@
           "primaryKey": false,
           "notNull": false
         },
-        "runtime": {
-          "name": "runtime",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "dependency_count": {
-          "name": "dependency_count",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
         "build_duration_ms": {
           "name": "build_duration_ms",
           "type": "integer",
@@ -2427,9 +2415,15 @@
           "method": "btree",
           "with": {}
         },
-        "junior_snapshots_profile_status_idx": {
-          "name": "junior_snapshots_profile_status_idx",
+        "junior_snapshots_workspace_profile_status_idx": {
+          "name": "junior_snapshots_workspace_profile_status_idx",
           "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
             {
               "expression": "profile_hash",
               "isExpression": false,
@@ -2492,6 +2486,18 @@
         "junior_snapshots_build_phase_check": {
           "name": "junior_snapshots_build_phase_check",
           "value": "\"junior_snapshots\".\"build_phase\" is null or \"junior_snapshots\".\"build_phase\" in ('created', 'dependencies_installed', 'repositories_prepared')"
+        },
+        "junior_snapshots_ready_fields_check": {
+          "name": "junior_snapshots_ready_fields_check",
+          "value": "\"junior_snapshots\".\"status\" <> 'ready' or (\"junior_snapshots\".\"snapshot_id\" is not null and \"junior_snapshots\".\"build_duration_ms\" is not null and \"junior_snapshots\".\"generated_at\" is not null)"
+        },
+        "junior_snapshots_build_fields_check": {
+          "name": "junior_snapshots_build_fields_check",
+          "value": "\"junior_snapshots\".\"status\" = 'ready' or (\"junior_snapshots\".\"build_started_at\" is not null and \"junior_snapshots\".\"build_phase\" is not null)"
+        },
+        "junior_snapshots_build_duration_check": {
+          "name": "junior_snapshots_build_duration_check",
+          "value": "\"junior_snapshots\".\"build_duration_ms\" is null or \"junior_snapshots\".\"build_duration_ms\" >= 0"
         }
       },
       "isRLSEnabled": false

--- a/packages/junior/migrations/meta/0032_snapshot.json
+++ b/packages/junior/migrations/meta/0032_snapshot.json
@@ -1,0 +1,2886 @@
+{
+  "id": "7f66cacd-886c-4bbd-8b80-ea3ce8a0a466",
+  "prevId": "6fe6b9af-5375-4f04-bc6e-3db5c77d5193",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.junior_agent_bindings": {
+      "name": "junior_agent_bindings",
+      "schema": "",
+      "columns": {
+        "parent_conversation_id": {
+          "name": "parent_conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_conversation_id": {
+          "name": "child_conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "junior_agent_bindings_child_idx": {
+          "name": "junior_agent_bindings_child_idx",
+          "columns": [
+            {
+              "expression": "child_conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "junior_agent_bindings_parent_conversation_id_junior_conversations_conversation_id_fk": {
+          "name": "junior_agent_bindings_parent_conversation_id_junior_conversations_conversation_id_fk",
+          "tableFrom": "junior_agent_bindings",
+          "tableTo": "junior_conversations",
+          "columnsFrom": ["parent_conversation_id"],
+          "columnsTo": ["conversation_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "junior_agent_bindings_child_conversation_id_junior_conversations_conversation_id_fk": {
+          "name": "junior_agent_bindings_child_conversation_id_junior_conversations_conversation_id_fk",
+          "tableFrom": "junior_agent_bindings",
+          "tableTo": "junior_conversations",
+          "columnsFrom": ["child_conversation_id"],
+          "columnsTo": ["conversation_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "junior_agent_bindings_parent_conversation_id_name_pk": {
+          "name": "junior_agent_bindings_parent_conversation_id_name_pk",
+          "columns": ["parent_conversation_id", "name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_agent_invocations": {
+      "name": "junior_agent_invocations",
+      "schema": "",
+      "columns": {
+        "invocation_id": {
+          "name": "invocation_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "parent_conversation_id": {
+          "name": "parent_conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_conversation_id": {
+          "name": "child_conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input": {
+          "name": "input",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_json": {
+          "name": "actor_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_context_json": {
+          "name": "credential_context_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_json": {
+          "name": "source_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination_json": {
+          "name": "destination_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination_visibility": {
+          "name": "destination_visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasoning_level": {
+          "name": "reasoning_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mailbox_status": {
+          "name": "mailbox_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "terminal_at": {
+          "name": "terminal_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "junior_agent_invocations_child_idx": {
+          "name": "junior_agent_invocations_child_idx",
+          "columns": [
+            {
+              "expression": "child_conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_agent_invocations_mailbox_idx": {
+          "name": "junior_agent_invocations_mailbox_idx",
+          "columns": [
+            {
+              "expression": "mailbox_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "junior_agent_invocations_parent_conversation_id_junior_conversations_conversation_id_fk": {
+          "name": "junior_agent_invocations_parent_conversation_id_junior_conversations_conversation_id_fk",
+          "tableFrom": "junior_agent_invocations",
+          "tableTo": "junior_conversations",
+          "columnsFrom": ["parent_conversation_id"],
+          "columnsTo": ["conversation_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "junior_agent_invocations_child_conversation_id_junior_conversations_conversation_id_fk": {
+          "name": "junior_agent_invocations_child_conversation_id_junior_conversations_conversation_id_fk",
+          "tableFrom": "junior_agent_invocations",
+          "tableTo": "junior_conversations",
+          "columnsFrom": ["child_conversation_id"],
+          "columnsTo": ["conversation_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_api_tokens": {
+      "name": "junior_api_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_email_normalized": {
+          "name": "owner_email_normalized",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_suffix": {
+          "name": "token_suffix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "junior_api_tokens_token_hash_uidx": {
+          "name": "junior_api_tokens_token_hash_uidx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_api_tokens_owner_email_idx": {
+          "name": "junior_api_tokens_owner_email_idx",
+          "columns": [
+            {
+              "expression": "owner_email_normalized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_artifacts": {
+      "name": "junior_artifacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ext": {
+          "name": "ext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delete_requested_at": {
+          "name": "delete_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "junior_artifacts_conversation_sha_uidx": {
+          "name": "junior_artifacts_conversation_sha_uidx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_artifacts_gc_idx": {
+          "name": "junior_artifacts_gc_idx",
+          "columns": [
+            {
+              "expression": "delete_requested_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_artifacts_conversation_idx": {
+          "name": "junior_artifacts_conversation_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_attachments": {
+      "name": "junior_attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delete_requested_at": {
+          "name": "delete_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "junior_attachments_conversation_idx": {
+          "name": "junior_attachments_conversation_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_attachments_gc_idx": {
+          "name": "junior_attachments_gc_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "delete_requested_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "junior_attachments_conversation_id_junior_conversations_conversation_id_fk": {
+          "name": "junior_attachments_conversation_id_junior_conversations_conversation_id_fk",
+          "tableFrom": "junior_attachments",
+          "tableTo": "junior_conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["conversation_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_conversation_annotations": {
+      "name": "junior_conversation_annotations",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plugin": {
+          "name": "plugin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "annotation_json": {
+          "name": "annotation_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "junior_conversation_annotations_conversation_id_fk": {
+          "name": "junior_conversation_annotations_conversation_id_fk",
+          "tableFrom": "junior_conversation_annotations",
+          "tableTo": "junior_conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["conversation_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "junior_conversation_annotations_pk": {
+          "name": "junior_conversation_annotations_pk",
+          "columns": ["conversation_id", "plugin", "kind", "key"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_conversation_bindings": {
+      "name": "junior_conversation_bindings",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_tenant_id": {
+          "name": "provider_tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "provider_destination_id": {
+          "name": "provider_destination_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_conversation_id": {
+          "name": "provider_conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "junior_conversation_bindings_conversation_idx": {
+          "name": "junior_conversation_bindings_conversation_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "junior_conversation_bindings_conversation_id_junior_conversations_conversation_id_fk": {
+          "name": "junior_conversation_bindings_conversation_id_junior_conversations_conversation_id_fk",
+          "tableFrom": "junior_conversation_bindings",
+          "tableTo": "junior_conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["conversation_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "junior_conversation_bindings_provider_conversation_pk": {
+          "name": "junior_conversation_bindings_provider_conversation_pk",
+          "columns": [
+            "provider",
+            "provider_tenant_id",
+            "provider_destination_id",
+            "provider_conversation_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_conversation_events": {
+      "name": "junior_conversation_events",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "history_version": {
+          "name": "history_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_identity_id": {
+          "name": "actor_identity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "junior_conversation_events_history_version_idx": {
+          "name": "junior_conversation_events_history_version_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "history_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_conversation_events_type_idx": {
+          "name": "junior_conversation_events_type_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_conversation_events_actor_identity_idx": {
+          "name": "junior_conversation_events_actor_identity_idx",
+          "columns": [
+            {
+              "expression": "actor_identity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_conversation_events_message_search_idx": {
+          "name": "junior_conversation_events_message_search_idx",
+          "columns": [
+            {
+              "expression": "to_tsvector('english', \"payload\"->>'text')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"junior_conversation_events\".\"type\" = 'message'",
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "junior_conversation_events_idempotency_idx": {
+          "name": "junior_conversation_events_idempotency_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "junior_conversation_events_actor_identity_id_junior_identities_id_fk": {
+          "name": "junior_conversation_events_actor_identity_id_junior_identities_id_fk",
+          "tableFrom": "junior_conversation_events",
+          "tableTo": "junior_identities",
+          "columnsFrom": ["actor_identity_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "junior_conversation_events_conversation_id_junior_conversations_conversation_id_fk": {
+          "name": "junior_conversation_events_conversation_id_junior_conversations_conversation_id_fk",
+          "tableFrom": "junior_conversation_events",
+          "tableTo": "junior_conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["conversation_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "junior_conversation_events_conversation_id_seq_pk": {
+          "name": "junior_conversation_events_conversation_id_seq_pk",
+          "columns": ["conversation_id", "seq"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_conversation_participants": {
+      "name": "junior_conversation_participants",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_conversation_id": {
+          "name": "root_conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "junior_conversation_participants_user_activity_idx": {
+          "name": "junior_conversation_participants_user_activity_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_message_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_conversation_participants_root_idx": {
+          "name": "junior_conversation_participants_root_idx",
+          "columns": [
+            {
+              "expression": "root_conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "junior_conversation_participants_user_id_junior_users_id_fk": {
+          "name": "junior_conversation_participants_user_id_junior_users_id_fk",
+          "tableFrom": "junior_conversation_participants",
+          "tableTo": "junior_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "junior_conversation_participants_root_conversation_id_junior_conversations_conversation_id_fk": {
+          "name": "junior_conversation_participants_root_conversation_id_junior_conversations_conversation_id_fk",
+          "tableFrom": "junior_conversation_participants",
+          "tableTo": "junior_conversations",
+          "columnsFrom": ["root_conversation_id"],
+          "columnsTo": ["conversation_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "junior_conversation_participants_user_root_pk": {
+          "name": "junior_conversation_participants_user_root_pk",
+          "columns": ["user_id", "root_conversation_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_conversations": {
+      "name": "junior_conversations",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_json": {
+          "name": "source_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin_type": {
+          "name": "origin_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin_id": {
+          "name": "origin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin_run_id": {
+          "name": "origin_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destination_id": {
+          "name": "destination_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destination_json": {
+          "name": "destination_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_identity_id": {
+          "name": "actor_identity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_identity_id": {
+          "name": "creator_identity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_subject_identity_id": {
+          "name": "credential_subject_identity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_json": {
+          "name": "actor_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_name": {
+          "name": "channel_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "execution_updated_at": {
+          "name": "execution_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_status": {
+          "name": "execution_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_checkpoint_at": {
+          "name": "last_checkpoint_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_enqueued_at": {
+          "name": "last_enqueued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_conversation_id": {
+          "name": "parent_conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_conversation_id": {
+          "name": "root_conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcript_purged_at": {
+          "name": "transcript_purged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "usage_json": {
+          "name": "usage_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_duration_ms": {
+          "name": "execution_duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "execution_usage_json": {
+          "name": "execution_usage_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metric_run_id": {
+          "name": "metric_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "junior_conversations_last_activity_idx": {
+          "name": "junior_conversations_last_activity_idx",
+          "columns": [
+            {
+              "expression": "last_activity_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_conversations_active_idx": {
+          "name": "junior_conversations_active_idx",
+          "columns": [
+            {
+              "expression": "coalesce(\"execution_updated_at\", \"updated_at\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"junior_conversations\".\"execution_status\" <> 'idle'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_conversations_destination_activity_idx": {
+          "name": "junior_conversations_destination_activity_idx",
+          "columns": [
+            {
+              "expression": "destination_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_activity_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_conversations_actor_activity_idx": {
+          "name": "junior_conversations_actor_activity_idx",
+          "columns": [
+            {
+              "expression": "actor_identity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_activity_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_conversations_origin_idx": {
+          "name": "junior_conversations_origin_idx",
+          "columns": [
+            {
+              "expression": "origin_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "origin_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_activity_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_conversations_parent_idx": {
+          "name": "junior_conversations_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_conversations_root_idx": {
+          "name": "junior_conversations_root_idx",
+          "columns": [
+            {
+              "expression": "root_conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "junior_conversations_destination_id_junior_destinations_id_fk": {
+          "name": "junior_conversations_destination_id_junior_destinations_id_fk",
+          "tableFrom": "junior_conversations",
+          "tableTo": "junior_destinations",
+          "columnsFrom": ["destination_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "junior_conversations_actor_identity_id_junior_identities_id_fk": {
+          "name": "junior_conversations_actor_identity_id_junior_identities_id_fk",
+          "tableFrom": "junior_conversations",
+          "tableTo": "junior_identities",
+          "columnsFrom": ["actor_identity_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "junior_conversations_creator_identity_id_junior_identities_id_fk": {
+          "name": "junior_conversations_creator_identity_id_junior_identities_id_fk",
+          "tableFrom": "junior_conversations",
+          "tableTo": "junior_identities",
+          "columnsFrom": ["creator_identity_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "junior_conversations_credential_subject_identity_id_junior_identities_id_fk": {
+          "name": "junior_conversations_credential_subject_identity_id_junior_identities_id_fk",
+          "tableFrom": "junior_conversations",
+          "tableTo": "junior_identities",
+          "columnsFrom": ["credential_subject_identity_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "junior_conversations_parent_conversation_id_junior_conversations_conversation_id_fk": {
+          "name": "junior_conversations_parent_conversation_id_junior_conversations_conversation_id_fk",
+          "tableFrom": "junior_conversations",
+          "tableTo": "junior_conversations",
+          "columnsFrom": ["parent_conversation_id"],
+          "columnsTo": ["conversation_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "junior_conversations_root_conversation_id_junior_conversations_conversation_id_fk": {
+          "name": "junior_conversations_root_conversation_id_junior_conversations_conversation_id_fk",
+          "tableFrom": "junior_conversations",
+          "tableTo": "junior_conversations",
+          "columnsFrom": ["root_conversation_id"],
+          "columnsTo": ["conversation_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_destinations": {
+      "name": "junior_destinations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_tenant_id": {
+          "name": "provider_tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "provider_destination_id": {
+          "name": "provider_destination_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_destination_id": {
+          "name": "parent_destination_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "junior_destinations_provider_destination_uidx": {
+          "name": "junior_destinations_provider_destination_uidx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_destination_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_destinations_provider_kind_idx": {
+          "name": "junior_destinations_provider_kind_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_event_tasks": {
+      "name": "junior_event_tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at_ms": {
+          "name": "created_at_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_json": {
+          "name": "task_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "junior_event_tasks_team_idx": {
+          "name": "junior_event_tasks_team_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at_ms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_event_tasks_match_idx": {
+          "name": "junior_event_tasks_match_idx",
+          "columns": [
+            {
+              "expression": "namespace",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at_ms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_identities": {
+      "name": "junior_identities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_tenant_id": {
+          "name": "provider_tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "provider_subject_id": {
+          "name": "provider_subject_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_normalized": {
+          "name": "email_normalized",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "junior_identities_provider_subject_uidx": {
+          "name": "junior_identities_provider_subject_uidx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_identities_user_idx": {
+          "name": "junior_identities_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_identities_verified_email_idx": {
+          "name": "junior_identities_verified_email_idx",
+          "columns": [
+            {
+              "expression": "email_normalized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"junior_identities\".\"email_verified\" = true AND \"junior_identities\".\"email_normalized\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_identities_kind_provider_idx": {
+          "name": "junior_identities_kind_provider_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "junior_identities_user_id_junior_users_id_fk": {
+          "name": "junior_identities_user_id_junior_users_id_fk",
+          "tableFrom": "junior_identities",
+          "tableTo": "junior_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_location_configurations": {
+      "name": "junior_location_configurations",
+      "schema": "",
+      "columns": {
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "junior_location_configurations_location_id_junior_destinations_id_fk": {
+          "name": "junior_location_configurations_location_id_junior_destinations_id_fk",
+          "tableFrom": "junior_location_configurations",
+          "tableTo": "junior_destinations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "junior_location_configurations_location_id_key_pk": {
+          "name": "junior_location_configurations_location_id_key_pk",
+          "columns": ["location_id", "key"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_scheduler_runs": {
+      "name": "junior_scheduler_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduled_for_ms": {
+          "name": "scheduled_for_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record": {
+          "name": "record",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "junior_scheduler_runs_task_status_idx": {
+          "name": "junior_scheduler_runs_task_status_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduled_for_ms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_scheduler_runs_status_idx": {
+          "name": "junior_scheduler_runs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduled_for_ms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_scheduler_tasks": {
+      "name": "junior_scheduler_tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_slack_user_id": {
+          "name": "creator_slack_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_identity_id": {
+          "name": "creator_identity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_run_at_ms": {
+          "name": "next_run_at_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_now_at_ms": {
+          "name": "run_now_at_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at_ms": {
+          "name": "created_at_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "record": {
+          "name": "record",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "junior_scheduler_tasks_creator_idx": {
+          "name": "junior_scheduler_tasks_creator_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "creator_slack_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at_ms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"junior_scheduler_tasks\".\"status\" <> 'deleted'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_scheduler_tasks_creator_identity_idx": {
+          "name": "junior_scheduler_tasks_creator_identity_idx",
+          "columns": [
+            {
+              "expression": "creator_identity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at_ms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"junior_scheduler_tasks\".\"status\" <> 'deleted' AND \"junior_scheduler_tasks\".\"creator_identity_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_scheduler_tasks_team_status_idx": {
+          "name": "junior_scheduler_tasks_team_status_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at_ms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"junior_scheduler_tasks\".\"status\" <> 'deleted'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_scheduler_tasks_run_now_due_idx": {
+          "name": "junior_scheduler_tasks_run_now_due_idx",
+          "columns": [
+            {
+              "expression": "run_now_at_ms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at_ms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"junior_scheduler_tasks\".\"status\" = 'active' AND \"junior_scheduler_tasks\".\"run_now_at_ms\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_scheduler_tasks_next_run_due_idx": {
+          "name": "junior_scheduler_tasks_next_run_due_idx",
+          "columns": [
+            {
+              "expression": "next_run_at_ms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at_ms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"junior_scheduler_tasks\".\"status\" = 'active' AND \"junior_scheduler_tasks\".\"next_run_at_ms\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_snapshots": {
+      "name": "junior_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_hash": {
+          "name": "profile_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime": {
+          "name": "runtime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dependency_count": {
+          "name": "dependency_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "build_duration_ms": {
+          "name": "build_duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "build_started_at": {
+          "name": "build_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "build_phase": {
+          "name": "build_phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "build_sandbox_name": {
+          "name": "build_sandbox_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "build_command_id": {
+          "name": "build_command_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "build_error": {
+          "name": "build_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "junior_snapshots_snapshot_id_uidx": {
+          "name": "junior_snapshots_snapshot_id_uidx",
+          "columns": [
+            {
+              "expression": "snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_snapshots_workspace_idx": {
+          "name": "junior_snapshots_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_snapshots_profile_status_idx": {
+          "name": "junior_snapshots_profile_status_idx",
+          "columns": [
+            {
+              "expression": "profile_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_snapshots_workspace_status_idx": {
+          "name": "junior_snapshots_workspace_status_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "junior_snapshots_workspace_id_junior_workspaces_id_fk": {
+          "name": "junior_snapshots_workspace_id_junior_workspaces_id_fk",
+          "tableFrom": "junior_snapshots",
+          "tableTo": "junior_workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "junior_snapshots_status_check": {
+          "name": "junior_snapshots_status_check",
+          "value": "\"junior_snapshots\".\"status\" in ('building', 'failed', 'ready')"
+        },
+        "junior_snapshots_build_phase_check": {
+          "name": "junior_snapshots_build_phase_check",
+          "value": "\"junior_snapshots\".\"build_phase\" is null or \"junior_snapshots\".\"build_phase\" in ('created', 'dependencies_installed', 'repositories_prepared')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.junior_stats": {
+      "name": "junior_stats",
+      "schema": "",
+      "columns": {
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metric": {
+          "name": "metric",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "junior_stats_date_namespace_metric_name_pk": {
+          "name": "junior_stats_date_namespace_metric_name_pk",
+          "columns": ["date", "namespace", "metric", "name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_task_executions": {
+      "name": "junior_task_executions",
+      "schema": "",
+      "columns": {
+        "execution_id": {
+          "name": "execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executed_at_ms": {
+          "name": "executed_at_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "junior_task_executions_task_time_idx": {
+          "name": "junior_task_executions_task_time_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "namespace",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "executed_at_ms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_task_executions_time_kind_idx": {
+          "name": "junior_task_executions_time_kind_idx",
+          "columns": [
+            {
+              "expression": "executed_at_ms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_task_executions_conversation_time_idx": {
+          "name": "junior_task_executions_conversation_time_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "executed_at_ms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "junior_task_executions_conversation_id_junior_conversations_conversation_id_fk": {
+          "name": "junior_task_executions_conversation_id_junior_conversations_conversation_id_fk",
+          "tableFrom": "junior_task_executions",
+          "tableTo": "junior_conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["conversation_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "junior_task_executions_kind_namespace_execution_id_pk": {
+          "name": "junior_task_executions_kind_namespace_execution_id_pk",
+          "columns": ["kind", "namespace", "execution_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "junior_task_executions_kind_check": {
+          "name": "junior_task_executions_kind_check",
+          "value": "\"junior_task_executions\".\"kind\" in ('scheduled', 'event')"
+        },
+        "junior_task_executions_status_check": {
+          "name": "junior_task_executions_status_check",
+          "value": "\"junior_task_executions\".\"status\" in ('blocked', 'completed', 'failed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.junior_users": {
+      "name": "junior_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "primary_email": {
+          "name": "primary_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "primary_email_normalized": {
+          "name": "primary_email_normalized",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "junior_users_primary_email_normalized_uidx": {
+          "name": "junior_users_primary_email_normalized_uidx",
+          "columns": [
+            {
+              "expression": "primary_email_normalized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_workspace_repos": {
+      "name": "junior_workspace_repos",
+      "schema": "",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "junior_workspace_repos_workspace_id_junior_workspaces_id_fk": {
+          "name": "junior_workspace_repos_workspace_id_junior_workspaces_id_fk",
+          "tableFrom": "junior_workspace_repos",
+          "tableTo": "junior_workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "junior_workspace_repos_workspace_id_provider_repo_pk": {
+          "name": "junior_workspace_repos_workspace_id_provider_repo_pk",
+          "columns": ["workspace_id", "provider", "repo"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_workspaces": {
+      "name": "junior_workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "setup_script": {
+          "name": "setup_script",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "junior_workspaces_name_idx": {
+          "name": "junior_workspaces_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/junior/migrations/meta/_journal.json
+++ b/packages/junior/migrations/meta/_journal.json
@@ -225,6 +225,13 @@
       "when": 1786762860381,
       "tag": "0031_wild_phantom_reporter",
       "breakpoints": true
+    },
+    {
+      "idx": 32,
+      "version": "7",
+      "when": 1786954953911,
+      "tag": "0032_workspace_snapshots_table",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/junior/src/chat/sandbox/session.ts
+++ b/packages/junior/src/chat/sandbox/session.ts
@@ -506,10 +506,10 @@ export function createSandboxRuntime(
           });
           // Durable dashboard facts belong in SQL. Redis remains the hot registry.
           if (workspace) {
-            await recordResolvedWorkspaceSnapshot(workspace.id, {
-              ...created.snapshot,
-              runtime,
-            });
+            await recordResolvedWorkspaceSnapshot(
+              workspace.id,
+              created.snapshot,
+            );
           }
           return created.session;
         },

--- a/packages/junior/src/chat/sandbox/session.ts
+++ b/packages/junior/src/chat/sandbox/session.ts
@@ -26,6 +26,7 @@ import {
   resolve as resolveSnapshot,
   type Snapshot,
 } from "@/chat/sandbox/snapshot/resolve";
+import { recordResolvedWorkspaceSnapshot } from "@/chat/sandbox/snapshot/store";
 import { syncSkillsToSandbox } from "@/chat/sandbox/skill-sync";
 import {
   createSandboxSession,
@@ -37,7 +38,6 @@ import {
 import { sleep } from "@/chat/sleep";
 import type { SkillMetadata } from "@/chat/skills";
 import type { SandboxRef } from "@/chat/sandbox/ref";
-import { recordResolvedWorkspaceSnapshot } from "@/chat/workspaces/store";
 import type { Workspace } from "@/chat/workspaces/types";
 import { SANDBOX_WORKSPACE_ROOT } from "@/chat/sandbox/paths";
 const DEFAULT_MAX_OUTPUT_LENGTH = 30_000;
@@ -506,10 +506,10 @@ export function createSandboxRuntime(
           });
           // Durable dashboard facts belong in SQL. Redis remains the hot registry.
           if (workspace) {
-            await recordResolvedWorkspaceSnapshot(
-              workspace.id,
-              created.snapshot,
-            );
+            await recordResolvedWorkspaceSnapshot(workspace.id, {
+              ...created.snapshot,
+              runtime,
+            });
           }
           return created.session;
         },

--- a/packages/junior/src/chat/sandbox/snapshot/store.ts
+++ b/packages/junior/src/chat/sandbox/snapshot/store.ts
@@ -1,0 +1,376 @@
+import { randomUUID } from "node:crypto";
+import { and, desc, eq, inArray, ne } from "drizzle-orm";
+import { getSqlExecutor } from "@/chat/db";
+import { logException } from "@/chat/logging";
+import type { JuniorDatabase } from "@/db/db";
+import { juniorSnapshots, juniorWorkspaces } from "@/db/schema";
+import type {
+  WorkspaceSnapshot,
+  WorkspaceSnapshotBuild,
+} from "@/chat/workspaces/types";
+
+type SnapshotRow = typeof juniorSnapshots.$inferSelect;
+
+export type WorkspaceSnapshotRows = {
+  ready: SnapshotRow | undefined;
+  build: SnapshotRow | undefined;
+};
+
+function emptySnapshotRows(): WorkspaceSnapshotRows {
+  return { ready: undefined, build: undefined };
+}
+
+function collectSnapshotRows(rows: SnapshotRow[]): WorkspaceSnapshotRows {
+  const result = emptySnapshotRows();
+  for (const row of rows) {
+    if (!result.ready && row.status === "ready") {
+      result.ready = row;
+    }
+    if (!result.build && row.status !== "ready") {
+      result.build = row;
+    }
+    if (result.ready && result.build) break;
+  }
+  return result;
+}
+
+/** Map a ready SQL row to the dashboard/runtime snapshot view. */
+export function snapshotFromRow(
+  row: SnapshotRow | undefined,
+): WorkspaceSnapshot | null {
+  if (
+    !row ||
+    row.status !== "ready" ||
+    !row.snapshotId ||
+    !row.generatedAt ||
+    row.buildDurationMs == null
+  ) {
+    return null;
+  }
+  // Legacy ready rows may omit runtime or dependency facts.
+  return {
+    id: row.snapshotId,
+    generatedAt: row.generatedAt,
+    buildDurationMs: row.buildDurationMs,
+    profileHash: row.profileHash,
+    runtime: row.runtime ?? "node22",
+    dependencyCount: row.dependencyCount ?? 0,
+  };
+}
+
+/** Map an in-flight or failed SQL row to the snapshot build view. */
+export function snapshotBuildFromRow(
+  row: SnapshotRow | undefined,
+): WorkspaceSnapshotBuild | null {
+  if (!row || !row.buildStartedAt) return null;
+  return {
+    status: row.status,
+    phase: row.buildPhase ?? "created",
+    profileHash: row.profileHash,
+    startedAt: row.buildStartedAt,
+    sandboxName: row.buildSandboxName,
+    commandId: row.buildCommandId,
+    error: row.buildError,
+  };
+}
+
+/** Load the latest ready artifact and non-ready build per Workspace. */
+export async function loadLatestSnapshotsByWorkspace(
+  db: JuniorDatabase,
+  workspaceIds: string[],
+): Promise<Map<string, WorkspaceSnapshotRows>> {
+  const byWorkspace = new Map<string, WorkspaceSnapshotRows>();
+  if (workspaceIds.length === 0) return byWorkspace;
+  const rows = await db
+    .select()
+    .from(juniorSnapshots)
+    .where(inArray(juniorSnapshots.workspaceId, workspaceIds))
+    .orderBy(desc(juniorSnapshots.updatedAt), desc(juniorSnapshots.createdAt));
+  const grouped = new Map<string, SnapshotRow[]>();
+  for (const row of rows) {
+    const list = grouped.get(row.workspaceId);
+    if (list) list.push(row);
+    else grouped.set(row.workspaceId, [row]);
+  }
+  for (const workspaceId of workspaceIds) {
+    byWorkspace.set(
+      workspaceId,
+      collectSnapshotRows(grouped.get(workspaceId) ?? []),
+    );
+  }
+  return byWorkspace;
+}
+
+/** Load the latest ready artifact and non-ready build for one Workspace. */
+export async function loadLatestSnapshots(
+  db: JuniorDatabase,
+  workspaceId: string,
+): Promise<WorkspaceSnapshotRows> {
+  const rows = await db
+    .select()
+    .from(juniorSnapshots)
+    .where(eq(juniorSnapshots.workspaceId, workspaceId))
+    .orderBy(desc(juniorSnapshots.updatedAt), desc(juniorSnapshots.createdAt));
+  return collectSnapshotRows(rows);
+}
+
+/** Load ready and in-flight rows for one Workspace profile hash. */
+export async function loadSnapshotsForProfile(
+  db: JuniorDatabase,
+  workspaceId: string,
+  profileHash: string,
+): Promise<WorkspaceSnapshotRows> {
+  const rows = await db
+    .select()
+    .from(juniorSnapshots)
+    .where(
+      and(
+        eq(juniorSnapshots.workspaceId, workspaceId),
+        eq(juniorSnapshots.profileHash, profileHash),
+      ),
+    )
+    .orderBy(desc(juniorSnapshots.updatedAt), desc(juniorSnapshots.createdAt));
+  return collectSnapshotRows(rows);
+}
+
+/** Drop in-flight or failed rows when a recipe changes. Keep ready rows. */
+export async function clearNonReadySnapshots(
+  db: JuniorDatabase,
+  workspaceId: string,
+): Promise<string[]> {
+  // DELETE … RETURNING ensures a concurrent row cannot disappear without
+  // returning its builder reference to the caller.
+  const deleted = await db
+    .delete(juniorSnapshots)
+    .where(
+      and(
+        eq(juniorSnapshots.workspaceId, workspaceId),
+        ne(juniorSnapshots.status, "ready"),
+      ),
+    )
+    .returning({
+      sandboxName: juniorSnapshots.buildSandboxName,
+    });
+  return deleted
+    .map((row) => row.sandboxName)
+    .filter((name): name is string => Boolean(name));
+}
+
+/** Drop one ready row whose provider snapshot no longer exists. */
+export async function invalidateMissingReadySnapshot(params: {
+  workspaceId: string;
+  profileHash: string;
+  snapshotId: string;
+}): Promise<void> {
+  const executor = getSqlExecutor();
+  await executor.transaction(async () => {
+    const db = executor.db();
+    await db
+      .delete(juniorSnapshots)
+      .where(
+        and(
+          eq(juniorSnapshots.workspaceId, params.workspaceId),
+          eq(juniorSnapshots.profileHash, params.profileHash),
+          eq(juniorSnapshots.status, "ready"),
+          eq(juniorSnapshots.snapshotId, params.snapshotId),
+        ),
+      );
+  });
+}
+
+/** Record the full Sandbox snapshot after a successful Workspace prepare. */
+export async function setWorkspaceSnapshot(
+  workspaceId: string,
+  snapshot: WorkspaceSnapshot,
+): Promise<void> {
+  const executor = getSqlExecutor();
+  await executor.transaction(async () => {
+    const db = executor.db();
+    const workspaceRows = await db
+      .select({ id: juniorWorkspaces.id })
+      .from(juniorWorkspaces)
+      .where(eq(juniorWorkspaces.id, workspaceId))
+      .limit(1);
+    if (!workspaceRows[0]) return;
+
+    const now = new Date();
+    const existing = await db
+      .select()
+      .from(juniorSnapshots)
+      .where(
+        and(
+          eq(juniorSnapshots.workspaceId, workspaceId),
+          eq(juniorSnapshots.profileHash, snapshot.profileHash),
+        ),
+      )
+      .orderBy(desc(juniorSnapshots.updatedAt), desc(juniorSnapshots.createdAt))
+      .limit(1);
+    const current = existing[0];
+
+    // Keep prior ready rows with different snapshot ids for later cleanup.
+    if (current && current.status !== "ready") {
+      await db
+        .update(juniorSnapshots)
+        .set({
+          status: "ready",
+          snapshotId: snapshot.id,
+          runtime: snapshot.runtime,
+          dependencyCount: snapshot.dependencyCount,
+          buildDurationMs: snapshot.buildDurationMs,
+          generatedAt: snapshot.generatedAt,
+          buildSandboxName: null,
+          buildCommandId: null,
+          buildError: null,
+          updatedAt: now,
+        })
+        .where(eq(juniorSnapshots.id, current.id));
+      return;
+    }
+
+    if (
+      current &&
+      current.status === "ready" &&
+      current.snapshotId === snapshot.id
+    ) {
+      await db
+        .update(juniorSnapshots)
+        .set({
+          runtime: snapshot.runtime,
+          dependencyCount: snapshot.dependencyCount,
+          buildDurationMs: snapshot.buildDurationMs,
+          generatedAt: snapshot.generatedAt,
+          buildSandboxName: null,
+          buildCommandId: null,
+          buildError: null,
+          updatedAt: now,
+        })
+        .where(eq(juniorSnapshots.id, current.id));
+      return;
+    }
+
+    await db.insert(juniorSnapshots).values({
+      id: randomUUID(),
+      workspaceId,
+      profileHash: snapshot.profileHash,
+      status: "ready",
+      snapshotId: snapshot.id,
+      runtime: snapshot.runtime,
+      dependencyCount: snapshot.dependencyCount,
+      buildDurationMs: snapshot.buildDurationMs,
+      generatedAt: snapshot.generatedAt,
+      buildStartedAt: null,
+      buildSandboxName: null,
+      buildCommandId: null,
+      buildError: null,
+      createdAt: now,
+      updatedAt: now,
+    });
+  });
+}
+
+/** Record a Workspace snapshot build that can continue across execution slices. */
+export async function setWorkspaceSnapshotBuild(
+  workspaceId: string,
+  build: WorkspaceSnapshotBuild,
+): Promise<void> {
+  const executor = getSqlExecutor();
+  await executor.transaction(async () => {
+    const db = executor.db();
+    const workspaceRows = await db
+      .select({ id: juniorWorkspaces.id })
+      .from(juniorWorkspaces)
+      .where(eq(juniorWorkspaces.id, workspaceId))
+      .limit(1);
+    if (!workspaceRows[0]) return;
+
+    const now = new Date();
+    const existing = await db
+      .select()
+      .from(juniorSnapshots)
+      .where(
+        and(
+          eq(juniorSnapshots.workspaceId, workspaceId),
+          eq(juniorSnapshots.profileHash, build.profileHash),
+        ),
+      )
+      .orderBy(desc(juniorSnapshots.updatedAt), desc(juniorSnapshots.createdAt))
+      .limit(1);
+    const current = existing[0];
+
+    // Never overwrite a ready artifact with build state. Insert a new row so
+    // the prior ready snapshot stays available.
+    if (current && current.status !== "ready") {
+      await db
+        .update(juniorSnapshots)
+        .set({
+          status: build.status,
+          buildStartedAt: build.startedAt,
+          buildPhase: build.phase,
+          buildSandboxName: build.sandboxName,
+          buildCommandId: build.commandId,
+          buildError: build.error,
+          updatedAt: now,
+        })
+        .where(eq(juniorSnapshots.id, current.id));
+      return;
+    }
+
+    await db.insert(juniorSnapshots).values({
+      id: randomUUID(),
+      workspaceId,
+      profileHash: build.profileHash,
+      status: build.status,
+      snapshotId: null,
+      runtime: null,
+      dependencyCount: null,
+      buildDurationMs: null,
+      generatedAt: null,
+      buildStartedAt: build.startedAt,
+      buildPhase: build.phase,
+      buildSandboxName: build.sandboxName,
+      buildCommandId: build.commandId,
+      buildError: build.error,
+      createdAt: now,
+      updatedAt: now,
+    });
+  });
+}
+
+/** Persist Workspace snapshot facts when resolve returns a concrete entry. */
+export async function recordResolvedWorkspaceSnapshot(
+  workspaceId: string,
+  snapshot: {
+    snapshotId?: string;
+    profileHash?: string;
+    createdAtMs?: number;
+    buildDurationMs?: number;
+    runtime?: string;
+    dependencyCount?: number;
+  },
+): Promise<void> {
+  if (
+    !snapshot.snapshotId ||
+    !snapshot.profileHash ||
+    snapshot.createdAtMs == null ||
+    snapshot.buildDurationMs == null ||
+    !snapshot.runtime ||
+    snapshot.dependencyCount == null
+  ) {
+    return;
+  }
+  try {
+    await setWorkspaceSnapshot(workspaceId, {
+      id: snapshot.snapshotId,
+      generatedAt: new Date(snapshot.createdAtMs),
+      buildDurationMs: snapshot.buildDurationMs,
+      profileHash: snapshot.profileHash,
+      runtime: snapshot.runtime,
+      dependencyCount: snapshot.dependencyCount,
+    });
+  } catch (error) {
+    // Dashboard enrichment must not fail a prepared Workspace Sandbox.
+    logException(error, "sandbox.workspace_snapshot.persist.failed", {
+      "app.workspace.id": workspaceId,
+    });
+  }
+}

--- a/packages/junior/src/chat/sandbox/snapshot/store.ts
+++ b/packages/junior/src/chat/sandbox/snapshot/store.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { and, desc, eq, inArray, ne } from "drizzle-orm";
+import { and, desc, eq, ne } from "drizzle-orm";
 import { getSqlExecutor } from "@/chat/db";
 import { logException } from "@/chat/logging";
 import type { JuniorDatabase } from "@/db/db";
@@ -11,61 +11,36 @@ import type {
 
 type SnapshotRow = typeof juniorSnapshots.$inferSelect;
 
-export type WorkspaceSnapshotRows = {
-  ready: SnapshotRow | undefined;
-  build: SnapshotRow | undefined;
-};
-
-function emptySnapshotRows(): WorkspaceSnapshotRows {
-  return { ready: undefined, build: undefined };
+/** Current ready artifact and build state for one Workspace profile. */
+export interface WorkspaceSnapshots {
+  ready: WorkspaceSnapshot | null;
+  build: WorkspaceSnapshotBuild | null;
 }
 
-function collectSnapshotRows(rows: SnapshotRow[]): WorkspaceSnapshotRows {
-  const result = emptySnapshotRows();
-  for (const row of rows) {
-    if (!result.ready && row.status === "ready") {
-      result.ready = row;
-    }
-    if (!result.build && row.status !== "ready") {
-      result.build = row;
-    }
-    if (result.ready && result.build) break;
-  }
-  return result;
-}
-
-/** Map a ready SQL row to the dashboard/runtime snapshot view. */
-export function snapshotFromRow(
-  row: SnapshotRow | undefined,
-): WorkspaceSnapshot | null {
+function snapshotFromRow(row: SnapshotRow): WorkspaceSnapshot {
   if (
-    !row ||
     row.status !== "ready" ||
     !row.snapshotId ||
     !row.generatedAt ||
     row.buildDurationMs == null
   ) {
-    return null;
+    throw new Error(`Invalid ready Workspace snapshot row: ${row.id}`);
   }
-  // Legacy ready rows may omit runtime or dependency facts.
   return {
     id: row.snapshotId,
     generatedAt: row.generatedAt,
     buildDurationMs: row.buildDurationMs,
     profileHash: row.profileHash,
-    runtime: row.runtime ?? "node22",
-    dependencyCount: row.dependencyCount ?? 0,
   };
 }
 
-/** Map an in-flight or failed SQL row to the snapshot build view. */
-export function snapshotBuildFromRow(
-  row: SnapshotRow | undefined,
-): WorkspaceSnapshotBuild | null {
-  if (!row || !row.buildStartedAt) return null;
+function snapshotBuildFromRow(row: SnapshotRow): WorkspaceSnapshotBuild {
+  if (row.status === "ready" || !row.buildStartedAt || !row.buildPhase) {
+    throw new Error(`Invalid Workspace snapshot build row: ${row.id}`);
+  }
   return {
     status: row.status,
-    phase: row.buildPhase ?? "created",
+    phase: row.buildPhase,
     profileHash: row.profileHash,
     startedAt: row.buildStartedAt,
     sandboxName: row.buildSandboxName,
@@ -74,63 +49,39 @@ export function snapshotBuildFromRow(
   };
 }
 
-/** Load the latest ready artifact and non-ready build per Workspace. */
-export async function loadLatestSnapshotsByWorkspace(
-  db: JuniorDatabase,
-  workspaceIds: string[],
-): Promise<Map<string, WorkspaceSnapshotRows>> {
-  const byWorkspace = new Map<string, WorkspaceSnapshotRows>();
-  if (workspaceIds.length === 0) return byWorkspace;
-  const rows = await db
-    .select()
-    .from(juniorSnapshots)
-    .where(inArray(juniorSnapshots.workspaceId, workspaceIds))
-    .orderBy(desc(juniorSnapshots.updatedAt), desc(juniorSnapshots.createdAt));
-  const grouped = new Map<string, SnapshotRow[]>();
-  for (const row of rows) {
-    const list = grouped.get(row.workspaceId);
-    if (list) list.push(row);
-    else grouped.set(row.workspaceId, [row]);
-  }
-  for (const workspaceId of workspaceIds) {
-    byWorkspace.set(
-      workspaceId,
-      collectSnapshotRows(grouped.get(workspaceId) ?? []),
-    );
-  }
-  return byWorkspace;
-}
-
-/** Load the latest ready artifact and non-ready build for one Workspace. */
-export async function loadLatestSnapshots(
-  db: JuniorDatabase,
-  workspaceId: string,
-): Promise<WorkspaceSnapshotRows> {
-  const rows = await db
-    .select()
-    .from(juniorSnapshots)
-    .where(eq(juniorSnapshots.workspaceId, workspaceId))
-    .orderBy(desc(juniorSnapshots.updatedAt), desc(juniorSnapshots.createdAt));
-  return collectSnapshotRows(rows);
-}
-
-/** Load ready and in-flight rows for one Workspace profile hash. */
+/** Load bounded ready and build views for one Workspace profile hash. */
 export async function loadSnapshotsForProfile(
   db: JuniorDatabase,
   workspaceId: string,
   profileHash: string,
-): Promise<WorkspaceSnapshotRows> {
-  const rows = await db
-    .select()
-    .from(juniorSnapshots)
-    .where(
-      and(
-        eq(juniorSnapshots.workspaceId, workspaceId),
-        eq(juniorSnapshots.profileHash, profileHash),
-      ),
-    )
-    .orderBy(desc(juniorSnapshots.updatedAt), desc(juniorSnapshots.createdAt));
-  return collectSnapshotRows(rows);
+): Promise<WorkspaceSnapshots> {
+  const profile = and(
+    eq(juniorSnapshots.workspaceId, workspaceId),
+    eq(juniorSnapshots.profileHash, profileHash),
+  );
+  const order = [
+    desc(juniorSnapshots.updatedAt),
+    desc(juniorSnapshots.createdAt),
+    desc(juniorSnapshots.id),
+  ] as const;
+  const [readyRows, buildRows] = await Promise.all([
+    db
+      .select()
+      .from(juniorSnapshots)
+      .where(and(profile, eq(juniorSnapshots.status, "ready")))
+      .orderBy(...order)
+      .limit(1),
+    db
+      .select()
+      .from(juniorSnapshots)
+      .where(and(profile, ne(juniorSnapshots.status, "ready")))
+      .orderBy(...order)
+      .limit(1),
+  ]);
+  return {
+    ready: readyRows[0] ? snapshotFromRow(readyRows[0]) : null,
+    build: buildRows[0] ? snapshotBuildFromRow(buildRows[0]) : null,
+  };
 }
 
 /** Drop in-flight or failed rows when a recipe changes. Keep ready rows. */
@@ -214,10 +165,10 @@ export async function setWorkspaceSnapshot(
         .set({
           status: "ready",
           snapshotId: snapshot.id,
-          runtime: snapshot.runtime,
-          dependencyCount: snapshot.dependencyCount,
           buildDurationMs: snapshot.buildDurationMs,
           generatedAt: snapshot.generatedAt,
+          buildStartedAt: null,
+          buildPhase: null,
           buildSandboxName: null,
           buildCommandId: null,
           buildError: null,
@@ -235,10 +186,10 @@ export async function setWorkspaceSnapshot(
       await db
         .update(juniorSnapshots)
         .set({
-          runtime: snapshot.runtime,
-          dependencyCount: snapshot.dependencyCount,
           buildDurationMs: snapshot.buildDurationMs,
           generatedAt: snapshot.generatedAt,
+          buildStartedAt: null,
+          buildPhase: null,
           buildSandboxName: null,
           buildCommandId: null,
           buildError: null,
@@ -254,8 +205,6 @@ export async function setWorkspaceSnapshot(
       profileHash: snapshot.profileHash,
       status: "ready",
       snapshotId: snapshot.id,
-      runtime: snapshot.runtime,
-      dependencyCount: snapshot.dependencyCount,
       buildDurationMs: snapshot.buildDurationMs,
       generatedAt: snapshot.generatedAt,
       buildStartedAt: null,
@@ -321,8 +270,6 @@ export async function setWorkspaceSnapshotBuild(
       profileHash: build.profileHash,
       status: build.status,
       snapshotId: null,
-      runtime: null,
-      dependencyCount: null,
       buildDurationMs: null,
       generatedAt: null,
       buildStartedAt: build.startedAt,
@@ -344,17 +291,13 @@ export async function recordResolvedWorkspaceSnapshot(
     profileHash?: string;
     createdAtMs?: number;
     buildDurationMs?: number;
-    runtime?: string;
-    dependencyCount?: number;
   },
 ): Promise<void> {
   if (
     !snapshot.snapshotId ||
     !snapshot.profileHash ||
     snapshot.createdAtMs == null ||
-    snapshot.buildDurationMs == null ||
-    !snapshot.runtime ||
-    snapshot.dependencyCount == null
+    snapshot.buildDurationMs == null
   ) {
     return;
   }
@@ -364,8 +307,6 @@ export async function recordResolvedWorkspaceSnapshot(
       generatedAt: new Date(snapshot.createdAtMs),
       buildDurationMs: snapshot.buildDurationMs,
       profileHash: snapshot.profileHash,
-      runtime: snapshot.runtime,
-      dependencyCount: snapshot.dependencyCount,
     });
   } catch (error) {
     // Dashboard enrichment must not fail a prepared Workspace Sandbox.

--- a/packages/junior/src/chat/workspaces/store.ts
+++ b/packages/junior/src/chat/workspaces/store.ts
@@ -1,38 +1,31 @@
 import { randomUUID } from "node:crypto";
 import { and, asc, eq, sql } from "drizzle-orm";
 import { getSqlExecutor } from "@/chat/db";
-import { logException } from "@/chat/logging";
+import {
+  clearNonReadySnapshots,
+  loadLatestSnapshots,
+  loadLatestSnapshotsByWorkspace,
+  snapshotBuildFromRow,
+  snapshotFromRow,
+  type WorkspaceSnapshotRows,
+} from "@/chat/sandbox/snapshot/store";
 import type { JuniorDatabase } from "@/db/db";
 import { juniorWorkspaceRepos, juniorWorkspaces } from "@/db/schema";
-import type { Workspace, WorkspaceSnapshot } from "./types";
+import type { Workspace } from "./types";
 import {
   normalizeWorkspaceRecipe,
   WorkspaceValidationError,
   type WorkspaceRecipeInput,
 } from "./validation";
 
-function snapshotFromRow(
-  row: typeof juniorWorkspaces.$inferSelect,
-): WorkspaceSnapshot | null {
-  if (
-    !row.snapshotId ||
-    !row.snapshotGeneratedAt ||
-    row.snapshotBuildDurationMs == null ||
-    !row.snapshotProfileHash
-  ) {
-    return null;
-  }
-  return {
-    id: row.snapshotId,
-    generatedAt: row.snapshotGeneratedAt,
-    buildDurationMs: row.snapshotBuildDurationMs,
-    profileHash: row.snapshotProfileHash,
-  };
+function emptySnapshotRows(): WorkspaceSnapshotRows {
+  return { ready: undefined, build: undefined };
 }
 
 function workspaceFromRows(
   row: typeof juniorWorkspaces.$inferSelect,
   repos: Array<typeof juniorWorkspaceRepos.$inferSelect>,
+  snapshots: WorkspaceSnapshotRows,
 ): Workspace {
   return {
     id: row.id,
@@ -42,7 +35,8 @@ function workspaceFromRows(
       provider: repo.provider,
       repo: repo.repo,
     })),
-    snapshot: snapshotFromRow(row),
+    snapshot: snapshotFromRow(snapshots.ready),
+    snapshotBuild: snapshotBuildFromRow(snapshots.build),
   };
 }
 
@@ -122,10 +116,15 @@ export async function listWorkspaces(db: JuniorDatabase): Promise<Workspace[]> {
         asc(juniorWorkspaceRepos.repo),
       ),
   ]);
+  const snapshots = await loadLatestSnapshotsByWorkspace(
+    db,
+    workspaces.map((workspace) => workspace.id),
+  );
   return workspaces.map((workspace) =>
     workspaceFromRows(
       workspace,
       repos.filter((repo) => repo.workspaceId === workspace.id),
+      snapshots.get(workspace.id) ?? emptySnapshotRows(),
     ),
   );
 }
@@ -170,6 +169,7 @@ export async function getWorkspaceByName(
   return workspaceFromRows(
     workspace,
     await loadWorkspaceRepos(db, workspace.id),
+    await loadLatestSnapshots(db, workspace.id),
   );
 }
 
@@ -188,6 +188,7 @@ export async function getWorkspace(
   return workspaceFromRows(
     workspace,
     await loadWorkspaceRepos(db, workspace.id),
+    await loadLatestSnapshots(db, workspace.id),
   );
 }
 
@@ -264,19 +265,14 @@ export async function updateWorkspace(
         .set({
           name: recipe.name,
           setupScript: recipe.setupScript,
-          ...(snapshotChanged
-            ? {
-                snapshotId: null,
-                snapshotGeneratedAt: null,
-                snapshotBuildDurationMs: null,
-                snapshotProfileHash: null,
-              }
-            : {}),
           updatedAt: now,
         })
         .where(eq(juniorWorkspaces.id, id))
         .returning();
       await replaceWorkspaceRepos(db, id, recipe.repos);
+      if (snapshotChanged) {
+        await clearNonReadySnapshots(db, id);
+      }
       return rows[0];
     });
     if (!updated) return undefined;
@@ -303,58 +299,6 @@ export async function deleteWorkspace(id: string): Promise<boolean> {
       .returning({ id: juniorWorkspaces.id });
     return rows.length > 0;
   });
-}
-
-/** Record the current Sandbox snapshot after a successful Workspace prepare. */
-export async function setWorkspaceSnapshot(
-  workspaceId: string,
-  snapshot: WorkspaceSnapshot,
-): Promise<void> {
-  const executor = getSqlExecutor();
-  await executor
-    .db()
-    .update(juniorWorkspaces)
-    .set({
-      snapshotId: snapshot.id,
-      snapshotGeneratedAt: snapshot.generatedAt,
-      snapshotBuildDurationMs: snapshot.buildDurationMs,
-      snapshotProfileHash: snapshot.profileHash,
-      updatedAt: new Date(),
-    })
-    .where(eq(juniorWorkspaces.id, workspaceId));
-}
-
-/** Persist dashboard snapshot facts when resolve returned a concrete entry. */
-export async function recordResolvedWorkspaceSnapshot(
-  workspaceId: string,
-  snapshot: {
-    snapshotId?: string;
-    profileHash?: string;
-    createdAtMs?: number;
-    buildDurationMs?: number;
-  },
-): Promise<void> {
-  if (
-    !snapshot.snapshotId ||
-    !snapshot.profileHash ||
-    snapshot.createdAtMs == null ||
-    snapshot.buildDurationMs == null
-  ) {
-    return;
-  }
-  try {
-    await setWorkspaceSnapshot(workspaceId, {
-      id: snapshot.snapshotId,
-      generatedAt: new Date(snapshot.createdAtMs),
-      buildDurationMs: snapshot.buildDurationMs,
-      profileHash: snapshot.profileHash,
-    });
-  } catch (error) {
-    // Dashboard enrichment must not fail a prepared Workspace Sandbox.
-    logException(error, "sandbox.workspace_snapshot.persist.failed", {
-      "app.workspace.id": workspaceId,
-    });
-  }
 }
 
 export { WorkspaceValidationError };

--- a/packages/junior/src/chat/workspaces/store.ts
+++ b/packages/junior/src/chat/workspaces/store.ts
@@ -1,31 +1,25 @@
 import { randomUUID } from "node:crypto";
 import { and, asc, eq, sql } from "drizzle-orm";
 import { getSqlExecutor } from "@/chat/db";
+import { hash as workspaceProfileHash } from "@/chat/sandbox/snapshot/profile";
+import { SANDBOX_RUNTIME } from "@/chat/sandbox/snapshot/runtime";
 import {
   clearNonReadySnapshots,
-  loadLatestSnapshots,
-  loadLatestSnapshotsByWorkspace,
-  snapshotBuildFromRow,
-  snapshotFromRow,
-  type WorkspaceSnapshotRows,
+  loadSnapshotsForProfile,
 } from "@/chat/sandbox/snapshot/store";
 import type { JuniorDatabase } from "@/db/db";
 import { juniorWorkspaceRepos, juniorWorkspaces } from "@/db/schema";
-import type { Workspace } from "./types";
+import type { Workspace, WorkspaceSnapshot } from "./types";
 import {
   normalizeWorkspaceRecipe,
   WorkspaceValidationError,
   type WorkspaceRecipeInput,
 } from "./validation";
 
-function emptySnapshotRows(): WorkspaceSnapshotRows {
-  return { ready: undefined, build: undefined };
-}
-
 function workspaceFromRows(
   row: typeof juniorWorkspaces.$inferSelect,
   repos: Array<typeof juniorWorkspaceRepos.$inferSelect>,
-  snapshots: WorkspaceSnapshotRows,
+  snapshot: WorkspaceSnapshot | null,
 ): Workspace {
   return {
     id: row.id,
@@ -35,9 +29,24 @@ function workspaceFromRows(
       provider: repo.provider,
       repo: repo.repo,
     })),
-    snapshot: snapshotFromRow(snapshots.ready),
-    snapshotBuild: snapshotBuildFromRow(snapshots.build),
+    snapshot,
   };
+}
+
+async function workspaceWithSnapshot(
+  db: JuniorDatabase,
+  row: typeof juniorWorkspaces.$inferSelect,
+  repos: Array<typeof juniorWorkspaceRepos.$inferSelect>,
+): Promise<Workspace> {
+  const workspace = workspaceFromRows(row, repos, null);
+  const profileHash = workspaceProfileHash(SANDBOX_RUNTIME, workspace);
+  if (!profileHash) return workspace;
+  const snapshots = await loadSnapshotsForProfile(
+    db,
+    workspace.id,
+    profileHash,
+  );
+  return { ...workspace, snapshot: snapshots.ready };
 }
 
 async function loadWorkspaceRepos(
@@ -116,15 +125,11 @@ export async function listWorkspaces(db: JuniorDatabase): Promise<Workspace[]> {
         asc(juniorWorkspaceRepos.repo),
       ),
   ]);
-  const snapshots = await loadLatestSnapshotsByWorkspace(
-    db,
-    workspaces.map((workspace) => workspace.id),
-  );
   return workspaces.map((workspace) =>
     workspaceFromRows(
       workspace,
       repos.filter((repo) => repo.workspaceId === workspace.id),
-      snapshots.get(workspace.id) ?? emptySnapshotRows(),
+      null,
     ),
   );
 }
@@ -166,10 +171,10 @@ export async function getWorkspaceByName(
     .limit(1);
   const workspace = rows[0];
   if (!workspace) return undefined;
-  return workspaceFromRows(
+  return await workspaceWithSnapshot(
+    db,
     workspace,
     await loadWorkspaceRepos(db, workspace.id),
-    await loadLatestSnapshots(db, workspace.id),
   );
 }
 
@@ -185,10 +190,10 @@ export async function getWorkspace(
     .limit(1);
   const workspace = rows[0];
   if (!workspace) return undefined;
-  return workspaceFromRows(
+  return await workspaceWithSnapshot(
+    db,
     workspace,
     await loadWorkspaceRepos(db, workspace.id),
-    await loadLatestSnapshots(db, workspace.id),
   );
 }
 

--- a/packages/junior/src/chat/workspaces/types.ts
+++ b/packages/junior/src/chat/workspaces/types.ts
@@ -10,11 +10,10 @@ export interface WorkspaceSnapshot {
   generatedAt: Date;
   buildDurationMs: number;
   profileHash: string;
-  runtime: string;
-  dependencyCount: number;
 }
 
-export type WorkspaceSnapshotStatus = "building" | "failed" | "ready";
+export type WorkspaceSnapshotBuildStatus = "building" | "failed";
+export type WorkspaceSnapshotStatus = WorkspaceSnapshotBuildStatus | "ready";
 export type WorkspaceSnapshotBuildPhase =
   | "created"
   | "dependencies_installed"
@@ -22,7 +21,7 @@ export type WorkspaceSnapshotBuildPhase =
 
 /** Current snapshot build for one Workspace recipe. */
 export interface WorkspaceSnapshotBuild {
-  status: WorkspaceSnapshotStatus;
+  status: WorkspaceSnapshotBuildStatus;
   phase: WorkspaceSnapshotBuildPhase;
   profileHash: string;
   startedAt: Date;
@@ -38,5 +37,4 @@ export interface Workspace {
   setupScript: string;
   repos: WorkspaceRepo[];
   snapshot: WorkspaceSnapshot | null;
-  snapshotBuild?: WorkspaceSnapshotBuild | null;
 }

--- a/packages/junior/src/chat/workspaces/types.ts
+++ b/packages/junior/src/chat/workspaces/types.ts
@@ -4,12 +4,31 @@ export interface WorkspaceRepo {
   repo: string;
 }
 
-/** Last successful Sandbox snapshot recorded for one Workspace recipe. */
+/** Ready Sandbox snapshot artifact owned by one Workspace recipe. */
 export interface WorkspaceSnapshot {
   id: string;
   generatedAt: Date;
   buildDurationMs: number;
   profileHash: string;
+  runtime: string;
+  dependencyCount: number;
+}
+
+export type WorkspaceSnapshotStatus = "building" | "failed" | "ready";
+export type WorkspaceSnapshotBuildPhase =
+  | "created"
+  | "dependencies_installed"
+  | "repositories_prepared";
+
+/** Current snapshot build for one Workspace recipe. */
+export interface WorkspaceSnapshotBuild {
+  status: WorkspaceSnapshotStatus;
+  phase: WorkspaceSnapshotBuildPhase;
+  profileHash: string;
+  startedAt: Date;
+  sandboxName: string | null;
+  commandId: string | null;
+  error: string | null;
 }
 
 /** Named recipe used to prepare reusable sandbox contents. */
@@ -19,4 +38,5 @@ export interface Workspace {
   setupScript: string;
   repos: WorkspaceRepo[];
   snapshot: WorkspaceSnapshot | null;
+  snapshotBuild?: WorkspaceSnapshotBuild | null;
 }

--- a/packages/junior/src/db/schema.ts
+++ b/packages/junior/src/db/schema.ts
@@ -20,6 +20,7 @@ import {
   juniorSchedulerRuns,
   juniorSchedulerTasks,
 } from "./schema/scheduled-tasks";
+import { juniorSnapshots } from "./schema/snapshots";
 import { juniorUsers } from "./schema/users";
 import { juniorWorkspaceRepos, juniorWorkspaces } from "./schema/workspaces";
 
@@ -38,6 +39,7 @@ export {
   juniorDestinations,
   juniorEventTasks,
   juniorIdentities,
+  juniorSnapshots,
   juniorStats,
   juniorTaskExecutions,
   juniorSchedulerRuns,
@@ -62,6 +64,7 @@ export const juniorSqlSchema = {
   juniorDestinations,
   juniorEventTasks,
   juniorIdentities,
+  juniorSnapshots,
   juniorStats,
   juniorTaskExecutions,
   juniorSchedulerRuns,

--- a/packages/junior/src/db/schema/snapshots.ts
+++ b/packages/junior/src/db/schema/snapshots.ts
@@ -1,0 +1,66 @@
+import { sql } from "drizzle-orm";
+import {
+  check,
+  index,
+  integer,
+  pgTable,
+  text,
+  uniqueIndex,
+} from "drizzle-orm/pg-core";
+import type {
+  WorkspaceSnapshotBuildPhase,
+  WorkspaceSnapshotStatus,
+} from "@/chat/workspaces/types";
+import { timestamptz } from "./timestamps";
+import { juniorWorkspaces } from "./workspaces";
+
+/**
+ * Sandbox snapshot build and ready artifact for one Workspace recipe.
+ * Keep prior ready rows so Vercel snapshot ids can be garbage-collected later.
+ */
+export const juniorSnapshots = pgTable(
+  "junior_snapshots",
+  {
+    id: text("id").primaryKey(),
+    workspaceId: text("workspace_id")
+      .notNull()
+      .references(() => juniorWorkspaces.id, { onDelete: "cascade" }),
+    profileHash: text("profile_hash").notNull(),
+    status: text("status").$type<WorkspaceSnapshotStatus>().notNull(),
+    // Ready artifact (provider snapshot id + Redis-equivalent details).
+    snapshotId: text("snapshot_id"),
+    runtime: text("runtime"),
+    dependencyCount: integer("dependency_count"),
+    buildDurationMs: integer("build_duration_ms"),
+    generatedAt: timestamptz("generated_at"),
+    // In-flight builder references for check-in across execution slices.
+    buildStartedAt: timestamptz("build_started_at"),
+    buildPhase: text("build_phase").$type<WorkspaceSnapshotBuildPhase>(),
+    buildSandboxName: text("build_sandbox_name"),
+    buildCommandId: text("build_command_id"),
+    buildError: text("build_error"),
+    createdAt: timestamptz("created_at").notNull(),
+    updatedAt: timestamptz("updated_at").notNull(),
+  },
+  (table) => [
+    check(
+      "junior_snapshots_status_check",
+      sql`${table.status} in ('building', 'failed', 'ready')`,
+    ),
+    check(
+      "junior_snapshots_build_phase_check",
+      sql`${table.buildPhase} is null or ${table.buildPhase} in ('created', 'dependencies_installed', 'repositories_prepared')`,
+    ),
+    // Provider snapshot ids are unique. Nulls stay allowed for in-flight rows.
+    uniqueIndex("junior_snapshots_snapshot_id_uidx").on(table.snapshotId),
+    index("junior_snapshots_workspace_idx").on(table.workspaceId),
+    index("junior_snapshots_profile_status_idx").on(
+      table.profileHash,
+      table.status,
+    ),
+    index("junior_snapshots_workspace_status_idx").on(
+      table.workspaceId,
+      table.status,
+    ),
+  ],
+);

--- a/packages/junior/src/db/schema/snapshots.ts
+++ b/packages/junior/src/db/schema/snapshots.ts
@@ -27,10 +27,8 @@ export const juniorSnapshots = pgTable(
       .references(() => juniorWorkspaces.id, { onDelete: "cascade" }),
     profileHash: text("profile_hash").notNull(),
     status: text("status").$type<WorkspaceSnapshotStatus>().notNull(),
-    // Ready artifact (provider snapshot id + Redis-equivalent details).
+    // Ready artifact facts.
     snapshotId: text("snapshot_id"),
-    runtime: text("runtime"),
-    dependencyCount: integer("dependency_count"),
     buildDurationMs: integer("build_duration_ms"),
     generatedAt: timestamptz("generated_at"),
     // In-flight builder references for check-in across execution slices.
@@ -51,10 +49,23 @@ export const juniorSnapshots = pgTable(
       "junior_snapshots_build_phase_check",
       sql`${table.buildPhase} is null or ${table.buildPhase} in ('created', 'dependencies_installed', 'repositories_prepared')`,
     ),
+    check(
+      "junior_snapshots_ready_fields_check",
+      sql`${table.status} <> 'ready' or (${table.snapshotId} is not null and ${table.buildDurationMs} is not null and ${table.generatedAt} is not null)`,
+    ),
+    check(
+      "junior_snapshots_build_fields_check",
+      sql`${table.status} = 'ready' or (${table.buildStartedAt} is not null and ${table.buildPhase} is not null)`,
+    ),
+    check(
+      "junior_snapshots_build_duration_check",
+      sql`${table.buildDurationMs} is null or ${table.buildDurationMs} >= 0`,
+    ),
     // Provider snapshot ids are unique. Nulls stay allowed for in-flight rows.
     uniqueIndex("junior_snapshots_snapshot_id_uidx").on(table.snapshotId),
     index("junior_snapshots_workspace_idx").on(table.workspaceId),
-    index("junior_snapshots_profile_status_idx").on(
+    index("junior_snapshots_workspace_profile_status_idx").on(
+      table.workspaceId,
       table.profileHash,
       table.status,
     ),

--- a/packages/junior/src/db/schema/workspaces.ts
+++ b/packages/junior/src/db/schema/workspaces.ts
@@ -1,10 +1,4 @@
-import {
-  integer,
-  pgTable,
-  primaryKey,
-  text,
-  uniqueIndex,
-} from "drizzle-orm/pg-core";
+import { pgTable, primaryKey, text, uniqueIndex } from "drizzle-orm/pg-core";
 import { timestamptz } from "./timestamps";
 
 /** Named recipe used to prepare a reusable Sandbox. */
@@ -14,11 +8,6 @@ export const juniorWorkspaces = pgTable(
     id: text("id").primaryKey(),
     name: text("name").notNull(),
     setupScript: text("setup_script").notNull().default(""),
-    // Last successful Workspace snapshot for the dashboard. Resolve still uses Redis.
-    snapshotId: text("snapshot_id"),
-    snapshotGeneratedAt: timestamptz("snapshot_generated_at"),
-    snapshotBuildDurationMs: integer("snapshot_build_duration_ms"),
-    snapshotProfileHash: text("snapshot_profile_hash"),
     createdAt: timestamptz("created_at").notNull(),
     updatedAt: timestamptz("updated_at").notNull(),
   },

--- a/packages/junior/tests/component/scheduled-tasks-sql.test.ts
+++ b/packages/junior/tests/component/scheduled-tasks-sql.test.ts
@@ -51,16 +51,33 @@ function coreMigrationsDir(): string {
   return path.resolve(process.cwd(), "migrations");
 }
 
+function readCoreMigrationJournal(): {
+  entries: Array<{ idx: number; tag: string }>;
+} {
+  return JSON.parse(
+    readFileSync(
+      path.join(coreMigrationsDir(), "meta", "_journal.json"),
+      "utf8",
+    ),
+  ) as { entries: Array<{ idx: number; tag: string }> };
+}
+
+/** Copy core migrations that predate scheduler table adoption. */
 function copyPreSchedulerCoreMigrations(): string {
   const source = coreMigrationsDir();
   const destination = mkdtempSync(
     path.join(tmpdir(), "junior-pre-scheduler-core-"),
   );
   mkdirSync(path.join(destination, "meta"));
-  const journal = JSON.parse(
-    readFileSync(path.join(source, "meta", "_journal.json"), "utf8"),
-  ) as { entries: Array<{ idx: number; tag: string }> };
-  const entries = journal.entries.filter((entry) => entry.idx < 16);
+  const journal = readCoreMigrationJournal();
+  const adoption = journal.entries.find((entry) => {
+    const sql = readFileSync(path.join(source, `${entry.tag}.sql`), "utf8");
+    return sql.includes("Adopt the former scheduler plugin tables");
+  });
+  if (!adoption) {
+    throw new Error("Scheduler adoption migration not found");
+  }
+  const entries = journal.entries.filter((entry) => entry.idx < adoption.idx);
   writeFileSync(
     path.join(destination, "meta", "_journal.json"),
     JSON.stringify({ ...journal, entries }),
@@ -173,10 +190,7 @@ describe("scheduled-task SQL storage", () => {
         ],
       );
 
-      await expect(migrateSchema(fixture.sql)).resolves.toMatchObject({
-        existing: 16,
-        migrated: 16,
-      });
+      await migrateSchema(fixture.sql);
       const [migrated] = await fixture.sql.query<{
         creatorIdentityId: string | null;
         creatorSlackUserId: string | null;

--- a/packages/junior/tests/integration/api/workspaces/routes.test.ts
+++ b/packages/junior/tests/integration/api/workspaces/routes.test.ts
@@ -9,14 +9,17 @@ import {
 } from "@/api/schema";
 import { closeDb, getDb, getSqlExecutor } from "@/chat/db";
 import { resolveViewerUser } from "@/chat/plugins/viewer";
-import { create as createSnapshotProfile, hash as workspaceProfileHash } from "@/chat/sandbox/snapshot/profile";
+import {
+  create as createSnapshotProfile,
+  hash as workspaceProfileHash,
+} from "@/chat/sandbox/snapshot/profile";
 import { SANDBOX_RUNTIME } from "@/chat/sandbox/snapshot/runtime";
+import { setWorkspaceSnapshot } from "@/chat/sandbox/snapshot/store";
 import { getStateAdapter } from "@/chat/state/adapter";
 import {
   createWorkspace,
   getWorkspace,
   getWorkspaceByName,
-  setWorkspaceSnapshot,
   updateWorkspace,
 } from "@/chat/workspaces/store";
 
@@ -42,24 +45,27 @@ describe("workspace admin API", () => {
   it("creates, lists, updates, and deletes Workspace recipes", async () => {
     const app = authenticatedApi();
 
-    const createResponse = await app.request("http://localhost/api/workspaces", {
-      body: JSON.stringify({
-        name: "Sentry",
-        setupScript: "pnpm install",
-        repos: [
-          {
-            provider: "github",
-            repo: "getsentry/sentry"
-          },
-          {
-            provider: "github",
-            repo: "getsentry/getsentry"
-          },
-        ]
-      }),
-      headers: { "content-type": "application/json" },
-      method: "POST"
-    });
+    const createResponse = await app.request(
+      "http://localhost/api/workspaces",
+      {
+        body: JSON.stringify({
+          name: "Sentry",
+          setupScript: "pnpm install",
+          repos: [
+            {
+              provider: "github",
+              repo: "getsentry/sentry",
+            },
+            {
+              provider: "github",
+              repo: "getsentry/getsentry",
+            },
+          ],
+        }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      },
+    );
     expect(createResponse.status).toBe(201);
     const created = workspaceSchema.parse(await createResponse.json());
     expect(created).toMatchObject({
@@ -69,14 +75,14 @@ describe("workspace admin API", () => {
         {
           provider: "github",
           repo: "getsentry/getsentry",
-          checkoutPath: "repos/getsentry"
+          checkoutPath: "repos/getsentry",
         },
         {
           provider: "github",
           repo: "getsentry/sentry",
-          checkoutPath: "repos/sentry"
+          checkoutPath: "repos/sentry",
         },
-      ]
+      ],
     });
 
     const listResponse = await app.request("http://localhost/api/workspaces");
@@ -96,12 +102,12 @@ describe("workspace admin API", () => {
           repos: [
             {
               provider: "github",
-              repo: "getsentry/sentry"
+              repo: "getsentry/sentry",
             },
-          ]
+          ],
         }),
         headers: { "content-type": "application/json" },
-        method: "PUT"
+        method: "PUT",
       },
     );
     expect(updateResponse.status).toBe(200);
@@ -114,9 +120,9 @@ describe("workspace admin API", () => {
         {
           provider: "github",
           repo: "getsentry/sentry",
-          checkoutPath: "repos/sentry"
+          checkoutPath: "repos/sentry",
         },
-      ]
+      ],
     });
 
     const deleteResponse = await app.request(
@@ -133,7 +139,7 @@ describe("workspace admin API", () => {
     );
     expect(missing.status).toBe(404);
     expect(apiErrorSchema.parse(await missing.json())).toEqual({
-      error: "Workspace not found."
+      error: "Workspace not found.",
     });
   });
 
@@ -196,14 +202,17 @@ describe("workspace admin API", () => {
 
   it("returns SQL-backed snapshot metadata on Workspace detail", async () => {
     const app = authenticatedApi();
-    const createResponse = await app.request("http://localhost/api/workspaces", {
-      body: JSON.stringify({
-        name: "snapshot-duration",
-        repos: [{ provider: "github", repo: "getsentry/sentry" }],
-      }),
-      headers: { "content-type": "application/json" },
-      method: "POST",
-    });
+    const createResponse = await app.request(
+      "http://localhost/api/workspaces",
+      {
+        body: JSON.stringify({
+          name: "snapshot-duration",
+          repos: [{ provider: "github", repo: "getsentry/sentry" }],
+        }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      },
+    );
     expect(createResponse.status).toBe(201);
     const created = workspaceSchema.parse(await createResponse.json());
     expect(created.snapshot).toBeNull();
@@ -218,6 +227,8 @@ describe("workspace admin API", () => {
       generatedAt: new Date("2026-03-01T00:00:00.000Z"),
       buildDurationMs: 12_345,
       profileHash: profileHash!,
+      runtime: SANDBOX_RUNTIME,
+      dependencyCount: 0,
     });
 
     const detailResponse = await app.request(
@@ -236,14 +247,17 @@ describe("workspace admin API", () => {
 
   it("preserves snapshot metadata for a rename and clears it after the recipe changes", async () => {
     const app = authenticatedApi();
-    const createResponse = await app.request("http://localhost/api/workspaces", {
-      body: JSON.stringify({
-        name: "snapshot-stale",
-        repos: [{ provider: "github", repo: "getsentry/sentry" }],
-      }),
-      headers: { "content-type": "application/json" },
-      method: "POST",
-    });
+    const createResponse = await app.request(
+      "http://localhost/api/workspaces",
+      {
+        body: JSON.stringify({
+          name: "snapshot-stale",
+          repos: [{ provider: "github", repo: "getsentry/sentry" }],
+        }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      },
+    );
     expect(createResponse.status).toBe(201);
     const created = workspaceSchema.parse(await createResponse.json());
     const workspace = await getWorkspace(getDb(), created.id);
@@ -256,6 +270,8 @@ describe("workspace admin API", () => {
       generatedAt: new Date("2026-03-01T00:00:00.000Z"),
       buildDurationMs: 9_000,
       profileHash: profileHash!,
+      runtime: SANDBOX_RUNTIME,
+      dependencyCount: 0,
     });
 
     const renameResponse = await app.request(
@@ -299,6 +315,26 @@ describe("workspace admin API", () => {
       id: created.id,
       snapshot: null,
     });
+
+    const revertResponse = await app.request(
+      `http://localhost/api/workspaces/${created.id}`,
+      {
+        body: JSON.stringify({
+          name: "snapshot-renamed",
+          repos: [{ provider: "github", repo: "getsentry/sentry" }],
+        }),
+        headers: { "content-type": "application/json" },
+        method: "PUT",
+      },
+    );
+    expect(revertResponse.status).toBe(200);
+    const revertedDetail = await app.request(
+      `http://localhost/api/workspaces/${created.id}`,
+    );
+    expect(workspaceSchema.parse(await revertedDetail.json())).toMatchObject({
+      id: created.id,
+      snapshot: { id: "snap_old", buildDurationMs: 9_000 },
+    });
   });
 
   it("rejects invalid recipes with the stable error contract", async () => {
@@ -307,10 +343,10 @@ describe("workspace admin API", () => {
       {
         body: JSON.stringify({
           name: "bad name",
-          repos: [{ provider: "github", repo: "getsentry/sentry" }]
+          repos: [{ provider: "github", repo: "getsentry/sentry" }],
         }),
         headers: { "content-type": "application/json" },
-        method: "POST"
+        method: "POST",
       },
     );
 
@@ -328,9 +364,9 @@ describe("workspace admin API", () => {
       repos: [
         {
           provider: "github",
-          repo: "getsentry/junior"
+          repo: "getsentry/junior",
         },
-      ]
+      ],
     });
 
     await executor.execute(`
@@ -354,9 +390,9 @@ FOR EACH ROW EXECUTE FUNCTION junior_test_reject_workspace_repo()
           repos: [
             {
               provider: "github",
-              repo: "getsentry/sentry"
+              repo: "getsentry/sentry",
             },
-          ]
+          ],
         }),
       ).rejects.toThrow(/junior_workspace_repos/);
       expect(
@@ -370,9 +406,9 @@ FOR EACH ROW EXECUTE FUNCTION junior_test_reject_workspace_repo()
           repos: [
             {
               provider: "github",
-              repo: "getsentry/sentry"
+              repo: "getsentry/sentry",
             },
-          ]
+          ],
         }),
       ).rejects.toThrow(/junior_workspace_repos/);
       expect(await getWorkspace(getDb(), original.id)).toEqual(original);
@@ -393,25 +429,25 @@ FOR EACH ROW EXECUTE FUNCTION junior_test_reject_workspace_repo()
       repos: [
         {
           provider: "github",
-          repo: "getsentry/sentry"
+          repo: "getsentry/sentry",
         },
-      ]
+      ],
     };
     const first = await app.request("http://localhost/api/workspaces", {
       body: JSON.stringify(body),
       headers: { "content-type": "application/json" },
-      method: "POST"
+      method: "POST",
     });
     expect(first.status).toBe(201);
 
     const second = await app.request("http://localhost/api/workspaces", {
       body: JSON.stringify(body),
       headers: { "content-type": "application/json" },
-      method: "POST"
+      method: "POST",
     });
     expect(second.status).toBe(400);
     expect(apiErrorSchema.parse(await second.json())).toEqual({
-      error: "Workspace name already exists: shared"
+      error: "Workspace name already exists: shared",
     });
   });
 });

--- a/packages/junior/tests/integration/api/workspaces/routes.test.ts
+++ b/packages/junior/tests/integration/api/workspaces/routes.test.ts
@@ -227,8 +227,6 @@ describe("workspace admin API", () => {
       generatedAt: new Date("2026-03-01T00:00:00.000Z"),
       buildDurationMs: 12_345,
       profileHash: profileHash!,
-      runtime: SANDBOX_RUNTIME,
-      dependencyCount: 0,
     });
 
     const detailResponse = await app.request(
@@ -245,7 +243,7 @@ describe("workspace admin API", () => {
     });
   });
 
-  it("preserves snapshot metadata for a rename and clears it after the recipe changes", async () => {
+  it("selects snapshot metadata for the current Workspace recipe", async () => {
     const app = authenticatedApi();
     const createResponse = await app.request(
       "http://localhost/api/workspaces",
@@ -270,8 +268,6 @@ describe("workspace admin API", () => {
       generatedAt: new Date("2026-03-01T00:00:00.000Z"),
       buildDurationMs: 9_000,
       profileHash: profileHash!,
-      runtime: SANDBOX_RUNTIME,
-      dependencyCount: 0,
     });
 
     const renameResponse = await app.request(
@@ -314,6 +310,20 @@ describe("workspace admin API", () => {
     expect(workspaceSchema.parse(await detailResponse.json())).toMatchObject({
       id: created.id,
       snapshot: null,
+    });
+
+    const changedWorkspace = await getWorkspace(getDb(), created.id);
+    expect(changedWorkspace).toBeDefined();
+    const changedProfileHash = workspaceProfileHash(
+      SANDBOX_RUNTIME,
+      changedWorkspace!,
+    );
+    expect(changedProfileHash).toBeTruthy();
+    await setWorkspaceSnapshot(created.id, {
+      id: "snap_new",
+      generatedAt: new Date("2026-03-02T00:00:00.000Z"),
+      buildDurationMs: 10_000,
+      profileHash: changedProfileHash!,
     });
 
     const revertResponse = await app.request(

--- a/packages/junior/tests/integration/workspace-snapshot-migration.test.ts
+++ b/packages/junior/tests/integration/workspace-snapshot-migration.test.ts
@@ -37,26 +37,21 @@ INSERT INTO junior_workspaces (
 
       const [snapshot] = await fixture.sql.query<{
         buildDurationMs: number;
-        dependencyCount: number;
         generatedAt: Date;
         profileHash: string;
-        runtime: string;
         snapshotId: string;
         status: string;
         workspaceId: string;
       }>(`
 SELECT
   workspace_id AS "workspaceId", profile_hash AS "profileHash", status,
-  snapshot_id AS "snapshotId", runtime,
-  dependency_count AS "dependencyCount",
-  build_duration_ms AS "buildDurationMs", generated_at AS "generatedAt"
+  snapshot_id AS "snapshotId", build_duration_ms AS "buildDurationMs",
+  generated_at AS "generatedAt"
 FROM junior_snapshots
 `);
       expect(snapshot).toMatchObject({
         buildDurationMs: 12_345,
-        dependencyCount: 0,
         profileHash: "profile-legacy",
-        runtime: "node22",
         snapshotId: "snap_legacy",
         status: "ready",
         workspaceId: "workspace-legacy-snapshot",
@@ -64,8 +59,18 @@ FROM junior_snapshots
       expect(snapshot?.generatedAt.toISOString()).toBe(
         "2026-03-01T00:00:00.000Z",
       );
+      await expect(
+        fixture.sql.execute(`
+INSERT INTO junior_snapshots (
+  id, workspace_id, profile_hash, status, created_at, updated_at
+) VALUES (
+  'invalid-ready', 'workspace-legacy-snapshot', 'profile-invalid', 'ready',
+  CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+)
+`),
+      ).rejects.toThrow(/junior_snapshots_ready_fields_check/);
     } finally {
       await fixture.close();
     }
-  });
+  }, 10_000);
 });

--- a/packages/junior/tests/integration/workspace-snapshot-migration.test.ts
+++ b/packages/junior/tests/integration/workspace-snapshot-migration.test.ts
@@ -1,0 +1,71 @@
+import { fileURLToPath } from "node:url";
+import { readMigrationFiles } from "drizzle-orm/migrator";
+import { describe, expect, it } from "vitest";
+import { applyCoreMigrations } from "../fixtures/conversation-sql-migrations";
+import { createLocalJuniorSqlFixture } from "../fixtures/sql";
+
+const coreMigrations = readMigrationFiles({
+  migrationsFolder: fileURLToPath(new URL("../../migrations", import.meta.url)),
+});
+
+describe("Workspace snapshot migration", () => {
+  it("moves legacy snapshot facts into snapshot history", async () => {
+    const fixture = await createLocalJuniorSqlFixture();
+    const migrationIndex = coreMigrations.findIndex((migration) =>
+      migration.sql.some((statement) =>
+        statement.includes('CREATE TABLE "junior_snapshots"'),
+      ),
+    );
+    const migration = coreMigrations[migrationIndex];
+    if (!migration) throw new Error("Workspace snapshot migration not found");
+
+    try {
+      await applyCoreMigrations(fixture, coreMigrations, 0, migrationIndex);
+      await fixture.sql.execute(`
+INSERT INTO junior_workspaces (
+  id, name, setup_script, snapshot_id, snapshot_generated_at,
+  snapshot_build_duration_ms, snapshot_profile_hash, created_at, updated_at
+) VALUES (
+  'workspace-legacy-snapshot', 'legacy-snapshot', '', 'snap_legacy',
+  '2026-03-01T00:00:00.000Z', 12345, 'profile-legacy',
+  '2026-02-01T00:00:00.000Z', '2026-03-01T00:00:00.000Z'
+)
+`);
+      for (const statement of migration.sql) {
+        await fixture.sql.execute(statement);
+      }
+
+      const [snapshot] = await fixture.sql.query<{
+        buildDurationMs: number;
+        dependencyCount: number;
+        generatedAt: Date;
+        profileHash: string;
+        runtime: string;
+        snapshotId: string;
+        status: string;
+        workspaceId: string;
+      }>(`
+SELECT
+  workspace_id AS "workspaceId", profile_hash AS "profileHash", status,
+  snapshot_id AS "snapshotId", runtime,
+  dependency_count AS "dependencyCount",
+  build_duration_ms AS "buildDurationMs", generated_at AS "generatedAt"
+FROM junior_snapshots
+`);
+      expect(snapshot).toMatchObject({
+        buildDurationMs: 12_345,
+        dependencyCount: 0,
+        profileHash: "profile-legacy",
+        runtime: "node22",
+        snapshotId: "snap_legacy",
+        status: "ready",
+        workspaceId: "workspace-legacy-snapshot",
+      });
+      expect(snapshot?.generatedAt.toISOString()).toBe(
+        "2026-03-01T00:00:00.000Z",
+      );
+    } finally {
+      await fixture.close();
+    }
+  });
+});


### PR DESCRIPTION
Workspace snapshot artifacts and build checkpoints now live in a dedicated `junior_snapshots` table instead of recipe columns. The migration backfills existing ready snapshots before it removes the legacy fields. Workspace reads and writes now use the new snapshot store, while snapshot construction stays on the current inline path.

Ready rows remain available across recipe changes. This lets a workspace reuse its prior artifact when its recipe changes back. The store clears only non-ready rows.

This separates the persistence contract needed by #1599 from its long-running builder and host-continuation behavior. A focused migration case verifies that existing snapshot facts survive the cutover.
