### PR TITLE
feat(code): add repository and code change analytics

### DIFF
--- a/TERMINOLOGY.md
+++ b/TERMINOLOGY.md
@@ -6,6 +6,12 @@ Canonical words used across Junior's code and documentation.
 
 - **Workspace**: a named recipe that selects repositories and setup
   instructions for a Sandbox snapshot.
+- **Repository**: a source-code repository known to Junior, regardless of its
+  hosting service.
+- **Code change**: a proposed change to a repository. GitHub calls it a pull
+  request. GitLab calls it a merge request.
+- **Commit**: one recorded repository revision. Its hosting service owns the
+  commit identifier.
 - **Sandbox**: an isolated execution environment for a run or snapshot build.
 - **Conversation**: the durable container for visible history and execution
   state, identified by a globally unique `conversationId`.

--- a/packages/junior-dashboard/src/app.ts
+++ b/packages/junior-dashboard/src/app.ts
@@ -496,6 +496,9 @@ function dashboardPagePaths(
   const paths: Array<{ nested?: boolean; path: string }> = [
     { path: basePath },
     {
+      path: basePath === "/" ? "/code" : `${basePath}/code`,
+    },
+    {
       nested: true,
       path: basePath === "/" ? "/conversations" : `${basePath}/conversations`,
     },

--- a/packages/junior-dashboard/src/client/App.tsx
+++ b/packages/junior-dashboard/src/client/App.tsx
@@ -26,6 +26,7 @@ import { isNewConversationPath } from "./conversations/conversationRoutes";
 import { ConversationWorkspace } from "./conversations/ConversationWorkspace";
 import { useConversationData } from "./conversations/queries";
 import { ComponentsPage } from "./pages/dev/ComponentsPage";
+import { CodePage } from "./pages/code/CodePage";
 import { LocationDetailPage } from "./pages/locations/LocationDetailPage";
 import { LocationsPage } from "./pages/locations/LocationsPage";
 import { PeoplePage } from "./pages/people/PeoplePage";
@@ -91,6 +92,7 @@ export function DashboardShell() {
       conversationDisplayTitle(mobileConversation)
     : undefined;
   const primaryNavItems = [
+    { key: "code", label: "Code", to: "/code" },
     ...(loggedIn
       ? [{ key: "tasks", label: "Tasks", to: "/tasks" }]
       : []),
@@ -297,6 +299,7 @@ export function DashboardShell() {
           }
           path="/"
         />
+        <Route element={<CodePage />} path="/code" />
         <Route
           element={<Navigate replace to="/" />}
           path="/conversations/new"

--- a/packages/junior-dashboard/src/client/api.ts
+++ b/packages/junior-dashboard/src/client/api.ts
@@ -4,6 +4,7 @@ import type { LocationDetailReport } from "@sentry/junior/api/schema";
 import {
   conversationFeedSchema,
   conversationStatsReportSchema,
+  codeOverviewReportSchema,
   statsReportSchema,
 } from "@sentry/junior/api/schema";
 import {
@@ -97,6 +98,16 @@ export function useConversationsData(status: "active" | "archived" = "active") {
         `/api/conversations${status === "archived" ? "?status=archived" : ""}`,
         signal,
       ),
+    retry: false,
+  });
+}
+
+/** Fetch repository and code change analytics. */
+export function useCodeOverviewData() {
+  return useQuery({
+    queryKey: ["dashboard", "code"],
+    queryFn: ({ signal }) =>
+      fetchDashboardJson(codeOverviewReportSchema, "/api/code", signal),
     retry: false,
   });
 }

--- a/packages/junior-dashboard/src/client/pages/code/CodePage.tsx
+++ b/packages/junior-dashboard/src/client/pages/code/CodePage.tsx
@@ -1,0 +1,184 @@
+import type { CodeOverviewReport } from "@sentry/junior/api/schema";
+import { CircleDot, GitMerge, GitPullRequest, LibraryBig } from "lucide-react";
+import { useCodeOverviewData } from "../../api";
+import { EmptyTelemetry } from "../../components/EmptyTelemetry";
+import { LoadingView } from "../../components/LoadingView";
+import { StatusChip } from "../../components/StatusChip";
+import { Card } from "../../components/layout/Card";
+import { PageHeader } from "../../components/layout/PageHeader";
+import { PageLayout } from "../../components/layout/PageLayout";
+import { StatCard } from "../../components/metrics/StatCard";
+import { formatCompactNumber } from "../../format";
+
+function mergeRate(value: number | undefined): string {
+  return value === undefined ? "—" : `${Math.round(value * 100)}%`;
+}
+
+function stateTone(state: "closed" | "merged" | "open") {
+  if (state === "merged") return "success" as const;
+  if (state === "open") return "info" as const;
+  return "neutral" as const;
+}
+
+/** Render code analytics and recent code changes. */
+export function CodePage() {
+  const query = useCodeOverviewData();
+  if (!query.data && !query.error) {
+    return (
+      <PageLayout>
+        <LoadingView label="Loading code activity" />
+      </PageLayout>
+    );
+  }
+  return (
+    <PageLayout>
+      <PageHeader
+        description="Repositories and code changes created by Junior."
+        title="Code"
+      />
+      {query.error ? (
+        <EmptyTelemetry>
+          Code activity is unavailable. Try refreshing the dashboard.
+        </EmptyTelemetry>
+      ) : null}
+      {query.data ? <CodeOverview data={query.data} /> : null}
+    </PageLayout>
+  );
+}
+
+function CodeOverview(props: { data: CodeOverviewReport }) {
+  const data = props.data;
+  return (
+    <>
+      <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+        <StatCard
+          detail="Across all repositories"
+          icon={CircleDot}
+          label="Open changes"
+          value={formatCompactNumber(data.summary.open)}
+        />
+        <StatCard
+          detail="In the last 30 days"
+          icon={GitPullRequest}
+          label="Created"
+          value={formatCompactNumber(data.summary.created)}
+        />
+        <StatCard
+          detail="In the last 30 days"
+          icon={GitMerge}
+          label="Merged"
+          value={formatCompactNumber(data.summary.merged)}
+        />
+        <StatCard
+          detail="Share of completed changes that merged"
+          icon={LibraryBig}
+          label="Merge rate"
+          value={mergeRate(data.summary.mergeRate)}
+        />
+      </div>
+      <Card as="section">
+        <div className="border-b border-dashboard-border-subtle px-4 py-3 font-display text-lg text-dashboard-text">
+          Repositories
+        </div>
+        {data.repositories.length === 0 ? (
+          <div className="p-4">
+            <EmptyTelemetry>
+              No code activity has been recorded yet.
+            </EmptyTelemetry>
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full border-collapse text-left">
+              <thead className="font-mono text-xs uppercase tracking-[0.1em] text-dashboard-text-muted">
+                <tr className="border-b border-dashboard-border-subtle">
+                  <th className="px-4 py-2.5 font-medium">Repository</th>
+                  <th className="px-4 py-2.5 text-right font-medium">Open</th>
+                  <th className="px-4 py-2.5 text-right font-medium">
+                    Created
+                  </th>
+                  <th className="px-4 py-2.5 text-right font-medium">Merged</th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.repositories.map((repository) => (
+                  <tr
+                    className="border-b border-dashboard-border-subtle last:border-b-0"
+                    key={repository.id}
+                  >
+                    <td className="px-4 py-3">
+                      <div className="font-display text-sm text-dashboard-text">
+                        {repository.url ? (
+                          <a
+                            className="text-inherit no-underline hover:text-cyan-100"
+                            href={repository.url}
+                            rel="noreferrer"
+                            target="_blank"
+                          >
+                            {repository.name}
+                          </a>
+                        ) : (
+                          repository.name
+                        )}
+                      </div>
+                      <div className="mt-1 font-mono text-xs text-dashboard-text-muted">
+                        {repository.provider}
+                      </div>
+                    </td>
+                    <td className="px-4 py-3 text-right font-mono text-sm text-dashboard-text">
+                      {repository.open}
+                    </td>
+                    <td className="px-4 py-3 text-right font-mono text-sm text-dashboard-text">
+                      {repository.created}
+                    </td>
+                    <td className="px-4 py-3 text-right font-mono text-sm text-dashboard-text">
+                      {repository.merged}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </Card>
+      {data.changes.length > 0 ? (
+        <Card as="section">
+          <div className="border-b border-dashboard-border-subtle px-4 py-3 font-display text-lg text-dashboard-text">
+            Recent changes
+          </div>
+          <div>
+            {data.changes.map((change) => (
+              <div
+                className="flex min-w-0 items-center justify-between gap-4 border-b border-dashboard-border-subtle px-4 py-3 last:border-b-0"
+                key={change.id}
+              >
+                <div className="min-w-0">
+                  <div className="truncate font-display text-sm text-dashboard-text">
+                    {change.url ? (
+                      <a
+                        className="text-inherit no-underline hover:text-cyan-100"
+                        href={change.url}
+                        rel="noreferrer"
+                        target="_blank"
+                      >
+                        {change.title ??
+                          `${change.repository} #${change.number}`}
+                      </a>
+                    ) : (
+                      (change.title ?? `${change.repository} #${change.number}`)
+                    )}
+                  </div>
+                  <div className="mt-1 truncate font-mono text-xs text-dashboard-text-muted">
+                    {change.repository} #{change.number} · {change.provider}
+                  </div>
+                </div>
+                <StatusChip size="compact" tone={stateTone(change.state)}>
+                  {change.state}
+                </StatusChip>
+              </div>
+            ))}
+          </div>
+        </Card>
+      ) : null}
+    </>
+  );
+}

--- a/packages/junior-dashboard/src/mock-reporting/fixtures.ts
+++ b/packages/junior-dashboard/src/mock-reporting/fixtures.ts
@@ -14,6 +14,7 @@ import type {
   ConversationStatsItem,
   ConversationStatsReport,
   ConversationSummaryReport,
+  CodeOverviewReport,
   LocationDetailReport,
   LocationActorSummaryReport,
   LocationActivityDayReport,
@@ -26,6 +27,69 @@ import type {
   TaskList,
   TaskSummary,
 } from "@sentry/junior/api/schema";
+
+/** Build code activity for local dashboard development and QA. */
+export function readMockCodeOverview(nowMs = Date.now()): CodeOverviewReport {
+  const windowEnd = new Date(nowMs).toISOString();
+  const windowStart = new Date(nowMs - 30 * 86_400_000).toISOString();
+  return {
+    changes: [
+      {
+        id: "6:github:9001",
+        number: 42,
+        openedAt: new Date(nowMs - 2 * 86_400_000).toISOString(),
+        provider: "github",
+        repository: "getsentry/payments",
+        state: "open",
+        title: "Reduce checkout latency",
+        url: "https://github.com/getsentry/payments/pull/42",
+      },
+      {
+        id: "6:github:9002",
+        mergedAt: new Date(nowMs - 4 * 86_400_000).toISOString(),
+        number: 781,
+        openedAt: new Date(nowMs - 6 * 86_400_000).toISOString(),
+        provider: "github",
+        repository: "getsentry/junior",
+        state: "merged",
+        title: "Keep repository context across turns",
+        url: "https://github.com/getsentry/junior/pull/781",
+      },
+    ],
+    generatedAt: windowEnd,
+    repositories: [
+      {
+        closed: 1,
+        created: 5,
+        id: "6:github:2001",
+        merged: 4,
+        name: "getsentry/junior",
+        open: 1,
+        provider: "github",
+        url: "https://github.com/getsentry/junior",
+      },
+      {
+        closed: 0,
+        created: 3,
+        id: "6:github:2002",
+        merged: 2,
+        name: "getsentry/payments",
+        open: 1,
+        provider: "github",
+        url: "https://github.com/getsentry/payments",
+      },
+    ],
+    summary: {
+      closed: 1,
+      created: 8,
+      merged: 6,
+      mergeRate: 6 / 7,
+      open: 2,
+    },
+    windowEnd,
+    windowStart,
+  };
+}
 
 const ACTIVE_CONVERSATION_ID = "slack:CQA123:1770003600.000200";
 const INCIDENT_CONVERSATION_ID = "slack:CQA123:1770000000.000100";

--- a/packages/junior-dashboard/src/mock-reporting/fixtures.ts
+++ b/packages/junior-dashboard/src/mock-reporting/fixtures.ts
@@ -35,7 +35,7 @@ export function readMockCodeOverview(nowMs = Date.now()): CodeOverviewReport {
   return {
     changes: [
       {
-        id: "6:github:9001",
+        id: "00000000-0000-4000-8000-000000000001",
         number: 42,
         openedAt: new Date(nowMs - 2 * 86_400_000).toISOString(),
         provider: "github",
@@ -45,7 +45,7 @@ export function readMockCodeOverview(nowMs = Date.now()): CodeOverviewReport {
         url: "https://github.com/getsentry/payments/pull/42",
       },
       {
-        id: "6:github:9002",
+        id: "00000000-0000-4000-8000-000000000002",
         mergedAt: new Date(nowMs - 4 * 86_400_000).toISOString(),
         number: 781,
         openedAt: new Date(nowMs - 6 * 86_400_000).toISOString(),
@@ -61,7 +61,7 @@ export function readMockCodeOverview(nowMs = Date.now()): CodeOverviewReport {
       {
         closed: 1,
         created: 5,
-        id: "6:github:2001",
+        id: "00000000-0000-4000-8000-000000000003",
         merged: 4,
         name: "getsentry/junior",
         open: 1,
@@ -71,7 +71,7 @@ export function readMockCodeOverview(nowMs = Date.now()): CodeOverviewReport {
       {
         closed: 0,
         created: 3,
-        id: "6:github:2002",
+        id: "00000000-0000-4000-8000-000000000004",
         merged: 2,
         name: "getsentry/payments",
         open: 1,

--- a/packages/junior-dashboard/src/mock-reporting/routes.ts
+++ b/packages/junior-dashboard/src/mock-reporting/routes.ts
@@ -15,6 +15,7 @@ import {
   conversationParamsSchema,
   conversationPendingMessagesReportSchema,
   conversationStatsReportSchema,
+  codeOverviewReportSchema,
   locationDetailReportSchema,
   locationDirectoryReportSchema,
   locationParamsSchema,
@@ -33,6 +34,7 @@ import {
   readMockConversationFeed,
   readMockConversationPendingMessages,
   readMockConversationStats,
+  readMockCodeOverview,
   readMockLocationDetail,
   readMockLocationDirectory,
   readMockPeopleDirectory,
@@ -53,6 +55,10 @@ export function createMockReportingApi(): Hono<{
   Variables: JuniorApiVariables;
 }> {
   const app = new Hono<{ Variables: JuniorApiVariables }>();
+
+  app.get("/code", () =>
+    jsonResponse(codeOverviewReportSchema, readMockCodeOverview()),
+  );
 
   app.get("/people", () =>
     jsonResponse(actorDirectoryReportSchema, readMockPeopleDirectory()),

--- a/packages/junior-dashboard/tests/dashboard-mock-routes.test.ts
+++ b/packages/junior-dashboard/tests/dashboard-mock-routes.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   actorDirectoryReportSchema,
+  codeOverviewReportSchema,
   conversationDetailReportSchema,
   conversationEventPageSchema,
   type ConversationSummaryReport,
@@ -80,6 +81,15 @@ describe("dashboard canonical-event mock routes", () => {
     await expect(me.json()).resolves.toEqual({
       user: { email: "dev@example.com", emailVerified: true },
     });
+
+    const code = await app.fetch(new Request("http://localhost/api/code"));
+    expect(code.status).toBe(200);
+    const codeOverview = codeOverviewReportSchema.parse(await code.json());
+    expect(codeOverview.changes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ repository: "getsentry/junior" }),
+      ]),
+    );
 
     const conversations = await app.fetch(
       new Request("http://localhost/api/conversations"),

--- a/packages/junior-dashboard/tests/dashboard-routes.test.ts
+++ b/packages/junior-dashboard/tests/dashboard-routes.test.ts
@@ -58,6 +58,7 @@ describe("dashboard routes", () => {
     const app = dashboard(null);
 
     for (const path of [
+      "/code",
       "/conversations",
       "/conversations/slack%3AC1%3A123",
       "/conversations/slack%3AC1%3A123?view=tools",
@@ -424,6 +425,7 @@ describe("dashboard routes", () => {
     });
 
     for (const path of [
+      "/code",
       "/conversations",
       "/conversations/slack%3AC1%3A123",
       "/locations",

--- a/packages/junior-github/migrations/0008_native_code_backfill.sql
+++ b/packages/junior-github/migrations/0008_native_code_backfill.sql
@@ -7,7 +7,7 @@ INSERT INTO junior_code_repositories (
   updated_at
 )
 SELECT DISTINCT ON (repository_id)
-  gen_random_uuid()::text,
+  gen_random_uuid(),
   repository_full_name,
   'github',
   repository_id,
@@ -36,7 +36,7 @@ INSERT INTO junior_code_changes (
   url
 )
 SELECT
-  gen_random_uuid()::text,
+  gen_random_uuid(),
   github_change.closed_at,
   github_change.conversation_ids,
   github_change.merged_at,

--- a/packages/junior-github/migrations/0008_native_code_backfill.sql
+++ b/packages/junior-github/migrations/0008_native_code_backfill.sql
@@ -7,7 +7,7 @@ INSERT INTO junior_code_repositories (
   updated_at
 )
 SELECT DISTINCT ON (repository_id)
-  '6:github:' || repository_id,
+  gen_random_uuid()::text,
   repository_full_name,
   'github',
   repository_id,
@@ -15,7 +15,7 @@ SELECT DISTINCT ON (repository_id)
   updated_at
 FROM junior_github_pull_requests
 ORDER BY repository_id, updated_at DESC
-ON CONFLICT (id) DO UPDATE SET
+ON CONFLICT (provider, provider_id) DO UPDATE SET
   name = EXCLUDED.name,
   url = EXCLUDED.url,
   updated_at = EXCLUDED.updated_at
@@ -36,20 +36,26 @@ INSERT INTO junior_code_changes (
   url
 )
 SELECT
-  '6:github:' || pull_request_id,
-  closed_at,
-  conversation_ids,
-  merged_at,
-  number,
-  opened_at,
+  gen_random_uuid()::text,
+  github_change.closed_at,
+  github_change.conversation_ids,
+  github_change.merged_at,
+  github_change.number,
+  github_change.opened_at,
   'github',
-  pull_request_id,
-  '6:github:' || repository_id,
-  CASE state WHEN 'closed_unmerged' THEN 'closed' ELSE state END,
-  updated_at,
-  'https://github.com/' || repository_full_name || '/pull/' || number
-FROM junior_github_pull_requests
-ON CONFLICT (id) DO UPDATE SET
+  github_change.pull_request_id,
+  repository.id,
+  CASE github_change.state
+    WHEN 'closed_unmerged' THEN 'closed'
+    ELSE github_change.state
+  END,
+  github_change.updated_at,
+  'https://github.com/' || github_change.repository_full_name || '/pull/' || github_change.number
+FROM junior_github_pull_requests AS github_change
+JOIN junior_code_repositories AS repository
+  ON repository.provider = 'github'
+  AND repository.provider_id = github_change.repository_id
+ON CONFLICT (provider, provider_id) DO UPDATE SET
   closed_at = EXCLUDED.closed_at,
   conversation_ids = ARRAY(
     SELECT DISTINCT value

--- a/packages/junior-github/migrations/0008_native_code_backfill.sql
+++ b/packages/junior-github/migrations/0008_native_code_backfill.sql
@@ -1,0 +1,68 @@
+INSERT INTO junior_code_repositories (
+  id,
+  name,
+  provider,
+  provider_id,
+  url,
+  updated_at
+)
+SELECT DISTINCT ON (repository_id)
+  '6:github:' || repository_id,
+  repository_full_name,
+  'github',
+  repository_id,
+  'https://github.com/' || repository_full_name,
+  updated_at
+FROM junior_github_pull_requests
+ORDER BY repository_id, updated_at DESC
+ON CONFLICT (id) DO UPDATE SET
+  name = EXCLUDED.name,
+  url = EXCLUDED.url,
+  updated_at = EXCLUDED.updated_at
+WHERE junior_code_repositories.updated_at <= EXCLUDED.updated_at;
+--> statement-breakpoint
+INSERT INTO junior_code_changes (
+  id,
+  closed_at,
+  conversation_ids,
+  merged_at,
+  number,
+  opened_at,
+  provider,
+  provider_id,
+  repository_id,
+  state,
+  updated_at,
+  url
+)
+SELECT
+  '6:github:' || pull_request_id,
+  closed_at,
+  conversation_ids,
+  merged_at,
+  number,
+  opened_at,
+  'github',
+  pull_request_id,
+  '6:github:' || repository_id,
+  CASE state WHEN 'closed_unmerged' THEN 'closed' ELSE state END,
+  updated_at,
+  'https://github.com/' || repository_full_name || '/pull/' || number
+FROM junior_github_pull_requests
+ON CONFLICT (id) DO UPDATE SET
+  closed_at = EXCLUDED.closed_at,
+  conversation_ids = ARRAY(
+    SELECT DISTINCT value
+    FROM unnest(
+      junior_code_changes.conversation_ids || EXCLUDED.conversation_ids
+    ) AS value
+    ORDER BY value
+  ),
+  merged_at = EXCLUDED.merged_at,
+  number = EXCLUDED.number,
+  opened_at = EXCLUDED.opened_at,
+  repository_id = EXCLUDED.repository_id,
+  state = EXCLUDED.state,
+  updated_at = EXCLUDED.updated_at,
+  url = EXCLUDED.url
+WHERE junior_code_changes.updated_at <= EXCLUDED.updated_at;

--- a/packages/junior-github/migrations/meta/0008_snapshot.json
+++ b/packages/junior-github/migrations/meta/0008_snapshot.json
@@ -1,0 +1,348 @@
+{
+  "id": "da9cceed-a211-4f1b-a5b8-ac4237b9caf5",
+  "prevId": "a54d392c-28bb-4cd3-ba14-1bcfa793fcce",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.junior_github_issues": {
+      "name": "junior_github_issues",
+      "schema": "",
+      "columns": {
+        "issue_id": {
+          "name": "issue_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_full_name": {
+          "name": "repository_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_reason": {
+          "name": "state_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversation_ids": {
+          "name": "conversation_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "junior_github_issues_opened_at_idx": {
+          "name": "junior_github_issues_opened_at_idx",
+          "columns": [
+            {
+              "expression": "opened_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "junior_github_issues_closed_at_idx": {
+          "name": "junior_github_issues_closed_at_idx",
+          "columns": [
+            {
+              "expression": "closed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "junior_github_issues_open_idx": {
+          "name": "junior_github_issues_open_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"junior_github_issues\".\"state\" = 'open'",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_github_pull_request_issues": {
+      "name": "junior_github_pull_request_issues",
+      "schema": "",
+      "columns": {
+        "pull_request_id": {
+          "name": "pull_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_repository_full_name": {
+          "name": "issue_repository_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_number": {
+          "name": "issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "junior_github_pull_request_issues_pull_request_id_junior_github_pull_requests_pull_request_id_fk": {
+          "name": "junior_github_pull_request_issues_pull_request_id_junior_github_pull_requests_pull_request_id_fk",
+          "tableFrom": "junior_github_pull_request_issues",
+          "columnsFrom": ["pull_request_id"],
+          "tableTo": "junior_github_pull_requests",
+          "columnsTo": ["pull_request_id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "junior_github_pull_request_issues_pull_request_id_issue_repository_full_name_issue_number_pk": {
+          "name": "junior_github_pull_request_issues_pull_request_id_issue_repository_full_name_issue_number_pk",
+          "columns": [
+            "pull_request_id",
+            "issue_repository_full_name",
+            "issue_number"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_github_pull_requests": {
+      "name": "junior_github_pull_requests",
+      "schema": "",
+      "columns": {
+        "pull_request_id": {
+          "name": "pull_request_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_full_name": {
+          "name": "repository_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_composition": {
+          "name": "commit_composition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversation_ids": {
+          "name": "conversation_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merged_at": {
+          "name": "merged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "junior_github_pull_requests_opened_at_idx": {
+          "name": "junior_github_pull_requests_opened_at_idx",
+          "columns": [
+            {
+              "expression": "opened_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "junior_github_pull_requests_merged_at_idx": {
+          "name": "junior_github_pull_requests_merged_at_idx",
+          "columns": [
+            {
+              "expression": "merged_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "junior_github_pull_requests_closed_at_idx": {
+          "name": "junior_github_pull_requests_closed_at_idx",
+          "columns": [
+            {
+              "expression": "closed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "junior_github_pull_requests_open_idx": {
+          "name": "junior_github_pull_requests_open_idx",
+          "columns": [
+            {
+              "expression": "pull_request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"junior_github_pull_requests\".\"state\" = 'open'",
+          "concurrently": false
+        },
+        "junior_github_pull_requests_unmerged_conversations_idx": {
+          "name": "junior_github_pull_requests_unmerged_conversations_idx",
+          "columns": [
+            {
+              "expression": "conversation_ids",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gin",
+          "where": "\"junior_github_pull_requests\".\"state\" <> 'merged'",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "views": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/junior-github/migrations/meta/_journal.json
+++ b/packages/junior-github/migrations/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1786486305688,
       "tag": "0007_shallow_millenium_guard",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1787598510781,
+      "tag": "0008_native_code_backfill",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/junior-github/src/plugin.ts
+++ b/packages/junior-github/src/plugin.ts
@@ -299,6 +299,7 @@ export function githubPlugin(
                   ),
               });
             },
+            codeChanges: ctx.codeChanges,
             db: ctx.db as GitHubDb,
             installationId: () => readEnv(installationIdEnv),
             installationIdEnv,

--- a/packages/junior-github/src/pull-request-outcomes/store.ts
+++ b/packages/junior-github/src/pull-request-outcomes/store.ts
@@ -21,6 +21,7 @@ const githubPullRequestOutcomeInputSchema = z
     repositoryFullName: z.string().min(1),
     repositoryId: z.string().min(1),
     state: githubPullRequestStateSchema,
+    title: z.string().min(1).optional(),
     updatedAt: z.date(),
   })
   .strict();

--- a/packages/junior-github/src/webhooks/handler.ts
+++ b/packages/junior-github/src/webhooks/handler.ts
@@ -1,5 +1,7 @@
 import { createHmac, timingSafeEqual } from "node:crypto";
 import type {
+  CodeChangeInput,
+  CodeChangePublisher,
   PluginConversationAnnotations,
   PluginLogger,
   PluginRoute,
@@ -12,6 +14,7 @@ import {
   recordGitHubIssueOutcome,
 } from "../issue-outcomes/store.js";
 import {
+  type GitHubPullRequestOutcomeInput,
   recordGitHubPullRequestConversations,
   recordGitHubPullRequestLinkedIssues,
   recordGitHubPullRequestOutcome,
@@ -78,6 +81,29 @@ function webhookInstallationId(body: unknown): number | undefined {
   return parseInstallationId((installation as { id?: unknown }).id);
 }
 
+function githubCodeChange(
+  outcome: GitHubPullRequestOutcomeInput,
+  conversationIds: string[],
+): CodeChangeInput {
+  return {
+    closedAt: outcome.closedAt,
+    conversationIds,
+    mergedAt: outcome.mergedAt,
+    number: outcome.number,
+    openedAt: outcome.openedAt,
+    providerId: outcome.pullRequestId,
+    repository: {
+      name: outcome.repositoryFullName,
+      providerId: outcome.repositoryId,
+      url: `https://github.com/${outcome.repositoryFullName}`,
+    },
+    state: outcome.state === "closed_unmerged" ? "closed" : outcome.state,
+    title: outcome.title,
+    updatedAt: outcome.updatedAt,
+    url: `https://github.com/${outcome.repositoryFullName}/pull/${outcome.number}`,
+  };
+}
+
 /** Create the public, signed GitHub webhook route owned by the plugin. */
 export function createGitHubWebhookRoute(args: {
   annotations: PluginConversationAnnotations;
@@ -87,6 +113,7 @@ export function createGitHubWebhookRoute(args: {
     number: number;
     repositoryFullName: string;
   }): Promise<GitHubPullRequestCommitComposition | undefined>;
+  codeChanges: CodeChangePublisher;
   db: GitHubDb;
   installationId(): string | undefined;
   installationIdEnv: string;
@@ -146,6 +173,14 @@ export function createGitHubWebhookRoute(args: {
           args.db,
           pullRequestOutcome,
         );
+        if (recordedOutcome.applied) {
+          await args.codeChanges.record(
+            githubCodeChange(
+              pullRequestOutcome,
+              recordedOutcome.conversationIds,
+            ),
+          );
+        }
         if (recordedOutcome.applied && pullRequestOutcome.state !== "open") {
           const status =
             pullRequestOutcome.state === "merged" ? "merged" : "closed";
@@ -217,6 +252,12 @@ export function createGitHubWebhookRoute(args: {
             pullRequestConversations,
           )
         : false;
+      if (recordedPullRequestConversations && pullRequestConversations) {
+        await args.codeChanges.associateConversations({
+          conversationIds: pullRequestConversations.conversationIds,
+          providerId: pullRequestConversations.pullRequestId,
+        });
+      }
       const recordedPullRequestLinkedIssues = pullRequestLinkedIssues
         ? await recordGitHubPullRequestLinkedIssues(
             args.db,

--- a/packages/junior-github/src/webhooks/pull-request-outcome.ts
+++ b/packages/junior-github/src/webhooks/pull-request-outcome.ts
@@ -23,6 +23,7 @@ const canonicalPullRequestOutcomeSchema = z
         merged: z.boolean(),
         merged_at: z.string().nullable().optional(),
         number: z.number().int().positive(),
+        title: z.string().min(1).optional(),
         updated_at: z.string(),
         user: z.object({ login: z.string().min(1) }).strict(),
       })
@@ -48,6 +49,7 @@ const pullRequestOutcomeSchema = z
         merged: z.boolean(),
         merged_at: z.string().nullable().optional(),
         number: z.number().int().positive(),
+        title: z.string().min(1).optional(),
         updated_at: z.string(),
         user: z.object({ login: z.string().min(1) }).passthrough(),
       })
@@ -71,6 +73,7 @@ const pullRequestOutcomeSchema = z
         merged: provider.pull_request.merged,
         merged_at: provider.pull_request.merged_at,
         number: provider.pull_request.number,
+        title: provider.pull_request.title,
         updated_at: provider.pull_request.updated_at,
         user: { login: provider.pull_request.user.login },
       },
@@ -190,6 +193,7 @@ export function normalizeGitHubPullRequestOutcome(args: {
     repositoryFullName: parsed.repository.full_name,
     repositoryId: String(parsed.repository.id),
     state,
+    title: pullRequest.title,
     updatedAt,
   };
 }

--- a/packages/junior-github/tests/webhook-outcomes.test.ts
+++ b/packages/junior-github/tests/webhook-outcomes.test.ts
@@ -261,6 +261,10 @@ function webhookRoute(
     appIdEnv: "GITHUB_APP_ID",
     botEmail,
     classifyPullRequestCommits,
+    codeChanges: {
+      async associateConversations() {},
+      async record() {},
+    },
     db: fixture.db(),
     installationId: () => "456",
     installationIdEnv: "GITHUB_INSTALLATION_ID",
@@ -1384,6 +1388,7 @@ describe("GitHub-owned pull request outcomes", () => {
 
   it("derives ownership identity from the configured bot email environment", async () => {
     const fixture = await createGitHubFixture();
+    const codeChangesRecord = vi.fn(async () => {});
     vi.stubEnv(
       "CUSTOM_GITHUB_BOT_EMAIL",
       "264270552+sentry-junior[bot]@users.noreply.github.com",
@@ -1409,6 +1414,10 @@ describe("GitHub-owned pull request outcomes", () => {
         db: fixture.db(),
         log: { error() {}, info() {}, warn() {} },
         plugin: { name: "github" },
+        codeChanges: {
+          async associateConversations() {},
+          record: codeChangesRecord,
+        },
         resourceEvents: { async publish() {} },
       });
 
@@ -1420,6 +1429,17 @@ describe("GitHub-owned pull request outcomes", () => {
       ).resolves.toEqual([
         expect.objectContaining({ pullRequestId: "1001", state: "open" }),
       ]);
+      expect(codeChangesRecord).toHaveBeenCalledWith(
+        expect.objectContaining({
+          number: 946,
+          providerId: "1001",
+          repository: expect.objectContaining({
+            name: "getsentry/junior",
+            providerId: "2001",
+          }),
+          state: "open",
+        }),
+      );
     } finally {
       await fixture.close();
     }
@@ -1478,6 +1498,10 @@ describe("GitHub-owned pull request outcomes", () => {
               },
             };
           },
+        },
+        codeChanges: {
+          async associateConversations() {},
+          async record() {},
         },
         db: fixture.db(),
         log: { error() {}, info() {}, warn() {} },

--- a/packages/junior-plugin-api/src/code.ts
+++ b/packages/junior-plugin-api/src/code.ts
@@ -1,0 +1,37 @@
+import { z } from "zod";
+
+export const codeChangeStateSchema = z.enum(["closed", "merged", "open"]);
+export type CodeChangeState = z.output<typeof codeChangeStateSchema>;
+
+export const codeChangeInputSchema = z
+  .object({
+    closedAt: z.date().optional(),
+    conversationIds: z.array(z.string().min(1)).default([]),
+    mergedAt: z.date().optional(),
+    number: z.number().int().positive(),
+    openedAt: z.date(),
+    providerId: z.string().min(1),
+    repository: z
+      .object({
+        name: z.string().min(1),
+        providerId: z.string().min(1),
+        url: z.string().url().optional(),
+      })
+      .strict(),
+    state: codeChangeStateSchema,
+    title: z.string().min(1).optional(),
+    updatedAt: z.date(),
+    url: z.string().url().optional(),
+  })
+  .strict();
+
+export type CodeChangeInput = z.input<typeof codeChangeInputSchema>;
+
+/** Write code changes from a plugin to Junior's code records. */
+export interface CodeChangePublisher {
+  associateConversations(input: {
+    conversationIds: string[];
+    providerId: string;
+  }): Promise<void>;
+  record(input: CodeChangeInput): Promise<void>;
+}

--- a/packages/junior-plugin-api/src/index.ts
+++ b/packages/junior-plugin-api/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./annotations";
+export * from "./code";
 export * from "./conversation-events";
 export * from "./schemas";
 export * from "./context";

--- a/packages/junior-plugin-api/src/operations.ts
+++ b/packages/junior-plugin-api/src/operations.ts
@@ -6,6 +6,7 @@ import type { PluginReadState, PluginState } from "./state";
 import type { ResourceEventPublisher } from "./resource-events";
 import type { PluginConversationAnnotations } from "./annotations";
 import type { PluginConversationEventStats } from "./conversation-events";
+import type { CodeChangePublisher } from "./code";
 
 export interface HeartbeatHookContext extends PluginContext {
   agent: {
@@ -153,6 +154,8 @@ export type PluginRouteApp = {
 
 export interface RouteRegistrationHookContext extends PluginContext {
   annotations: PluginConversationAnnotations;
+  /** Provider-neutral write boundary for Junior's native code index. */
+  codeChanges: CodeChangePublisher;
   /** Core-owned delivery boundary for provider webhook events. */
   resourceEvents: ResourceEventPublisher;
 }

--- a/packages/junior/migrations/0036_complex_rage.sql
+++ b/packages/junior/migrations/0036_complex_rage.sql
@@ -1,5 +1,5 @@
 CREATE TABLE "junior_code_changes" (
-	"id" text PRIMARY KEY NOT NULL,
+	"id" uuid PRIMARY KEY NOT NULL,
 	"closed_at" timestamp with time zone,
 	"conversation_ids" text[] DEFAULT ARRAY[]::text[] NOT NULL,
 	"merged_at" timestamp with time zone,
@@ -7,7 +7,7 @@ CREATE TABLE "junior_code_changes" (
 	"opened_at" timestamp with time zone NOT NULL,
 	"provider" text NOT NULL,
 	"provider_id" text NOT NULL,
-	"repository_id" text NOT NULL,
+	"repository_id" uuid NOT NULL,
 	"state" text NOT NULL,
 	"title" text,
 	"updated_at" timestamp with time zone NOT NULL,
@@ -15,7 +15,7 @@ CREATE TABLE "junior_code_changes" (
 );
 --> statement-breakpoint
 CREATE TABLE "junior_code_repositories" (
-	"id" text PRIMARY KEY NOT NULL,
+	"id" uuid PRIMARY KEY NOT NULL,
 	"name" text NOT NULL,
 	"provider" text NOT NULL,
 	"provider_id" text NOT NULL,

--- a/packages/junior/migrations/0036_complex_rage.sql
+++ b/packages/junior/migrations/0036_complex_rage.sql
@@ -1,0 +1,32 @@
+CREATE TABLE "junior_code_changes" (
+	"id" text PRIMARY KEY NOT NULL,
+	"closed_at" timestamp with time zone,
+	"conversation_ids" text[] DEFAULT ARRAY[]::text[] NOT NULL,
+	"merged_at" timestamp with time zone,
+	"number" integer NOT NULL,
+	"opened_at" timestamp with time zone NOT NULL,
+	"provider" text NOT NULL,
+	"provider_id" text NOT NULL,
+	"repository_id" text NOT NULL,
+	"state" text NOT NULL,
+	"title" text,
+	"updated_at" timestamp with time zone NOT NULL,
+	"url" text
+);
+--> statement-breakpoint
+CREATE TABLE "junior_code_repositories" (
+	"id" text PRIMARY KEY NOT NULL,
+	"name" text NOT NULL,
+	"provider" text NOT NULL,
+	"provider_id" text NOT NULL,
+	"url" text,
+	"updated_at" timestamp with time zone NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "junior_code_changes" ADD CONSTRAINT "junior_code_changes_repository_id_junior_code_repositories_id_fk" FOREIGN KEY ("repository_id") REFERENCES "public"."junior_code_repositories"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "junior_code_changes_provider_id_idx" ON "junior_code_changes" USING btree ("provider","provider_id");--> statement-breakpoint
+CREATE INDEX "junior_code_changes_opened_at_idx" ON "junior_code_changes" USING btree ("opened_at");--> statement-breakpoint
+CREATE INDEX "junior_code_changes_merged_at_idx" ON "junior_code_changes" USING btree ("merged_at");--> statement-breakpoint
+CREATE INDEX "junior_code_changes_closed_at_idx" ON "junior_code_changes" USING btree ("closed_at");--> statement-breakpoint
+CREATE INDEX "junior_code_changes_open_idx" ON "junior_code_changes" USING btree ("id") WHERE "junior_code_changes"."state" = 'open';--> statement-breakpoint
+CREATE UNIQUE INDEX "junior_code_repositories_provider_id_idx" ON "junior_code_repositories" USING btree ("provider","provider_id");

--- a/packages/junior/migrations/meta/0036_snapshot.json
+++ b/packages/junior/migrations/meta/0036_snapshot.json
@@ -1,0 +1,3186 @@
+{
+  "id": "7afb21c1-f6f3-4369-a7bb-7a29e0af3226",
+  "prevId": "7268868b-d27e-4f42-a0f4-6c981de70f1a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.junior_agent_bindings": {
+      "name": "junior_agent_bindings",
+      "schema": "",
+      "columns": {
+        "parent_conversation_id": {
+          "name": "parent_conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_conversation_id": {
+          "name": "child_conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "junior_agent_bindings_child_idx": {
+          "name": "junior_agent_bindings_child_idx",
+          "columns": [
+            {
+              "expression": "child_conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "junior_agent_bindings_parent_conversation_id_junior_conversations_conversation_id_fk": {
+          "name": "junior_agent_bindings_parent_conversation_id_junior_conversations_conversation_id_fk",
+          "tableFrom": "junior_agent_bindings",
+          "tableTo": "junior_conversations",
+          "columnsFrom": ["parent_conversation_id"],
+          "columnsTo": ["conversation_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "junior_agent_bindings_child_conversation_id_junior_conversations_conversation_id_fk": {
+          "name": "junior_agent_bindings_child_conversation_id_junior_conversations_conversation_id_fk",
+          "tableFrom": "junior_agent_bindings",
+          "tableTo": "junior_conversations",
+          "columnsFrom": ["child_conversation_id"],
+          "columnsTo": ["conversation_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "junior_agent_bindings_parent_conversation_id_name_pk": {
+          "name": "junior_agent_bindings_parent_conversation_id_name_pk",
+          "columns": ["parent_conversation_id", "name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_agent_invocations": {
+      "name": "junior_agent_invocations",
+      "schema": "",
+      "columns": {
+        "invocation_id": {
+          "name": "invocation_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "parent_conversation_id": {
+          "name": "parent_conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_conversation_id": {
+          "name": "child_conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input": {
+          "name": "input",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_json": {
+          "name": "actor_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_context_json": {
+          "name": "credential_context_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_json": {
+          "name": "source_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination_json": {
+          "name": "destination_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination_visibility": {
+          "name": "destination_visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasoning_level": {
+          "name": "reasoning_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mailbox_status": {
+          "name": "mailbox_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "terminal_at": {
+          "name": "terminal_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "junior_agent_invocations_child_idx": {
+          "name": "junior_agent_invocations_child_idx",
+          "columns": [
+            {
+              "expression": "child_conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_agent_invocations_mailbox_idx": {
+          "name": "junior_agent_invocations_mailbox_idx",
+          "columns": [
+            {
+              "expression": "mailbox_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "junior_agent_invocations_parent_conversation_id_junior_conversations_conversation_id_fk": {
+          "name": "junior_agent_invocations_parent_conversation_id_junior_conversations_conversation_id_fk",
+          "tableFrom": "junior_agent_invocations",
+          "tableTo": "junior_conversations",
+          "columnsFrom": ["parent_conversation_id"],
+          "columnsTo": ["conversation_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "junior_agent_invocations_child_conversation_id_junior_conversations_conversation_id_fk": {
+          "name": "junior_agent_invocations_child_conversation_id_junior_conversations_conversation_id_fk",
+          "tableFrom": "junior_agent_invocations",
+          "tableTo": "junior_conversations",
+          "columnsFrom": ["child_conversation_id"],
+          "columnsTo": ["conversation_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_api_tokens": {
+      "name": "junior_api_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_email_normalized": {
+          "name": "owner_email_normalized",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_suffix": {
+          "name": "token_suffix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "junior_api_tokens_token_hash_uidx": {
+          "name": "junior_api_tokens_token_hash_uidx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_api_tokens_owner_email_idx": {
+          "name": "junior_api_tokens_owner_email_idx",
+          "columns": [
+            {
+              "expression": "owner_email_normalized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_artifacts": {
+      "name": "junior_artifacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ext": {
+          "name": "ext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delete_requested_at": {
+          "name": "delete_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "junior_artifacts_conversation_sha_uidx": {
+          "name": "junior_artifacts_conversation_sha_uidx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_artifacts_gc_idx": {
+          "name": "junior_artifacts_gc_idx",
+          "columns": [
+            {
+              "expression": "delete_requested_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_artifacts_conversation_idx": {
+          "name": "junior_artifacts_conversation_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_attachments": {
+      "name": "junior_attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delete_requested_at": {
+          "name": "delete_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "junior_attachments_conversation_idx": {
+          "name": "junior_attachments_conversation_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_attachments_gc_idx": {
+          "name": "junior_attachments_gc_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "delete_requested_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "junior_attachments_conversation_id_junior_conversations_conversation_id_fk": {
+          "name": "junior_attachments_conversation_id_junior_conversations_conversation_id_fk",
+          "tableFrom": "junior_attachments",
+          "tableTo": "junior_conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["conversation_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_code_changes": {
+      "name": "junior_code_changes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversation_ids": {
+          "name": "conversation_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "merged_at": {
+          "name": "merged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "junior_code_changes_provider_id_idx": {
+          "name": "junior_code_changes_provider_id_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_code_changes_opened_at_idx": {
+          "name": "junior_code_changes_opened_at_idx",
+          "columns": [
+            {
+              "expression": "opened_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_code_changes_merged_at_idx": {
+          "name": "junior_code_changes_merged_at_idx",
+          "columns": [
+            {
+              "expression": "merged_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_code_changes_closed_at_idx": {
+          "name": "junior_code_changes_closed_at_idx",
+          "columns": [
+            {
+              "expression": "closed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_code_changes_open_idx": {
+          "name": "junior_code_changes_open_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"junior_code_changes\".\"state\" = 'open'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "junior_code_changes_repository_id_junior_code_repositories_id_fk": {
+          "name": "junior_code_changes_repository_id_junior_code_repositories_id_fk",
+          "tableFrom": "junior_code_changes",
+          "tableTo": "junior_code_repositories",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_code_repositories": {
+      "name": "junior_code_repositories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "junior_code_repositories_provider_id_idx": {
+          "name": "junior_code_repositories_provider_id_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_conversation_annotations": {
+      "name": "junior_conversation_annotations",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plugin": {
+          "name": "plugin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "annotation_json": {
+          "name": "annotation_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "junior_conversation_annotations_conversation_id_fk": {
+          "name": "junior_conversation_annotations_conversation_id_fk",
+          "tableFrom": "junior_conversation_annotations",
+          "tableTo": "junior_conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["conversation_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "junior_conversation_annotations_pk": {
+          "name": "junior_conversation_annotations_pk",
+          "columns": ["conversation_id", "plugin", "kind", "key"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_conversation_bindings": {
+      "name": "junior_conversation_bindings",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_tenant_id": {
+          "name": "provider_tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "provider_destination_id": {
+          "name": "provider_destination_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_conversation_id": {
+          "name": "provider_conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "junior_conversation_bindings_conversation_idx": {
+          "name": "junior_conversation_bindings_conversation_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "junior_conversation_bindings_conversation_id_junior_conversations_conversation_id_fk": {
+          "name": "junior_conversation_bindings_conversation_id_junior_conversations_conversation_id_fk",
+          "tableFrom": "junior_conversation_bindings",
+          "tableTo": "junior_conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["conversation_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "junior_conversation_bindings_provider_conversation_pk": {
+          "name": "junior_conversation_bindings_provider_conversation_pk",
+          "columns": [
+            "provider",
+            "provider_tenant_id",
+            "provider_destination_id",
+            "provider_conversation_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_conversation_events": {
+      "name": "junior_conversation_events",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "history_version": {
+          "name": "history_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_identity_id": {
+          "name": "actor_identity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "junior_conversation_events_history_version_idx": {
+          "name": "junior_conversation_events_history_version_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "history_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_conversation_events_type_idx": {
+          "name": "junior_conversation_events_type_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_conversation_events_actor_identity_idx": {
+          "name": "junior_conversation_events_actor_identity_idx",
+          "columns": [
+            {
+              "expression": "actor_identity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_conversation_events_message_search_idx": {
+          "name": "junior_conversation_events_message_search_idx",
+          "columns": [
+            {
+              "expression": "to_tsvector('english', \"payload\"->>'text')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"junior_conversation_events\".\"type\" = 'message'",
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "junior_conversation_events_idempotency_idx": {
+          "name": "junior_conversation_events_idempotency_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "junior_conversation_events_actor_identity_id_junior_identities_id_fk": {
+          "name": "junior_conversation_events_actor_identity_id_junior_identities_id_fk",
+          "tableFrom": "junior_conversation_events",
+          "tableTo": "junior_identities",
+          "columnsFrom": ["actor_identity_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "junior_conversation_events_conversation_id_junior_conversations_conversation_id_fk": {
+          "name": "junior_conversation_events_conversation_id_junior_conversations_conversation_id_fk",
+          "tableFrom": "junior_conversation_events",
+          "tableTo": "junior_conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["conversation_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "junior_conversation_events_conversation_id_seq_pk": {
+          "name": "junior_conversation_events_conversation_id_seq_pk",
+          "columns": ["conversation_id", "seq"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_conversation_participants": {
+      "name": "junior_conversation_participants",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_conversation_id": {
+          "name": "root_conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "junior_conversation_participants_user_activity_idx": {
+          "name": "junior_conversation_participants_user_activity_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_message_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_conversation_participants_root_idx": {
+          "name": "junior_conversation_participants_root_idx",
+          "columns": [
+            {
+              "expression": "root_conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "junior_conversation_participants_user_id_junior_users_id_fk": {
+          "name": "junior_conversation_participants_user_id_junior_users_id_fk",
+          "tableFrom": "junior_conversation_participants",
+          "tableTo": "junior_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "junior_conversation_participants_root_conversation_id_junior_conversations_conversation_id_fk": {
+          "name": "junior_conversation_participants_root_conversation_id_junior_conversations_conversation_id_fk",
+          "tableFrom": "junior_conversation_participants",
+          "tableTo": "junior_conversations",
+          "columnsFrom": ["root_conversation_id"],
+          "columnsTo": ["conversation_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "junior_conversation_participants_user_root_pk": {
+          "name": "junior_conversation_participants_user_root_pk",
+          "columns": ["user_id", "root_conversation_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_conversations": {
+      "name": "junior_conversations",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_json": {
+          "name": "source_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin_type": {
+          "name": "origin_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin_id": {
+          "name": "origin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin_run_id": {
+          "name": "origin_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destination_id": {
+          "name": "destination_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destination_json": {
+          "name": "destination_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_identity_id": {
+          "name": "actor_identity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_identity_id": {
+          "name": "creator_identity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_subject_identity_id": {
+          "name": "credential_subject_identity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_json": {
+          "name": "actor_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_name": {
+          "name": "channel_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "execution_updated_at": {
+          "name": "execution_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_status": {
+          "name": "execution_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_checkpoint_at": {
+          "name": "last_checkpoint_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_enqueued_at": {
+          "name": "last_enqueued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_conversation_id": {
+          "name": "parent_conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_conversation_id": {
+          "name": "root_conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcript_purged_at": {
+          "name": "transcript_purged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "usage_json": {
+          "name": "usage_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_duration_ms": {
+          "name": "execution_duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "execution_usage_json": {
+          "name": "execution_usage_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metric_run_id": {
+          "name": "metric_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "junior_conversations_last_activity_idx": {
+          "name": "junior_conversations_last_activity_idx",
+          "columns": [
+            {
+              "expression": "last_activity_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_conversations_active_idx": {
+          "name": "junior_conversations_active_idx",
+          "columns": [
+            {
+              "expression": "coalesce(\"execution_updated_at\", \"updated_at\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"junior_conversations\".\"execution_status\" <> 'idle'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_conversations_destination_activity_idx": {
+          "name": "junior_conversations_destination_activity_idx",
+          "columns": [
+            {
+              "expression": "destination_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_activity_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_conversations_actor_activity_idx": {
+          "name": "junior_conversations_actor_activity_idx",
+          "columns": [
+            {
+              "expression": "actor_identity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_activity_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_conversations_origin_idx": {
+          "name": "junior_conversations_origin_idx",
+          "columns": [
+            {
+              "expression": "origin_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "origin_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_activity_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_conversations_parent_idx": {
+          "name": "junior_conversations_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_conversations_root_idx": {
+          "name": "junior_conversations_root_idx",
+          "columns": [
+            {
+              "expression": "root_conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "junior_conversations_destination_id_junior_destinations_id_fk": {
+          "name": "junior_conversations_destination_id_junior_destinations_id_fk",
+          "tableFrom": "junior_conversations",
+          "tableTo": "junior_destinations",
+          "columnsFrom": ["destination_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "junior_conversations_actor_identity_id_junior_identities_id_fk": {
+          "name": "junior_conversations_actor_identity_id_junior_identities_id_fk",
+          "tableFrom": "junior_conversations",
+          "tableTo": "junior_identities",
+          "columnsFrom": ["actor_identity_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "junior_conversations_creator_identity_id_junior_identities_id_fk": {
+          "name": "junior_conversations_creator_identity_id_junior_identities_id_fk",
+          "tableFrom": "junior_conversations",
+          "tableTo": "junior_identities",
+          "columnsFrom": ["creator_identity_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "junior_conversations_credential_subject_identity_id_junior_identities_id_fk": {
+          "name": "junior_conversations_credential_subject_identity_id_junior_identities_id_fk",
+          "tableFrom": "junior_conversations",
+          "tableTo": "junior_identities",
+          "columnsFrom": ["credential_subject_identity_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "junior_conversations_parent_conversation_id_junior_conversations_conversation_id_fk": {
+          "name": "junior_conversations_parent_conversation_id_junior_conversations_conversation_id_fk",
+          "tableFrom": "junior_conversations",
+          "tableTo": "junior_conversations",
+          "columnsFrom": ["parent_conversation_id"],
+          "columnsTo": ["conversation_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "junior_conversations_root_conversation_id_junior_conversations_conversation_id_fk": {
+          "name": "junior_conversations_root_conversation_id_junior_conversations_conversation_id_fk",
+          "tableFrom": "junior_conversations",
+          "tableTo": "junior_conversations",
+          "columnsFrom": ["root_conversation_id"],
+          "columnsTo": ["conversation_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_destinations": {
+      "name": "junior_destinations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_tenant_id": {
+          "name": "provider_tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "provider_destination_id": {
+          "name": "provider_destination_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_destination_id": {
+          "name": "parent_destination_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "junior_destinations_provider_destination_uidx": {
+          "name": "junior_destinations_provider_destination_uidx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_destination_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_destinations_provider_kind_idx": {
+          "name": "junior_destinations_provider_kind_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_event_tasks": {
+      "name": "junior_event_tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at_ms": {
+          "name": "created_at_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_json": {
+          "name": "task_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "junior_event_tasks_team_idx": {
+          "name": "junior_event_tasks_team_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at_ms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_event_tasks_match_idx": {
+          "name": "junior_event_tasks_match_idx",
+          "columns": [
+            {
+              "expression": "namespace",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at_ms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_identities": {
+      "name": "junior_identities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_tenant_id": {
+          "name": "provider_tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "provider_subject_id": {
+          "name": "provider_subject_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_normalized": {
+          "name": "email_normalized",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "junior_identities_provider_subject_uidx": {
+          "name": "junior_identities_provider_subject_uidx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_identities_user_idx": {
+          "name": "junior_identities_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_identities_verified_email_idx": {
+          "name": "junior_identities_verified_email_idx",
+          "columns": [
+            {
+              "expression": "email_normalized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"junior_identities\".\"email_verified\" = true AND \"junior_identities\".\"email_normalized\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_identities_kind_provider_idx": {
+          "name": "junior_identities_kind_provider_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "junior_identities_user_id_junior_users_id_fk": {
+          "name": "junior_identities_user_id_junior_users_id_fk",
+          "tableFrom": "junior_identities",
+          "tableTo": "junior_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_location_configurations": {
+      "name": "junior_location_configurations",
+      "schema": "",
+      "columns": {
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "junior_location_configurations_location_id_junior_destinations_id_fk": {
+          "name": "junior_location_configurations_location_id_junior_destinations_id_fk",
+          "tableFrom": "junior_location_configurations",
+          "tableTo": "junior_destinations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "junior_location_configurations_location_id_key_pk": {
+          "name": "junior_location_configurations_location_id_key_pk",
+          "columns": ["location_id", "key"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_scheduler_runs": {
+      "name": "junior_scheduler_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduled_for_ms": {
+          "name": "scheduled_for_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record": {
+          "name": "record",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "junior_scheduler_runs_task_status_idx": {
+          "name": "junior_scheduler_runs_task_status_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduled_for_ms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_scheduler_runs_status_idx": {
+          "name": "junior_scheduler_runs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduled_for_ms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_scheduler_tasks": {
+      "name": "junior_scheduler_tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_slack_user_id": {
+          "name": "creator_slack_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_identity_id": {
+          "name": "creator_identity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_run_at_ms": {
+          "name": "next_run_at_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_now_at_ms": {
+          "name": "run_now_at_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at_ms": {
+          "name": "created_at_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "record": {
+          "name": "record",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "junior_scheduler_tasks_creator_idx": {
+          "name": "junior_scheduler_tasks_creator_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "creator_slack_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at_ms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"junior_scheduler_tasks\".\"status\" <> 'deleted'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_scheduler_tasks_creator_identity_idx": {
+          "name": "junior_scheduler_tasks_creator_identity_idx",
+          "columns": [
+            {
+              "expression": "creator_identity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at_ms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"junior_scheduler_tasks\".\"status\" <> 'deleted' AND \"junior_scheduler_tasks\".\"creator_identity_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_scheduler_tasks_team_status_idx": {
+          "name": "junior_scheduler_tasks_team_status_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at_ms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"junior_scheduler_tasks\".\"status\" <> 'deleted'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_scheduler_tasks_run_now_due_idx": {
+          "name": "junior_scheduler_tasks_run_now_due_idx",
+          "columns": [
+            {
+              "expression": "run_now_at_ms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at_ms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"junior_scheduler_tasks\".\"status\" = 'active' AND \"junior_scheduler_tasks\".\"run_now_at_ms\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_scheduler_tasks_next_run_due_idx": {
+          "name": "junior_scheduler_tasks_next_run_due_idx",
+          "columns": [
+            {
+              "expression": "next_run_at_ms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at_ms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"junior_scheduler_tasks\".\"status\" = 'active' AND \"junior_scheduler_tasks\".\"next_run_at_ms\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_snapshots": {
+      "name": "junior_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_hash": {
+          "name": "profile_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "build_duration_ms": {
+          "name": "build_duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "build_started_at": {
+          "name": "build_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "build_phase": {
+          "name": "build_phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "build_sandbox_name": {
+          "name": "build_sandbox_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "build_command_id": {
+          "name": "build_command_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "build_error": {
+          "name": "build_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "junior_snapshots_snapshot_id_uidx": {
+          "name": "junior_snapshots_snapshot_id_uidx",
+          "columns": [
+            {
+              "expression": "snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_snapshots_workspace_idx": {
+          "name": "junior_snapshots_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_snapshots_workspace_profile_status_idx": {
+          "name": "junior_snapshots_workspace_profile_status_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "profile_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_snapshots_active_build_uidx": {
+          "name": "junior_snapshots_active_build_uidx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "profile_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"junior_snapshots\".\"status\" = 'building'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_snapshots_workspace_status_idx": {
+          "name": "junior_snapshots_workspace_status_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "junior_snapshots_workspace_id_junior_workspaces_id_fk": {
+          "name": "junior_snapshots_workspace_id_junior_workspaces_id_fk",
+          "tableFrom": "junior_snapshots",
+          "tableTo": "junior_workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "junior_snapshots_status_check": {
+          "name": "junior_snapshots_status_check",
+          "value": "\"junior_snapshots\".\"status\" in ('building', 'failed', 'ready')"
+        },
+        "junior_snapshots_build_phase_check": {
+          "name": "junior_snapshots_build_phase_check",
+          "value": "\"junior_snapshots\".\"build_phase\" is null or \"junior_snapshots\".\"build_phase\" in ('created', 'dependencies_installed', 'repositories_prepared')"
+        },
+        "junior_snapshots_ready_fields_check": {
+          "name": "junior_snapshots_ready_fields_check",
+          "value": "\"junior_snapshots\".\"status\" <> 'ready' or (\"junior_snapshots\".\"snapshot_id\" is not null and \"junior_snapshots\".\"build_duration_ms\" is not null and \"junior_snapshots\".\"generated_at\" is not null)"
+        },
+        "junior_snapshots_build_fields_check": {
+          "name": "junior_snapshots_build_fields_check",
+          "value": "\"junior_snapshots\".\"status\" = 'ready' or (\"junior_snapshots\".\"build_started_at\" is not null and \"junior_snapshots\".\"build_phase\" is not null)"
+        },
+        "junior_snapshots_build_duration_check": {
+          "name": "junior_snapshots_build_duration_check",
+          "value": "\"junior_snapshots\".\"build_duration_ms\" is null or \"junior_snapshots\".\"build_duration_ms\" >= 0"
+        },
+        "junior_snapshots_size_bytes_check": {
+          "name": "junior_snapshots_size_bytes_check",
+          "value": "\"junior_snapshots\".\"size_bytes\" is null or \"junior_snapshots\".\"size_bytes\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.junior_stats": {
+      "name": "junior_stats",
+      "schema": "",
+      "columns": {
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metric": {
+          "name": "metric",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "junior_stats_date_namespace_metric_name_pk": {
+          "name": "junior_stats_date_namespace_metric_name_pk",
+          "columns": ["date", "namespace", "metric", "name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_task_executions": {
+      "name": "junior_task_executions",
+      "schema": "",
+      "columns": {
+        "execution_id": {
+          "name": "execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executed_at_ms": {
+          "name": "executed_at_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "junior_task_executions_task_time_idx": {
+          "name": "junior_task_executions_task_time_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "namespace",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "executed_at_ms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_task_executions_time_kind_idx": {
+          "name": "junior_task_executions_time_kind_idx",
+          "columns": [
+            {
+              "expression": "executed_at_ms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_task_executions_conversation_time_idx": {
+          "name": "junior_task_executions_conversation_time_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "executed_at_ms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "junior_task_executions_conversation_id_junior_conversations_conversation_id_fk": {
+          "name": "junior_task_executions_conversation_id_junior_conversations_conversation_id_fk",
+          "tableFrom": "junior_task_executions",
+          "tableTo": "junior_conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["conversation_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "junior_task_executions_kind_namespace_execution_id_pk": {
+          "name": "junior_task_executions_kind_namespace_execution_id_pk",
+          "columns": ["kind", "namespace", "execution_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "junior_task_executions_kind_check": {
+          "name": "junior_task_executions_kind_check",
+          "value": "\"junior_task_executions\".\"kind\" in ('scheduled', 'event')"
+        },
+        "junior_task_executions_status_check": {
+          "name": "junior_task_executions_status_check",
+          "value": "\"junior_task_executions\".\"status\" in ('blocked', 'completed', 'failed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.junior_users": {
+      "name": "junior_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "primary_email": {
+          "name": "primary_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "primary_email_normalized": {
+          "name": "primary_email_normalized",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "junior_users_primary_email_normalized_uidx": {
+          "name": "junior_users_primary_email_normalized_uidx",
+          "columns": [
+            {
+              "expression": "primary_email_normalized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_workspace_repos": {
+      "name": "junior_workspace_repos",
+      "schema": "",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "junior_workspace_repos_workspace_id_junior_workspaces_id_fk": {
+          "name": "junior_workspace_repos_workspace_id_junior_workspaces_id_fk",
+          "tableFrom": "junior_workspace_repos",
+          "tableTo": "junior_workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "junior_workspace_repos_workspace_id_provider_repo_pk": {
+          "name": "junior_workspace_repos_workspace_id_provider_repo_pk",
+          "columns": ["workspace_id", "provider", "repo"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_workspaces": {
+      "name": "junior_workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "setup_script": {
+          "name": "setup_script",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "junior_workspaces_name_idx": {
+          "name": "junior_workspaces_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/junior/migrations/meta/0036_snapshot.json
+++ b/packages/junior/migrations/meta/0036_snapshot.json
@@ -613,7 +613,7 @@
       "columns": {
         "id": {
           "name": "id",
-          "type": "text",
+          "type": "uuid",
           "primaryKey": true,
           "notNull": true
         },
@@ -662,7 +662,7 @@
         },
         "repository_id": {
           "name": "repository_id",
-          "type": "text",
+          "type": "uuid",
           "primaryKey": false,
           "notNull": true
         },
@@ -798,7 +798,7 @@
       "columns": {
         "id": {
           "name": "id",
-          "type": "text",
+          "type": "uuid",
           "primaryKey": true,
           "notNull": true
         },

--- a/packages/junior/migrations/meta/_journal.json
+++ b/packages/junior/migrations/meta/_journal.json
@@ -253,6 +253,13 @@
       "when": 1787454188316,
       "tag": "0035_workspace_snapshot_size_bytes",
       "breakpoints": true
+    },
+    {
+      "idx": 36,
+      "version": "7",
+      "when": 1787598193137,
+      "tag": "0036_complex_rage",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/junior/src/api.ts
+++ b/packages/junior/src/api.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
 import { createVercelAttachmentStorage } from "./chat/attachments/vercel";
 import { createConversationRoutes } from "./api/conversations/routes";
+import { createCodeRoutes } from "./api/code/routes";
 import { jsonResponse } from "./api/http";
 import { createLocationRoutes } from "./api/locations/routes";
 import { createPeopleRoutes } from "./api/people/routes";
@@ -69,6 +70,7 @@ export function createJuniorApi(): Hono<JuniorApiEnv> {
       attachmentStorage: createVercelAttachmentStorage(),
     }),
   );
+  app.route("/api/code", createCodeRoutes());
   app.route("/api/personal-tokens", createPersonalTokenRoutes());
   app.route("/api/people", createPeopleRoutes());
   app.route("/api/locations", createLocationRoutes());

--- a/packages/junior/src/api/code/overview.ts
+++ b/packages/junior/src/api/code/overview.ts
@@ -1,0 +1,132 @@
+import { desc, eq, gte, or, sql } from "drizzle-orm";
+import { z } from "zod";
+import { getDb } from "@/chat/db";
+import { juniorCodeChanges, juniorCodeRepositories } from "@/db/schema";
+import { codeOverviewReportSchema } from "../schema/code";
+
+const DAY_MS = 24 * 60 * 60 * 1_000;
+const WINDOW_DAYS = 30;
+
+const summaryRowSchema = z
+  .object({
+    closed: z.number().int().nonnegative(),
+    created: z.number().int().nonnegative(),
+    merged: z.number().int().nonnegative(),
+    open: z.number().int().nonnegative(),
+  })
+  .strict();
+
+const repositoryRowSchema = summaryRowSchema
+  .extend({
+    id: z.string().min(1),
+    name: z.string().min(1),
+    provider: z.string().min(1),
+    url: z.string().nullable(),
+  })
+  .strict();
+
+function queryRows(result: unknown): unknown[] {
+  if (
+    typeof result !== "object" ||
+    result === null ||
+    !("rows" in result) ||
+    !Array.isArray(result.rows)
+  ) {
+    throw new TypeError("Code overview query did not return rows");
+  }
+  return result.rows;
+}
+
+/** Read code activity created by Junior across installed code plugins. */
+export async function readCodeOverview(nowMs = Date.now()) {
+  const db = getDb();
+  const windowEnd = new Date(nowMs);
+  const windowStart = new Date(nowMs - WINDOW_DAYS * DAY_MS);
+  const changes = juniorCodeChanges;
+  const repositories = juniorCodeRepositories;
+  const [summaryResult, repositoryResult, recentChanges] = await Promise.all([
+    db.execute(sql`
+      SELECT
+        count(*) FILTER (WHERE ${changes.openedAt} >= ${windowStart})::integer AS "created",
+        count(*) FILTER (WHERE ${changes.mergedAt} >= ${windowStart})::integer AS "merged",
+        count(*) FILTER (
+          WHERE ${changes.state} = 'closed' AND ${changes.closedAt} >= ${windowStart}
+        )::integer AS "closed",
+        count(*) FILTER (WHERE ${changes.state} = 'open')::integer AS "open"
+      FROM ${changes}
+    `),
+    db.execute(sql`
+      SELECT
+        ${repositories.id} AS "id",
+        ${repositories.name} AS "name",
+        ${repositories.provider} AS "provider",
+        ${repositories.url} AS "url",
+        count(${changes.id}) FILTER (WHERE ${changes.openedAt} >= ${windowStart})::integer AS "created",
+        count(${changes.id}) FILTER (WHERE ${changes.mergedAt} >= ${windowStart})::integer AS "merged",
+        count(${changes.id}) FILTER (
+          WHERE ${changes.state} = 'closed' AND ${changes.closedAt} >= ${windowStart}
+        )::integer AS "closed",
+        count(${changes.id}) FILTER (WHERE ${changes.state} = 'open')::integer AS "open"
+      FROM ${repositories}
+      LEFT JOIN ${changes} ON ${changes.repositoryId} = ${repositories.id}
+      WHERE ${changes.openedAt} >= ${windowStart}
+        OR ${changes.mergedAt} >= ${windowStart}
+        OR ${changes.closedAt} >= ${windowStart}
+        OR ${changes.state} = 'open'
+      GROUP BY ${repositories.id}
+      ORDER BY "merged" DESC, "created" DESC, ${repositories.name} ASC
+      LIMIT 25
+    `),
+    db
+      .select({
+        closedAt: changes.closedAt,
+        id: changes.id,
+        mergedAt: changes.mergedAt,
+        number: changes.number,
+        openedAt: changes.openedAt,
+        provider: changes.provider,
+        repository: repositories.name,
+        state: changes.state,
+        title: changes.title,
+        url: changes.url,
+      })
+      .from(changes)
+      .innerJoin(repositories, eq(changes.repositoryId, repositories.id))
+      .where(
+        or(
+          gte(changes.openedAt, windowStart),
+          gte(changes.mergedAt, windowStart),
+          gte(changes.closedAt, windowStart),
+          eq(changes.state, "open"),
+        ),
+      )
+      .orderBy(desc(changes.updatedAt))
+      .limit(25),
+  ]);
+  const summary = summaryRowSchema.parse(queryRows(summaryResult)[0]);
+  const completed = summary.merged + summary.closed;
+  return codeOverviewReportSchema.parse({
+    changes: recentChanges.map((change) => ({
+      ...change,
+      closedAt: change.closedAt?.toISOString(),
+      mergedAt: change.mergedAt?.toISOString(),
+      openedAt: change.openedAt.toISOString(),
+      title: change.title ?? undefined,
+      url: change.url ?? undefined,
+    })),
+    generatedAt: windowEnd.toISOString(),
+    repositories: z
+      .array(repositoryRowSchema)
+      .parse(queryRows(repositoryResult))
+      .map((repository) => ({
+        ...repository,
+        url: repository.url ?? undefined,
+      })),
+    summary: {
+      ...summary,
+      mergeRate: completed > 0 ? summary.merged / completed : undefined,
+    },
+    windowEnd: windowEnd.toISOString(),
+    windowStart: windowStart.toISOString(),
+  });
+}

--- a/packages/junior/src/api/code/routes.ts
+++ b/packages/junior/src/api/code/routes.ts
@@ -1,0 +1,14 @@
+import { Hono } from "hono";
+import { jsonResponse } from "../http";
+import type { JuniorApiEnv } from "../route";
+import { codeOverviewReportSchema } from "../schema/code";
+import { readCodeOverview } from "./overview";
+
+/** Create the code analytics API. */
+export function createCodeRoutes(): Hono<JuniorApiEnv> {
+  const app = new Hono<JuniorApiEnv>();
+  app.get("/", async () =>
+    jsonResponse(codeOverviewReportSchema, await readCodeOverview()),
+  );
+  return app;
+}

--- a/packages/junior/src/api/schema.ts
+++ b/packages/junior/src/api/schema.ts
@@ -1,6 +1,17 @@
 export { dailyConversationActivitySchema } from "./activity";
 export type { DailyConversationActivity } from "./activity";
 export {
+  codeChangeSummaryReportSchema,
+  codeChangeSummarySchema,
+  codeOverviewReportSchema,
+  codeRepositorySummarySchema,
+} from "./schema/code";
+export type {
+  CodeChangeSummaryReport,
+  CodeOverviewReport,
+  CodeRepositorySummary,
+} from "./schema/code";
+export {
   acceptedConversationMessageSchema,
   archiveConversationBodySchema,
   archiveConversationResponseSchema,

--- a/packages/junior/src/api/schema/code.ts
+++ b/packages/junior/src/api/schema/code.ts
@@ -1,0 +1,57 @@
+import { z } from "zod";
+import { codeChangeStateSchema } from "@sentry/junior-plugin-api";
+
+export const codeChangeSummarySchema = z
+  .object({
+    closed: z.number().int().nonnegative(),
+    created: z.number().int().nonnegative(),
+    merged: z.number().int().nonnegative(),
+    mergeRate: z.number().min(0).max(1).optional(),
+    open: z.number().int().nonnegative(),
+  })
+  .strict();
+
+export const codeRepositorySummarySchema = z
+  .object({
+    closed: z.number().int().nonnegative(),
+    created: z.number().int().nonnegative(),
+    id: z.string().min(1),
+    merged: z.number().int().nonnegative(),
+    name: z.string().min(1),
+    open: z.number().int().nonnegative(),
+    provider: z.string().min(1),
+    url: z.string().url().optional(),
+  })
+  .strict();
+
+export const codeChangeSummaryReportSchema = z
+  .object({
+    closedAt: z.string().optional(),
+    id: z.string().min(1),
+    mergedAt: z.string().optional(),
+    number: z.number().int().positive(),
+    openedAt: z.string(),
+    provider: z.string().min(1),
+    repository: z.string().min(1),
+    state: codeChangeStateSchema,
+    title: z.string().optional(),
+    url: z.string().url().optional(),
+  })
+  .strict();
+
+export const codeOverviewReportSchema = z
+  .object({
+    changes: z.array(codeChangeSummaryReportSchema),
+    generatedAt: z.string(),
+    repositories: z.array(codeRepositorySummarySchema),
+    summary: codeChangeSummarySchema,
+    windowEnd: z.string(),
+    windowStart: z.string(),
+  })
+  .strict();
+
+export type CodeChangeSummaryReport = z.infer<
+  typeof codeChangeSummaryReportSchema
+>;
+export type CodeOverviewReport = z.infer<typeof codeOverviewReportSchema>;
+export type CodeRepositorySummary = z.infer<typeof codeRepositorySummarySchema>;

--- a/packages/junior/src/api/schema/code.ts
+++ b/packages/junior/src/api/schema/code.ts
@@ -15,7 +15,7 @@ export const codeRepositorySummarySchema = z
   .object({
     closed: z.number().int().nonnegative(),
     created: z.number().int().nonnegative(),
-    id: z.string().min(1),
+    id: z.string().uuid(),
     merged: z.number().int().nonnegative(),
     name: z.string().min(1),
     open: z.number().int().nonnegative(),
@@ -27,7 +27,7 @@ export const codeRepositorySummarySchema = z
 export const codeChangeSummaryReportSchema = z
   .object({
     closedAt: z.string().optional(),
-    id: z.string().min(1),
+    id: z.string().uuid(),
     mergedAt: z.string().optional(),
     number: z.number().int().positive(),
     openedAt: z.string(),

--- a/packages/junior/src/app.ts
+++ b/packages/junior/src/app.ts
@@ -422,6 +422,7 @@ function dashboardHostRoutePaths(dashboard: JuniorDashboardOptions): string[] {
   const peoplePath = pagePath("people");
   const pagePaths = [
     basePath,
+    pagePath("code"),
     conversationsPath,
     `${conversationsPath}/*`,
     pagePath("locations"),
@@ -462,6 +463,7 @@ function dashboardHostRoutePaths(dashboard: JuniorDashboardOptions): string[] {
     "/api/tasks",
     "/api/tasks/*",
     "/api/skills",
+    "/api/code",
     "/api/stats",
     "/api/conversations",
     "/api/conversations/*",

--- a/packages/junior/src/chat/code/publisher.ts
+++ b/packages/junior/src/chat/code/publisher.ts
@@ -1,0 +1,17 @@
+import type { CodeChangePublisher } from "@sentry/junior-plugin-api";
+import { getDb } from "@/chat/db";
+import { associateCodeChangeConversations, recordCodeChange } from "./store";
+
+/** Connect a plugin to Junior's code records. */
+export function createCodeChangePublisher(
+  provider: string,
+): CodeChangePublisher {
+  return {
+    async associateConversations(input) {
+      await associateCodeChangeConversations(getDb(), provider, input);
+    },
+    async record(input) {
+      await recordCodeChange(getDb(), provider, input);
+    },
+  };
+}

--- a/packages/junior/src/chat/code/store.ts
+++ b/packages/junior/src/chat/code/store.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { and, eq, lte, sql } from "drizzle-orm";
 import {
   codeChangeInputSchema,
@@ -6,10 +7,6 @@ import {
 import type { JuniorDatabase } from "@/db/db";
 import { juniorCodeChanges, juniorCodeRepositories } from "@/db/schema";
 
-function codeRecordId(provider: string, providerId: string): string {
-  return `${provider.length}:${provider}:${providerId}`;
-}
-
 /** Record the latest details for one code change created by Junior. */
 export async function recordCodeChange(
   db: JuniorDatabase,
@@ -17,11 +14,10 @@ export async function recordCodeChange(
   input: CodeChangeInput,
 ): Promise<void> {
   const change = codeChangeInputSchema.parse(input);
-  const repositoryId = codeRecordId(provider, change.repository.providerId);
-  await db
+  const repositories = await db
     .insert(juniorCodeRepositories)
     .values({
-      id: repositoryId,
+      id: randomUUID(),
       name: change.repository.name,
       provider,
       providerId: change.repository.providerId,
@@ -29,16 +25,35 @@ export async function recordCodeChange(
       updatedAt: change.updatedAt,
     })
     .onConflictDoUpdate({
-      target: juniorCodeRepositories.id,
+      target: [
+        juniorCodeRepositories.provider,
+        juniorCodeRepositories.providerId,
+      ],
       set: {
         name: change.repository.name,
         ...(change.repository.url ? { url: change.repository.url } : undefined),
         updatedAt: change.updatedAt,
       },
       where: lte(juniorCodeRepositories.updatedAt, change.updatedAt),
-    });
+    })
+    .returning({ id: juniorCodeRepositories.id });
+  const existingRepositories = repositories[0]
+    ? []
+    : await db
+        .select({ id: juniorCodeRepositories.id })
+        .from(juniorCodeRepositories)
+        .where(
+          and(
+            eq(juniorCodeRepositories.provider, provider),
+            eq(juniorCodeRepositories.providerId, change.repository.providerId),
+          ),
+        )
+        .limit(1);
+  const repositoryId = repositories[0]?.id ?? existingRepositories[0]?.id;
+  if (!repositoryId) {
+    throw new Error("Code repository upsert returned no row");
+  }
 
-  const id = codeRecordId(provider, change.providerId);
   const conversationIds = sql.join(
     change.conversationIds.map((conversationId) => sql`${conversationId}`),
     sql`, `,
@@ -70,17 +85,14 @@ export async function recordCodeChange(
     .values({
       ...values,
       conversationIds: change.conversationIds,
-      id,
+      id: randomUUID(),
       provider,
       providerId: change.providerId,
     })
     .onConflictDoUpdate({
-      target: juniorCodeChanges.id,
+      target: [juniorCodeChanges.provider, juniorCodeChanges.providerId],
       set: values,
-      where: and(
-        eq(juniorCodeChanges.provider, provider),
-        lte(juniorCodeChanges.updatedAt, change.updatedAt),
-      ),
+      where: lte(juniorCodeChanges.updatedAt, change.updatedAt),
     });
 }
 

--- a/packages/junior/src/chat/code/store.ts
+++ b/packages/junior/src/chat/code/store.ts
@@ -1,0 +1,116 @@
+import { and, eq, lte, sql } from "drizzle-orm";
+import {
+  codeChangeInputSchema,
+  type CodeChangeInput,
+} from "@sentry/junior-plugin-api";
+import type { JuniorDatabase } from "@/db/db";
+import { juniorCodeChanges, juniorCodeRepositories } from "@/db/schema";
+
+function codeRecordId(provider: string, providerId: string): string {
+  return `${provider.length}:${provider}:${providerId}`;
+}
+
+/** Record the latest details for one code change created by Junior. */
+export async function recordCodeChange(
+  db: JuniorDatabase,
+  provider: string,
+  input: CodeChangeInput,
+): Promise<void> {
+  const change = codeChangeInputSchema.parse(input);
+  const repositoryId = codeRecordId(provider, change.repository.providerId);
+  await db
+    .insert(juniorCodeRepositories)
+    .values({
+      id: repositoryId,
+      name: change.repository.name,
+      provider,
+      providerId: change.repository.providerId,
+      url: change.repository.url,
+      updatedAt: change.updatedAt,
+    })
+    .onConflictDoUpdate({
+      target: juniorCodeRepositories.id,
+      set: {
+        name: change.repository.name,
+        ...(change.repository.url ? { url: change.repository.url } : undefined),
+        updatedAt: change.updatedAt,
+      },
+      where: lte(juniorCodeRepositories.updatedAt, change.updatedAt),
+    });
+
+  const id = codeRecordId(provider, change.providerId);
+  const conversationIds = sql.join(
+    change.conversationIds.map((conversationId) => sql`${conversationId}`),
+    sql`, `,
+  );
+  const values = {
+    closedAt: change.closedAt ?? null,
+    conversationIds:
+      change.conversationIds.length > 0
+        ? sql<string[]>`ARRAY(
+            SELECT DISTINCT value
+            FROM unnest(
+              ${juniorCodeChanges.conversationIds}
+              || ARRAY[${conversationIds}]::text[]
+            ) AS value
+            ORDER BY value
+          )`
+        : juniorCodeChanges.conversationIds,
+    mergedAt: change.mergedAt ?? null,
+    number: change.number,
+    openedAt: change.openedAt,
+    repositoryId,
+    state: change.state,
+    ...(change.title ? { title: change.title } : undefined),
+    updatedAt: change.updatedAt,
+    url: change.url ?? null,
+  };
+  await db
+    .insert(juniorCodeChanges)
+    .values({
+      ...values,
+      conversationIds: change.conversationIds,
+      id,
+      provider,
+      providerId: change.providerId,
+    })
+    .onConflictDoUpdate({
+      target: juniorCodeChanges.id,
+      set: values,
+      where: and(
+        eq(juniorCodeChanges.provider, provider),
+        lte(juniorCodeChanges.updatedAt, change.updatedAt),
+      ),
+    });
+}
+
+/** Add conversation links to an existing code change. */
+export async function associateCodeChangeConversations(
+  db: JuniorDatabase,
+  provider: string,
+  input: { conversationIds: string[]; providerId: string },
+): Promise<void> {
+  if (input.conversationIds.length === 0) return;
+  const conversationIds = sql.join(
+    input.conversationIds.map((conversationId) => sql`${conversationId}`),
+    sql`, `,
+  );
+  await db
+    .update(juniorCodeChanges)
+    .set({
+      conversationIds: sql`ARRAY(
+        SELECT DISTINCT value
+        FROM unnest(
+          ${juniorCodeChanges.conversationIds}
+          || ARRAY[${conversationIds}]::text[]
+        ) AS value
+        ORDER BY value
+      )`,
+    })
+    .where(
+      and(
+        eq(juniorCodeChanges.provider, provider),
+        eq(juniorCodeChanges.providerId, input.providerId),
+      ),
+    );
+}

--- a/packages/junior/src/chat/plugins/agent-hooks.ts
+++ b/packages/junior/src/chat/plugins/agent-hooks.ts
@@ -54,6 +54,7 @@ import type { Actor } from "@/chat/actor";
 import { z } from "zod";
 import { workspaceRepoCheckoutPath } from "@/chat/workspaces/checkout-path";
 import { listWorkspaceNamesByRepository } from "@/chat/workspaces/store";
+import { createCodeChangePublisher } from "@/chat/code/publisher";
 
 /** Signal that a plugin intentionally denied a tool execution. */
 export class PluginHookDeniedError extends Error {
@@ -864,6 +865,7 @@ export function getPluginRoutes(options: {
             plugin: pluginName,
           }),
       },
+      codeChanges: createCodeChangePublisher(pluginName),
       resourceEvents: {
         async publish(event) {
           const parsed = resourceEventInputSchema.parse(event);

--- a/packages/junior/src/db/schema.ts
+++ b/packages/junior/src/db/schema.ts
@@ -1,5 +1,6 @@
 import { juniorArtifacts } from "./schema/artifacts";
 import { juniorAttachments } from "./schema/attachments";
+import { juniorCodeChanges, juniorCodeRepositories } from "./schema/code";
 import { juniorConversationAnnotations } from "./schema/conversation-annotations";
 import { juniorApiTokens } from "./schema/api-tokens";
 import { juniorConversationEvents } from "./schema/conversation-events";
@@ -27,6 +28,8 @@ import { juniorWorkspaceRepos, juniorWorkspaces } from "./schema/workspaces";
 export {
   juniorArtifacts,
   juniorAttachments,
+  juniorCodeChanges,
+  juniorCodeRepositories,
   juniorConversationAnnotations,
   juniorApiTokens,
   juniorAgentBindings,
@@ -52,6 +55,8 @@ export {
 export const juniorSqlSchema = {
   juniorArtifacts,
   juniorAttachments,
+  juniorCodeChanges,
+  juniorCodeRepositories,
   juniorConversationAnnotations,
   juniorApiTokens,
   juniorAgentBindings,

--- a/packages/junior/src/db/schema/code.ts
+++ b/packages/junior/src/db/schema/code.ts
@@ -5,6 +5,7 @@ import {
   pgTable,
   text,
   uniqueIndex,
+  uuid,
 } from "drizzle-orm/pg-core";
 import type { CodeChangeState } from "@sentry/junior-plugin-api";
 import { timestamptz } from "./timestamps";
@@ -13,7 +14,7 @@ import { timestamptz } from "./timestamps";
 export const juniorCodeRepositories = pgTable(
   "junior_code_repositories",
   {
-    id: text("id").primaryKey(),
+    id: uuid("id").primaryKey(),
     name: text("name").notNull(),
     provider: text("provider").notNull(),
     providerId: text("provider_id").notNull(),
@@ -32,7 +33,7 @@ export const juniorCodeRepositories = pgTable(
 export const juniorCodeChanges = pgTable(
   "junior_code_changes",
   {
-    id: text("id").primaryKey(),
+    id: uuid("id").primaryKey(),
     closedAt: timestamptz("closed_at"),
     conversationIds: text("conversation_ids")
       .array()
@@ -43,7 +44,7 @@ export const juniorCodeChanges = pgTable(
     openedAt: timestamptz("opened_at").notNull(),
     provider: text("provider").notNull(),
     providerId: text("provider_id").notNull(),
-    repositoryId: text("repository_id")
+    repositoryId: uuid("repository_id")
       .notNull()
       .references(() => juniorCodeRepositories.id, { onDelete: "cascade" }),
     state: text("state").$type<CodeChangeState>().notNull(),

--- a/packages/junior/src/db/schema/code.ts
+++ b/packages/junior/src/db/schema/code.ts
@@ -1,0 +1,66 @@
+import { sql } from "drizzle-orm";
+import {
+  index,
+  integer,
+  pgTable,
+  text,
+  uniqueIndex,
+} from "drizzle-orm/pg-core";
+import type { CodeChangeState } from "@sentry/junior-plugin-api";
+import { timestamptz } from "./timestamps";
+
+/** Repository known to Junior through an installed code plugin. */
+export const juniorCodeRepositories = pgTable(
+  "junior_code_repositories",
+  {
+    id: text("id").primaryKey(),
+    name: text("name").notNull(),
+    provider: text("provider").notNull(),
+    providerId: text("provider_id").notNull(),
+    url: text("url"),
+    updatedAt: timestamptz("updated_at").notNull(),
+  },
+  (table) => [
+    uniqueIndex("junior_code_repositories_provider_id_idx").on(
+      table.provider,
+      table.providerId,
+    ),
+  ],
+);
+
+/** Latest known state for one code change created by Junior. */
+export const juniorCodeChanges = pgTable(
+  "junior_code_changes",
+  {
+    id: text("id").primaryKey(),
+    closedAt: timestamptz("closed_at"),
+    conversationIds: text("conversation_ids")
+      .array()
+      .notNull()
+      .default(sql`ARRAY[]::text[]`),
+    mergedAt: timestamptz("merged_at"),
+    number: integer("number").notNull(),
+    openedAt: timestamptz("opened_at").notNull(),
+    provider: text("provider").notNull(),
+    providerId: text("provider_id").notNull(),
+    repositoryId: text("repository_id")
+      .notNull()
+      .references(() => juniorCodeRepositories.id, { onDelete: "cascade" }),
+    state: text("state").$type<CodeChangeState>().notNull(),
+    title: text("title"),
+    updatedAt: timestamptz("updated_at").notNull(),
+    url: text("url"),
+  },
+  (table) => [
+    uniqueIndex("junior_code_changes_provider_id_idx").on(
+      table.provider,
+      table.providerId,
+    ),
+    index("junior_code_changes_opened_at_idx").on(table.openedAt),
+    index("junior_code_changes_merged_at_idx").on(table.mergedAt),
+    index("junior_code_changes_closed_at_idx").on(table.closedAt),
+    index("junior_code_changes_open_idx")
+      .on(table.id)
+      .where(sql`${table.state} = 'open'`),
+  ],
+);

--- a/packages/junior/tests/integration/api/code.test.ts
+++ b/packages/junior/tests/integration/api/code.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, test, vi } from "vitest";
+import { z } from "zod";
+import type { CodeChangeInput } from "@sentry/junior-plugin-api";
 import { createJuniorApi } from "@/api";
 import { codeOverviewReportSchema } from "@/api/schema";
 import { recordCodeChange } from "@/chat/code/store";
 import { migrateSchema } from "@/chat/conversations/sql/migrations";
+import { juniorCodeChanges, juniorCodeRepositories } from "@/db/schema";
 import { createConfiguredJuniorSqlFixture } from "../../fixtures/sql";
 
 describe("code API", () => {
@@ -11,7 +14,7 @@ describe("code API", () => {
     vi.setSystemTime(new Date("2026-08-24T12:00:00.000Z"));
     try {
       await migrateSchema(fixture.sql);
-      await recordCodeChange(fixture.sql.db(), "github", {
+      const codeChange = {
         conversationIds: ["conversation-1"],
         mergedAt: new Date("2026-08-22T12:00:00.000Z"),
         number: 42,
@@ -26,6 +29,25 @@ describe("code API", () => {
         title: "Make code native",
         updatedAt: new Date("2026-08-22T12:00:00.000Z"),
         url: "https://github.com/getsentry/junior/pull/42",
+      } satisfies CodeChangeInput;
+      await recordCodeChange(fixture.sql.db(), "github", codeChange);
+      await recordCodeChange(fixture.sql.db(), "github", codeChange);
+
+      const repositories = await fixture.sql
+        .db()
+        .select()
+        .from(juniorCodeRepositories);
+      const changes = await fixture.sql.db().select().from(juniorCodeChanges);
+      expect(repositories).toHaveLength(1);
+      expect(changes).toHaveLength(1);
+      expect(z.string().uuid().parse(repositories[0]?.id)).toBe(
+        repositories[0]?.id,
+      );
+      expect(z.string().uuid().parse(changes[0]?.id)).toBe(changes[0]?.id);
+      expect(repositories[0]?.providerId).toBe("repository-1");
+      expect(changes[0]).toMatchObject({
+        providerId: "change-42",
+        repositoryId: repositories[0]?.id,
       });
 
       const response = await createJuniorApi().request(

--- a/packages/junior/tests/integration/api/code.test.ts
+++ b/packages/junior/tests/integration/api/code.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test, vi } from "vitest";
+import { createJuniorApi } from "@/api";
+import { codeOverviewReportSchema } from "@/api/schema";
+import { recordCodeChange } from "@/chat/code/store";
+import { migrateSchema } from "@/chat/conversations/sql/migrations";
+import { createConfiguredJuniorSqlFixture } from "../../fixtures/sql";
+
+describe("code API", () => {
+  test("reports code changes across hosting services", async () => {
+    const fixture = createConfiguredJuniorSqlFixture();
+    vi.setSystemTime(new Date("2026-08-24T12:00:00.000Z"));
+    try {
+      await migrateSchema(fixture.sql);
+      await recordCodeChange(fixture.sql.db(), "github", {
+        conversationIds: ["conversation-1"],
+        mergedAt: new Date("2026-08-22T12:00:00.000Z"),
+        number: 42,
+        openedAt: new Date("2026-08-20T12:00:00.000Z"),
+        providerId: "change-42",
+        repository: {
+          name: "getsentry/junior",
+          providerId: "repository-1",
+          url: "https://github.com/getsentry/junior",
+        },
+        state: "merged",
+        title: "Make code native",
+        updatedAt: new Date("2026-08-22T12:00:00.000Z"),
+        url: "https://github.com/getsentry/junior/pull/42",
+      });
+
+      const response = await createJuniorApi().request(
+        "http://localhost/api/code",
+      );
+      expect(response.status).toBe(200);
+      const report = codeOverviewReportSchema.parse(await response.json());
+      expect(report.summary).toEqual({
+        closed: 0,
+        created: 1,
+        merged: 1,
+        mergeRate: 1,
+        open: 0,
+      });
+      expect(report.repositories).toEqual([
+        expect.objectContaining({
+          created: 1,
+          merged: 1,
+          name: "getsentry/junior",
+          provider: "github",
+        }),
+      ]);
+      expect(report.changes).toEqual([
+        expect.objectContaining({
+          number: 42,
+          repository: "getsentry/junior",
+          state: "merged",
+          title: "Make code native",
+        }),
+      ]);
+    } finally {
+      vi.useRealTimers();
+      await fixture.close();
+    }
+  });
+});


### PR DESCRIPTION
Junior now owns repository and code change records, and the dashboard has a top-level Code page with 30-day change totals, repository activity, and recent changes. Code plugins write through a shared contract; the GitHub plugin translates pull request webhooks into that contract.

The core migration creates the shared tables with native PostgreSQL UUID keys. Each plugin keeps its own IDs as text in a separate unique key. A GitHub plugin migration backfills existing pull request outcomes, while new webhooks update both the existing GitHub data and the shared records. Existing GitHub reports and unfinished-work behavior remain unchanged.

This keeps commit classification inside the GitHub plugin for now. Shared commit analytics can follow when Junior stores commits as first-class records instead of copying a GitHub-only value.
