### PR TITLE
ref(chat): use native Turn execution for Conversation API

### DIFF
--- a/packages/junior/scripts/acp-local-server.ts
+++ b/packages/junior/scripts/acp-local-server.ts
@@ -31,11 +31,9 @@ function localPort(): number {
 }
 
 await migrateSchema(getSqlExecutor());
-const harness = await createConversationWorkWebHarness({
-  modelStream: streamScript(
-    process.env.JUNIOR_ACP_LOCAL_REPLY?.trim() || DEFAULT_REPLY,
-  ),
-});
+const harness = await createConversationWorkWebHarness(
+  streamScript(process.env.JUNIOR_ACP_LOCAL_REPLY?.trim() || DEFAULT_REPLY),
+);
 // Use the loopback request origin, not deployed callback origins from env files.
 delete process.env.JUNIOR_BASE_URL;
 delete process.env.VERCEL_PROJECT_PRODUCTION_URL;
@@ -46,7 +44,7 @@ const app = await createApp({
 });
 let drainActive = false;
 
-/** Drain queued API Turn work while the smoke client waits for its response. */
+/** Drain queued Conversation API work while the smoke client waits. */
 async function drainQueuedWork(): Promise<void> {
   if (drainActive || !harness.queue.hasQueuedMessages()) return;
   drainActive = true;

--- a/packages/junior/src/chat/api-turns/cancellation.ts
+++ b/packages/junior/src/chat/api-turns/cancellation.ts
@@ -1,4 +1,4 @@
-/** App-scoped control for one active API Turn per Conversation. */
+/** App-scoped control for one active Turn started by the Conversation API. */
 export interface ApiTurnCancellation {
   begin(conversationId: string): AbortSignal | undefined;
   cancel(conversationId: string): boolean;
@@ -14,7 +14,7 @@ interface ActiveApiTurnCancellation {
   parked: boolean;
 }
 
-/** Create in-process cancellation state for active API Turns. */
+/** Create in-process cancellation state for Turns from the Conversation API. */
 export function createApiTurnCancellation(): ApiTurnCancellation {
   const active = new Map<string, ActiveApiTurnCancellation>();
 
@@ -36,7 +36,7 @@ export function createApiTurnCancellation(): ApiTurnCancellation {
       if (!entry) {
         return false;
       }
-      entry.controller.abort(new Error("API Turn cancelled"));
+      entry.controller.abort(new Error("Turn cancelled"));
       return true;
     },
     disconnect(conversationId, signal) {
@@ -71,7 +71,7 @@ export function createApiTurnCancellation(): ApiTurnCancellation {
   };
 }
 
-/** Close one cancelled API Turn without a failure reply or retry. */
+/** Close one cancelled Turn without a failure reply or retry. */
 export async function completeCancelledApiTurn(args: {
   acknowledge(): Promise<void>;
   actorId: string;
@@ -89,7 +89,7 @@ export async function completeCancelledApiTurn(args: {
     await abandonTurnRecord({
       conversationId: args.conversationId,
       turnId: args.turnId,
-      errorMessage: "API Turn cancelled",
+      errorMessage: "Turn cancelled",
     });
     clearPendingAuth(args.conversation, args.turnId);
     markConversationMessage(args.conversation, args.userMessageId, {

--- a/packages/junior/src/chat/api-turns/cancellation.ts
+++ b/packages/junior/src/chat/api-turns/cancellation.ts
@@ -78,7 +78,6 @@ export async function completeCancelledApiTurn(args: {
   cancellation?: ApiTurnCancellation;
   conversation: ThreadConversationState;
   conversationId: string;
-  lifecycle: ConversationTurnLifecycle;
   sandboxRef?: SandboxRef;
   signal?: AbortSignal;
   turnId: string;
@@ -112,7 +111,9 @@ export async function completeCancelledApiTurn(args: {
       conversation: args.conversation,
       sandboxRef: args.sandboxRef,
     });
-    await args.lifecycle.complete({
+    await new ConversationTurnLifecycleService(
+      getConversationEventStore(),
+    ).complete({
       conversationId: args.conversationId,
       createdAtMs: Date.now(),
       outcome: "cancelled",
@@ -125,7 +126,8 @@ export async function completeCancelledApiTurn(args: {
   }
   await args.acknowledge();
 }
-import type { ConversationTurnLifecycle } from "@/chat/conversations/turn-lifecycle";
+import { ConversationTurnLifecycleService } from "@/chat/conversations/turn-lifecycle";
+import { getConversationEventStore } from "@/chat/db";
 import { deleteWebAuthorization } from "@/chat/api-turns/authorization";
 import { persistThreadStateById } from "@/chat/runtime/thread-state";
 import { markTurnClosed } from "@/chat/runtime/turn";

--- a/packages/junior/src/chat/api-turns/cancellation.ts
+++ b/packages/junior/src/chat/api-turns/cancellation.ts
@@ -36,7 +36,7 @@ export function createApiTurnCancellation(): ApiTurnCancellation {
       if (!entry) {
         return false;
       }
-      entry.controller.abort(new Error("Turn cancelled"));
+      entry.controller.abort(new DOMException("Turn cancelled", "AbortError"));
       return true;
     },
     disconnect(conversationId, signal) {

--- a/packages/junior/src/chat/api-turns/work.ts
+++ b/packages/junior/src/chat/api-turns/work.ts
@@ -1,4 +1,4 @@
-/** API Turns run the shared agent and save replies without external delivery. */
+/** Conversation API work runs a native Turn and keeps replies in the Conversation. */
 import { createHash } from "node:crypto";
 import type { StateAdapter } from "chat";
 import {
@@ -358,7 +358,7 @@ export async function createAndEnqueueApiConversation(
   );
 }
 
-/** Append one API message and optionally require an idle Conversation. */
+/** Append one Conversation API message and optionally require an idle Conversation. */
 export function appendAndEnqueueApiConversationMessage(
   input: AppendApiConversationMessageInput,
   options: EnqueueOptions & { exclusive: true },
@@ -435,7 +435,7 @@ function hasLostTurnInputCommit(error: unknown): boolean {
   return isTurnInputCommitLostError(error) || isTurnInputCommitLostError(cause);
 }
 
-/** Build the mailbox consumer for API-authored root turns. */
+/** Create the worker for messages from the Conversation API. */
 export function createApiTurnWorker(
   agentRunner: AgentRunner,
   cancellation?: ApiTurnCancellation,
@@ -446,12 +446,12 @@ export function createApiTurnWorker(
     const resolved = await resolveApiTurnWork(context);
     if (!resolved) {
       throw new Error(
-        `API turn worker received non-API work for ${context.conversationId}`,
+        `Conversation API worker received other work for ${context.conversationId}`,
       );
     }
     if (context.publishExternally) {
       throw new Error(
-        `API turn work must not publish externally for ${context.conversationId}`,
+        `Conversation API work cannot publish to a provider for ${context.conversationId}`,
       );
     }
 
@@ -492,7 +492,7 @@ export function createApiTurnWorker(
       );
       if (!resumedActor) {
         throw new Error(
-          `API turn resume missing actor for ${context.conversationId}`,
+          `Conversation API resume missing actor for ${context.conversationId}`,
         );
       }
       actor = resumedActor;
@@ -535,7 +535,7 @@ export function createApiTurnWorker(
             await context.attempt.ack();
           } catch {
             throw new TurnInputCommitLostError(
-              `Conversation work lease lost before API turn inbox ack for ${context.conversationId}`,
+              `Conversation work lease lost before Conversation API message acknowledgement for ${context.conversationId}`,
             );
           }
           acknowledged = true;
@@ -588,7 +588,7 @@ export function createApiTurnWorker(
           const userMessage = getTurnUserMessage(conversation, turnId);
           if (!userMessage) {
             throw new Error(
-              `Unable to locate the persisted user message for API turn "${turnId}"`,
+              `Unable to locate the persisted user message for Turn "${turnId}"`,
             );
           }
           userMessageId = userMessage.id;
@@ -688,7 +688,7 @@ export function createApiTurnWorker(
           }
           if (!isResume) {
             // Match Slack: a newer user message supersedes an auth-parked turn
-            // instead of leaving two active API turns or letting a late OAuth
+            // instead of leaving two active Turns or letting a late OAuth
             // wake resume stale work.
             const authParked = (
               await listTurnSummaries(context.conversationId)
@@ -792,9 +792,7 @@ export function createApiTurnWorker(
             },
             async (result) => {
               if (cancellationSignal?.aborted) {
-                throw (
-                  cancellationSignal.reason ?? new Error("API Turn cancelled")
-                );
+                throw cancellationSignal.reason ?? new Error("Turn cancelled");
               }
 
               finishCancellation();
@@ -978,7 +976,7 @@ export function createApiTurnWorker(
   };
 }
 
-/** Route API turn work before falling through to other consumers. */
+/** Route Conversation API work before other work. */
 export function routeApiTurnWork(options: {
   apiTurnWorker: (
     context: ConversationWorkerContext,

--- a/packages/junior/src/chat/api-turns/work.ts
+++ b/packages/junior/src/chat/api-turns/work.ts
@@ -792,7 +792,10 @@ export function createApiTurnWorker(
             },
             async (result) => {
               if (cancellationSignal?.aborted) {
-                throw cancellationSignal.reason ?? new Error("Turn cancelled");
+                throw (
+                  cancellationSignal.reason ??
+                  new DOMException("Turn cancelled", "AbortError")
+                );
               }
 
               finishCancellation();

--- a/packages/junior/src/chat/api-turns/work.ts
+++ b/packages/junior/src/chat/api-turns/work.ts
@@ -1,12 +1,4 @@
-/**
- * API-authored conversation turns.
- *
- * Dashboard and product API messages enter the shared mailbox with
- * `publishExternally: false`. The worker leases the conversation, runs the
- * shared agent path, and accepts replies into the conversation log only.
- * Continues of Slack-rooted conversations keep the Slack destination for
- * location context and never publish back to Slack.
- */
+/** API Turns run the shared agent and save replies without external delivery. */
 import { createHash } from "node:crypto";
 import type { StateAdapter } from "chat";
 import {
@@ -25,15 +17,13 @@ import {
   hydrateConversationMessages,
   persistConversationMessages,
 } from "@/chat/conversations/messages";
-import {
-  ConversationTurnLifecycleService,
-  type ConversationTurnLifecycle,
-} from "@/chat/conversations/turn-lifecycle";
+import { ConversationTurnLifecycleService } from "@/chat/conversations/turn-lifecycle";
 import type { ConversationTurnFailureCode } from "@/chat/conversations/history";
 import { credentialContextForActor } from "@/chat/credentials/context";
 import { getConversationEventStore, getConversationStore } from "@/chat/db";
 import { logException, setTags, withLogContext } from "@/chat/logging";
 import type { AgentRunner } from "@/chat/runtime/agent-runner";
+import { AgentRunError, executeTurn } from "@/chat/runtime/turn-execution";
 import { buildDeliveredTurnStatePatch } from "@/chat/runtime/delivered-turn-state";
 import {
   getPersistedSandboxState,
@@ -83,7 +73,6 @@ import {
   scheduleSessionCompletedPluginTasks,
 } from "@/chat/plugins/task-runner";
 import type { SandboxRef } from "@/chat/sandbox/ref";
-import type { AgentRunResult } from "@/chat/services/turn-result";
 import type { StoredSlackActor } from "@/chat/actor";
 import {
   createWebAuthorization,
@@ -447,11 +436,10 @@ function hasLostTurnInputCommit(error: unknown): boolean {
 }
 
 /** Build the mailbox consumer for API-authored root turns. */
-export function createApiTurnWorker(options: {
-  agentRunner: AgentRunner;
-  cancellation?: ApiTurnCancellation;
-  turnLifecycle?: ConversationTurnLifecycle;
-}) {
+export function createApiTurnWorker(
+  agentRunner: AgentRunner,
+  cancellation?: ApiTurnCancellation,
+) {
   return async (
     context: ConversationWorkerContext,
   ): Promise<ConversationWorkerResult> => {
@@ -467,9 +455,9 @@ export function createApiTurnWorker(options: {
       );
     }
 
-    const lifecycle =
-      options.turnLifecycle ??
-      new ConversationTurnLifecycleService(getConversationEventStore());
+    const lifecycle = new ConversationTurnLifecycleService(
+      getConversationEventStore(),
+    );
 
     const isResume = resolved.kind === "resume";
     let actor: WebActor;
@@ -562,7 +550,7 @@ export function createApiTurnWorker(options: {
         let sandboxRef: SandboxRef | undefined =
           getPersistedSandboxState(persisted);
         const initialSandboxRef = sandboxRef;
-        const appSignal = options.cancellation?.signal(context.conversationId);
+        const appSignal = cancellation?.signal(context.conversationId);
         const stopSignal = context.stopSignal?.();
         const cancellationSignal =
           appSignal && stopSignal
@@ -570,7 +558,7 @@ export function createApiTurnWorker(options: {
             : (appSignal ?? stopSignal);
         const finishCancellation = (): void => {
           if (appSignal) {
-            options.cancellation?.finish(context.conversationId, appSignal);
+            cancellation?.finish(context.conversationId, appSignal);
           }
         };
         const completeCancelledTurn =
@@ -579,10 +567,9 @@ export function createApiTurnWorker(options: {
               await completeCancelledApiTurn({
                 acknowledge,
                 actorId: actor.userId,
-                cancellation: options.cancellation,
+                cancellation,
                 conversation,
                 conversationId: context.conversationId,
-                lifecycle,
                 sandboxRef,
                 signal: appSignal,
                 turnId,
@@ -654,7 +641,7 @@ export function createApiTurnWorker(options: {
         let failureCode: ConversationTurnFailureCode = "persistence_failed";
         let modelFailureEventId: string | undefined;
         let modelFailureCaptureAttempted = false;
-        let reply: AgentRunResult | undefined;
+        let completedSuccessfully = false;
 
         const deliverAssistantMessage = async (
           value: AssistantMessage | string,
@@ -753,56 +740,125 @@ export function createApiTurnWorker(options: {
           currentRunId = `api-run:${stableHex(turnId, String(startedAtMs))}`;
           setTags({ runId: currentRunId });
 
-          const outcome = await options.agentRunner.run({
-            conversationId: context.conversationId,
-            turnId,
-            runId: currentRunId,
-            instruction: {
-              text,
-              context: buildConversationContext(conversation, {
-                excludeMessageId: userMessageId,
-              }),
-            },
-            history: piMessages,
-            actor,
-            credentialContext: credentialContextForActor(actor),
-            destination,
-            publishExternally: false,
-            source,
-            surface: "api",
-            ...(cancellationSignal
-              ? { signal: cancellationSignal }
-              : undefined),
-            authorization: createWebAuthorization({
-              actorId: actor.userId,
+          const outcome = await executeTurn(
+            agentRunner,
+            {
               conversationId: context.conversationId,
-            }),
-            state: {
-              pendingAuth: conversation.processing.pendingAuth,
-              sandboxRef,
-            },
-            delivery: deliverAssistantMessage,
-            durability: {
-              onInputCommitted: acknowledge,
-              shouldYield: context.shouldYield,
-              onSandboxRefChanged: async (nextSandboxRef) => {
-                sandboxRef = nextSandboxRef;
-                await persistThreadStateById(context.conversationId, {
-                  conversation,
-                  sandboxRef,
-                });
+              turnId,
+              runId: currentRunId,
+              instruction: {
+                text,
+                context: buildConversationContext(conversation, {
+                  excludeMessageId: userMessageId,
+                }),
               },
-              recordPendingAuth: async (pendingAuth) => {
-                conversation.processing.pendingAuth = pendingAuth;
-                await persistThreadStateById(context.conversationId, {
-                  conversation,
-                  sandboxRef,
-                });
+              history: piMessages,
+              actor,
+              credentialContext: credentialContextForActor(actor),
+              destination,
+              publishExternally: false,
+              source,
+              surface: "api",
+              ...(cancellationSignal
+                ? { signal: cancellationSignal }
+                : undefined),
+              authorization: createWebAuthorization({
+                actorId: actor.userId,
+                conversationId: context.conversationId,
+              }),
+              state: {
+                pendingAuth: conversation.processing.pendingAuth,
+                sandboxRef,
+              },
+              delivery: deliverAssistantMessage,
+              durability: {
+                onInputCommitted: acknowledge,
+                shouldYield: context.shouldYield,
+                onSandboxRefChanged: async (nextSandboxRef) => {
+                  sandboxRef = nextSandboxRef;
+                  await persistThreadStateById(context.conversationId, {
+                    conversation,
+                    sandboxRef,
+                  });
+                },
+                recordPendingAuth: async (pendingAuth) => {
+                  conversation.processing.pendingAuth = pendingAuth;
+                  await persistThreadStateById(context.conversationId, {
+                    conversation,
+                    sandboxRef,
+                  });
+                },
               },
             },
-          });
+            async (result) => {
+              if (cancellationSignal?.aborted) {
+                throw (
+                  cancellationSignal.reason ?? new Error("API Turn cancelled")
+                );
+              }
 
-          if (cancellationSignal?.aborted) {
+              finishCancellation();
+              modelFailureCaptureAttempted =
+                result.diagnostics.outcome !== "success";
+              const finalized = finalizeFailedTurnReplyWithEvent({
+                reply: result,
+                logException,
+              });
+              const reply = finalized.reply;
+              modelFailureEventId = finalized.eventId;
+              if (reply.diagnostics.outcome !== "success") {
+                await deliverAssistantMessage(reply.text);
+              }
+
+              const completedState = buildDeliveredTurnStatePatch({
+                conversation,
+                reply,
+                sessionId: turnId,
+                userMessageId,
+              });
+              await persistThreadStateById(context.conversationId, {
+                conversation: completedState.conversation,
+                sandboxRef: reply.sandboxRef ?? sandboxRef,
+              });
+              if (reply.piMessages?.length) {
+                // Prefer the live checkpoint slice after yield/resume; first
+                // completion has no prior record and starts at slice 1.
+                const latest = await getTurnRecord(
+                  context.conversationId,
+                  turnId,
+                );
+                await saveTurnCheckpoint({
+                  mode: "completed",
+                  conversationId: context.conversationId,
+                  turnId,
+                  sliceId: latest?.sliceId ?? 1,
+                  messages: reply.piMessages,
+                  durationMs: reply.diagnostics.durationMs,
+                  usage: reply.diagnostics.usage,
+                  destination,
+                  publishExternally: false,
+                  source,
+                  actor,
+                  surface: "api",
+                });
+              }
+
+              completedSuccessfully = reply.diagnostics.outcome === "success";
+              return completedSuccessfully
+                ? {
+                    outcome: assistantMessageDelivered ? "success" : "no_reply",
+                  }
+                : {
+                    ...(modelFailureEventId
+                      ? { eventId: modelFailureEventId }
+                      : undefined),
+                    failureCode: "model_execution_failed",
+                    outcome: "failed",
+                  };
+            },
+          );
+
+          if (outcome.status !== "completed" && cancellationSignal?.aborted) {
             return await completeCancelledTurn();
           }
 
@@ -822,62 +878,12 @@ export function createApiTurnWorker(options: {
               sandboxRef,
             });
             if (appSignal) {
-              options.cancellation?.park(context.conversationId, appSignal);
+              cancellation?.park(context.conversationId, appSignal);
             }
             await acknowledge();
             return { status: "paused" };
           }
-          finishCancellation();
-          reply = outcome.result;
-          modelFailureCaptureAttempted =
-            reply.diagnostics.outcome !== "success";
-          const finalized = finalizeFailedTurnReplyWithEvent({
-            reply,
-            logException,
-          });
-          reply = finalized.reply;
-          modelFailureEventId = finalized.eventId;
-          if (reply.diagnostics.outcome !== "success") {
-            await deliverAssistantMessage(reply.text);
-          }
-
-          const completedState = buildDeliveredTurnStatePatch({
-            conversation,
-            reply,
-            sessionId: turnId,
-            userMessageId,
-          });
-          await persistThreadStateById(context.conversationId, {
-            conversation: completedState.conversation,
-            sandboxRef: reply.sandboxRef ?? sandboxRef,
-          });
-          if (reply.piMessages?.length) {
-            // Prefer the live checkpoint slice after yield/resume; first
-            // completion has no prior record and starts at slice 1.
-            const latest = await getTurnRecord(context.conversationId, turnId);
-            await saveTurnCheckpoint({
-              mode: "completed",
-              conversationId: context.conversationId,
-              turnId,
-              sliceId: latest?.sliceId ?? 1,
-              messages: reply.piMessages,
-              durationMs: reply.diagnostics.durationMs,
-              usage: reply.diagnostics.usage,
-              destination,
-              publishExternally: false,
-              source,
-              actor,
-              surface: "api",
-            });
-          }
-
-          if (reply.diagnostics.outcome === "success") {
-            await lifecycle.complete({
-              conversationId: context.conversationId,
-              createdAtMs: Date.now(),
-              outcome: assistantMessageDelivered ? "success" : "no_reply",
-              turnId,
-            });
+          if (completedSuccessfully) {
             try {
               await scheduleSessionCompletedPluginTasks(
                 {
@@ -909,29 +915,20 @@ export function createApiTurnWorker(options: {
                 turnId,
               });
             }
-          } else {
-            await lifecycle.fail({
-              conversationId: context.conversationId,
-              createdAtMs: Date.now(),
-              ...(modelFailureEventId
-                ? { eventId: modelFailureEventId }
-                : undefined),
-              failureCode: "model_execution_failed",
-              turnId,
-            });
           }
 
           await acknowledge();
           return { status: "completed" };
         } catch (error) {
-          if (hasLostTurnInputCommit(error)) {
+          const failure = error instanceof AgentRunError ? error.cause : error;
+          if (hasLostTurnInputCommit(failure)) {
             return { status: "lost_lease" };
           }
           if (cancellationSignal?.aborted) {
             return await completeCancelledTurn();
           }
           if (!context.attempt.isFinalAttempt) {
-            throw error;
+            throw failure;
           }
 
           const failureEventId =
@@ -939,7 +936,7 @@ export function createApiTurnWorker(options: {
               ? modelFailureEventId
               : captureApiBoundaryFailure({
                   conversationId: context.conversationId,
-                  error,
+                  error: failure,
                   failureCode,
                   runId: currentRunId,
                   turnId,

--- a/packages/junior/src/chat/app/conversation-work.ts
+++ b/packages/junior/src/chat/app/conversation-work.ts
@@ -42,7 +42,7 @@ interface ConversationWorkOptions {
 
 export type ConversationWorkCallbackOptions =
   VercelConversationWorkCallbackOptions & {
-    /** App-scoped control for API Turn cancellation across request handlers. */
+    /** App-scoped Turn cancellation for Conversation API request handlers. */
     apiTurnCancellation?: ApiTurnCancellation;
   };
 

--- a/packages/junior/src/chat/app/conversation-work.ts
+++ b/packages/junior/src/chat/app/conversation-work.ts
@@ -124,11 +124,10 @@ export function createConversationWork(
     conversationStore: options.conversationStore,
     queue: options.queue,
     run: routeApiTurnWork({
-      apiTurnWorker: createApiTurnWorker({
-        agentRunner: options.agentRunner,
-        cancellation: apiTurnCancellation,
-        turnLifecycle: services.replyExecutor?.turnLifecycle,
-      }),
+      apiTurnWorker: createApiTurnWorker(
+        options.agentRunner,
+        apiTurnCancellation,
+      ),
       fallbackWorker: routeAgentInvocationWork({
         invocationWorker: createAgentInvocationWorker(options.agentRunner),
         fallbackWorker: providerWorker,

--- a/packages/junior/src/chat/runtime/turn-execution.ts
+++ b/packages/junior/src/chat/runtime/turn-execution.ts
@@ -15,6 +15,7 @@ type SavedTurnResult =
       outcome: CompleteConversationTurnInput["outcome"];
     }
   | {
+      eventId?: string;
       finishedAtMs?: number;
       failureCode: FailConversationTurnInput["failureCode"];
       outcome: "failed";
@@ -67,6 +68,7 @@ export async function executeTurn(
   if (saved.outcome === "failed") {
     await lifecycle.fail({
       ...common,
+      ...(saved.eventId ? { eventId: saved.eventId } : undefined),
       failureCode: saved.failureCode,
     });
   } else {

--- a/packages/junior/src/chat/sandbox/errors.ts
+++ b/packages/junior/src/chat/sandbox/errors.ts
@@ -148,11 +148,7 @@ export function isAbortError(error: unknown): boolean {
     if (!(candidate instanceof Error)) return false;
     if (candidate.name === "AbortError") return true;
     const message = candidate.message.toLowerCase();
-    return (
-      message === "api turn cancelled" ||
-      message === "api turn canceled" ||
-      message.startsWith("executeagentrun timed out after")
-    );
+    return message.startsWith("executeagentrun timed out after");
   });
 }
 

--- a/packages/junior/tests/component/sandbox/snapshot/workspace.test.ts
+++ b/packages/junior/tests/component/sandbox/snapshot/workspace.test.ts
@@ -17,6 +17,7 @@ vi.mock("@vercel/sandbox", () => ({
 
 import { closeDb, getDb } from "@/chat/db";
 import { FUNCTION_TIMEOUT_BUFFER_SECONDS, getChatConfig } from "@/chat/config";
+import { createApiTurnCancellation } from "@/chat/api-turns/cancellation";
 import { runWithTurnRequestDeadline } from "@/chat/runtime/request-deadline";
 import { deleteWorkspaceSnapshotBuilders } from "@/chat/sandbox/snapshot/builder-sandbox";
 import * as profile from "@/chat/sandbox/snapshot/profile";
@@ -196,6 +197,56 @@ describe("Workspace snapshot completion", () => {
       loadSnapshotsForProfile(getDb(), workspace.id, value.hash),
     ).resolves.toMatchObject({
       build: { status: "failed", error: "status code 404" },
+      ready: null,
+    });
+  });
+
+  it("keeps a build open when Conversation API cancellation stops it", async () => {
+    const workspace = await createWorkspace({
+      name: `snapshot-cancelled-${randomUUID()}`,
+      setupScript: "printf ready",
+      repos: [],
+    });
+    const value = profile.create(SANDBOX_RUNTIME, workspace);
+    if (!value) throw new Error("Workspace snapshot profile is missing");
+
+    await setWorkspaceSnapshotBuild(
+      workspace.id,
+      {
+        id: randomUUID(),
+        status: "building",
+        phase: "created",
+        profileHash: value.hash,
+        startedAt: new Date(),
+        sandboxName: "cancelled-builder",
+        commandId: null,
+        error: null,
+      },
+      { insertIfMissing: true },
+    );
+    const cancellation = createApiTurnCancellation();
+    const signal = cancellation.begin("conversation-1");
+    if (!signal) throw new Error("Expected an active Turn signal");
+    sandboxGetMock.mockImplementation(async () => {
+      cancellation.cancel("conversation-1");
+      throw signal.reason;
+    });
+
+    await expect(
+      resolveWorkspaceSnapshot({
+        workspace,
+        runtime: SANDBOX_RUNTIME,
+        signal,
+        shouldStop: () => false,
+        applyNetworkPolicy: async () => {},
+        removeCredentialRoute: false,
+      }),
+    ).rejects.toMatchObject({ name: "AbortError", message: "Turn cancelled" });
+
+    await expect(
+      loadSnapshotsForProfile(getDb(), workspace.id, value.hash),
+    ).resolves.toMatchObject({
+      build: { status: "building", error: null },
       ready: null,
     });
   });

--- a/packages/junior/tests/component/turn-execution.test.ts
+++ b/packages/junior/tests/component/turn-execution.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { createLocalSource } from "@sentry/junior-plugin-api";
 import type { AgentRun } from "@/chat/agent/types";
-import { executeTurn } from "@/chat/runtime/turn-execution";
+import { AgentRunError, executeTurn } from "@/chat/runtime/turn-execution";
 
 const conversationId = "local:test:turn-execution";
 const run = {
@@ -13,6 +13,26 @@ const run = {
 } satisfies AgentRun;
 
 describe("Turn execution", () => {
+  it("marks agent errors so the worker can apply agent retry rules", async () => {
+    const agentError = new Error("model request failed");
+
+    await expect(
+      executeTurn(
+        {
+          run: vi.fn(async () => {
+            throw agentError;
+          }),
+        },
+        run,
+        vi.fn(),
+      ),
+    ).rejects.toMatchObject({
+      cause: agentError,
+      message: agentError.message,
+      name: "AgentRunError",
+    } satisfies Partial<AgentRunError>);
+  });
+
   it("leaves save errors for the worker to retry", async () => {
     const saveError = new Error("result save failed");
 

--- a/packages/junior/tests/fixtures/api-turn.ts
+++ b/packages/junior/tests/fixtures/api-turn.ts
@@ -18,8 +18,6 @@ import {
   createConversationWork,
   type ConversationWorkCallbackOptions,
 } from "@/chat/app/conversation-work";
-import type { JuniorRuntimeServiceOverrides } from "@/chat/app/services";
-import type { ConversationTurnLifecycle } from "@/chat/conversations/turn-lifecycle";
 import type { ConversationStore } from "@/chat/conversations/store";
 import {
   closeDb,
@@ -133,7 +131,6 @@ export async function createConversationWorkWebHarness(
   options: {
     agentRunner?: AgentRunner;
     modelStream?: StreamFn;
-    turnLifecycle?: ConversationTurnLifecycle;
   } = {},
 ): Promise<ConversationWorkWebHarness> {
   const conversationStore = getConversationStore();
@@ -148,20 +145,11 @@ export async function createConversationWorkWebHarness(
       return await executeAgentRun(request, modelStream);
     },
   };
-  const replyExecutor: NonNullable<
-    JuniorRuntimeServiceOverrides["replyExecutor"]
-  > = { agentRunner };
-  if (options.turnLifecycle) {
-    replyExecutor.turnLifecycle = options.turnLifecycle;
-  }
   const work = createConversationWork({
     agentRunner,
     conversationStore,
     getSlackAdapter: () => createSlackAdapterFixture(),
     queue,
-    services: {
-      replyExecutor,
-    },
     state,
   });
   const actor = apiTurnTestActor;

--- a/packages/junior/tests/fixtures/api-turn.ts
+++ b/packages/junior/tests/fixtures/api-turn.ts
@@ -37,7 +37,7 @@ import {
 } from "./conversation-work";
 import { testViewer } from "./user";
 
-/** Default verified dashboard viewer for web turn tests. */
+/** Default verified dashboard viewer for Conversation API tests. */
 const API_TURN_TEST_EMAIL = "alice@example.com";
 export const apiTurnTestActor = {
   platform: "web" as const,
@@ -55,7 +55,7 @@ export type ApiTurnWorkFixture = {
 };
 
 /**
- * Wire the standard product store + queue + state path for web turn tests.
+ * Wire the standard product store, queue, and state for Conversation API tests.
  *
  * Callers should run `closeApiTurnWorkFixture` from `afterEach`.
  */
@@ -113,7 +113,7 @@ export type ConversationWorkWebHarness = {
     idempotencyKey: string;
     message: string;
   }) => Promise<{ messageId: string }>;
-  /** Drain the durable queue through the production web/API turn router. */
+  /** Drain the durable queue through the production Conversation API route. */
   drain: () => Promise<void>;
   /** Read participant pending-messages, including authorization prompts. */
   pendingMessages: (
@@ -124,22 +124,19 @@ export type ConversationWorkWebHarness = {
 };
 
 /**
- * Compose the production web ingress → durable queue → API turn → agent path.
- * Fake only model generation at the executeAgentRun stream boundary.
+ * Compose the production Conversation API, queue, and agent path.
+ * Fake only model generation at the agent Run boundary.
  */
 export async function createConversationWorkWebHarness(
-  options: {
-    agentRunner?: AgentRunner;
-    modelStream?: StreamFn;
-  } = {},
+  streamFn: StreamFn = streamReplies("Conversation API request complete."),
 ): Promise<ConversationWorkWebHarness> {
   const conversationStore = getConversationStore();
   const queue = createConversationWorkQueueTestAdapter();
   const state = getStateAdapter();
   await state.connect();
-  let modelStream = options.modelStream ?? streamReplies("Web turn complete.");
+  let modelStream = streamFn;
   const agentRuns: AgentRun[] = [];
-  const agentRunner: AgentRunner = options.agentRunner ?? {
+  const agentRunner: AgentRunner = {
     run: async (request) => {
       agentRuns.push(request);
       return await executeAgentRun(request, modelStream);

--- a/packages/junior/tests/integration/acp-http-recovery.test.ts
+++ b/packages/junior/tests/integration/acp-http-recovery.test.ts
@@ -6,10 +6,7 @@ import { completeAcpAuthorization } from "@/api/acp/auth";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createApp } from "@/app";
 import { createAcpConversations } from "@/api/acp/conversations";
-import {
-  ConversationTurnLifecycleService,
-  type ConversationTurnLifecycle,
-} from "@/chat/conversations/turn-lifecycle";
+import { ConversationTurnLifecycleService } from "@/chat/conversations/turn-lifecycle";
 import { getConversationEventStore } from "@/chat/db";
 import { processConversationQueueMessage } from "@/chat/task-execution/vercel-callback";
 import { recordConversationExecution } from "@/chat/task-execution/state";
@@ -744,9 +741,9 @@ describe("remote ACP recovery", () => {
   }, 20_000);
 
   it("returns a terminal after failed cleanup and during a later Turn", async () => {
-    const harness = await createConversationWorkWebHarness({
-      modelStream: streamReplies("First Turn complete."),
-    });
+    const harness = await createConversationWorkWebHarness(
+      streamReplies("First Turn complete."),
+    );
     const conversations = createAcpConversations({
       conversationStore: harness.conversationStore,
       eventStore: getConversationEventStore(),

--- a/packages/junior/tests/integration/acp-http-recovery.test.ts
+++ b/packages/junior/tests/integration/acp-http-recovery.test.ts
@@ -322,8 +322,8 @@ describe("remote ACP recovery", () => {
   it("rejects a second active prompt from another app instance", async () => {
     const modelStarted = deferred();
     const releaseModel = deferred();
-    const harness = await createConversationWorkWebHarness({
-      modelStream: createModelStream([
+    const harness = await createConversationWorkWebHarness(
+      createModelStream([
         {
           type: "text",
           text: "First prompt complete.",
@@ -331,7 +331,7 @@ describe("remote ACP recovery", () => {
           waitFor: releaseModel.promise,
         },
       ]),
-    });
+    );
     const app = await createApp({
       conversationWork: harness.conversationWork,
     });
@@ -410,9 +410,9 @@ describe("remote ACP recovery", () => {
         SLACK_BOT_TOKEN: "xoxb-test-token",
       };
       pluginApp = await createPluginAppFixture([EVAL_MCP_PLUGIN_ROOT]);
-      const harness = await createConversationWorkWebHarness({
-        modelStream: streamMcpSearch("Auth-paused Turn must not reply."),
-      });
+      const harness = await createConversationWorkWebHarness(
+        streamMcpSearch("Auth-paused Turn must not reply."),
+      );
       const app = await createApp({
         conversationWork: harness.conversationWork,
       });
@@ -489,12 +489,12 @@ describe("remote ACP recovery", () => {
   }, 20_000);
 
   it("cancels a yielded Turn from another app instance", async () => {
-    const harness = await createConversationWorkWebHarness({
-      modelStream: createModelStream([
+    const harness = await createConversationWorkWebHarness(
+      createModelStream([
         { type: "toolCall", name: "systemTime", arguments: {} },
         { type: "text", text: "Cancelled resume must not reply." },
       ]),
-    });
+    );
     const app = await createApp({
       conversationWork: harness.conversationWork,
     });
@@ -552,9 +552,9 @@ describe("remote ACP recovery", () => {
   it("holds terminal output until acknowledgement, then accepts a follow-up", async () => {
     const terminalPersisted = deferred();
     const releaseWorker = deferred();
-    const harness = await createConversationWorkWebHarness({
-      modelStream: streamReplies("Follow-up complete."),
-    });
+    const harness = await createConversationWorkWebHarness(
+      streamReplies("Follow-up complete."),
+    );
     const run = harness.conversationWork.run;
     let holdFirstAcknowledgement = true;
     harness.conversationWork.run = async (context) =>
@@ -816,9 +816,9 @@ describe("remote ACP recovery", () => {
   });
 
   it("recovers prompt admission after the first queue send fails", async () => {
-    const harness = await createConversationWorkWebHarness({
-      modelStream: streamReplies("Recovered queue reply."),
-    });
+    const harness = await createConversationWorkWebHarness(
+      streamReplies("Recovered queue reply."),
+    );
     const app = await createApp({
       conversationWork: harness.conversationWork,
     });

--- a/packages/junior/tests/integration/acp-http-recovery.test.ts
+++ b/packages/junior/tests/integration/acp-http-recovery.test.ts
@@ -555,25 +555,26 @@ describe("remote ACP recovery", () => {
   it("holds terminal output until acknowledgement, then accepts a follow-up", async () => {
     const terminalPersisted = deferred();
     const releaseWorker = deferred();
-    const persistedLifecycle = new ConversationTurnLifecycleService(
-      getConversationEventStore(),
-    );
-    let blockFirstCompletion = true;
-    const turnLifecycle = {
-      start: async (input) => await persistedLifecycle.start(input),
-      complete: async (input) => {
-        await persistedLifecycle.complete(input);
-        if (!blockFirstCompletion) return;
-        blockFirstCompletion = false;
-        terminalPersisted.resolve();
-        await releaseWorker.promise;
-      },
-      fail: async (input) => await persistedLifecycle.fail(input),
-    } satisfies ConversationTurnLifecycle;
     const harness = await createConversationWorkWebHarness({
       modelStream: streamReplies("Follow-up complete."),
-      turnLifecycle,
     });
+    const run = harness.conversationWork.run;
+    let holdFirstAcknowledgement = true;
+    harness.conversationWork.run = async (context) =>
+      await run({
+        ...context,
+        attempt: {
+          ...context.attempt,
+          ack: async () => {
+            if (holdFirstAcknowledgement) {
+              holdFirstAcknowledgement = false;
+              terminalPersisted.resolve();
+              await releaseWorker.promise;
+            }
+            await context.attempt.ack();
+          },
+        },
+      });
     let observePendingRead = false;
     let pendingReadObserved = false;
     let sessionStateKey: string | undefined;
@@ -685,7 +686,10 @@ describe("remote ACP recovery", () => {
       throw new Error("ACP cancellation handler was not ready");
     }
     await cancelActiveTurn();
-    const draining = harness.drain();
+    const draining = processConversationQueueMessage(
+      harness.queue.takeMessage(),
+      harness.conversationWork,
+    );
     await terminalPersisted.promise;
     observePendingRead = true;
     await vi.waitFor(() => {

--- a/packages/junior/tests/integration/acp-http.test.ts
+++ b/packages/junior/tests/integration/acp-http.test.ts
@@ -208,9 +208,9 @@ describe("remote ACP HTTP", () => {
   });
 
   it("runs, reloads, and protects a private Conversation across app instances", async () => {
-    const harness = await createConversationWorkWebHarness({
-      modelStream: streamReplies("First ACP reply."),
-    });
+    const harness = await createConversationWorkWebHarness(
+      streamReplies("First ACP reply."),
+    );
     const app = await createApp({
       conversationWork: harness.conversationWork,
     });
@@ -427,9 +427,9 @@ describe("remote ACP HTTP", () => {
   }, 20_000);
 
   it("deduplicates exact retries without colliding payloads or id types", async () => {
-    const harness = await createConversationWorkWebHarness({
-      modelStream: streamReplies("Typed id reply."),
-    });
+    const harness = await createConversationWorkWebHarness(
+      streamReplies("Typed id reply."),
+    );
     const app = await createApp({
       conversationWork: harness.conversationWork,
     });
@@ -621,9 +621,9 @@ describe("remote ACP HTTP", () => {
   });
 
   it("finishes durable work after the ACP connection closes", async () => {
-    const harness = await createConversationWorkWebHarness({
-      modelStream: streamReplies("Completed after disconnect."),
-    });
+    const harness = await createConversationWorkWebHarness(
+      streamReplies("Completed after disconnect."),
+    );
     const app = await createApp({
       conversationWork: harness.conversationWork,
     });
@@ -746,8 +746,8 @@ describe("remote ACP HTTP", () => {
   it("cancels the active Turn and accepts a later prompt", async () => {
     const modelStarted = deferred();
     const releaseModel = deferred();
-    const harness = await createConversationWorkWebHarness({
-      modelStream: createModelStream([
+    const harness = await createConversationWorkWebHarness(
+      createModelStream([
         {
           type: "text",
           text: "This reply must not be stored.",
@@ -755,7 +755,7 @@ describe("remote ACP HTTP", () => {
           waitFor: releaseModel.promise,
         },
       ]),
-    });
+    );
     const app = await createApp({
       conversationWork: harness.conversationWork,
     });
@@ -859,11 +859,9 @@ describe("remote ACP HTTP", () => {
   }, 20_000);
 
   it("maps one durable failed Turn to a protocol error", async () => {
-    const harness = await createConversationWorkWebHarness({
-      modelStream: createModelStream([
-        { type: "error", errorMessage: "model unavailable" },
-      ]),
-    });
+    const harness = await createConversationWorkWebHarness(
+      createModelStream([{ type: "error", errorMessage: "model unavailable" }]),
+    );
     const app = await createApp({
       conversationWork: harness.conversationWork,
     });

--- a/packages/junior/tests/integration/api-turn-work.test.ts
+++ b/packages/junior/tests/integration/api-turn-work.test.ts
@@ -132,14 +132,14 @@ describe("api turn conversation work", () => {
     });
 
     const agentRuns: AgentRun[] = [];
-    const worker = createApiTurnWorker({
-      agentRunner: createModelAgentRunnerForRun((run) => {
+    const worker = createApiTurnWorker(
+      createModelAgentRunnerForRun((run) => {
         agentRuns.push(run);
         return createModelStream([
           { type: "text", text: "Stored only in Junior." },
         ]);
       }),
-    });
+    );
     const route = routeApiTurnWork({
       apiTurnWorker: worker,
       fallbackWorker: async () => {
@@ -202,6 +202,31 @@ describe("api turn conversation work", () => {
       state: "completed",
       surface: "api",
     });
+
+    const turnEvents = (
+      await getConversationEventStore().loadHistory(accepted.conversationId)
+    ).filter(
+      (event) =>
+        event.data.type === "turn_started" ||
+        event.data.type === "turn_completed" ||
+        event.data.type === "turn_failed",
+    );
+    expect(turnEvents).toEqual([
+      expect.objectContaining({
+        data: expect.objectContaining({
+          surface: "api",
+          turnId: apiTurnIdForMessage(accepted.messageId),
+          type: "turn_started",
+        }),
+      }),
+      expect.objectContaining({
+        data: expect.objectContaining({
+          outcome: "success",
+          turnId: apiTurnIdForMessage(accepted.messageId),
+          type: "turn_completed",
+        }),
+      }),
+    ]);
   });
 
   it("feeds private source visibility into the agent run", async () => {
@@ -225,14 +250,14 @@ describe("api turn conversation work", () => {
     });
 
     const agentRuns: AgentRun[] = [];
-    const worker = createApiTurnWorker({
-      agentRunner: createModelAgentRunnerForRun((run) => {
+    const worker = createApiTurnWorker(
+      createModelAgentRunnerForRun((run) => {
         agentRuns.push(run);
         return createModelStream([
           { type: "text", text: "Private reply stays in Junior." },
         ]);
       }),
-    });
+    );
     const route = routeApiTurnWork({
       apiTurnWorker: worker,
       fallbackWorker: async () => {
@@ -281,15 +306,15 @@ describe("api turn conversation work", () => {
     if (!signal) throw new Error("Expected an active Turn signal");
     cancellation.cancel(accepted.conversationId);
     const agentRuns: AgentRun[] = [];
-    const worker = createApiTurnWorker({
-      agentRunner: createModelAgentRunnerForRun((run) => {
+    const worker = createApiTurnWorker(
+      createModelAgentRunnerForRun((run) => {
         agentRuns.push(run);
         return createModelStream([
           { type: "text", text: "Cancelled Turn must not reach the agent." },
         ]);
       }),
       cancellation,
-    });
+    );
 
     await expect(
       worker({
@@ -476,14 +501,14 @@ describe("api turn conversation work", () => {
     });
 
     const agentRuns: AgentRun[] = [];
-    const worker = createApiTurnWorker({
-      agentRunner: createModelAgentRunnerForRun((run) => {
+    const worker = createApiTurnWorker(
+      createModelAgentRunnerForRun((run) => {
         agentRuns.push(run);
         return createModelStream([
           { type: "text", text: "Dashboard-only reply." },
         ]);
       }),
-    });
+    );
     const route = routeApiTurnWork({
       apiTurnWorker: worker,
       fallbackWorker: async () => {

--- a/packages/junior/tests/integration/api-turn-work.test.ts
+++ b/packages/junior/tests/integration/api-turn-work.test.ts
@@ -26,7 +26,7 @@ import {
 import { createModelAgentRunnerForRun } from "../fixtures/agent-runner";
 import { createModelStream } from "../fixtures/model-stream";
 
-describe("api turn conversation work", () => {
+describe("Conversation API work", () => {
   afterEach(async () => {
     await closeApiTurnWorkFixture();
     vi.restoreAllMocks();
@@ -90,7 +90,7 @@ describe("api turn conversation work", () => {
     });
   });
 
-  it("enqueues public web turns with public source visibility and runs them on the worker", async () => {
+  it("runs a public Conversation API message with public source visibility", async () => {
     const { actor, conversationStore, queue, state } =
       await createApiTurnWorkFixture();
     const accepted = await createAndEnqueueApiConversation(
@@ -143,7 +143,9 @@ describe("api turn conversation work", () => {
     const route = routeApiTurnWork({
       apiTurnWorker: worker,
       fallbackWorker: async () => {
-        throw new Error("fallback worker must not run for web turns");
+        throw new Error(
+          "fallback worker must not run for Conversation API work",
+        );
       },
     });
 
@@ -261,7 +263,9 @@ describe("api turn conversation work", () => {
     const route = routeApiTurnWork({
       apiTurnWorker: worker,
       fallbackWorker: async () => {
-        throw new Error("fallback worker must not run for web turns");
+        throw new Error(
+          "fallback worker must not run for Conversation API work",
+        );
       },
     });
 
@@ -339,7 +343,7 @@ describe("api turn conversation work", () => {
     expect(cancellation.begin(accepted.conversationId)).toBeDefined();
   });
 
-  it("routes empty resume wakes to the active API turn", async () => {
+  it("routes an empty resume wake to the active Turn", async () => {
     const { actor, conversationStore, queue, state } =
       await createApiTurnWorkFixture();
     const accepted = await createAndEnqueueApiConversation(

--- a/packages/junior/tests/integration/web-auth-orchestration.test.ts
+++ b/packages/junior/tests/integration/web-auth-orchestration.test.ts
@@ -65,10 +65,10 @@ describe("web auth orchestration", () => {
     process.env = { ...ORIGINAL_ENV };
   });
 
-  it("parks a web turn for MCP auth, exposes the prompt, and resumes after OAuth", async () => {
-    const q = await createConversationWorkWebHarness({
-      modelStream: streamMcpSearchAndCall("Eval Auth tool completed."),
-    });
+  it("parks a Turn from the Conversation API for MCP auth, shows the prompt, and resumes after OAuth", async () => {
+    const q = await createConversationWorkWebHarness(
+      streamMcpSearchAndCall("Eval Auth tool completed."),
+    );
     const started = await q.start({
       idempotencyKey: "web-auth-park-resume-1",
       message: "use eval-auth and confirm the connection",
@@ -102,10 +102,10 @@ describe("web auth orchestration", () => {
     );
   });
 
-  it("supersedes an auth-parked web turn and clears the dashboard prompt", async () => {
-    const q = await createConversationWorkWebHarness({
-      modelStream: streamMcpSearch("Eval Auth is connected."),
-    });
+  it("supersedes an auth-parked Turn from the Conversation API and clears the prompt", async () => {
+    const q = await createConversationWorkWebHarness(
+      streamMcpSearch("Eval Auth is connected."),
+    );
     const started = await q.start({
       idempotencyKey: "web-auth-supersede-1",
       message: "connect eval-auth first",
@@ -159,10 +159,10 @@ describe("web auth orchestration", () => {
     ).toBe(true);
   });
 
-  it("stops queued and auth-paused web Turns without process state", async () => {
-    const q = await createConversationWorkWebHarness({
-      modelStream: streamMcpSearch("This response must not run."),
-    });
+  it("stops queued and auth-paused Turns from the Conversation API without process state", async () => {
+    const q = await createConversationWorkWebHarness(
+      streamMcpSearch("This response must not run."),
+    );
     const started = await q.start({
       idempotencyKey: "web-auth-stop-1",
       message: "connect eval-auth first",
@@ -228,9 +228,9 @@ describe("web auth orchestration", () => {
   });
 
   it("does not resume a superseded web auth turn after a late OAuth callback", async () => {
-    const q = await createConversationWorkWebHarness({
-      modelStream: streamMcpSearch("Eval Auth is connected."),
-    });
+    const q = await createConversationWorkWebHarness(
+      streamMcpSearch("Eval Auth is connected."),
+    );
     const started = await q.start({
       idempotencyKey: "web-auth-late-oauth-1",
       message: "connect eval-auth first",

--- a/packages/junior/tests/unit/chat/sandbox/errors.test.ts
+++ b/packages/junior/tests/unit/chat/sandbox/errors.test.ts
@@ -35,7 +35,6 @@ describe("isAbortError", () => {
     const abortError = new Error("The operation was aborted");
     abortError.name = "AbortError";
     expect(isAbortError(abortError)).toBe(true);
-    expect(isAbortError(new Error("API Turn cancelled"))).toBe(true);
     expect(
       isAbortError(new Error("executeAgentRun timed out after 720000ms")),
     ).toBe(true);

--- a/policies/error-handling.md
+++ b/policies/error-handling.md
@@ -16,6 +16,12 @@ duplicate diagnostics.
   be expressed with `finally`.
 - If a catch block handles an error, it must either finish the recovery or
   rethrow with useful domain context. Avoid log-and-rethrow duplicates.
+- Preserve catch boundaries during a refactor. A catch for agent execution must
+  not absorb later save, delivery, or lifecycle errors that have different
+  retry rules.
+- When adjacent async steps have different failure owners, show that split in
+  the control flow or with a small typed error. Add one focused test that proves
+  the errors reach the correct owners.
 - Use `finally` for cleanup that must run without changing error ownership.
 - Keep best-effort observers explicit. If correctness depends on the operation,
   it is not best-effort.

--- a/policies/error-handling.md
+++ b/policies/error-handling.md
@@ -16,12 +16,12 @@ duplicate diagnostics.
   be expressed with `finally`.
 - If a catch block handles an error, it must either finish the recovery or
   rethrow with useful domain context. Avoid log-and-rethrow duplicates.
-- Preserve catch boundaries during a refactor. A catch for agent execution must
-  not absorb later save, delivery, or lifecycle errors that have different
-  retry rules.
-- When adjacent async steps have different failure owners, show that split in
-  the control flow or with a small typed error. Add one focused test that proves
-  the errors reach the correct owners.
+- Do not change which errors a catch handles during a refactor. A catch for an
+  agent Run must not also handle later save, delivery, or Turn event errors.
+  Those operations can have different retry rules.
+- When adjacent async steps need different error handling, keep them in separate
+  `try` blocks or use a small typed error. Add one focused test that proves each
+  error reaches the correct handler.
 - Use `finally` for cleanup that must run without changing error ownership.
 - Keep best-effort observers explicit. If correctness depends on the operation,
   it is not best-effort.

--- a/policies/error-handling.md
+++ b/policies/error-handling.md
@@ -16,12 +16,9 @@ duplicate diagnostics.
   be expressed with `finally`.
 - If a catch block handles an error, it must either finish the recovery or
   rethrow with useful domain context. Avoid log-and-rethrow duplicates.
-- Do not change which errors a catch handles during a refactor. A catch for an
-  agent Run must not also handle later save, delivery, or Turn event errors.
-  Those operations can have different retry rules.
-- When adjacent async steps need different error handling, keep them in separate
-  `try` blocks or use a small typed error. Add one focused test that proves each
-  error reaches the correct handler.
+- During a refactor, preserve which errors each `catch` handles. Moving async
+  work across a `try` boundary can change retries or fallback behavior even
+  when the successful path is unchanged.
 - Use `finally` for cleanup that must run without changing error ownership.
 - Keep best-effort observers explicit. If correctness depends on the operation,
   it is not best-effort.

--- a/policies/interface-design.md
+++ b/policies/interface-design.md
@@ -60,17 +60,16 @@ function names are all part of that interface.
   owning module documentation and avoid using it for nearby concepts.
 - Add an interface only when it removes real coupling or represents a stable
   edge.
-- Treat an options object of functions or services as dependency injection.
-  Renaming the object or passing it through another function does not reduce
-  coupling.
-- Separate operation input from services. Import stable repo-owned services
-  from their owner. Pass a boundary only when the caller selects its behavior,
-  such as model execution, transport, or time. An existing process-wide store
-  is not caller selection.
-- Do not use a one-field service options object. Pass the one required external
-  capability directly.
-- Do not add a factory, bound function, or capability object only to hide a
-  dependency bag. It must remove caller knowledge or enforce an owning rule.
+- An options object of functions or services is dependency injection. Renaming
+  or forwarding it does not reduce coupling.
+- Keep operation input separate from services. Import stable app services from
+  their owning module. Pass a service only when the caller must choose its
+  behavior, such as model execution, transport, or time. Do not pass a
+  configured app store through unrelated callers.
+- Do not use a one-field service options object. Pass the one required service
+  directly.
+- Do not add a factory, bound function, or wrapper object only to hide several
+  services. It must remove caller responsibility or enforce an owning rule.
 - Avoid one-hop wrappers, renamed aliases, and helper layers that only forward
   arguments, options, or dependencies. Call the owning capability directly
   unless the intermediate function enforces a rule, translates an edge, or owns

--- a/policies/interface-design.md
+++ b/policies/interface-design.md
@@ -60,16 +60,16 @@ function names are all part of that interface.
   owning module documentation and avoid using it for nearby concepts.
 - Add an interface only when it removes real coupling or represents a stable
   edge.
-- An options object of functions or services is dependency injection. Renaming
-  or forwarding it does not reduce coupling.
-- Keep operation input separate from services. Import stable app services from
-  their owning module. Pass a service only when the caller must choose its
-  behavior, such as model execution, transport, or time. Do not pass a
-  configured app store through unrelated callers.
+- Passing services through parameters is dependency injection. Putting those
+  services in an options object does not change that.
+- Keep work data separate from services. Import stable app services from their
+  owning module. Pass a service only when the caller must choose it, such as
+  model execution, transport, or time. Do not pass an app store through callers
+  that do not own it.
 - Do not use a one-field service options object. Pass the one required service
   directly.
-- Do not add a factory, bound function, or wrapper object only to hide several
-  services. It must remove caller responsibility or enforce an owning rule.
+- Do not add a factory or wrapper only to hide service parameters. It must
+  remove a choice from callers or enforce a rule that it owns.
 - Avoid one-hop wrappers, renamed aliases, and helper layers that only forward
   arguments, options, or dependencies. Call the owning capability directly
   unless the intermediate function enforces a rule, translates an edge, or owns

--- a/policies/interface-design.md
+++ b/policies/interface-design.md
@@ -60,6 +60,17 @@ function names are all part of that interface.
   owning module documentation and avoid using it for nearby concepts.
 - Add an interface only when it removes real coupling or represents a stable
   edge.
+- Treat an options object of functions or services as dependency injection.
+  Renaming the object or passing it through another function does not reduce
+  coupling.
+- Separate operation input from services. Import stable repo-owned services
+  from their owner. Pass a boundary only when the caller selects its behavior,
+  such as model execution, transport, or time. An existing process-wide store
+  is not caller selection.
+- Do not use a one-field service options object. Pass the one required external
+  capability directly.
+- Do not add a factory, bound function, or capability object only to hide a
+  dependency bag. It must remove caller knowledge or enforce an owning rule.
 - Avoid one-hop wrappers, renamed aliases, and helper layers that only forward
   arguments, options, or dependencies. Call the owning capability directly
   unless the intermediate function enforces a rule, translates an edge, or owns


### PR DESCRIPTION
The Conversation API worker now calls core executeTurn instead of calling AgentRunner and writing final Turn events itself. The worker still owns Conversation API authorization, cancellation, Conversation state, reply storage, and plugin work. Slack behavior does not change.

This is the small change described in #1563. It does not change IDs, routing, stored state, or retry and recovery rules. Existing api-turns paths and names remain for now. #1563 removes them after the native API is live.

The worker receives AgentRunner directly because the caller chooses it. It gets fixed app services from the modules that own them. Integration tests can replace only model output. They cannot replace the Junior worker or Turn event code.

Existing integration tests cover successful replies, no Slack publish, Turn events, cancellation, authorization pause and resume, ACP reconnect, and later messages. The policy changes state that an options object is still dependency injection and that a refactor must preserve error handling.

Failures after the agent finishes can still cause a second model Run. This is a real existing defect, but it needs its own design and behavior tests. #1686 tracks that work instead of adding recovery rules to this refactor.

Refs #1563