### PR TITLE
fix(acp): Accept resource links in prompts

### DIFF
--- a/packages/junior/src/api/acp/README.md
+++ b/packages/junior/src/api/acp/README.md
@@ -10,8 +10,10 @@ client. Personal tokens do not grant ACP access.
 
 ACP maps a session to a private Conversation. It uses the existing
 web Actor, API Turn mailbox, worker, event store, and Conversation access rules.
-Client paths do not select the Junior sandbox. Client MCP servers, resource
-links, media, filesystem callbacks, and terminal callbacks are not supported.
+Client paths do not select the Junior sandbox. ACP prompt resource links are
+accepted by reference and stored as text. Junior does not fetch their URIs.
+Client MCP servers, embedded resources, media, filesystem callbacks, and
+terminal callbacks are not supported.
 `session/cancel` stops the active Turn and returns the ACP `cancelled` stop
 reason.
 

--- a/packages/junior/src/api/acp/route.ts
+++ b/packages/junior/src/api/acp/route.ts
@@ -104,16 +104,36 @@ function rejectUnsupportedMcpServers(mcpServers: readonly unknown[]): void {
   }
 }
 
-/** Convert supported ACP text blocks to one bounded API Turn message. */
+function resourceLinkText(
+  block: Extract<PromptParams["prompt"][number], { type: "resource_link" }>,
+): string {
+  return [
+    "Resource link:",
+    `Name: ${block.name}`,
+    `URI: ${block.uri}`,
+    ...(block.title ? [`Title: ${block.title}`] : []),
+    ...(block.description ? [`Description: ${block.description}`] : []),
+    ...(block.mimeType ? [`MIME type: ${block.mimeType}`] : []),
+    ...(block.size !== undefined && block.size !== null
+      ? [`Size: ${block.size} bytes`]
+      : []),
+  ].join("\n");
+}
+
+/** Convert supported ACP content blocks to one bounded API Turn message. */
 function promptText(prompt: PromptParams["prompt"]): string {
   if (prompt.length === 0) {
     throw acp.RequestError.invalidParams(
       { field: "prompt" },
-      "Junior accepts one or more text blocks only",
+      "Junior accepts one or more text or resource link blocks",
     );
   }
   const blocks: string[] = [];
   for (const block of prompt) {
+    if (block.type === "resource_link") {
+      blocks.push(resourceLinkText(block));
+      continue;
+    }
     if (!block.text.trim()) {
       throw acp.RequestError.invalidParams(
         { field: "prompt" },

--- a/packages/junior/src/api/acp/schema.ts
+++ b/packages/junior/src/api/acp/schema.ts
@@ -117,10 +117,29 @@ const textContentBlockSchema = z
   })
   .strict();
 
+const resourceLinkContentBlockSchema = z
+  .object({
+    _meta: metaSchema.optional(),
+    annotations: annotationsSchema.nullable().optional(),
+    description: z.string().nullable().optional(),
+    mimeType: z.string().nullable().optional(),
+    name: z.string(),
+    size: z.number().finite().nullable().optional(),
+    title: z.string().nullable().optional(),
+    type: z.literal("resource_link"),
+    uri: z.string(),
+  })
+  .strict();
+
 export const promptParamsSchema = z
   .object({
     _meta: metaSchema.optional(),
-    prompt: z.array(textContentBlockSchema),
+    prompt: z.array(
+      z.discriminatedUnion("type", [
+        textContentBlockSchema,
+        resourceLinkContentBlockSchema,
+      ]),
+    ),
     sessionId: acpSessionIdSchema,
   })
   .strict();

--- a/packages/junior/tests/integration/acp-http.test.ts
+++ b/packages/junior/tests/integration/acp-http.test.ts
@@ -217,6 +217,8 @@ describe("remote ACP HTTP", () => {
     const secondApp = await createApp({
       conversationWork: createIndependentConversationWork(harness),
     });
+    const expectedFirstPromptText =
+      "First\nACP prompt.\nResource link:\nName: client file\nURI: file:///client/workspace/file.ts\nTitle: Workspace file\nDescription: Relevant TypeScript source\nMIME type: text/typescript\nSize: 123 bytes";
     const fetch = appFetch(app, secondApp);
     const firstUpdates: acp.SessionUpdate[] = [];
     let resolveFirstSession!: (sessionId: string) => void;
@@ -258,6 +260,15 @@ describe("remote ACP HTTP", () => {
           prompt: [
             { type: "text", text: "First" },
             { type: "text", text: "ACP prompt." },
+            {
+              type: "resource_link",
+              name: "client file",
+              uri: "file:///client/workspace/file.ts",
+              title: "Workspace file",
+              description: "Relevant TypeScript source",
+              mimeType: "text/typescript",
+              size: 123,
+            },
           ],
         });
         return { result, sessionId: session.sessionId };
@@ -293,7 +304,7 @@ describe("remote ACP HTTP", () => {
       source: { platform: "web", visibility: "private" },
     });
     await expect(harness.historyTexts(sessionId)).resolves.toEqual([
-      "First\nACP prompt.",
+      expectedFirstPromptText,
       "First ACP reply.",
     ]);
 
@@ -367,7 +378,7 @@ describe("remote ACP HTTP", () => {
     });
     expect(harness.queue.hasQueuedMessages()).toBe(false);
     await expect(harness.historyTexts(sessionId)).resolves.toEqual([
-      "First\nACP prompt.",
+      expectedFirstPromptText,
       "First ACP reply.",
     ]);
 
@@ -407,7 +418,7 @@ describe("remote ACP HTTP", () => {
     expect(secondUpdates).toEqual([
       expect.objectContaining({
         sessionUpdate: "user_message_chunk",
-        content: { type: "text", text: "First\nACP prompt." },
+        content: { type: "text", text: expectedFirstPromptText },
       }),
       expect.objectContaining({
         sessionUpdate: "agent_message_chunk",
@@ -419,7 +430,7 @@ describe("remote ACP HTTP", () => {
       }),
     ]);
     await expect(harness.historyTexts(sessionId)).resolves.toEqual([
-      "First\nACP prompt.",
+      expectedFirstPromptText,
       "First ACP reply.",
       "Follow up.",
       "Second ACP reply.",
@@ -945,13 +956,6 @@ describe("remote ACP HTTP", () => {
         for (const prompt of [
           [
             {
-              type: "resource_link" as const,
-              name: "client file",
-              uri: "file:///client/workspace/file.ts",
-            },
-          ],
-          [
-            {
               type: "image" as const,
               data: "AA==",
               mimeType: "image/png",
@@ -982,9 +986,8 @@ describe("remote ACP HTTP", () => {
     });
 
     expect(errors.mcpError).toMatchObject({ code: -32602 });
-    expect(errors.promptErrors).toHaveLength(5);
+    expect(errors.promptErrors).toHaveLength(4);
     expect(errors.promptErrors).toEqual([
-      expect.objectContaining({ code: -32602 }),
       expect.objectContaining({ code: -32602 }),
       expect.objectContaining({ code: -32602 }),
       expect.objectContaining({ code: -32602 }),


### PR DESCRIPTION
Accept ACP `resource_link` content blocks in session prompts and preserve their name, URI, title, description, MIME type, and size in the Conversation message. Resource links now survive session load and replay like text prompts.

ACP requires agents to support text and resource links as baseline prompt content. Junior previously rejected links at the schema boundary. This passes the reference to the agent without fetching the client-controlled URI. Image and embedded content remain gated by Junior's advertised capabilities.
