### PR TITLE
ref(memory): remove viewer collection facade

### DIFF
--- a/packages/junior-memory/src/api.ts
+++ b/packages/junior-memory/src/api.ts
@@ -12,10 +12,14 @@ import {
 } from "@sentry/junior-plugin-api";
 import type { MemoryDb } from "./store";
 import {
-  createViewerMemories,
+  archiveMemory,
+  getMemory,
+  getMemoryStats,
+  getMemoryTimeline,
   InvalidMemoryCursorError,
+  listMemories,
   MemoryNotFoundError,
-  type ViewerMemory,
+  type MemoryView,
 } from "./viewer";
 import { MEMORY_SOURCE_PLATFORMS } from "./types";
 
@@ -108,7 +112,7 @@ function json(body: unknown, status = 200): Response {
   });
 }
 
-function apiMemory(memory: ViewerMemory): z.output<typeof memoryApiSchema> {
+function apiMemory(memory: MemoryView): z.output<typeof memoryApiSchema> {
   return {
     content: memory.content,
     createdAt: new Date(memory.createdAtMs).toISOString(),
@@ -132,7 +136,7 @@ function viewerEmail(context: unknown): string | undefined {
   return parsed.data.auth.user.email?.trim().toLowerCase() || undefined;
 }
 
-/** Create the authenticated viewer-memory REST app. */
+/** Create the authenticated memory REST app. */
 export function createMemoryApi(options: MemoryApiOptions): PluginRouteApp {
   return {
     async fetch(request, context) {
@@ -155,13 +159,13 @@ export function createMemoryApi(options: MemoryApiOptions): PluginRouteApp {
 
       const viewer = await options.users.resolve(email);
       if (!viewer) return json({ error: "Authentication required." }, 401);
+      const userId = viewer.id;
 
-      const memories = createViewerMemories(options.db, viewer);
       try {
         if (isDashboard && isRead) {
           const [stats, days, extractionDays, recallDays] = await Promise.all([
-            memories.stats(),
-            memories.timeline({ days: 90 }),
+            getMemoryStats(options.db, userId),
+            getMemoryTimeline(options.db, userId, 90),
             options.eventStats.costsByDay({
               days: 90,
               eventName: "memories_captured",
@@ -196,7 +200,7 @@ export function createMemoryApi(options: MemoryApiOptions): PluginRouteApp {
             limit: url.searchParams.get("limit") ?? undefined,
             q: url.searchParams.get("q") ?? undefined,
           });
-          const page = await memories.list({
+          const page = await listMemories(options.db, userId, {
             cursor: query.cursor,
             limit: query.limit,
             ...(query.q ? { query: query.q } : undefined),
@@ -214,19 +218,23 @@ export function createMemoryApi(options: MemoryApiOptions): PluginRouteApp {
         }
 
         if (memoryPath && isRead) {
-          const memory = memoryApiSchema.parse(
-            apiMemory(await memories.get(decodeURIComponent(memoryPath[1]!))),
+          const memory = await getMemory(
+            options.db,
+            userId,
+            decodeURIComponent(memoryPath[1]!),
           );
+          const body = memoryApiSchema.parse(apiMemory(memory));
           return request.method === "HEAD"
             ? new Response(null, {
                 headers: { "cache-control": "no-store" },
                 status: 200,
               })
-            : json(memory);
+            : json(body);
         }
 
         if (memoryPath && request.method === "DELETE") {
-          await memories.archive(decodeURIComponent(memoryPath[1]!));
+          const id = decodeURIComponent(memoryPath[1]!);
+          await archiveMemory(options.db, userId, id);
           return new Response(null, {
             headers: { "cache-control": "no-store" },
             status: 204,

--- a/packages/junior-memory/src/user-pages.ts
+++ b/packages/junior-memory/src/user-pages.ts
@@ -1,10 +1,6 @@
 /** Render memory in Junior's User page format. */
 import type { PluginUserPageDefinition } from "@sentry/junior-plugin-api";
-import {
-  createViewerMemories,
-  type MemoryVisibility,
-  type ViewerMemory,
-} from "./viewer";
+import { listMemories, type MemoryVisibility, type MemoryView } from "./viewer";
 import type { MemoryDb } from "./store";
 
 function titleCase(value: string): string {
@@ -19,7 +15,7 @@ function rememberedDate(createdAtMs: number): string {
   }).format(new Date(createdAtMs));
 }
 
-function originLabel(origin: ViewerMemory["origin"]): string {
+function originLabel(origin: MemoryView["origin"]): string {
   if (origin === "automatic") return "Automatic";
   if (origin === "explicit") return "Explicit";
   return "Other";
@@ -53,8 +49,7 @@ export function createMemoryUserPage(): PluginUserPageDefinition {
     description:
       "Personal and public memories Junior can use across conversations.",
     async read(ctx, input) {
-      const memories = createViewerMemories(ctx.db as MemoryDb, ctx.viewer);
-      const page = await memories.list({
+      const page = await listMemories(ctx.db as MemoryDb, ctx.viewer.id, {
         cursor: input.cursor,
         ...pageFilter(input.filter),
         limit: input.limit,

--- a/packages/junior-memory/src/viewer.ts
+++ b/packages/junior-memory/src/viewer.ts
@@ -1,5 +1,5 @@
 /**
- * Memory reads for an authenticated User.
+ * Memory access for an authenticated User.
  *
  * Every User can read public memory and private memory that they own.
  */
@@ -46,24 +46,20 @@ const pageInputSchema = z
     visibility: memoryVisibilitySchema.optional(),
   })
   .strict();
-const timelineInputSchema = z
-  .object({
-    days: z.number().int().min(1).max(365),
-  })
-  .strict();
+const timelineDaysSchema = z.number().int().min(1).max(365);
 
 /** Access label returned by dashboard and REST memory views. */
 export type MemoryVisibility = z.output<typeof memoryVisibilitySchema>;
 
 /** Memory fields returned to an authenticated User. */
-export type ViewerMemory = MemoryRecord & {
+export type MemoryView = MemoryRecord & {
   origin: "automatic" | "explicit" | "other";
   sourcePlatform: MemorySourcePlatform;
   visibility: MemoryVisibility;
 };
 
 interface MemoryPage {
-  memories: ViewerMemory[];
+  memories: MemoryView[];
   nextCursor?: string;
 }
 
@@ -138,15 +134,15 @@ function searchTerms(query: string): string[] {
   ];
 }
 
-function memoryOrigin(idempotencyKey: string | null): ViewerMemory["origin"] {
+function memoryOrigin(idempotencyKey: string | null): MemoryView["origin"] {
   if (idempotencyKey?.startsWith("session:")) return "automatic";
   if (idempotencyKey?.startsWith("tool:")) return "explicit";
   return "other";
 }
 
-function toViewerMemory(
+function toMemoryView(
   row: typeof juniorMemoryMemories.$inferSelect,
-): ViewerMemory {
+): MemoryView {
   const memory = parseMemoryRow(row);
   return {
     ...memory,
@@ -157,12 +153,11 @@ function toViewerMemory(
 }
 
 function cursorFilters(input: MemoryPageInput) {
-  const query = input.query?.trim() || undefined;
   return {
-    ...(input.kind ? { kind: input.kind } : undefined),
-    ...(input.origin ? { origin: input.origin } : undefined),
-    ...(query ? { query } : undefined),
-    ...(input.visibility ? { visibility: input.visibility } : undefined),
+    kind: input.kind,
+    origin: input.origin,
+    query: input.query?.trim() || undefined,
+    visibility: input.visibility,
   };
 }
 
@@ -199,217 +194,200 @@ function encodeCursor(
   ).toString("base64url");
 }
 
-/** Build memory operations for one authenticated User. */
-export function createViewerMemories(db: MemoryDb, user: { id: string }) {
-  return {
-    async archive(id: string) {
-      const memoryId = nonEmptyStringSchema.parse(id);
-      const nowMs = Date.now();
-      const updated = await db
-        .update(juniorMemoryMemories)
-        .set({
-          archivedAtMs: nowMs,
-          archiveReason: "user_removed",
-        })
-        .where(
-          and(
-            activeMemoryPredicate(user.id, nowMs, "private"),
-            eq(juniorMemoryMemories.id, memoryId),
-          ),
-        )
-        .returning();
-      if (!updated[0]) {
-        throw new MemoryNotFoundError();
-      }
-      await db
-        .delete(juniorMemoryEmbeddings)
-        .where(eq(juniorMemoryEmbeddings.memoryId, memoryId));
-      return parseMemoryRow(updated[0]);
-    },
+/** Archive one active private memory owned by the authenticated User. */
+export async function archiveMemory(db: MemoryDb, userId: string, id: string) {
+  const memoryId = nonEmptyStringSchema.parse(id);
+  const nowMs = Date.now();
+  const updated = await db
+    .update(juniorMemoryMemories)
+    .set({
+      archivedAtMs: nowMs,
+      archiveReason: "user_removed",
+    })
+    .where(
+      and(
+        activeMemoryPredicate(userId, nowMs, "private"),
+        eq(juniorMemoryMemories.id, memoryId),
+      ),
+    )
+    .returning();
+  if (!updated[0]) throw new MemoryNotFoundError();
+  await db
+    .delete(juniorMemoryEmbeddings)
+    .where(eq(juniorMemoryEmbeddings.memoryId, memoryId));
+  return parseMemoryRow(updated[0]);
+}
 
-    async get(id: string) {
-      const memoryId = nonEmptyStringSchema.parse(id);
-      const nowMs = Date.now();
-      const rows = await db
-        .select()
-        .from(juniorMemoryMemories)
-        .where(
-          and(
-            activeMemoryPredicate(user.id, nowMs),
-            eq(juniorMemoryMemories.id, memoryId),
-          ),
-        )
-        .limit(1);
-      if (!rows[0]) {
-        throw new MemoryNotFoundError();
-      }
-      return toViewerMemory(rows[0]);
-    },
+/** Read one active memory visible to the authenticated User. */
+export async function getMemory(
+  db: MemoryDb,
+  userId: string,
+  id: string,
+): Promise<MemoryView> {
+  const memoryId = nonEmptyStringSchema.parse(id);
+  const nowMs = Date.now();
+  const rows = await db
+    .select()
+    .from(juniorMemoryMemories)
+    .where(
+      and(
+        activeMemoryPredicate(userId, nowMs),
+        eq(juniorMemoryMemories.id, memoryId),
+      ),
+    )
+    .limit(1);
+  if (!rows[0]) throw new MemoryNotFoundError();
+  return toMemoryView(rows[0]);
+}
 
-    async list(input: MemoryPageInput): Promise<MemoryPage> {
-      input = pageInputSchema.parse(input);
-      const filters = cursorFilters(input);
-      const cursor = decodeCursor(input.cursor, filters);
-      const active = activeMemoryPredicate(
-        user.id,
-        Date.now(),
-        input.visibility,
-      );
-      const createdBefore = cursor
-        ? or(
-            lt(juniorMemoryMemories.createdAtMs, cursor.createdAtMs),
-            and(
-              eq(juniorMemoryMemories.createdAtMs, cursor.createdAtMs),
-              gt(juniorMemoryMemories.id, cursor.id),
+/** List one stable page of active memory visible to the authenticated User. */
+export async function listMemories(
+  db: MemoryDb,
+  userId: string,
+  input: MemoryPageInput,
+): Promise<MemoryPage> {
+  input = pageInputSchema.parse(input);
+  const filters = cursorFilters(input);
+  const cursor = decodeCursor(input.cursor, filters);
+  const active = activeMemoryPredicate(userId, Date.now(), input.visibility);
+  const createdBefore = cursor
+    ? or(
+        lt(juniorMemoryMemories.createdAtMs, cursor.createdAtMs),
+        and(
+          eq(juniorMemoryMemories.createdAtMs, cursor.createdAtMs),
+          gt(juniorMemoryMemories.id, cursor.id),
+        ),
+      )
+    : undefined;
+  const terms = input.query ? searchTerms(input.query) : [];
+  const search =
+    input.query === undefined
+      ? undefined
+      : terms.length === 0
+        ? sql`false`
+        : or(
+            ...terms.map((term) =>
+              ilike(juniorMemoryMemories.content, `%${term}%`),
             ),
-          )
+          );
+  const kind = input.kind
+    ? eq(juniorMemoryMemories.kind, input.kind)
+    : undefined;
+  const origin =
+    input.origin === "automatic"
+      ? like(juniorMemoryMemories.idempotencyKey, "session:%")
+      : input.origin === "explicit"
+        ? like(juniorMemoryMemories.idempotencyKey, "tool:%")
         : undefined;
-      const terms = input.query ? searchTerms(input.query) : [];
-      const search =
-        input.query === undefined
-          ? undefined
-          : terms.length === 0
-            ? sql`false`
-            : or(
-                ...terms.map((term) =>
-                  ilike(juniorMemoryMemories.content, `%${term}%`),
-                ),
-              );
-      const kind = input.kind
-        ? eq(juniorMemoryMemories.kind, input.kind)
-        : undefined;
-      const origin =
-        input.origin === "automatic"
-          ? like(juniorMemoryMemories.idempotencyKey, "session:%")
-          : input.origin === "explicit"
-            ? like(juniorMemoryMemories.idempotencyKey, "tool:%")
-            : undefined;
-      const rows = await db
-        .select()
-        .from(juniorMemoryMemories)
-        .where(and(active, createdBefore, search, kind, origin))
-        .orderBy(
-          desc(juniorMemoryMemories.createdAtMs),
-          asc(juniorMemoryMemories.id),
-        )
-        .limit(input.limit + 1);
-      const hasNextPage = rows.length > input.limit;
-      const memories = rows.slice(0, input.limit).map(toViewerMemory);
-      const last = memories.at(-1);
-      return {
-        memories,
-        ...(hasNextPage && last
-          ? {
-              nextCursor: encodeCursor(
-                { createdAtMs: last.createdAtMs, id: last.id },
-                filters,
-              ),
-            }
-          : undefined),
-      };
-    },
+  const rows = await db
+    .select()
+    .from(juniorMemoryMemories)
+    .where(and(active, createdBefore, search, kind, origin))
+    .orderBy(
+      desc(juniorMemoryMemories.createdAtMs),
+      asc(juniorMemoryMemories.id),
+    )
+    .limit(input.limit + 1);
+  const memories = rows.slice(0, input.limit).map(toMemoryView);
+  const last = memories.at(-1);
+  if (rows.length <= input.limit || !last) return { memories };
+  const next = { createdAtMs: last.createdAtMs, id: last.id };
+  return { memories, nextCursor: encodeCursor(next, filters) };
+}
 
-    async stats() {
-      const nowMs = Date.now();
-      const active = activeMemoryPredicate(user.id, nowMs);
-      const [counts] = await db
-        .select({
-          active: sql<number>`count(*)`.mapWith(Number),
-          automatic:
-            sql<number>`count(*) filter (where ${juniorMemoryMemories.idempotencyKey} like 'session:%')`.mapWith(
-              Number,
-            ),
-          createdThirtyDays:
-            sql<number>`count(*) filter (where ${juniorMemoryMemories.createdAtMs} >= ${nowMs - 30 * DAY_MS})`.mapWith(
-              Number,
-            ),
-          embedded:
-            sql<number>`count(${juniorMemoryEmbeddings.memoryId})`.mapWith(
-              Number,
-            ),
-          explicit:
-            sql<number>`count(*) filter (where ${juniorMemoryMemories.idempotencyKey} like 'tool:%')`.mapWith(
-              Number,
-            ),
-          knowledge:
-            sql<number>`count(*) filter (where ${juniorMemoryMemories.kind} = 'knowledge')`.mapWith(
-              Number,
-            ),
-          private:
-            sql<number>`count(*) filter (where ${juniorMemoryMemories.scope} = 'private')`.mapWith(
-              Number,
-            ),
-          preference:
-            sql<number>`count(*) filter (where ${juniorMemoryMemories.kind} = 'preference')`.mapWith(
-              Number,
-            ),
-          procedure:
-            sql<number>`count(*) filter (where ${juniorMemoryMemories.kind} = 'procedure')`.mapWith(
-              Number,
-            ),
-          public:
-            sql<number>`count(*) filter (where ${juniorMemoryMemories.scope} = 'public')`.mapWith(
-              Number,
-            ),
-        })
-        .from(juniorMemoryMemories)
-        .leftJoin(
-          juniorMemoryEmbeddings,
-          eq(juniorMemoryEmbeddings.memoryId, juniorMemoryMemories.id),
-        )
-        .where(active);
-      return {
-        active: counts?.active ?? 0,
-        automatic: counts?.automatic ?? 0,
-        createdThirtyDays: counts?.createdThirtyDays ?? 0,
-        embedded: counts?.embedded ?? 0,
-        explicit: counts?.explicit ?? 0,
-        knowledge: counts?.knowledge ?? 0,
-        private: counts?.private ?? 0,
-        preference: counts?.preference ?? 0,
-        procedure: counts?.procedure ?? 0,
-        public: counts?.public ?? 0,
-      };
-    },
+/** Summarize active memory visible to the authenticated User. */
+export async function getMemoryStats(db: MemoryDb, userId: string) {
+  const nowMs = Date.now();
+  const [counts] = await db
+    .select({
+      active: sql<number>`count(*)`.mapWith(Number),
+      automatic:
+        sql<number>`count(*) filter (where ${juniorMemoryMemories.idempotencyKey} like 'session:%')`.mapWith(
+          Number,
+        ),
+      createdThirtyDays:
+        sql<number>`count(*) filter (where ${juniorMemoryMemories.createdAtMs} >= ${nowMs - 30 * DAY_MS})`.mapWith(
+          Number,
+        ),
+      embedded: sql<number>`count(${juniorMemoryEmbeddings.memoryId})`.mapWith(
+        Number,
+      ),
+      explicit:
+        sql<number>`count(*) filter (where ${juniorMemoryMemories.idempotencyKey} like 'tool:%')`.mapWith(
+          Number,
+        ),
+      knowledge:
+        sql<number>`count(*) filter (where ${juniorMemoryMemories.kind} = 'knowledge')`.mapWith(
+          Number,
+        ),
+      private:
+        sql<number>`count(*) filter (where ${juniorMemoryMemories.scope} = 'private')`.mapWith(
+          Number,
+        ),
+      preference:
+        sql<number>`count(*) filter (where ${juniorMemoryMemories.kind} = 'preference')`.mapWith(
+          Number,
+        ),
+      procedure:
+        sql<number>`count(*) filter (where ${juniorMemoryMemories.kind} = 'procedure')`.mapWith(
+          Number,
+        ),
+      public:
+        sql<number>`count(*) filter (where ${juniorMemoryMemories.scope} = 'public')`.mapWith(
+          Number,
+        ),
+    })
+    .from(juniorMemoryMemories)
+    .leftJoin(
+      juniorMemoryEmbeddings,
+      eq(juniorMemoryEmbeddings.memoryId, juniorMemoryMemories.id),
+    )
+    .where(activeMemoryPredicate(userId, nowMs));
+  if (!counts) throw new Error("Memory stats query returned no row.");
+  return counts;
+}
 
-    async timeline(input: { days: number }) {
-      input = timelineInputSchema.parse(input);
-      const todayMs = Date.parse(`${utcDate(Date.now())}T00:00:00.000Z`);
-      const startMs = todayMs - (input.days - 1) * DAY_MS;
-      const rows = await db
-        .select({
-          date: sql<string>`to_char(to_timestamp(${juniorMemoryMemories.createdAtMs} / 1000.0) AT TIME ZONE 'UTC', 'YYYY-MM-DD')`.as(
-            "date",
-          ),
-          private:
-            sql<number>`count(*) filter (where ${juniorMemoryMemories.scope} = 'private')`.mapWith(
-              Number,
-            ),
-          public:
-            sql<number>`count(*) filter (where ${juniorMemoryMemories.scope} = 'public')`.mapWith(
-              Number,
-            ),
-        })
-        .from(juniorMemoryMemories)
-        .where(
-          and(
-            visibleScopePredicate(user.id),
-            gt(juniorMemoryMemories.createdAtMs, startMs - 1),
-          ),
-        )
-        .groupBy(
-          sql`to_char(to_timestamp(${juniorMemoryMemories.createdAtMs} / 1000.0) AT TIME ZONE 'UTC', 'YYYY-MM-DD')`,
-        );
-      const byDate = new Map(rows.map((row) => [row.date, row]));
-      return Array.from({ length: input.days }, (_, index) => {
-        const date = utcDate(startMs + index * DAY_MS);
-        const row = byDate.get(date);
-        return {
-          date,
-          private: row?.private ?? 0,
-          public: row?.public ?? 0,
-        };
-      });
-    },
-  };
+/** Read daily memory creation totals visible to the authenticated User in UTC. */
+export async function getMemoryTimeline(
+  db: MemoryDb,
+  userId: string,
+  days: number,
+) {
+  days = timelineDaysSchema.parse(days);
+  const todayMs = Date.parse(`${utcDate(Date.now())}T00:00:00.000Z`);
+  const startMs = todayMs - (days - 1) * DAY_MS;
+  const rows = await db
+    .select({
+      date: sql<string>`to_char(to_timestamp(${juniorMemoryMemories.createdAtMs} / 1000.0) AT TIME ZONE 'UTC', 'YYYY-MM-DD')`.as(
+        "date",
+      ),
+      private:
+        sql<number>`count(*) filter (where ${juniorMemoryMemories.scope} = 'private')`.mapWith(
+          Number,
+        ),
+      public:
+        sql<number>`count(*) filter (where ${juniorMemoryMemories.scope} = 'public')`.mapWith(
+          Number,
+        ),
+    })
+    .from(juniorMemoryMemories)
+    .where(
+      and(
+        visibleScopePredicate(userId),
+        gt(juniorMemoryMemories.createdAtMs, startMs - 1),
+      ),
+    )
+    .groupBy(
+      sql`to_char(to_timestamp(${juniorMemoryMemories.createdAtMs} / 1000.0) AT TIME ZONE 'UTC', 'YYYY-MM-DD')`,
+    );
+  const byDate = new Map(rows.map((row) => [row.date, row]));
+  return Array.from({ length: days }, (_, index) => {
+    const date = utcDate(startMs + index * DAY_MS);
+    const row = byDate.get(date);
+    return {
+      date,
+      private: row?.private ?? 0,
+      public: row?.public ?? 0,
+    };
+  });
 }

--- a/packages/junior-memory/tests/storage.test.ts
+++ b/packages/junior-memory/tests/storage.test.ts
@@ -42,7 +42,7 @@ import {
   createMemorySearchTool,
   type MemoryReviewer,
 } from "../src/tools";
-import { createViewerMemories } from "../src/viewer";
+import { listMemories } from "../src/viewer";
 import { createMemoryStore, type MemoryDb } from "../src/store";
 import type {
   MemorySupersessionDecider,
@@ -1784,11 +1784,9 @@ describe("memory plugin storage", () => {
         },
       ]);
 
-      const listed = await createViewerMemories(memoryDb(fixture), {
-        email: "dashboard@example.com",
-        id: runtime.userId,
-        identities: [],
-      }).list({ limit: 10 });
+      const listed = await listMemories(memoryDb(fixture), runtime.userId, {
+        limit: 10,
+      });
       expect(listed.memories.map((memory) => memory.id)).toEqual([
         created.memory.id,
       ]);


### PR DESCRIPTION
Replaces the memory viewer object facade with named archive, get, list, stats, and timeline operations used directly by the REST API and User page. Authenticated User authority, public and private visibility, archive rules, cursor behavior, ordering, filters, and response shapes stay unchanged.

This is a hard cutover with no compatibility wrapper. The refactor is a small net deletion and keeps the existing real-SQL integration coverage.

Refs #1600
