### PR TITLE
feat(api-turns): stop active turns across workers

### DIFF
--- a/packages/junior/src/chat/api-turns/cancellation.ts
+++ b/packages/junior/src/chat/api-turns/cancellation.ts
@@ -85,6 +85,8 @@ export async function completeCancelledApiTurn(args: {
   userMessageId: string;
 }): Promise<void> {
   try {
+    const ownsPendingAuthorization =
+      args.conversation.processing.pendingAuth?.sessionId === args.turnId;
     await abandonTurnRecord({
       conversationId: args.conversationId,
       turnId: args.turnId,
@@ -100,10 +102,12 @@ export async function completeCancelledApiTurn(args: {
       nowMs: Date.now(),
       sessionId: args.turnId,
     });
-    await deleteWebAuthorization({
-      actorId: args.actorId,
-      conversationId: args.conversationId,
-    });
+    if (ownsPendingAuthorization) {
+      await deleteWebAuthorization({
+        actorId: args.actorId,
+        conversationId: args.conversationId,
+      });
+    }
     await persistThreadStateById(args.conversationId, {
       conversation: args.conversation,
       sandboxRef: args.sandboxRef,

--- a/packages/junior/src/chat/api-turns/routing.ts
+++ b/packages/junior/src/chat/api-turns/routing.ts
@@ -21,6 +21,47 @@ export type ApiTurnMailboxMetadata = z.output<
   typeof apiTurnMailboxMetadataSchema
 >;
 
+/** Return the active root API Turn for one Conversation, if it has one. */
+export async function getActiveApiTurnId(
+  conversationId: string,
+): Promise<string | undefined> {
+  const summaries = await listTurnSummaries(conversationId);
+  // Agent dispatch also writes surface "api". Those Turns own a dispatchId
+  // and must stay on the dispatch router.
+  const active = summaries.filter(
+    (summary) =>
+      summary.surface === "api" &&
+      !summary.dispatchId &&
+      (summary.state === "paused" || summary.state === "running"),
+  );
+  if (active.length > 1) {
+    throw new Error(
+      `Conversation ${conversationId} has multiple active web turns`,
+    );
+  }
+  const turnId = active[0]?.turnId;
+  if (!turnId) return undefined;
+  const record = await getTurnRecord(conversationId, turnId);
+  return record &&
+    record.surface === "api" &&
+    !record.dispatchId &&
+    (record.state === "paused" || record.state === "running")
+    ? turnId
+    : undefined;
+}
+
+/** Return the idle auth-paused root API Turn for one Conversation. */
+export async function getAuthPausedApiTurnId(
+  conversationId: string,
+): Promise<string | undefined> {
+  const turnId = await getActiveApiTurnId(conversationId);
+  if (!turnId) return undefined;
+  const record = await getTurnRecord(conversationId, turnId);
+  return record?.state === "paused" && record.resumeReason === "auth"
+    ? turnId
+    : undefined;
+}
+
 function parseApiTurnMessages(
   messages: readonly InboundMessage[],
 ): Array<{ message: InboundMessage; metadata: ApiTurnMailboxMetadata }> {
@@ -72,34 +113,8 @@ export async function resolveApiTurnWork(
     return undefined;
   }
 
-  const summaries = await listTurnSummaries(context.conversationId);
-  // Agent dispatch also writes surface "api". Those Turns own a dispatchId
-  // and must stay on the dispatch router, which runs after this route.
-  const active = summaries.filter(
-    (summary) =>
-      summary.surface === "api" &&
-      !summary.dispatchId &&
-      (summary.state === "paused" || summary.state === "running"),
-  );
-  if (active.length > 1) {
-    throw new Error(
-      `Conversation ${context.conversationId} has multiple active web turns`,
-    );
-  }
-  const turnId = active[0]?.turnId;
-  if (!turnId) {
-    return undefined;
-  }
-  const record = await getTurnRecord(context.conversationId, turnId);
-  if (
-    !record ||
-    record.surface !== "api" ||
-    Boolean(record.dispatchId) ||
-    (record.state !== "paused" && record.state !== "running")
-  ) {
-    return undefined;
-  }
-  return { kind: "resume", turnId };
+  const turnId = await getActiveApiTurnId(context.conversationId);
+  return turnId ? { kind: "resume", turnId } : undefined;
 }
 
 /** Return whether the leased attempt belongs to an API Turn. */

--- a/packages/junior/src/chat/api-turns/stop.ts
+++ b/packages/junior/src/chat/api-turns/stop.ts
@@ -1,0 +1,61 @@
+import type { StateAdapter } from "chat";
+import type { ConversationStore } from "@/chat/conversations/store";
+import { getAuthPausedApiTurnId } from "@/chat/api-turns/routing";
+import type { ConversationWorkQueue } from "@/chat/task-execution/queue";
+import {
+  ensureConversationWake,
+  getConversation,
+  requestConversationWork,
+  stopConversationWork,
+  type StopConversationWorkResult,
+} from "@/chat/task-execution/store";
+
+/** Stop the current API Turn and wake an idle durable resume when needed. */
+export async function stopApiConversationTurn(args: {
+  conversationId: string;
+  conversationStore?: ConversationStore;
+  nowMs?: number;
+  queue: ConversationWorkQueue;
+  state?: StateAdapter;
+}): Promise<StopConversationWorkResult> {
+  const nowMs = args.nowMs ?? Date.now();
+  const stop = async (): Promise<StopConversationWorkResult> =>
+    await stopConversationWork({
+      conversationId: args.conversationId,
+      conversationStore: args.conversationStore,
+      nowMs,
+      state: args.state,
+    });
+  let result = await stop();
+
+  if (
+    result.status === "no_work" &&
+    (await getAuthPausedApiTurnId(args.conversationId))
+  ) {
+    const conversation = await getConversation({
+      conversationId: args.conversationId,
+      state: args.state,
+    });
+    await requestConversationWork({
+      conversationId: args.conversationId,
+      conversationStore: args.conversationStore,
+      destination: conversation?.destination,
+      nowMs,
+      state: args.state,
+    });
+    result = await stop();
+  }
+
+  if (result.status === "requested") {
+    await ensureConversationWake({
+      conversationId: args.conversationId,
+      conversationStore: args.conversationStore,
+      idempotencyKey: `api-stop:${args.conversationId}:${result.runId}`,
+      nowMs,
+      queue: args.queue,
+      replaceExistingWake: true,
+      state: args.state,
+    });
+  }
+  return result;
+}

--- a/packages/junior/src/chat/api-turns/work.ts
+++ b/packages/junior/src/chat/api-turns/work.ts
@@ -158,7 +158,8 @@ export function createApiConversationId(args: {
   )}`;
 }
 
-function apiMessageId(args: {
+/** Build the retry-stable Message id used by one API mailbox request. */
+export function apiConversationMessageId(args: {
   conversationId: string;
   idempotencyKey: string;
 }): string {
@@ -372,7 +373,7 @@ export async function appendAndEnqueueApiConversationMessage(
     throw new Error("API conversation actor requires a verified email");
   }
   const nowMs = options.nowMs ?? Date.now();
-  const messageId = apiMessageId({
+  const messageId = apiConversationMessageId({
     conversationId: input.conversationId,
     idempotencyKey: input.idempotencyKey,
   });
@@ -540,6 +541,40 @@ export function createApiTurnWorker(options: {
         let sandboxRef: SandboxRef | undefined =
           getPersistedSandboxState(persisted);
         const initialSandboxRef = sandboxRef;
+        const appSignal = options.cancellation?.signal(context.conversationId);
+        const stopSignal = context.stopSignal?.();
+        const cancellationSignal =
+          appSignal && stopSignal
+            ? AbortSignal.any([appSignal, stopSignal])
+            : (appSignal ?? stopSignal);
+        const finishCancellation = (): void => {
+          if (appSignal) {
+            options.cancellation?.finish(context.conversationId, appSignal);
+          }
+        };
+        const completeCancelledTurn =
+          async (): Promise<ConversationWorkerResult> => {
+            try {
+              await completeCancelledApiTurn({
+                acknowledge,
+                actorId: actor.userId,
+                cancellation: options.cancellation,
+                conversation,
+                conversationId: context.conversationId,
+                lifecycle,
+                sandboxRef,
+                signal: appSignal,
+                turnId,
+                userMessageId,
+              });
+            } catch (error) {
+              if (hasLostTurnInputCommit(error)) {
+                return { status: "lost_lease" };
+              }
+              throw error;
+            }
+            return { status: "completed" };
+          };
 
         if (isResume) {
           const userMessage = getTurnUserMessage(conversation, turnId);
@@ -552,43 +587,10 @@ export function createApiTurnWorker(options: {
           text = userMessage.text;
           startedAtMs = userMessage.createdAtMs;
           inputMessageIds = [userMessageId];
+          if (cancellationSignal?.aborted) {
+            return await completeCancelledTurn();
+          }
         } else {
-          // Match Slack: a newer user message supersedes an auth-parked turn
-          // instead of leaving two active API turns or letting a late OAuth
-          // wake resume stale work.
-          const authParked = (
-            await listTurnSummaries(context.conversationId)
-          ).filter(
-            (summary) =>
-              summary.surface === "api" &&
-              !summary.dispatchId &&
-              summary.state === "paused" &&
-              summary.resumeReason === "auth",
-          );
-          for (const parked of authParked) {
-            await abandonTurnRecord({
-              conversationId: context.conversationId,
-              turnId: parked.turnId,
-              errorMessage:
-                "Auth-parked session superseded by a new user message",
-            });
-            // Keep pendingAuth: MCP OAuth still needs it to accept an in-flight
-            // connect and store credentials. The abandoned turn record makes a
-            // late callback a resume no-op, matching Slack supersede behavior.
-            markTurnClosed({
-              conversation,
-              nowMs: Date.now(),
-              sessionId: parked.turnId,
-            });
-          }
-          if (authParked.length > 0) {
-            // Drop the dashboard connect prompt so a superseded OAuth flow
-            // cannot leave a stale banner after the user moves on.
-            await deleteWebAuthorization({
-              actorId: actor.userId,
-              conversationId: context.conversationId,
-            });
-          }
           upsertConversationMessage(conversation, {
             id: userMessageId,
             role: "user",
@@ -617,6 +619,9 @@ export function createApiTurnWorker(options: {
             surface: "api",
             turnId,
           });
+          if (cancellationSignal?.aborted) {
+            return await completeCancelledTurn();
+          }
           startActiveTurn({
             conversation,
             nextTurnId: turnId,
@@ -629,41 +634,6 @@ export function createApiTurnWorker(options: {
         let modelFailureEventId: string | undefined;
         let modelFailureCaptureAttempted = false;
         let reply: AgentRunResult | undefined;
-        const cancellationSignal = options.cancellation?.signal(
-          context.conversationId,
-        );
-        const finishCancellation = (): void => {
-          if (cancellationSignal) {
-            options.cancellation?.finish(
-              context.conversationId,
-              cancellationSignal,
-            );
-          }
-        };
-
-        const completeCancelledTurn =
-          async (): Promise<ConversationWorkerResult> => {
-            try {
-              await completeCancelledApiTurn({
-                acknowledge,
-                actorId: actor.userId,
-                cancellation: options.cancellation,
-                conversation,
-                conversationId: context.conversationId,
-                lifecycle,
-                sandboxRef,
-                signal: cancellationSignal,
-                turnId,
-                userMessageId,
-              });
-            } catch (error) {
-              if (hasLostTurnInputCommit(error)) {
-                return { status: "lost_lease" };
-              }
-              throw error;
-            }
-            return { status: "completed" };
-          };
 
         const deliverAssistantMessage = async (
           value: AssistantMessage | string,
@@ -705,6 +675,50 @@ export function createApiTurnWorker(options: {
         };
 
         try {
+          if (cancellationSignal?.aborted) {
+            return await completeCancelledTurn();
+          }
+          if (!isResume) {
+            // Match Slack: a newer user message supersedes an auth-parked turn
+            // instead of leaving two active API turns or letting a late OAuth
+            // wake resume stale work.
+            const authParked = (
+              await listTurnSummaries(context.conversationId)
+            ).filter(
+              (summary) =>
+                summary.surface === "api" &&
+                !summary.dispatchId &&
+                summary.state === "paused" &&
+                summary.resumeReason === "auth",
+            );
+            for (const parked of authParked) {
+              if (cancellationSignal?.aborted) {
+                return await completeCancelledTurn();
+              }
+              await abandonTurnRecord({
+                conversationId: context.conversationId,
+                turnId: parked.turnId,
+                errorMessage:
+                  "Auth-parked session superseded by a new user message",
+              });
+              // Keep pendingAuth: MCP OAuth still needs it to accept an in-flight
+              // connect and store credentials. The abandoned turn record makes a
+              // late callback a resume no-op, matching Slack supersede behavior.
+              markTurnClosed({
+                conversation,
+                nowMs: Date.now(),
+                sessionId: parked.turnId,
+              });
+            }
+            if (authParked.length > 0) {
+              // Drop the dashboard connect prompt so a superseded OAuth flow
+              // cannot leave a stale banner after the user moves on.
+              await deleteWebAuthorization({
+                actorId: actor.userId,
+                conversationId: context.conversationId,
+              });
+            }
+          }
           await persistThreadStateById(context.conversationId, {
             conversation,
           });
@@ -784,14 +798,11 @@ export function createApiTurnWorker(options: {
               conversation,
               sandboxRef,
             });
-            if (cancellationSignal) {
-              options.cancellation?.park(
-                context.conversationId,
-                cancellationSignal,
-              );
+            if (appSignal) {
+              options.cancellation?.park(context.conversationId, appSignal);
             }
             await acknowledge();
-            return { status: "completed" };
+            return { status: "paused" };
           }
           finishCancellation();
           reply = outcome.result;

--- a/packages/junior/src/chat/app/conversation-work.ts
+++ b/packages/junior/src/chat/app/conversation-work.ts
@@ -127,6 +127,7 @@ export function createConversationWork(
       apiTurnWorker: createApiTurnWorker({
         agentRunner: options.agentRunner,
         cancellation: apiTurnCancellation,
+        turnLifecycle: services.replyExecutor?.turnLifecycle,
       }),
       fallbackWorker: routeAgentInvocationWork({
         invocationWorker: createAgentInvocationWorker({

--- a/packages/junior/src/chat/task-execution/state.ts
+++ b/packages/junior/src/chat/task-execution/state.ts
@@ -132,6 +132,12 @@ export interface Lease {
   token: string;
 }
 
+/** Durable request to stop the current Conversation run. */
+export interface ConversationStop {
+  requestedAtMs: number;
+  runId: string;
+}
+
 export interface ConversationExecution {
   inboundMessageIds: string[];
   lastCheckpointAtMs?: number;
@@ -143,6 +149,7 @@ export interface ConversationExecution {
   pendingMessages: InboundMessage[];
   runId?: string;
   status: ExecutionStatus;
+  stop?: ConversationStop;
   updatedAtMs?: number;
 }
 
@@ -201,6 +208,27 @@ export interface AppendInboundMessageResult {
 export interface AppendAndEnqueueInboundMessageResult extends AppendInboundMessageResult {
   queueMessageId?: string;
 }
+
+/** Result of requesting that the current Conversation run stop. */
+export type StopConversationWorkResult =
+  | { status: "no_work" }
+  | { runId: string; status: "requested" };
+
+/** Result of clearing one stop observed by the matching leased run. */
+export interface CompleteConversationStopResult {
+  status: "cleared" | "lost_lease" | "none";
+  removedInboundMessageIds: string[];
+}
+
+/** Result of an append that rejects new work while a Conversation is runnable. */
+export type AppendExclusiveInboundMessageResult =
+  | AppendInboundMessageResult
+  | { status: "active" };
+
+/** Exclusive append result with an optional queue delivery id. */
+export type AppendAndEnqueueExclusiveInboundMessageResult =
+  | AppendAndEnqueueInboundMessageResult
+  | { status: "active" };
 
 export interface RequestConversationWorkResult {
   status: "created" | "updated";
@@ -374,6 +402,17 @@ function normalizeLease(value: unknown): Lease | undefined {
   };
 }
 
+function normalizeStop(value: unknown): ConversationStop | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const runId = toOptionalString(value.runId);
+  const requestedAtMs = toOptionalNumber(value.requestedAtMs);
+  return runId && typeof requestedAtMs === "number"
+    ? { requestedAtMs, runId }
+    : undefined;
+}
+
 /** Decode execution state and repair idle records that still own work. */
 function normalizeExecution(
   conversationId: string,
@@ -409,6 +448,9 @@ function normalizeExecution(
     : [];
 
   const lease = normalizeLease(value.lease);
+  const runId = toOptionalString(value.runId);
+  const normalizedStop = normalizeStop(value.stop);
+  const stop = normalizedStop?.runId === runId ? normalizedStop : undefined;
   const normalizedStatus =
     status === "idle" && lease
       ? "running"
@@ -429,7 +471,8 @@ function normalizeExecution(
     lastEnqueuedAtMs: toOptionalNumber(value.lastEnqueuedAtMs),
     lastProgressAtMs: toOptionalNumber(value.lastProgressAtMs),
     retryCount: toOptionalNumber(value.retryCount),
-    runId: toOptionalString(value.runId),
+    runId,
+    stop,
     updatedAtMs: toOptionalNumber(value.updatedAtMs),
   };
 }
@@ -1062,12 +1105,12 @@ export function hasRunnableConversationWork(
   return hasRunnableWork(conversation);
 }
 
-/** Persist one inbound message idempotently in its conversation mailbox. */
-export async function appendInboundMessage(args: {
+async function appendInboundMessageWithAdmission(args: {
+  exclusive: boolean;
   message: InboundMessage;
   nowMs?: number;
   state?: StateAdapter;
-}): Promise<AppendInboundMessageResult> {
+}): Promise<AppendExclusiveInboundMessageResult> {
   const nowMs = args.nowMs ?? now();
   return await withConversationMutation(
     { conversationId: args.message.conversationId, state: args.state },
@@ -1125,6 +1168,9 @@ export async function appendInboundMessage(args: {
         );
         return { status: "duplicate" };
       }
+      if (args.exclusive && hasRunnableWork(current)) {
+        return { status: "active" };
+      }
 
       const status =
         current.execution.lease && current.execution.status === "running"
@@ -1161,6 +1207,34 @@ export async function appendInboundMessage(args: {
       return { status: "appended" };
     },
   );
+}
+
+/** Persist one inbound message idempotently in its conversation mailbox. */
+export async function appendInboundMessage(args: {
+  message: InboundMessage;
+  nowMs?: number;
+  state?: StateAdapter;
+}): Promise<AppendInboundMessageResult> {
+  const result = await appendInboundMessageWithAdmission({
+    ...args,
+    exclusive: false,
+  });
+  if (result.status === "active") {
+    throw new Error("Non-exclusive mailbox append returned active");
+  }
+  return result;
+}
+
+/** Append only when the Conversation has no other runnable work. */
+export async function appendExclusiveInboundMessage(args: {
+  message: InboundMessage;
+  nowMs?: number;
+  state?: StateAdapter;
+}): Promise<AppendExclusiveInboundMessageResult> {
+  return await appendInboundMessageWithAdmission({
+    ...args,
+    exclusive: true,
+  });
 }
 
 /** Mark a conversation runnable when there is no new mailbox message. */
@@ -1612,6 +1686,93 @@ export async function ackMessages(args: {
   });
 }
 
+function isHumanFacingMessage(message: InboundMessage): boolean {
+  return message.source === "web" || message.source === "slack";
+}
+
+/** Persist a stop request for the current run without process affinity. */
+export async function stopConversationWork(args: {
+  conversationId: string;
+  nowMs?: number;
+  state?: StateAdapter;
+}): Promise<StopConversationWorkResult> {
+  const nowMs = args.nowMs ?? now();
+  return await withConversationMutation(args, async (state, lock) => {
+    const current = await readConversation(state, args.conversationId);
+    if (!current || !hasRunnableWork(current)) {
+      return { status: "no_work" };
+    }
+
+    const runId = current.execution.runId ?? randomUUID();
+    await writeConversation(
+      state,
+      lock,
+      withExecutionUpdate(
+        current,
+        {
+          ...current.execution,
+          runId,
+          stop: { requestedAtMs: nowMs, runId },
+        },
+        nowMs,
+      ),
+    );
+    return { runId, status: "requested" };
+  });
+}
+
+/** Clear one observed stop request and discard older human-facing mailbox work. */
+export async function completeConversationStop(args: {
+  conversationId: string;
+  leaseToken: string;
+  nowMs?: number;
+  runId: string;
+  state?: StateAdapter;
+}): Promise<CompleteConversationStopResult> {
+  const nowMs = args.nowMs ?? now();
+  return await withConversationMutation(args, async (state, lock) => {
+    const current = await readConversation(state, args.conversationId);
+    if (!current || current.execution.lease?.token !== args.leaseToken) {
+      return { status: "lost_lease", removedInboundMessageIds: [] };
+    }
+    const stop = current.execution.stop;
+    if (!stop || stop.runId !== args.runId) {
+      return { status: "none", removedInboundMessageIds: [] };
+    }
+
+    const removedInboundMessageIds: string[] = [];
+    const pendingMessages = current.execution.pendingMessages.filter(
+      (message) => {
+        const shouldStop =
+          isHumanFacingMessage(message) &&
+          message.receivedAtMs <= stop.requestedAtMs;
+        if (shouldStop) {
+          removedInboundMessageIds.push(message.inboundMessageId);
+        }
+        return !shouldStop;
+      },
+    );
+    await writeConversation(
+      state,
+      lock,
+      withExecutionUpdate(
+        current,
+        {
+          ...current.execution,
+          lastEnqueuedAtMs:
+            pendingMessages.length === 0
+              ? undefined
+              : current.execution.lastEnqueuedAtMs,
+          pendingMessages,
+          stop: undefined,
+        },
+        nowMs,
+      ),
+    );
+    return { status: "cleared", removedInboundMessageIds };
+  });
+}
+
 /** Cancel human-facing pending mailbox rows without requiring a worker lease. */
 export async function cancelHumanFacingPendingMessages(args: {
   conversationId: string;
@@ -1634,15 +1795,13 @@ export async function cancelHumanFacingPendingMessages(args: {
     const cancelledInboundMessageIds: string[] = [];
     const pendingMessages: InboundMessage[] = [];
     for (const message of current.execution.pendingMessages) {
-      const isHumanFacing =
-        message.source === "web" || message.source === "slack";
       const isRequested =
         requestedIds === undefined ||
         requestedIds.has(message.inboundMessageId);
       const isInSnapshot =
         args.receivedBeforeMs === undefined ||
         message.receivedAtMs <= args.receivedBeforeMs;
-      if (isHumanFacing && isRequested && isInSnapshot) {
+      if (isHumanFacingMessage(message) && isRequested && isInSnapshot) {
         cancelledInboundMessageIds.push(message.inboundMessageId);
         continue;
       }
@@ -1671,6 +1830,7 @@ export async function cancelHumanFacingPendingMessages(args: {
           retryCount: becomesIdle ? 0 : current.execution.retryCount,
           runId: becomesIdle ? undefined : current.execution.runId,
           status: becomesIdle ? "idle" : current.execution.status,
+          stop: becomesIdle ? undefined : current.execution.stop,
         },
         nowMs,
       ),
@@ -1809,6 +1969,7 @@ export async function recordConversationRetry(args: {
           pendingMessages: stopped ? [] : current.execution.pendingMessages,
           runId: stopped ? undefined : current.execution.runId,
           status: stopped ? "failed" : "paused",
+          stop: stopped ? undefined : current.execution.stop,
         },
         nowMs,
       ),
@@ -1823,6 +1984,8 @@ export async function completeConversationWork(args: {
   leaseToken: string;
   madeProgress?: boolean;
   nowMs?: number;
+  /** Keep a raced stop runnable after the adapter pauses a Turn. */
+  resumeIfStopped?: boolean;
   state?: StateAdapter;
 }): Promise<"completed" | "lost_lease" | "pending"> {
   const nowMs = args.nowMs ?? now();
@@ -1832,7 +1995,9 @@ export async function completeConversationWork(args: {
       return "lost_lease";
     }
     const hasPending = pendingMessages(current).length > 0;
-    const needsRun = current.execution.status === "paused";
+    const needsRun =
+      current.execution.status === "paused" ||
+      (args.resumeIfStopped === true && current.execution.stop !== undefined);
     const runnable = needsRun || hasPending;
     await writeConversation(
       state,
@@ -1852,6 +2017,7 @@ export async function completeConversationWork(args: {
               ? current.execution.retryCount
               : 0,
           runId: runnable ? current.execution.runId : undefined,
+          stop: runnable ? current.execution.stop : undefined,
         },
         nowMs,
       ),
@@ -1986,6 +2152,7 @@ export async function deadLetterAttempt(args: {
           lease: undefined,
           status: runnable ? "pending" : "failed",
           runId: runnable ? current.execution.runId : undefined,
+          stop: runnable ? current.execution.stop : undefined,
         },
         nowMs,
       ),
@@ -2024,6 +2191,7 @@ export async function clearExpiredConversationLease(args: {
           pendingMessages: stopped ? [] : current.execution.pendingMessages,
           runId: stopped ? undefined : current.execution.runId,
           status: stopped ? "failed" : "paused",
+          stop: stopped ? undefined : current.execution.stop,
         },
         nowMs,
       ),

--- a/packages/junior/src/chat/task-execution/state.ts
+++ b/packages/junior/src/chat/task-execution/state.ts
@@ -134,7 +134,7 @@ export interface Lease {
 
 /** Durable request to stop the current Conversation run. */
 export interface ConversationStop {
-  requestedAtMs: number;
+  inboundMessageIds: string[];
   runId: string;
 }
 
@@ -406,11 +406,15 @@ function normalizeStop(value: unknown): ConversationStop | undefined {
   if (!isRecord(value)) {
     return undefined;
   }
+  const inboundMessageIds = Array.isArray(value.inboundMessageIds)
+    ? uniqueStrings(
+        value.inboundMessageIds.filter(
+          (id): id is string => typeof id === "string",
+        ),
+      )
+    : [];
   const runId = toOptionalString(value.runId);
-  const requestedAtMs = toOptionalNumber(value.requestedAtMs);
-  return runId && typeof requestedAtMs === "number"
-    ? { requestedAtMs, runId }
-    : undefined;
+  return runId ? { inboundMessageIds, runId } : undefined;
 }
 
 /** Decode execution state and repair idle records that still own work. */
@@ -1704,6 +1708,9 @@ export async function stopConversationWork(args: {
     }
 
     const runId = current.execution.runId ?? randomUUID();
+    const inboundMessageIds = current.execution.pendingMessages
+      .filter(isHumanFacingMessage)
+      .map((message) => message.inboundMessageId);
     await writeConversation(
       state,
       lock,
@@ -1712,7 +1719,7 @@ export async function stopConversationWork(args: {
         {
           ...current.execution,
           runId,
-          stop: { requestedAtMs: nowMs, runId },
+          stop: { inboundMessageIds, runId },
         },
         nowMs,
       ),
@@ -1740,12 +1747,13 @@ export async function completeConversationStop(args: {
       return { status: "none", removedInboundMessageIds: [] };
     }
 
+    const stoppedInboundMessageIds = new Set(stop.inboundMessageIds);
     const removedInboundMessageIds: string[] = [];
     const pendingMessages = current.execution.pendingMessages.filter(
       (message) => {
-        const shouldStop =
-          isHumanFacingMessage(message) &&
-          message.receivedAtMs <= stop.requestedAtMs;
+        const shouldStop = stoppedInboundMessageIds.has(
+          message.inboundMessageId,
+        );
         if (shouldStop) {
           removedInboundMessageIds.push(message.inboundMessageId);
         }

--- a/packages/junior/src/chat/task-execution/state.ts
+++ b/packages/junior/src/chat/task-execution/state.ts
@@ -1992,7 +1992,7 @@ export async function completeConversationWork(args: {
   leaseToken: string;
   madeProgress?: boolean;
   nowMs?: number;
-  /** Keep a raced stop runnable after the adapter pauses a Turn. */
+  /** Keep a raced stop runnable after a stop-aware adapter returns. */
   resumeIfStopped?: boolean;
   state?: StateAdapter;
 }): Promise<"completed" | "lost_lease" | "pending"> {

--- a/packages/junior/src/chat/task-execution/store.ts
+++ b/packages/junior/src/chat/task-execution/store.ts
@@ -20,8 +20,10 @@ export {
   type AttemptFailure,
   type AppendAndEnqueueInboundMessageResult,
   type AppendInboundMessageResult,
+  type CompleteConversationStopResult,
   type Conversation,
   type ConversationExecution,
+  type ConversationStop,
   type ConversationWorkLease,
   type ConversationWorkState,
   type ExecutionStatus,
@@ -34,9 +36,12 @@ export {
   type StartConversationWorkActive,
   type StartConversationWorkNoWork,
   type StartConversationWorkResult,
+  type StopConversationWorkResult,
 } from "@/chat/task-execution/state";
 import type {
+  AppendAndEnqueueExclusiveInboundMessageResult,
   AppendAndEnqueueInboundMessageResult,
+  AppendExclusiveInboundMessageResult,
   Conversation,
   InboundMessage,
 } from "@/chat/task-execution/state";
@@ -234,20 +239,17 @@ export async function appendInboundMessage(args: {
   return result;
 }
 
-/** Persist inbound work and ensure a worker wake-up. */
-export async function appendAndEnqueueInboundMessage(args: {
+async function enqueueAfterAppend(args: {
+  appendResult: AppendExclusiveInboundMessageResult;
   message: InboundMessage;
   conversationStore?: ConversationStore;
   nowMs?: number;
   queue: ConversationWorkQueue;
   state?: StateAdapter;
-}): Promise<AppendAndEnqueueInboundMessageResult> {
+}): Promise<AppendAndEnqueueExclusiveInboundMessageResult> {
   const nowMs = args.nowMs ?? now();
-  const appendResult = await workState.appendInboundMessage({
-    message: args.message,
-    nowMs,
-    state: args.state,
-  });
+  const appendResult = args.appendResult;
+  if (appendResult.status === "active") return appendResult;
   let idempotencyKey = args.message.inboundMessageId;
   if (appendResult.status === "duplicate") {
     const conversation = await workState.getConversation({
@@ -299,6 +301,80 @@ export async function appendAndEnqueueInboundMessage(args: {
       ? { queueMessageId: wake.queueMessageId }
       : {}),
   };
+}
+
+/** Persist inbound work and ensure a worker wake-up. */
+export async function appendAndEnqueueInboundMessage(args: {
+  message: InboundMessage;
+  conversationStore?: ConversationStore;
+  nowMs?: number;
+  queue: ConversationWorkQueue;
+  state?: StateAdapter;
+}): Promise<AppendAndEnqueueInboundMessageResult> {
+  const nowMs = args.nowMs ?? now();
+  const result = await enqueueAfterAppend({
+    ...args,
+    appendResult: await workState.appendInboundMessage({
+      message: args.message,
+      nowMs,
+      state: args.state,
+    }),
+    nowMs,
+  });
+  if (result.status === "active") {
+    throw new Error("Non-exclusive mailbox enqueue returned active");
+  }
+  return result;
+}
+
+/** Persist exclusive inbound work and wake its worker when admitted. */
+export async function appendAndEnqueueExclusiveInboundMessage(args: {
+  message: InboundMessage;
+  conversationStore?: ConversationStore;
+  nowMs?: number;
+  queue: ConversationWorkQueue;
+  state?: StateAdapter;
+}): Promise<AppendAndEnqueueExclusiveInboundMessageResult> {
+  const nowMs = args.nowMs ?? now();
+  return await enqueueAfterAppend({
+    ...args,
+    appendResult: await workState.appendExclusiveInboundMessage({
+      message: args.message,
+      nowMs,
+      state: args.state,
+    }),
+    nowMs,
+  });
+}
+
+/** Persist a stop request for the current Conversation run. */
+export async function stopConversationWork(args: {
+  conversationId: string;
+  conversationStore?: ConversationStore;
+  nowMs?: number;
+  state?: StateAdapter;
+}) {
+  const result = await workState.stopConversationWork(args);
+  if (result.status === "requested") {
+    await recordExecutionMetadata(args);
+  }
+  return result;
+}
+
+/** Finish an observed stop request under the current worker lease. */
+export async function completeConversationStop(args: {
+  conversationId: string;
+  conversationStore?: ConversationStore;
+  leaseToken: string;
+  nowMs?: number;
+  runId: string;
+  state?: StateAdapter;
+}) {
+  const result = await workState.completeConversationStop(args);
+  if (result.status === "cleared") {
+    await recordExecutionMetadata(args);
+  }
+  return result;
 }
 
 /** Clear an accepted wake marker after its delivery finds no runnable work. */
@@ -478,6 +554,8 @@ export async function completeConversationWork(args: {
   madeProgress?: boolean;
   conversationStore?: ConversationStore;
   nowMs?: number;
+  /** Keep a raced stop runnable after the adapter pauses a Turn. */
+  resumeIfStopped?: boolean;
   state?: StateAdapter;
 }) {
   const result = await workState.completeConversationWork(args);

--- a/packages/junior/src/chat/task-execution/store.ts
+++ b/packages/junior/src/chat/task-execution/store.ts
@@ -554,7 +554,7 @@ export async function completeConversationWork(args: {
   madeProgress?: boolean;
   conversationStore?: ConversationStore;
   nowMs?: number;
-  /** Keep a raced stop runnable after the adapter pauses a Turn. */
+  /** Keep a raced stop runnable after a stop-aware adapter returns. */
   resumeIfStopped?: boolean;
   state?: StateAdapter;
 }) {

--- a/packages/junior/src/chat/task-execution/worker.ts
+++ b/packages/junior/src/chat/task-execution/worker.ts
@@ -15,6 +15,7 @@ import {
   beginConversationResume,
   checkInConversationWork,
   clearConsumedConversationWake,
+  completeConversationStop,
   completeConversationWork,
   CONVERSATION_WORK_CHECK_IN_INTERVAL_MS,
   CONVERSATION_WORK_MAX_RETRIES,
@@ -36,6 +37,7 @@ import {
 } from "./store";
 
 export const CONVERSATION_WORK_DEFER_DELAY_MS = 15_000;
+const CONVERSATION_STOP_CHECK_INTERVAL_MS = 500;
 
 export interface ConversationWorkerContext {
   attempt: InboxAttempt;
@@ -45,6 +47,8 @@ export interface ConversationWorkerContext {
   publishExternally: boolean;
   /** True when the current execution slice must stop at its next safe boundary. */
   shouldYield(): boolean;
+  /** Return an AbortSignal backed by the durable Conversation stop request. */
+  stopSignal?(): AbortSignal;
 }
 
 export interface InboxAttempt {
@@ -59,7 +63,8 @@ export interface InboxAttempt {
 }
 
 export interface ConversationWorkerResult {
-  status: "completed" | "deferred" | "lost_lease" | "yielded";
+  /** `paused` waits for an external wake but must resume if a stop raced it. */
+  status: "completed" | "deferred" | "lost_lease" | "paused" | "yielded";
 }
 
 export interface ConversationWorkProcessResult {
@@ -281,6 +286,70 @@ function startLeaseCheckIn(args: {
   return timer;
 }
 
+/** Poll shared state only when a worker adapter asks to observe remote stops. */
+function createConversationStopSignal(args: {
+  conversationId: string;
+  initialStopRunId?: string;
+  options: ProcessConversationWorkOptions;
+  runId: string;
+}) {
+  const controller = new AbortController();
+  let checking = false;
+  let failureCaptured = false;
+  let listening = false;
+  let timer: ReturnType<typeof setInterval> | undefined;
+
+  const requestStop = (): void => {
+    if (!controller.signal.aborted) {
+      controller.abort(new Error("Conversation work stopped"));
+    }
+  };
+  if (args.initialStopRunId === args.runId) {
+    requestStop();
+  }
+
+  const check = async (): Promise<void> => {
+    if (checking || controller.signal.aborted) return;
+    checking = true;
+    try {
+      const current = await getConversationWorkState({
+        conversationId: args.conversationId,
+        state: args.options.state,
+      });
+      if (current?.execution.stop?.runId === args.runId) {
+        requestStop();
+      }
+    } catch (error) {
+      if (!failureCaptured) {
+        failureCaptured = true;
+        logException(error, "conversation.work.stop_check.failed");
+      }
+    } finally {
+      checking = false;
+    }
+  };
+
+  return {
+    close(): void {
+      if (timer) clearInterval(timer);
+    },
+    wasObserved(): boolean {
+      return listening && controller.signal.aborted;
+    },
+    signal(): AbortSignal {
+      listening = true;
+      if (!timer && !controller.signal.aborted) {
+        timer = setInterval(
+          () => void check(),
+          CONVERSATION_STOP_CHECK_INTERVAL_MS,
+        );
+        timer.unref?.();
+      }
+      return controller.signal;
+    },
+  };
+}
+
 /** Process one queue wake-up for a conversation. */
 export async function processConversationWork(
   message: ConversationQueueMessage,
@@ -470,6 +539,7 @@ async function processConversationWorkInContext(
 
   try {
     let hasRun = false;
+    let resumeIfStopped = false;
     while (true) {
       attemptMessageIds = [];
       const leasedWork = await getConversationWorkState({
@@ -494,6 +564,10 @@ async function processConversationWorkInContext(
 
       const resumePending = leasedWork.execution.status === "paused";
       const attemptMessages = selectAttemptMessages(leasedWork);
+      const runId = leasedWork.execution.runId;
+      if (!runId) {
+        throw new Error(`Conversation run is missing for ${conversationId}`);
+      }
       attemptStartMessageIds = new Set(
         leasedWork.messages.map((message) => message.inboundMessageId),
       );
@@ -549,6 +623,12 @@ async function processConversationWorkInContext(
           );
         }
       };
+      const stop = createConversationStopSignal({
+        conversationId,
+        initialStopRunId: leasedWork.execution.stop?.runId,
+        options,
+        runId,
+      });
       const workerContext: ConversationWorkerContext = {
         attempt: {
           ack,
@@ -564,10 +644,16 @@ async function processConversationWorkInContext(
         destination,
         publishExternally,
         shouldYield,
+        stopSignal: stop.signal,
         checkIn,
       };
 
-      const result = await options.run(workerContext);
+      let result: ConversationWorkerResult;
+      try {
+        result = await options.run(workerContext);
+      } finally {
+        stop.close();
+      }
       hasRun = true;
       if (result.status === "lost_lease") {
         await requestLostLeaseRecovery({
@@ -588,6 +674,27 @@ async function processConversationWorkInContext(
           options,
         });
         return { status: "lost_lease" };
+      }
+      if (result.status === "completed" && stop.wasObserved()) {
+        const stopped = await completeConversationStop({
+          conversationId,
+          conversationStore: options.conversationStore,
+          leaseToken: lease.leaseToken,
+          nowMs: now(options),
+          runId,
+          state: options.state,
+        });
+        if (stopped.status === "lost_lease") {
+          markLeaseLost();
+          await requestLostLeaseRecovery({
+            conversationId,
+            destination,
+            leaseToken: lease.leaseToken,
+            nowMs: now(options),
+            options,
+          });
+          return { status: "lost_lease" };
+        }
       }
       if (result.status === "yielded") {
         const sliceRequested = await requestAnotherSlice({
@@ -671,6 +778,11 @@ async function processConversationWorkInContext(
         }
       }
 
+      if (result.status === "paused") {
+        resumeIfStopped = true;
+        break;
+      }
+
       const next = await getConversationWorkState({
         conversationId,
         state: options.state,
@@ -690,6 +802,8 @@ async function processConversationWorkInContext(
       conversationId,
       leaseToken: lease.leaseToken,
       madeProgress: !failedWithoutProgress,
+      // A stop that raced an external pause must reach the paused Turn.
+      resumeIfStopped,
       conversationStore: options.conversationStore,
       nowMs: now(options),
       state: options.state,

--- a/packages/junior/src/chat/task-execution/worker.ts
+++ b/packages/junior/src/chat/task-execution/worker.ts
@@ -333,6 +333,9 @@ function createConversationStopSignal(args: {
     close(): void {
       if (timer) clearInterval(timer);
     },
+    isEnabled(): boolean {
+      return listening;
+    },
     wasObserved(): boolean {
       return listening && controller.signal.aborted;
     },
@@ -654,6 +657,7 @@ async function processConversationWorkInContext(
       } finally {
         stop.close();
       }
+      resumeIfStopped ||= stop.isEnabled();
       hasRun = true;
       if (result.status === "lost_lease") {
         await requestLostLeaseRecovery({
@@ -779,7 +783,6 @@ async function processConversationWorkInContext(
       }
 
       if (result.status === "paused") {
-        resumeIfStopped = true;
         break;
       }
 

--- a/packages/junior/tests/component/task-execution/conversation-work.test.ts
+++ b/packages/junior/tests/component/task-execution/conversation-work.test.ts
@@ -1708,12 +1708,14 @@ describe("conversation work execution", () => {
 
     await appendInboundMessage({
       message: inboundMessage("m3", {
-        createdAtMs: 3_000,
-        receivedAtMs: 3_000,
+        // The append happens after the stop. Equal timestamps must not make
+        // this later message part of the stop request.
+        createdAtMs: 2_000,
+        receivedAtMs: 2_000,
       }),
-      nowMs: 3_000,
+      nowMs: 2_000,
     });
-    currentNowMs = 3_000;
+    currentNowMs = 2_000;
     finishRun.resolve();
 
     await expect(running).resolves.toEqual({ status: "pending_requeued" });
@@ -1763,7 +1765,7 @@ describe("conversation work execution", () => {
     ).resolves.toMatchObject({
       execution: {
         status: "paused",
-        stop: expect.objectContaining({ requestedAtMs: 2_000 }),
+        stop: expect.objectContaining({ inboundMessageIds: [] }),
       },
     });
 

--- a/packages/junior/tests/component/task-execution/conversation-work.test.ts
+++ b/packages/junior/tests/component/task-execution/conversation-work.test.ts
@@ -1788,6 +1788,87 @@ describe("conversation work execution", () => {
     });
   });
 
+  it("resumes a stop written after the adapter returns", async () => {
+    const queue = createConversationWorkQueueTestAdapter();
+    const state = getStateAdapter();
+    const completionBlocked = deferred<void>();
+    const releaseCompletion = deferred<void>();
+    const mutationLockKey = `junior:conversation:v2:mutation:${CONVERSATION_ID}`;
+    let holdCompletion = false;
+    const workerState = new Proxy(state, {
+      get(target, prop, receiver) {
+        if (prop === "acquireLock") {
+          return async (key: string, ttlMs: number) => {
+            if (holdCompletion && key === mutationLockKey) {
+              holdCompletion = false;
+              completionBlocked.resolve();
+              await releaseCompletion.promise;
+            }
+            return target.acquireLock(key, ttlMs);
+          };
+        }
+        const value = Reflect.get(target, prop, receiver);
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    }) as StateAdapter;
+
+    await requestConversationWork({
+      conversationId: CONVERSATION_ID,
+      destination: SLACK_DESTINATION,
+      nowMs: 1_000,
+      state,
+    });
+    const running = processConversationWork(conversationQueueMessage(), {
+      queue,
+      state: workerState,
+      run: async (context) => {
+        const signal = context.stopSignal?.();
+        if (!signal) throw new Error("Expected a Conversation stop signal");
+        expect(signal.aborted).toBe(false);
+        holdCompletion = true;
+        return { status: "completed" };
+      },
+    });
+
+    await completionBlocked.promise;
+    await expect(
+      stopConversationWork({
+        conversationId: CONVERSATION_ID,
+        nowMs: 2_000,
+        state,
+      }),
+    ).resolves.toMatchObject({ status: "requested" });
+    releaseCompletion.resolve();
+
+    await expect(running).resolves.toEqual({ status: "pending_requeued" });
+    await expect(
+      getConversationWorkState({ conversationId: CONVERSATION_ID, state }),
+    ).resolves.toMatchObject({
+      execution: {
+        status: "paused",
+        stop: expect.objectContaining({ runId: expect.any(String) }),
+      },
+    });
+
+    await expect(
+      processConversationWork(queue.takeMessage(), {
+        queue,
+        state: workerState,
+        run: async (context) => {
+          const signal = context.stopSignal?.();
+          if (!signal) throw new Error("Expected a Conversation stop signal");
+          expect(signal.aborted).toBe(true);
+          return { status: "completed" };
+        },
+      }),
+    ).resolves.toEqual({ status: "completed" });
+    await expect(
+      getConversationWorkState({ conversationId: CONVERSATION_ID, state }),
+    ).resolves.toMatchObject({
+      execution: { status: "idle", stop: undefined },
+    });
+  });
+
   it("reports lost lease after periodic check-in loses ownership", async () => {
     vi.useFakeTimers({ now: 1_000 });
     const queue = createConversationWorkQueueTestAdapter();

--- a/packages/junior/tests/component/task-execution/conversation-work.test.ts
+++ b/packages/junior/tests/component/task-execution/conversation-work.test.ts
@@ -25,6 +25,7 @@ import {
   requestConversationWork,
   releaseConversationWork,
   startConversationWork,
+  stopConversationWork,
   type InboundMessage,
 } from "@/chat/task-execution/store";
 import {
@@ -1654,6 +1655,135 @@ describe("conversation work execution", () => {
 
     finish.resolve();
     await expect(running).resolves.toEqual({ status: "completed" });
+  });
+
+  it("observes a remote stop and removes older human mailbox work", async () => {
+    vi.useFakeTimers({ now: 1_000 });
+    let currentNowMs = 1_000;
+    const queue = createConversationWorkQueueTestAdapter();
+    await appendInboundMessage({ message: inboundMessage("m1"), nowMs: 1_000 });
+    const entered = deferred<void>();
+    const stopObserved = deferred<void>();
+    const finishRun = deferred<void>();
+
+    const running = processConversationWork(conversationQueueMessage(), {
+      nowMs: () => currentNowMs,
+      queue,
+      softYieldAfterMs: 1_000,
+      run: async (context) => {
+        await context.attempt.ack();
+        const signal = context.stopSignal?.();
+        if (!signal) throw new Error("Expected a Conversation stop signal");
+        if (signal.aborted) {
+          stopObserved.resolve();
+        } else {
+          signal.addEventListener("abort", () => stopObserved.resolve(), {
+            once: true,
+          });
+        }
+        entered.resolve();
+        await stopObserved.promise;
+        await finishRun.promise;
+        return { status: "completed" };
+      },
+    });
+
+    await entered.promise;
+    await appendInboundMessage({
+      message: inboundMessage("m2", {
+        createdAtMs: 1_500,
+        receivedAtMs: 1_500,
+      }),
+      nowMs: 1_500,
+    });
+
+    await expect(
+      stopConversationWork({
+        conversationId: CONVERSATION_ID,
+        nowMs: 2_000,
+      }),
+    ).resolves.toMatchObject({ status: "requested" });
+    await vi.advanceTimersByTimeAsync(500);
+    await stopObserved.promise;
+
+    await appendInboundMessage({
+      message: inboundMessage("m3", {
+        createdAtMs: 3_000,
+        receivedAtMs: 3_000,
+      }),
+      nowMs: 3_000,
+    });
+    currentNowMs = 3_000;
+    finishRun.resolve();
+
+    await expect(running).resolves.toEqual({ status: "pending_requeued" });
+    await expect(
+      getConversationWorkState({ conversationId: CONVERSATION_ID }),
+    ).resolves.toMatchObject({
+      execution: { stop: undefined },
+      messages: [expect.objectContaining({ inboundMessageId: "m3" })],
+    });
+  });
+
+  it("resumes a paused Turn when its stop missed the live poll", async () => {
+    vi.useFakeTimers({ now: 1_000 });
+    let currentNowMs = 1_000;
+    const queue = createConversationWorkQueueTestAdapter();
+    await appendInboundMessage({ message: inboundMessage("m1"), nowMs: 1_000 });
+    const entered = deferred<void>();
+    const finish = deferred<void>();
+
+    const running = processConversationWork(conversationQueueMessage(), {
+      nowMs: () => currentNowMs,
+      queue,
+      run: async (context) => {
+        await context.attempt.ack();
+        const signal = context.stopSignal?.();
+        if (!signal) throw new Error("Expected a Conversation stop signal");
+        expect(signal.aborted).toBe(false);
+        entered.resolve();
+        await finish.promise;
+        return { status: "paused" };
+      },
+    });
+
+    await entered.promise;
+    currentNowMs = 2_000;
+    await expect(
+      stopConversationWork({
+        conversationId: CONVERSATION_ID,
+        nowMs: currentNowMs,
+      }),
+    ).resolves.toMatchObject({ status: "requested" });
+    finish.resolve();
+
+    await expect(running).resolves.toEqual({ status: "pending_requeued" });
+    await expect(
+      getConversationWorkState({ conversationId: CONVERSATION_ID }),
+    ).resolves.toMatchObject({
+      execution: {
+        status: "paused",
+        stop: expect.objectContaining({ requestedAtMs: 2_000 }),
+      },
+    });
+
+    await expect(
+      processConversationWork(queue.takeMessage(), {
+        nowMs: () => currentNowMs,
+        queue,
+        run: async (context) => {
+          const signal = context.stopSignal?.();
+          if (!signal) throw new Error("Expected a Conversation stop signal");
+          expect(signal.aborted).toBe(true);
+          return { status: "completed" };
+        },
+      }),
+    ).resolves.toEqual({ status: "completed" });
+    await expect(
+      getConversationWorkState({ conversationId: CONVERSATION_ID }),
+    ).resolves.toMatchObject({
+      execution: { status: "idle", stop: undefined },
+    });
   });
 
   it("reports lost lease after periodic check-in loses ownership", async () => {

--- a/packages/junior/tests/integration/web-auth-orchestration.test.ts
+++ b/packages/junior/tests/integration/web-auth-orchestration.test.ts
@@ -1,9 +1,8 @@
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { stopApiConversationTurn } from "@/chat/api-turns/stop";
 import { apiTurnIdForMessage } from "@/chat/api-turns/work";
-import {
-  getLatestMcpAuthSessionForUserProvider,
-} from "@/chat/mcp/auth-store";
+import { getLatestMcpAuthSessionForUserProvider } from "@/chat/mcp/auth-store";
 import { disconnectStateAdapter } from "@/chat/state/adapter";
 import { listTurnSummaries } from "@/chat/task-execution/checkpoint";
 import {
@@ -93,9 +92,9 @@ describe("web auth orchestration", () => {
       q.pendingMessages(started.conversationId),
     ).resolves.not.toHaveProperty("authorization");
     const history = await q.historyTexts(started.conversationId);
-    expect(history.some((text) => text.includes("Eval Auth tool completed"))).toBe(
-      true,
-    );
+    expect(
+      history.some((text) => text.includes("Eval Auth tool completed")),
+    ).toBe(true);
     await expect(listTurnSummaries(started.conversationId)).resolves.toEqual(
       expect.arrayContaining([
         expect.objectContaining({ state: "completed", surface: "api" }),
@@ -154,8 +153,78 @@ describe("web auth orchestration", () => {
     });
     const history = await q.historyTexts(started.conversationId);
     expect(
-      history.some((text) => text.includes("Answered without waiting for auth")),
+      history.some((text) =>
+        text.includes("Answered without waiting for auth"),
+      ),
     ).toBe(true);
+  });
+
+  it("stops queued and auth-paused web Turns without process state", async () => {
+    const q = await createConversationWorkWebHarness({
+      modelStream: streamMcpSearch("This response must not run."),
+    });
+    const started = await q.start({
+      idempotencyKey: "web-auth-stop-1",
+      message: "connect eval-auth first",
+    });
+    await q.drain();
+    await expectWebMcpAuthParked({
+      harness: q,
+      conversationId: started.conversationId,
+    });
+    const parkedTurnId = apiTurnIdForMessage(started.messageId);
+
+    await q.continue({
+      conversationId: started.conversationId,
+      idempotencyKey: "web-auth-stop-2",
+      message: "cancel this queued follow-up",
+    });
+    await expect(
+      stopApiConversationTurn({
+        conversationId: started.conversationId,
+        conversationStore: q.conversationStore,
+        queue: q.queue,
+        state: q.state,
+      }),
+    ).resolves.toMatchObject({ status: "requested" });
+    await q.drain();
+
+    await expect(listTurnSummaries(started.conversationId)).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          turnId: parkedTurnId,
+          state: "paused",
+          resumeReason: "auth",
+        }),
+      ]),
+    );
+    await expect(
+      q.pendingMessages(started.conversationId),
+    ).resolves.toHaveProperty("authorization");
+
+    await expect(
+      stopApiConversationTurn({
+        conversationId: started.conversationId,
+        conversationStore: q.conversationStore,
+        queue: q.queue,
+        state: q.state,
+      }),
+    ).resolves.toMatchObject({ status: "requested" });
+    await q.drain();
+
+    await expect(listTurnSummaries(started.conversationId)).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          turnId: parkedTurnId,
+          state: "abandoned",
+        }),
+      ]),
+    );
+    await expect(
+      q.pendingMessages(started.conversationId),
+    ).resolves.not.toHaveProperty("authorization");
+    await expectMcpAuthCleared(started.conversationId);
+    expect(q.agentRuns).toHaveLength(1);
   });
 
   it("does not resume a superseded web auth turn after a late OAuth callback", async () => {


### PR DESCRIPTION
API callers can now stop an active Turn even when the stop request reaches a different serverless worker. Core stores the stop in shared Conversation execution state. The active API worker observes it, aborts the Turn, and removes only the queued human inputs that existed when the stop was requested. Later input remains queued. A stop also wakes yielded or OAuth-paused work so another execution slice can finish the cancellation.

Core also adds exclusive mailbox admission so a caller can reject an overlapping prompt atomically. Slack does not opt into stop polling. This PR adds no ACP protocol, SSE, authentication, or routes; #1589 is stacked on it and uses these two provider-neutral capabilities.
