### PR TITLE
ref(slack): use native Turn execution

### DIFF
--- a/packages/junior-evals/src/behavior-harness.ts
+++ b/packages/junior-evals/src/behavior-harness.ts
@@ -1734,292 +1734,291 @@ function buildRuntimeServices(
           },
         }
       : {}),
-    replyExecutor: {
-      turnLifecycle,
-      agentRunner: {
-        run: async (request) => {
-          const pendingSteeringDelivery = steeringDelivery.deliver;
-          const runRequest = pendingSteeringDelivery
+    agentRunner: {
+      run: async (request) => {
+        const pendingSteeringDelivery = steeringDelivery.deliver;
+        const runRequest = pendingSteeringDelivery
+          ? {
+              ...request,
+              durability: {
+                ...request.durability,
+                onInputCommitted: async () => {
+                  await request.durability?.onInputCommitted?.();
+                  if (steeringDelivery.deliver !== pendingSteeringDelivery) {
+                    return;
+                  }
+                  steeringDelivery.deliver = undefined;
+                  await pendingSteeringDelivery();
+                },
+              },
+            }
+          : request;
+        const timeoutResume = scenario.overrides?.timeout_resume;
+        const activeTurnCompaction = scenario.overrides?.active_turn_compaction;
+        if (activeTurnCompaction && !activeTurnCompactionInjected) {
+          activeTurnCompactionInjected = true;
+          await runRequest.durability?.onInputCommitted?.();
+          const nowMs = Date.now();
+          const actor = actorFromRun(runRequest);
+          const piMessages = [
+            {
+              role: "user",
+              content: [
+                {
+                  type: "text",
+                  text: `<${TURN_CONTEXT_TAG}>\nEval continuation fixture.\n</${TURN_CONTEXT_TAG}>`,
+                },
+              ],
+              timestamp: nowMs,
+            },
+            {
+              role: "user",
+              content: [
+                {
+                  type: "text",
+                  text: renderCurrentInstruction(runRequest.instruction.text),
+                },
+              ],
+              timestamp: nowMs + 1,
+            },
+            {
+              role: "user",
+              content: [
+                {
+                  type: "text",
+                  text: `${ACTIVE_TURN_COMPACTION_SUMMARY_PREFIX}\n${activeTurnCompaction.summary}`,
+                },
+              ],
+              timestamp: nowMs + 2,
+            },
+          ] as PiMessage[];
+          const sessionRecord = await upsertTurnRecord({
+            conversationId: runRequest.conversationId,
+            turnId: runRequest.turnId,
+            sliceId: 1,
+            state: "paused",
+            piMessages,
+            resumeReason: "yield",
+            destination: runRequest.destination,
+            destinationVisibility: runRequest.destinationVisibility,
+            source: runRequest.source,
+            surface: runRequest.surface,
+            actor,
+            trailingMessageProvenance: [
+              { authority: "instruction", actor },
+              { authority: "context" },
+            ],
+            turnStartMessageIndex: 0,
+          });
+          return {
+            status: "suspended",
+            reason: "yield" as const,
+            resumeVersion: sessionRecord.version,
+          };
+        }
+        if (timeoutResume && !timeoutResumeInjected) {
+          timeoutResumeInjected = true;
+          await runRequest.durability?.onInputCommitted?.();
+          const nowMs = Date.now();
+          const toolCallId = "eval-timeout-resume-tool-call";
+          const abortedAttempt = {
+            target: timeoutResume.tool_name,
+            aborted: true,
+          };
+          const timedOutResult = projectTimedOutToolResult({
+            content: [{ type: "text", text: JSON.stringify(abortedAttempt) }],
+            details: abortedAttempt,
+          });
+          if (
+            !timedOutResult?.content ||
+            timedOutResult.details === undefined
+          ) {
+            throw new Error("Failed to build timeout continuation fixture");
+          }
+          const piMessages = [
+            {
+              role: "user",
+              content: [{ type: "text", text: runRequest.instruction.text }],
+              timestamp: nowMs,
+            },
+            {
+              role: "assistant",
+              content: [
+                {
+                  type: "toolCall",
+                  id: toolCallId,
+                  name: timeoutResume.tool_name,
+                  arguments: timeoutResume.arguments,
+                },
+              ],
+              stopReason: "toolUse",
+              api: "eval-timeout-resume",
+              provider: "eval-timeout-resume",
+              model: "xai/grok-4.5",
+              timestamp: nowMs,
+              usage: { input: 0, output: 0, totalTokens: 0 },
+            },
+            {
+              role: "toolResult",
+              toolCallId,
+              toolName: timeoutResume.tool_name,
+              content: timedOutResult.content,
+              details: timedOutResult.details,
+              isError: timedOutResult.isError,
+              timestamp: nowMs,
+            },
+          ] as PiMessage[];
+          const sessionRecord = await upsertTurnRecord({
+            conversationId: runRequest.conversationId,
+            turnId: runRequest.turnId,
+            sliceId: 2,
+            state: "paused",
+            piMessages,
+            resumeReason: "timeout",
+            resumedFromSliceId: 1,
+            destination: runRequest.destination,
+            destinationVisibility: runRequest.destinationVisibility,
+            source: runRequest.source,
+            surface: runRequest.surface,
+            actor: actorFromRun(runRequest),
+            errorMessage: "Agent turn timed out at the eval fixture boundary",
+            turnStartMessageIndex: 0,
+          });
+          return {
+            status: "suspended",
+            reason: "timeout" as const,
+            resumeVersion: sessionRecord.version,
+          };
+        }
+        const mockImageGeneration = scenario.overrides?.mock_image_generation;
+        const replyText = replyTexts[replyState.successfulCount];
+        let scriptedStream: ReturnType<typeof createFauxCore> | undefined;
+        if (typeof replyText === "string") {
+          scriptedStream = createFauxCore({
+            api: "eval",
+            provider: "eval",
+          });
+          scriptedStream.setResponses([fauxAssistantMessage(replyText)]);
+        }
+
+        const gatewaySnapshot = snapshotEnv([
+          "AI_GATEWAY_API_KEY",
+          "VERCEL_OIDC_TOKEN",
+        ]);
+        const baseToolOverrides: ToolHooks["toolOverrides"] = {
+          ...(request.environment?.toolOverrides ?? {}),
+        };
+        const viewImageFixtures = new Map(
+          scenario.overrides?.view_image_files?.map((fixture) => [
+            fixture.path,
+            resolveEvalRelativePath(fixture.source),
+          ]) ?? [],
+        );
+        const toolOverrides = {
+          ...baseToolOverrides,
+          webFetch: createReplayWebFetchDeps(baseToolOverrides),
+          webSearch: createReplayWebSearchDeps(baseToolOverrides),
+          ...(mockImageGeneration
+            ? { imageGenerate: createMockImageGenerateDeps() }
+            : {}),
+          ...(viewImageFixtures.size > 0
             ? {
-                ...request,
-                durability: {
-                  ...request.durability,
-                  onInputCommitted: async () => {
-                    await request.durability?.onInputCommitted?.();
-                    if (steeringDelivery.deliver !== pendingSteeringDelivery) {
-                      return;
-                    }
-                    steeringDelivery.deliver = undefined;
-                    await pendingSteeringDelivery();
+                viewImage: {
+                  readFile: async (imagePath: string) => {
+                    const sourcePath = viewImageFixtures.get(imagePath);
+                    return sourcePath ? await readFile(sourcePath) : null;
                   },
                 },
               }
-            : request;
-          const timeoutResume = scenario.overrides?.timeout_resume;
-          const activeTurnCompaction =
-            scenario.overrides?.active_turn_compaction;
-          if (activeTurnCompaction && !activeTurnCompactionInjected) {
-            activeTurnCompactionInjected = true;
-            await runRequest.durability?.onInputCommitted?.();
-            const nowMs = Date.now();
-            const actor = actorFromRun(runRequest);
-            const piMessages = [
-              {
-                role: "user",
-                content: [
-                  {
-                    type: "text",
-                    text: `<${TURN_CONTEXT_TAG}>\nEval continuation fixture.\n</${TURN_CONTEXT_TAG}>`,
-                  },
-                ],
-                timestamp: nowMs,
-              },
-              {
-                role: "user",
-                content: [
-                  {
-                    type: "text",
-                    text: renderCurrentInstruction(runRequest.instruction.text),
-                  },
-                ],
-                timestamp: nowMs + 1,
-              },
-              {
-                role: "user",
-                content: [
-                  {
-                    type: "text",
-                    text: `${ACTIVE_TURN_COMPACTION_SUMMARY_PREFIX}\n${activeTurnCompaction.summary}`,
-                  },
-                ],
-                timestamp: nowMs + 2,
-              },
-            ] as PiMessage[];
-            const sessionRecord = await upsertTurnRecord({
-              conversationId: runRequest.conversationId,
-              turnId: runRequest.turnId,
-              sliceId: 1,
-              state: "paused",
-              piMessages,
-              resumeReason: "yield",
-              destination: runRequest.destination,
-              destinationVisibility: runRequest.destinationVisibility,
-              source: runRequest.source,
-              surface: runRequest.surface,
-              actor,
-              trailingMessageProvenance: [
-                { authority: "instruction", actor },
-                { authority: "context" },
-              ],
-              turnStartMessageIndex: 0,
-            });
-            return {
-              status: "suspended",
-              reason: "yield" as const,
-              resumeVersion: sessionRecord.version,
-            };
-          }
-          if (timeoutResume && !timeoutResumeInjected) {
-            timeoutResumeInjected = true;
-            await runRequest.durability?.onInputCommitted?.();
-            const nowMs = Date.now();
-            const toolCallId = "eval-timeout-resume-tool-call";
-            const abortedAttempt = {
-              target: timeoutResume.tool_name,
-              aborted: true,
-            };
-            const timedOutResult = projectTimedOutToolResult({
-              content: [{ type: "text", text: JSON.stringify(abortedAttempt) }],
-              details: abortedAttempt,
-            });
-            if (
-              !timedOutResult?.content ||
-              timedOutResult.details === undefined
-            ) {
-              throw new Error("Failed to build timeout continuation fixture");
-            }
-            const piMessages = [
-              {
-                role: "user",
-                content: [{ type: "text", text: runRequest.instruction.text }],
-                timestamp: nowMs,
-              },
-              {
-                role: "assistant",
-                content: [
-                  {
-                    type: "toolCall",
-                    id: toolCallId,
-                    name: timeoutResume.tool_name,
-                    arguments: timeoutResume.arguments,
-                  },
-                ],
-                stopReason: "toolUse",
-                api: "eval-timeout-resume",
-                provider: "eval-timeout-resume",
-                model: "xai/grok-4.5",
-                timestamp: nowMs,
-                usage: { input: 0, output: 0, totalTokens: 0 },
-              },
-              {
-                role: "toolResult",
-                toolCallId,
-                toolName: timeoutResume.tool_name,
-                content: timedOutResult.content,
-                details: timedOutResult.details,
-                isError: timedOutResult.isError,
-                timestamp: nowMs,
-              },
-            ] as PiMessage[];
-            const sessionRecord = await upsertTurnRecord({
-              conversationId: runRequest.conversationId,
-              turnId: runRequest.turnId,
-              sliceId: 2,
-              state: "paused",
-              piMessages,
-              resumeReason: "timeout",
-              resumedFromSliceId: 1,
-              destination: runRequest.destination,
-              destinationVisibility: runRequest.destinationVisibility,
-              source: runRequest.source,
-              surface: runRequest.surface,
-              actor: actorFromRun(runRequest),
-              errorMessage: "Agent turn timed out at the eval fixture boundary",
-              turnStartMessageIndex: 0,
-            });
-            return {
-              status: "suspended",
-              reason: "timeout" as const,
-              resumeVersion: sessionRecord.version,
-            };
-          }
-          const mockImageGeneration = scenario.overrides?.mock_image_generation;
-          const replyText = replyTexts[replyState.successfulCount];
-          let scriptedStream: ReturnType<typeof createFauxCore> | undefined;
-          if (typeof replyText === "string") {
-            scriptedStream = createFauxCore({
-              api: "eval",
-              provider: "eval",
-            });
-            scriptedStream.setResponses([fauxAssistantMessage(replyText)]);
-          }
-
-          const gatewaySnapshot = snapshotEnv([
-            "AI_GATEWAY_API_KEY",
-            "VERCEL_OIDC_TOKEN",
+            : {}),
+        };
+        if (scenario.overrides?.unset_gateway_api_key) {
+          delete process.env.AI_GATEWAY_API_KEY;
+          delete process.env.VERCEL_OIDC_TOKEN;
+        }
+        try {
+          const pendingToolInvocations: EvalToolInvocation[] = [];
+          const replySignal = AbortSignal.any([
+            ...(signal ? [signal] : []),
+            AbortSignal.timeout(replyTimeoutMs),
           ]);
-          const baseToolOverrides: ToolHooks["toolOverrides"] = {
-            ...(request.environment?.toolOverrides ?? {}),
-          };
-          const viewImageFixtures = new Map(
-            scenario.overrides?.view_image_files?.map((fixture) => [
-              fixture.path,
-              resolveEvalRelativePath(fixture.source),
-            ]) ?? [],
-          );
-          const toolOverrides = {
-            ...baseToolOverrides,
-            webFetch: createReplayWebFetchDeps(baseToolOverrides),
-            webSearch: createReplayWebSearchDeps(baseToolOverrides),
-            ...(mockImageGeneration
-              ? { imageGenerate: createMockImageGenerateDeps() }
-              : {}),
-            ...(viewImageFixtures.size > 0
-              ? {
-                  viewImage: {
-                    readFile: async (imagePath: string) => {
-                      const sourcePath = viewImageFixtures.get(imagePath);
-                      return sourcePath ? await readFile(sourcePath) : null;
-                    },
-                  },
-                }
-              : {}),
-          };
-          if (scenario.overrides?.unset_gateway_api_key) {
-            delete process.env.AI_GATEWAY_API_KEY;
-            delete process.env.VERCEL_OIDC_TOKEN;
-          }
-          try {
-            const pendingToolInvocations: EvalToolInvocation[] = [];
-            const replySignal = AbortSignal.any([
-              ...(signal ? [signal] : []),
-              AbortSignal.timeout(replyTimeoutMs),
-            ]);
-            const outcome = await raceWithAbort(replySignal, () =>
-              executeAgentRun(
-                {
-                  ...runRequest,
-                  signal: replySignal,
-                  deadlineAtMs: Math.min(
-                    runRequest.deadlineAtMs ?? Number.POSITIVE_INFINITY,
-                    Date.now() + replyTimeoutMs,
-                  ),
-                  environment: {
-                    ...runRequest.environment,
-                    attachmentStorage:
-                      runRequest.environment?.attachmentStorage ??
-                      attachmentStorage,
-                    ...(env.configuredSkillDirs.length > 0
-                      ? { skillDirs: env.configuredSkillDirs }
-                      : {}),
-                    toolOverrides,
-                  },
-                  onEvent: async (event) => {
-                    await runRequest.onEvent?.(event);
-                    if (event.type === "tool_started") {
-                      const evalInvocation = toEvalToolInvocation({
-                        params: event.params,
-                        toolCallId: event.toolCallId,
-                        toolName: event.toolName,
-                      });
-                      observations.toolInvocations.push(evalInvocation);
-                      pendingToolInvocations.push(evalInvocation);
-                      return;
-                    }
-                    if (event.type !== "tool_finished") {
-                      return;
-                    }
-                    const result = event.report;
-                    const pendingIndex = pendingToolInvocations.findIndex(
-                      (candidate) => candidate.toolCallId === result.toolCallId,
-                    );
-                    if (pendingIndex === -1) {
-                      return;
-                    }
-                    const [invocation] = pendingToolInvocations.splice(
-                      pendingIndex,
-                      1,
-                    );
-                    invocation.completed = true;
-                    invocation.ok = result.ok;
-                    if (result.error) {
-                      invocation.error = result.error;
-                    }
-                    if (result.result !== undefined) {
-                      invocation.result = result.result;
-                    }
-                  },
+          const outcome = await raceWithAbort(replySignal, () =>
+            executeAgentRun(
+              {
+                ...runRequest,
+                signal: replySignal,
+                deadlineAtMs: Math.min(
+                  runRequest.deadlineAtMs ?? Number.POSITIVE_INFINITY,
+                  Date.now() + replyTimeoutMs,
+                ),
+                environment: {
+                  ...runRequest.environment,
+                  attachmentStorage:
+                    runRequest.environment?.attachmentStorage ??
+                    attachmentStorage,
+                  ...(env.configuredSkillDirs.length > 0
+                    ? { skillDirs: env.configuredSkillDirs }
+                    : {}),
+                  toolOverrides,
                 },
-                scriptedStream?.stream,
-              ),
-            );
-            const usage =
-              outcome.status === "completed"
-                ? outcome.result.diagnostics.usage
-                : outcome.usage;
-            observations.usage = addAgentTurnUsage(observations.usage, usage);
-            if (outcome.status === "completed") {
-              observations.modelIds.add(outcome.result.diagnostics.modelId);
-            }
-            replyState.successfulCount += 1;
-            return outcome;
-          } finally {
-            if (scenario.overrides?.unset_gateway_api_key) {
-              gatewaySnapshot.restore();
-            }
+                onEvent: async (event) => {
+                  await runRequest.onEvent?.(event);
+                  if (event.type === "tool_started") {
+                    const evalInvocation = toEvalToolInvocation({
+                      params: event.params,
+                      toolCallId: event.toolCallId,
+                      toolName: event.toolName,
+                    });
+                    observations.toolInvocations.push(evalInvocation);
+                    pendingToolInvocations.push(evalInvocation);
+                    return;
+                  }
+                  if (event.type !== "tool_finished") {
+                    return;
+                  }
+                  const result = event.report;
+                  const pendingIndex = pendingToolInvocations.findIndex(
+                    (candidate) => candidate.toolCallId === result.toolCallId,
+                  );
+                  if (pendingIndex === -1) {
+                    return;
+                  }
+                  const [invocation] = pendingToolInvocations.splice(
+                    pendingIndex,
+                    1,
+                  );
+                  invocation.completed = true;
+                  invocation.ok = result.ok;
+                  if (result.error) {
+                    invocation.error = result.error;
+                  }
+                  if (result.result !== undefined) {
+                    invocation.result = result.result;
+                  }
+                },
+              },
+              scriptedStream?.stream,
+            ),
+          );
+          const usage =
+            outcome.status === "completed"
+              ? outcome.result.diagnostics.usage
+              : outcome.usage;
+          observations.usage = addAgentTurnUsage(observations.usage, usage);
+          if (outcome.status === "completed") {
+            observations.modelIds.add(outcome.result.diagnostics.modelId);
           }
-        },
+          replyState.successfulCount += 1;
+          return outcome;
+        } finally {
+          if (scenario.overrides?.unset_gateway_api_key) {
+            gatewaySnapshot.restore();
+          }
+        }
       },
+    },
+    replyExecutor: {
+      turnLifecycle,
       wakePausedTurn: async (request) => {
         await wakePausedTurn(request, {
           queue: conversationWorkQueue,
@@ -2717,7 +2716,7 @@ export async function runEvalScenario(
       turnLifecycle,
       options.signal,
     );
-    const evalAgentRunner = services.replyExecutor?.agentRunner;
+    const evalAgentRunner = services.agentRunner;
     if (!evalAgentRunner) {
       throw new Error("Eval agent runner was not configured.");
     }

--- a/packages/junior-evals/tests/unit/harness/behavior-harness.test.ts
+++ b/packages/junior-evals/tests/unit/harness/behavior-harness.test.ts
@@ -92,12 +92,10 @@ vi.mock("@/chat/app/factory", () => ({
   createSlackRuntime: vi.fn(
     (options: {
       services?: {
-        replyExecutor?: {
-          agentRunner?: { run: (request: unknown) => Promise<unknown> };
-        };
+        agentRunner?: { run: (request: unknown) => Promise<unknown> };
       };
     }) => {
-      runtimeState.agentRunner = options.services?.replyExecutor?.agentRunner;
+      runtimeState.agentRunner = options.services?.agentRunner;
       return {
         handleNewMention: handleNewMentionMock,
         handleSubscribedMessage: handleSubscribedMessageMock,
@@ -148,8 +146,9 @@ describe("behavior harness", () => {
     );
     await runtimeState.agentRunner?.run({} as never);
 
-    const forwardedSignal = executeAgentRunMock.mock.calls[0]?.[0]
-      ?.signal as AbortSignal | undefined;
+    const forwardedSignal = executeAgentRunMock.mock.calls[0]?.[0]?.signal as
+      | AbortSignal
+      | undefined;
     expect(forwardedSignal).toBeDefined();
     expect(forwardedSignal).not.toBe(controller.signal);
     controller.abort();

--- a/packages/junior/src/app.ts
+++ b/packages/junior/src/app.ts
@@ -809,7 +809,7 @@ export async function createApp(options?: JuniorAppOptions): Promise<Hono> {
     tracePropagation,
   });
   const runtimeServiceOverrides = {
-    replyExecutor: { agentRunner },
+    agentRunner,
     sandbox: { tracePropagation },
   };
   let conversationWorkOptions: ConversationWorkCallbackOptions | undefined;

--- a/packages/junior/src/chat/app/conversation-work.ts
+++ b/packages/junior/src/chat/app/conversation-work.ts
@@ -58,9 +58,9 @@ export function createConversationWork(
   const apiTurnCancellation = createApiTurnCancellation();
   const services: JuniorRuntimeServiceOverrides = {
     ...options.services,
+    agentRunner: options.agentRunner,
     replyExecutor: {
       ...options.services?.replyExecutor,
-      agentRunner: options.agentRunner,
       getPausedTurnRequest:
         options.services?.replyExecutor?.getPausedTurnRequest ??
         (async (request) =>

--- a/packages/junior/src/chat/app/factory.ts
+++ b/packages/junior/src/chat/app/factory.ts
@@ -111,6 +111,7 @@ export function createSlackRuntime(options: CreateSlackRuntimeOptions) {
     },
   });
   const executeSlackTurn = createSlackTurn({
+    executeTurn: services.executeTurn,
     getSlackAdapter: options.getSlackAdapter,
     prepareTurnState,
     resolveUserAttachments: services.visionContext.resolveUserAttachments,

--- a/packages/junior/src/chat/app/services.ts
+++ b/packages/junior/src/chat/app/services.ts
@@ -30,7 +30,11 @@ import {
   type VisionContextDeps,
   type VisionContextService,
 } from "@/chat/slack/vision-context";
-import { createAgentRunner } from "@/chat/runtime/agent-runner";
+import {
+  createAgentRunner,
+  type AgentRunner,
+} from "@/chat/runtime/agent-runner";
+import { executeTurn, type ExecuteTurn } from "@/chat/runtime/turn-execution";
 import { ConversationTurnLifecycleService } from "@/chat/conversations/turn-lifecycle";
 import { getConversationEventStore } from "@/chat/db";
 import { bindSpawnAgent } from "@/chat/agent-invocations/spawn";
@@ -39,12 +43,14 @@ import { getVercelConversationWorkQueue } from "@/chat/task-execution/vercel-que
 export interface JuniorRuntimeServices {
   conversationMemory: ConversationMemoryService;
   contextCompactor: ContextCompactor;
+  executeTurn: ExecuteTurn;
   replyExecutor: SlackTurnServices;
   subscribedReplyPolicy: SubscribedReplyPolicy;
   visionContext: VisionContextService;
 }
 
 export interface JuniorRuntimeServiceOverrides {
+  agentRunner?: AgentRunner;
   conversationMemory?: Partial<ConversationMemoryDeps>;
   contextCompactor?: Partial<ContextCompactorDeps>;
   replyExecutor?: Partial<SlackTurnServices>;
@@ -74,7 +80,7 @@ export function createJuniorRuntimeServices(
       overrides.visionContext?.downloadFile ?? downloadPrivateSlackFile,
   });
   const agentRunner =
-    overrides.replyExecutor?.agentRunner ??
+    overrides.agentRunner ??
     createAgentRunner(executeAgentRunImpl, {
       bindSpawnAgent: (request) =>
         bindSpawnAgent(request, { queue: getVercelConversationWorkQueue }),
@@ -84,10 +90,11 @@ export function createJuniorRuntimeServices(
   return {
     conversationMemory,
     contextCompactor,
+    executeTurn: async (run, saveResult, timeoutMs) =>
+      await executeTurn(agentRunner, run, saveResult, timeoutMs),
     replyExecutor: {
       contextCompactor:
         overrides.replyExecutor?.contextCompactor ?? contextCompactor,
-      agentRunner,
       getPausedTurnRequest:
         overrides.replyExecutor?.getPausedTurnRequest ?? getPausedTurnRequest,
       lookupSlackUser:

--- a/packages/junior/src/chat/providers/slack/resume.ts
+++ b/packages/junior/src/chat/providers/slack/resume.ts
@@ -22,8 +22,7 @@ import {
 import type { AgentRunResult } from "@/chat/services/turn-result";
 import { getAssistantReplyText } from "@/chat/services/assistant-reply";
 import type { AssistantMessage } from "@earendil-works/pi-ai";
-import type { AgentRunner } from "@/chat/runtime/agent-runner";
-import { AgentRunError, executeTurn } from "@/chat/runtime/turn-execution";
+import { AgentRunError, type ExecuteTurn } from "@/chat/runtime/turn-execution";
 import { scheduleSessionCompletedPluginTasks } from "@/chat/plugins/task-runner";
 import {
   buildTurnFailureResponse,
@@ -188,7 +187,7 @@ interface ResumeSlackTurnArgs {
   ownsConversationLease?: boolean;
   initialText?: string;
   initialStatus?: AssistantStatusSpec;
-  agentRunner: AgentRunner;
+  executeTurn: ExecuteTurn;
   inputMessageIds?: string[];
   scheduleSessionCompletedPluginTasks?: typeof scheduleSessionCompletedPluginTasks;
   commitResult?: (result: AgentRunResult) => Promise<void>;
@@ -672,8 +671,7 @@ async function resumeSlackTurnInContext(
       });
     }
     const replyTimeoutMs = resolveReplyTimeoutMs();
-    const outcome = await executeTurn(
-      runArgs.agentRunner,
+    const outcome = await runArgs.executeTurn(
       run,
       async (result) => {
         const finalized = finalizeFailedTurnReplyWithEvent({

--- a/packages/junior/src/chat/providers/slack/turn.ts
+++ b/packages/junior/src/chat/providers/slack/turn.ts
@@ -40,8 +40,7 @@ import {
   type AgentRun,
   type AgentSteeringMessage,
 } from "@/chat/agent/types";
-import type { AgentRunner } from "@/chat/runtime/agent-runner";
-import { AgentRunError, executeTurn } from "@/chat/runtime/turn-execution";
+import { AgentRunError, type ExecuteTurn } from "@/chat/runtime/turn-execution";
 import {
   credentialContextForActor,
   type CredentialContext,
@@ -221,7 +220,6 @@ async function loadPiMessagesForTurn(args: {
 }
 
 export interface SlackTurnServices {
-  agentRunner: AgentRunner;
   contextCompactor: ContextCompactor;
   getPausedTurnRequest: (args: {
     conversationId: string;
@@ -237,6 +235,7 @@ export interface SlackTurnServices {
 }
 
 interface SlackTurnDeps {
+  executeTurn: ExecuteTurn;
   getSlackAdapter: () => SlackAdapter;
   resolveUserAttachments: (
     attachments: Message["attachments"] | undefined,
@@ -1301,11 +1300,7 @@ export function createSlackTurn(deps: SlackTurnDeps) {
               outcome: "failed" as const,
             };
           };
-          const outcome = await executeTurn(
-            deps.services.agentRunner,
-            run,
-            saveResult,
-          );
+          const outcome = await deps.executeTurn(run, saveResult);
           if (outcome.status === "awaiting_auth") {
             await recordDispatchOutcome("blocked", "failed");
             options.onTurnOutcome?.({ outcome: "blocked" });

--- a/packages/junior/src/chat/runtime/turn-execution.ts
+++ b/packages/junior/src/chat/runtime/turn-execution.ts
@@ -85,3 +85,10 @@ export async function executeTurn(
 
   return { status: "completed" };
 }
+
+/** Run the agent and finish a Turn after its caller saves the result. */
+export type ExecuteTurn = (
+  run: AgentRun,
+  saveResult: (result: AgentRunResult) => Promise<SavedTurnResult>,
+  timeoutMs?: number,
+) => Promise<TurnExecutionOutcome>;

--- a/packages/junior/src/chat/task-execution/paused-turn.ts
+++ b/packages/junior/src/chat/task-execution/paused-turn.ts
@@ -72,6 +72,7 @@ import {
 } from "@/chat/resource-events/actor";
 import type { AgentRunResult } from "@/chat/services/turn-result";
 import type { AgentRunner } from "@/chat/runtime/agent-runner";
+import { executeTurn } from "@/chat/runtime/turn-execution";
 import type { AgentRun } from "@/chat/agent/types";
 import { persistAuthPauseTurnState } from "@/chat/runtime/auth-pause-state";
 import { clearPendingAuth } from "@/chat/services/pending-auth";
@@ -394,7 +395,8 @@ async function runPausedTurnInContext(
     lockKey: payload.conversationId,
     // Queue continue runs under the conversation work lease already.
     ownsConversationLease: true,
-    agentRunner: options.agentRunner,
+    executeTurn: async (run, saveResult, timeoutMs) =>
+      await executeTurn(options.agentRunner, run, saveResult, timeoutMs),
     scheduleSessionCompletedPluginTasks:
       options.scheduleSessionCompletedPluginTasks,
     beforeStart: async () => {

--- a/packages/junior/src/handlers/mcp-oauth-callback.ts
+++ b/packages/junior/src/handlers/mcp-oauth-callback.ts
@@ -21,6 +21,7 @@ import { getMcpProviderErrorAttributes } from "@/chat/mcp/errors";
 import { logException, logWarn } from "@/chat/logging";
 import type { AgentRunResult } from "@/chat/services/turn-result";
 import type { AgentRunner } from "@/chat/runtime/agent-runner";
+import { executeTurn } from "@/chat/runtime/turn-execution";
 import {
   getLocationConfigurationService,
   getPersistedSandboxState,
@@ -284,7 +285,8 @@ async function resumeAuthorizedMcpTurn(args: {
     messageTs: getTurnUserSlackMessageTs(userMessage),
     lockKey: threadId,
     initialText: "",
-    agentRunner,
+    executeTurn: async (run, saveResult, timeoutMs) =>
+      await executeTurn(agentRunner, run, saveResult, timeoutMs),
     beforeStart: async () => {
       const lockedState = await getPersistedThreadState(threadId);
       const lockedConversation = coerceThreadConversationState(lockedState);

--- a/packages/junior/src/handlers/oauth-callback.ts
+++ b/packages/junior/src/handlers/oauth-callback.ts
@@ -72,6 +72,7 @@ import {
 } from "@/chat/services/turn-session-routing";
 import type { AgentRunResult } from "@/chat/services/turn-result";
 import type { AgentRunner } from "@/chat/runtime/agent-runner";
+import { executeTurn } from "@/chat/runtime/turn-execution";
 import { requireSlackDestination } from "@/chat/destination";
 import { relayLocalOAuthCallback } from "@/chat/local/oauth-relay";
 import { getSqlExecutor } from "@/chat/db";
@@ -302,7 +303,8 @@ async function resumeOAuthSessionRecordTurn(
     messageTs: getTurnUserSlackMessageTs(userMessage),
     lockKey: stored.resumeConversationId,
     initialText: "",
-    agentRunner: options.agentRunner,
+    executeTurn: async (run, saveResult, timeoutMs) =>
+      await executeTurn(options.agentRunner, run, saveResult, timeoutMs),
     beforeStart: async () => {
       const lockedState = await getPersistedThreadState(
         stored.resumeConversationId!,

--- a/packages/junior/tests/component/providers/slack/resume.test.ts
+++ b/packages/junior/tests/component/providers/slack/resume.test.ts
@@ -2,7 +2,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createSlackSource } from "@sentry/junior-plugin-api";
 import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 import { disconnectStateAdapter } from "@/chat/state/adapter";
-import { deliverAssistantMessagesForTest } from "../../../fixtures/agent-runner";
+import {
+  deliverAssistantMessagesForTest,
+  createTestTurnExecution,
+} from "../../../fixtures/agent-runner";
 import { getCapturedSlackApiCalls } from "../../../msw/handlers/slack-api";
 
 const ORIGINAL_STATE_ADAPTER = process.env.JUNIOR_STATE_ADAPTER;
@@ -86,11 +89,11 @@ describe("Slack resume result handling", () => {
           source: testSlackSource("1700000000.009"),
           actor: { platform: "slack", teamId: "T123", userId: "U123" },
         },
-        agentRunner: {
+        executeTurn: createTestTurnExecution({
           run: async () => {
             throw new Error("resume failed");
           },
-        },
+        }),
         onFailure: async () => {
           throw new Error("failure state unavailable");
         },
@@ -145,12 +148,12 @@ describe("Slack resume result handling", () => {
         source: testSlackSource("1700000000.008"),
         actor: { platform: "slack", teamId: "T123", userId: "U123" },
       },
-      agentRunner: {
+      executeTurn: createTestTurnExecution({
         run: async () => ({
           status: "awaiting_auth" as const,
           providerDisplayName: "Eval Auth",
         }),
-      },
+      }),
       onAuthPause: async () => undefined,
     });
 
@@ -189,10 +192,10 @@ describe("Slack resume result handling", () => {
         source: testSlackSource("1700000000.006"),
         actor: { platform: "slack", teamId: "T123", userId: "U123" },
       },
-      agentRunner: {
+      executeTurn: createTestTurnExecution({
         run: async () =>
           completedAgentRun({ text: "", diagnostics: makeDiagnostics() }),
-      },
+      }),
     });
 
     expect(getCapturedSlackApiCalls("chat.postMessage").at(-1)?.params).toEqual(
@@ -225,14 +228,14 @@ describe("Slack resume result handling", () => {
           source: testSlackSource("1700000000.011"),
           actor: { platform: "slack", teamId: "T123", userId: "U123" },
         },
-        agentRunner: {
+        executeTurn: createTestTurnExecution({
           run: async (run) => {
             await deliverAssistantMessagesForTest(run, [
               { text: "Final resumed answer" },
             ]);
             return successfulAgentRun("Final resumed answer");
           },
-        },
+        }),
         commitResult: async () => {
           throw new Error("state write failed");
         },
@@ -278,13 +281,13 @@ describe("Slack resume result handling", () => {
         source: testSlackSource("1700000000.013"),
         actor: { platform: "slack", teamId: "T123", userId: "U123" },
       },
-      agentRunner: {
+      executeTurn: createTestTurnExecution({
         run: async () => ({
           status: "suspended" as const,
           reason: "timeout" as const,
           resumeVersion: 3,
         }),
-      },
+      }),
       onSuspend,
     });
 
@@ -311,13 +314,13 @@ describe("Slack resume result handling", () => {
         source: testSlackSource("1700000000.014"),
         actor: { platform: "slack", teamId: "T123", userId: "U123" },
       },
-      agentRunner: {
+      executeTurn: createTestTurnExecution({
         run: async () => ({
           status: "suspended" as const,
           reason: "timeout" as const,
           resumeVersion: 3,
         }),
-      },
+      }),
       onSuspend: async () => {
         throw new Error("continuation scheduling failed");
       },

--- a/packages/junior/tests/component/task-execution/slack-conversation-work.test.ts
+++ b/packages/junior/tests/component/task-execution/slack-conversation-work.test.ts
@@ -275,49 +275,49 @@ describe("Slack conversation work execution", () => {
         text: "hello",
         authorId: "U123",
         metadata: {
-                  platform: "slack",
-                  route: "mention",
-                  message: {
-                    _type: "chat:Message",
-                    attachments: [],
-                    author: {
-                      userId: "U123",
-                      userName: "dcramer",
-                      fullName: "David Cramer",
-                      isBot: false,
-                      isMe: false,
+          platform: "slack",
+          route: "mention",
+          message: {
+            _type: "chat:Message",
+            attachments: [],
+            author: {
+              userId: "U123",
+              userName: "dcramer",
+              fullName: "David Cramer",
+              isBot: false,
+              isMe: false,
+            },
+            formatted: {
+              type: "root",
+              children: [
+                {
+                  type: "paragraph",
+                  children: [
+                    {
+                      type: "table",
+                      children: [],
                     },
-                    formatted: {
-                      type: "root",
-                      children: [
-                        {
-                          type: "paragraph",
-                          children: [
-                            {
-                              type: "table",
-                              children: [],
-                            },
-                          ],
-                        },
-                      ],
-                    },
-                    id: "1712345.0002",
-                    metadata: {
-                      dateSent: "2026-07-22T12:00:00.000Z",
-                      edited: false,
-                    },
-                    raw: {},
-                    text: "hello",
-                    threadId: CONVERSATION_ID,
-                  },
-                  thread: {
-                    _type: "chat:Thread",
-                    adapterName: "slack",
-                    channelId: "C123",
-                    id: CONVERSATION_ID,
-                    isDM: false,
-                  },
+                  ],
                 },
+              ],
+            },
+            id: "1712345.0002",
+            metadata: {
+              dateSent: "2026-07-22T12:00:00.000Z",
+              edited: false,
+            },
+            raw: {},
+            text: "hello",
+            threadId: CONVERSATION_ID,
+          },
+          thread: {
+            _type: "chat:Thread",
+            adapterName: "slack",
+            channelId: "C123",
+            id: CONVERSATION_ID,
+            isDM: false,
+          },
+        },
       },
       ...conversationQueueMessage(),
       destination: SLACK_DESTINATION,
@@ -1613,11 +1613,9 @@ describe("Slack conversation work execution", () => {
     const slackAdapter = createSlackAdapterFixture();
     const { slackRuntime } = createTestChatRuntime({
       services: {
-        replyExecutor: {
-          agentRunner: {
-            run: async () => {
-              throw new Error("persistent queued failure");
-            },
+        agentRunner: {
+          run: async () => {
+            throw new Error("persistent queued failure");
           },
         },
       },
@@ -1912,17 +1910,15 @@ describe("Slack conversation work execution", () => {
     let yieldedSessionId: string | undefined;
     const { slackRuntime } = createTestChatRuntime({
       services: {
-        replyExecutor: {
-          agentRunner: {
-            run: async (request) => {
-              const _text = request.instruction.text;
-              const context = request;
+        agentRunner: {
+          run: async (request) => {
+            const _text = request.instruction.text;
+            const context = request;
 
-              await context?.durability?.onInputCommitted?.();
-              currentNowMs = 242_000;
-              yieldedSessionId = context?.turnId;
-              return { status: "suspended", reason: "timeout", resumeVersion: 1 };
-            },
+            await context?.durability?.onInputCommitted?.();
+            currentNowMs = 242_000;
+            yieldedSessionId = context?.turnId;
+            return { status: "suspended", reason: "timeout", resumeVersion: 1 };
           },
         },
       },

--- a/packages/junior/tests/fixtures/acp-http.ts
+++ b/packages/junior/tests/fixtures/acp-http.ts
@@ -87,7 +87,7 @@ export function createIndependentConversationWork(
     conversationStore: harness.conversationStore,
     getSlackAdapter: () => createSlackAdapterFixture(),
     queue: harness.queue,
-    services: { replyExecutor: { agentRunner: harness.agentRunner } },
+    services: { agentRunner: harness.agentRunner },
     state,
   });
 }

--- a/packages/junior/tests/fixtures/agent-runner.ts
+++ b/packages/junior/tests/fixtures/agent-runner.ts
@@ -9,6 +9,7 @@ import { getAssistantReplyText } from "@/chat/services/assistant-reply";
 import type { PiMessage } from "@/chat/pi/messages";
 import { isAssistantMessage } from "@/chat/pi/transcript";
 import type { AgentRun } from "@/chat/agent/types";
+import { executeTurn, type ExecuteTurn } from "@/chat/runtime/turn-execution";
 
 function assistantMessage(text: string): AssistantMessage {
   return fauxAssistantMessage(text);
@@ -25,6 +26,12 @@ export const realAgentRunner: AgentRunner = {
     return await executeAgentRun(run);
   },
 };
+
+/** Create native Turn execution with a test AgentRunner. */
+export function createTestTurnExecution(agentRunner: AgentRunner): ExecuteTurn {
+  return async (run, saveResult, timeoutMs) =>
+    await executeTurn(agentRunner, run, saveResult, timeoutMs);
+}
 
 /** Run the real agent while replacing only model output. */
 export function createModelAgentRunner(streamFn: StreamFn): AgentRunner {

--- a/packages/junior/tests/fixtures/conversation-work.ts
+++ b/packages/junior/tests/fixtures/conversation-work.ts
@@ -464,7 +464,7 @@ export async function createConversationWorkSlackHarness(
     getSlackAdapter: () => adapter,
     queue: wakes,
     services: {
-      replyExecutor: { agentRunner },
+      agentRunner,
       subscribedReplyPolicy: {
         completeObject: async ({ schema }) => ({
           object: schema.parse({

--- a/packages/junior/tests/integration/durable-queue.test.ts
+++ b/packages/junior/tests/integration/durable-queue.test.ts
@@ -149,7 +149,7 @@ async function slack(options: { modelStream?: StreamFn } = {}) {
     conversationStore: getConversationStore(),
     getSlackAdapter: () => adapter,
     queue: wakes,
-    services: { replyExecutor: { agentRunner } },
+    services: { agentRunner },
     state,
   });
   return {

--- a/packages/junior/tests/integration/oauth-resume-slack.test.ts
+++ b/packages/junior/tests/integration/oauth-resume-slack.test.ts
@@ -9,6 +9,7 @@ import { disconnectStateAdapter } from "@/chat/state/adapter";
 import { getCapturedSlackApiCalls } from "../msw/handlers/slack-api";
 import {
   createModelAgentRunner,
+  createTestTurnExecution,
   neverRunAgentRunner,
 } from "../fixtures/agent-runner";
 import { createModelStream } from "../fixtures/model-stream";
@@ -78,8 +79,8 @@ describe("oauth resume slack integration", () => {
         source: testSlackSource("1700000000.001"),
         actor: { platform: "slack", teamId: "T123", userId: "U123" },
       },
-      agentRunner: modelReply(
-        "The budget deadline you mentioned earlier was Friday.",
+      executeTurn: createTestTurnExecution(
+        modelReply("The budget deadline you mentioned earlier was Friday."),
       ),
       commitResult: async () => {
         expect(
@@ -145,7 +146,7 @@ describe("oauth resume slack integration", () => {
         source: testSlackSource("1700000000.011"),
         actor: { platform: "slack", teamId: "T123", userId: "U123" },
       },
-      agentRunner,
+      executeTurn: createTestTurnExecution(agentRunner),
     });
 
     expect(getCapturedSlackApiCalls("assistant.threads.setStatus")).toEqual([]);
@@ -193,7 +194,7 @@ describe("oauth resume slack integration", () => {
         source: testSlackSource("1700000000.010"),
         actor: { platform: "slack", teamId: "T123", userId: "U123" },
       },
-      agentRunner: {
+      executeTurn: createTestTurnExecution({
         run: async (run) => {
           observedSignal = run.signal;
           run.signal?.addEventListener(
@@ -207,7 +208,7 @@ describe("oauth resume slack integration", () => {
             runEvents.push("agent settled");
           }
         },
-      },
+      }),
       onFailure,
     });
 
@@ -260,7 +261,7 @@ describe("oauth resume slack integration", () => {
         source: testSlackSource(threadTs),
         actor: { platform: "slack", teamId: "T123", userId: "U123" },
       },
-      agentRunner: modelReply("Done."),
+      executeTurn: createTestTurnExecution(modelReply("Done.")),
     });
 
     const postCalls = getCapturedSlackApiCalls("chat.postMessage");
@@ -308,7 +309,7 @@ describe("oauth resume slack integration", () => {
         source: testSlackSource("1700000000.002"),
         actor: { platform: "slack", teamId: "T123", userId: "U123" },
       },
-      agentRunner: modelReply(longReply),
+      executeTurn: createTestTurnExecution(modelReply(longReply)),
     });
 
     const postCalls = getCapturedSlackApiCalls("chat.postMessage");
@@ -355,16 +356,18 @@ describe("oauth resume slack integration", () => {
         source: testSlackSource("1700000000.003"),
         actor: { platform: "slack", teamId: "T123", userId: "U123" },
       },
-      agentRunner: createModelAgentRunner(
-        createModelStream([
-          {
-            type: "message",
-            message: fauxAssistantMessage("Partial output", {
-              stopReason: "error",
-              errorMessage: "The model stream stopped.",
-            }),
-          },
-        ]),
+      executeTurn: createTestTurnExecution(
+        createModelAgentRunner(
+          createModelStream([
+            {
+              type: "message",
+              message: fauxAssistantMessage("Partial output", {
+                stopReason: "error",
+                errorMessage: "The model stream stopped.",
+              }),
+            },
+          ]),
+        ),
       ),
     });
 

--- a/packages/junior/tests/integration/slack/assistant-thread-contract.test.ts
+++ b/packages/junior/tests/integration/slack/assistant-thread-contract.test.ts
@@ -85,9 +85,7 @@ async function createDirectMessageBot(modelStream: StreamFn) {
   const slackRuntime = createSlackRuntime({
     getSlackAdapter: () => bot.getAdapter("slack"),
     services: {
-      replyExecutor: {
-        agentRunner: createModelAgentRunner(modelStream),
-      },
+      agentRunner: createModelAgentRunner(modelStream),
     },
   });
 
@@ -115,9 +113,7 @@ async function createMentionBot(modelStream: StreamFn) {
   const slackRuntime = createSlackRuntime({
     getSlackAdapter: () => bot.getAdapter("slack"),
     services: {
-      replyExecutor: {
-        agentRunner: createModelAgentRunner(modelStream),
-      },
+      agentRunner: createModelAgentRunner(modelStream),
     },
   });
 

--- a/packages/junior/tests/integration/slack/attachment-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/attachment-behavior.test.ts
@@ -61,21 +61,19 @@ describe("Slack behavior: attachment handling", () => {
         visionContext: {
           completeText: completeTextMock,
         },
-        replyExecutor: {
-          agentRunner: createModelAgentRunnerForRun((request) => {
-            const attachments = request.instruction.attachments ?? [];
-            capturedAttachmentCounts.push(attachments.length);
-            if (attachments[0]) {
-              capturedAttachmentMediaTypes.push(attachments[0].mediaType);
-            }
-            return createModelStream([
-              {
-                type: "text",
-                text: "Image received. The chart trend is upward.",
-              },
-            ]);
-          }),
-        },
+        agentRunner: createModelAgentRunnerForRun((request) => {
+          const attachments = request.instruction.attachments ?? [];
+          capturedAttachmentCounts.push(attachments.length);
+          if (attachments[0]) {
+            capturedAttachmentMediaTypes.push(attachments[0].mediaType);
+          }
+          return createModelStream([
+            {
+              type: "text",
+              text: "Image received. The chart trend is upward.",
+            },
+          ]);
+        }),
       },
     });
 
@@ -140,9 +138,7 @@ describe("Slack behavior: attachment handling", () => {
         visionContext: {
           completeText: completeTextMock,
         },
-        replyExecutor: {
-          agentRunner: createModelAgentRunnerForRun(streamForRun),
-        },
+        agentRunner: createModelAgentRunnerForRun(streamForRun),
       },
     });
 

--- a/packages/junior/tests/integration/slack/attachment-media-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/attachment-media-behavior.test.ts
@@ -69,20 +69,18 @@ describe("Slack behavior: mixed attachment media", () => {
           visionContext: {
             completeText: completeTextMock,
           },
-          replyExecutor: {
-            agentRunner: createModelAgentRunnerForRun((request) => {
-              const attachments = request.instruction.attachments ?? [];
-              capturedAttachmentMediaTypes.push(
-                attachments.map((attachment) => attachment.mediaType),
-              );
-              capturedAttachmentNames.push(
-                attachments.map((attachment) => attachment.filename ?? ""),
-              );
-              return createModelStream([
-                { type: "text", text: "Processed attachments." },
-              ]);
-            }),
-          },
+          agentRunner: createModelAgentRunnerForRun((request) => {
+            const attachments = request.instruction.attachments ?? [];
+            capturedAttachmentMediaTypes.push(
+              attachments.map((attachment) => attachment.mediaType),
+            );
+            capturedAttachmentNames.push(
+              attachments.map((attachment) => attachment.filename ?? ""),
+            );
+            return createModelStream([
+              { type: "text", text: "Processed attachments." },
+            ]);
+          }),
         },
       },
       {
@@ -154,23 +152,21 @@ describe("Slack behavior: mixed attachment media", () => {
 
     const { slackRuntime } = await createRuntime({
       services: {
-        replyExecutor: {
-          agentRunner: createModelAgentRunnerForRun((request) => {
-            const attachments = request.instruction.attachments ?? [];
-            capturedAttachmentMediaTypes.push(
-              attachments.map((attachment) => attachment.mediaType),
-            );
-            capturedAttachmentNames.push(
-              attachments.map((attachment) => attachment.filename ?? ""),
-            );
-            capturedOmittedImageCounts.push(
-              request.instruction.omittedImageAttachmentCount ?? 0,
-            );
-            return createModelStream([
-              { type: "text", text: "Processed attachments." },
-            ]);
-          }),
-        },
+        agentRunner: createModelAgentRunnerForRun((request) => {
+          const attachments = request.instruction.attachments ?? [];
+          capturedAttachmentMediaTypes.push(
+            attachments.map((attachment) => attachment.mediaType),
+          );
+          capturedAttachmentNames.push(
+            attachments.map((attachment) => attachment.filename ?? ""),
+          );
+          capturedOmittedImageCounts.push(
+            request.instruction.omittedImageAttachmentCount ?? 0,
+          );
+          return createModelStream([
+            { type: "text", text: "Processed attachments." },
+          ]);
+        }),
       },
     });
 
@@ -227,9 +223,7 @@ describe("Slack behavior: mixed attachment media", () => {
 
     const { slackRuntime } = await createRuntime({
       services: {
-        replyExecutor: {
-          agentRunner: createModelAgentRunnerForRun(streamForRun),
-        },
+        agentRunner: createModelAgentRunnerForRun(streamForRun),
       },
     });
 

--- a/packages/junior/tests/integration/slack/bot-handlers.test.ts
+++ b/packages/junior/tests/integration/slack/bot-handlers.test.ts
@@ -225,10 +225,10 @@ describe("bot handlers (integration)", () => {
     const scheduleSessionCompletedPluginTasks = vi.fn(async () => undefined);
     const { slackRuntime } = createTestChatRuntime({
       services: {
+        agentRunner: createModelAgentRunner(
+          createModelStream([{ type: "text", text: "Hello from the bot!" }]),
+        ),
         replyExecutor: {
-          agentRunner: createModelAgentRunner(
-            createModelStream([{ type: "text", text: "Hello from the bot!" }]),
-          ),
           scheduleSessionCompletedPluginTasks,
         },
         visionContext: {
@@ -275,9 +275,7 @@ describe("bot handlers (integration)", () => {
     const conversationId = "slack:C0REPLAY:1700000000.000";
     const { slackRuntime } = createRuntime({
       services: {
-        replyExecutor: {
-          agentRunner: neverRunAgentRunner(),
-        },
+        agentRunner: neverRunAgentRunner(),
       },
     });
     const thread = await createTestThread({
@@ -435,13 +433,11 @@ describe("bot handlers (integration)", () => {
     const conversationId = "slack:C0ERR:1700000000.000";
     const { slackRuntime } = createTestChatRuntime({
       services: {
-        replyExecutor: {
-          agentRunner: createModelAgentRunner(
-            createModelStream([
-              { type: "error", errorMessage: "LLM unavailable" },
-            ]),
-          ),
-        },
+        agentRunner: createModelAgentRunner(
+          createModelStream([
+            { type: "error", errorMessage: "LLM unavailable" },
+          ]),
+        ),
         visionContext: {
           listThreadReplies: async () => [],
         },
@@ -488,11 +484,9 @@ describe("bot handlers (integration)", () => {
     const finalText = "This reply never reaches Slack.";
     const { slackRuntime } = createTestChatRuntime({
       services: {
-        replyExecutor: {
-          agentRunner: createModelAgentRunner(
-            createModelStream([{ type: "text", text: finalText }]),
-          ),
-        },
+        agentRunner: createModelAgentRunner(
+          createModelStream([{ type: "text", text: finalText }]),
+        ),
         visionContext: {
           listThreadReplies: async () => [],
         },
@@ -567,16 +561,14 @@ describe("bot handlers (integration)", () => {
     }> = [];
     const { slackRuntime } = createRuntime({
       services: {
-        replyExecutor: {
-          agentRunner: createModelAgentRunnerForRun((request) => {
-            capturedIdentity.push({
-              conversationId: request.conversationId,
-              turnId: request.turnId,
-              runId: request.runId,
-            });
-            return createModelStream([{ type: "text", text: "Done." }]);
-          }),
-        },
+        agentRunner: createModelAgentRunnerForRun((request) => {
+          capturedIdentity.push({
+            conversationId: request.conversationId,
+            turnId: request.turnId,
+            runId: request.runId,
+          });
+          return createModelStream([{ type: "text", text: "Done." }]);
+        }),
       },
     });
 
@@ -621,15 +613,13 @@ describe("bot handlers (integration)", () => {
     });
     const { slackRuntime } = createRuntime({
       services: {
-        replyExecutor: {
-          agentRunner: createModelAgentRunnerForRun((request) => {
-            agentRunCount += 1;
-            agentInstruction = request.instruction.text;
-            return createModelStream([
-              { type: "text", text: "Fresh answer without the provider." },
-            ]);
-          }),
-        },
+        agentRunner: createModelAgentRunnerForRun((request) => {
+          agentRunCount += 1;
+          agentInstruction = request.instruction.text;
+          return createModelStream([
+            { type: "text", text: "Fresh answer without the provider." },
+          ]);
+        }),
       },
     });
 
@@ -693,8 +683,8 @@ describe("bot handlers (integration)", () => {
     const ack = vi.fn();
     const { slackRuntime } = createRuntime({
       services: {
+        agentRunner: neverRunAgentRunner(),
         replyExecutor: {
-          agentRunner: neverRunAgentRunner(),
           wakePausedTurn: bindPausedTurnQueue(queue),
         },
       },
@@ -778,8 +768,8 @@ describe("bot handlers (integration)", () => {
     const queue = createConversationWorkQueueTestAdapter();
     const { slackRuntime } = createRuntime({
       services: {
+        agentRunner: neverRunAgentRunner(),
         replyExecutor: {
-          agentRunner: neverRunAgentRunner(),
           wakePausedTurn: bindPausedTurnQueue(queue),
         },
       },
@@ -835,8 +825,8 @@ describe("bot handlers (integration)", () => {
     const queue = createConversationWorkQueueTestAdapter();
     const { slackRuntime } = createRuntime({
       services: {
+        agentRunner: neverRunAgentRunner(),
         replyExecutor: {
-          agentRunner: neverRunAgentRunner(),
           wakePausedTurn: bindPausedTurnQueue(queue),
         },
       },
@@ -902,17 +892,15 @@ describe("bot handlers (integration)", () => {
     let capturedActorUserId: string | undefined;
     const { slackRuntime } = createRuntime({
       services: {
-        replyExecutor: {
-          agentRunner: createModelAgentRunnerForRun((request) => {
-            capturedInput = {
-              piMessages: request.history ? [...request.history] : undefined,
-            };
-            const runActor = request.actor;
-            capturedActorUserId =
-              runActor && "userId" in runActor ? runActor.userId : undefined;
-            return createModelStream([{ type: "text", text: "Recapped." }]);
-          }),
-        },
+        agentRunner: createModelAgentRunnerForRun((request) => {
+          capturedInput = {
+            piMessages: request.history ? [...request.history] : undefined,
+          };
+          const runActor = request.actor;
+          capturedActorUserId =
+            runActor && "userId" in runActor ? runActor.userId : undefined;
+          return createModelStream([{ type: "text", text: "Recapped." }]);
+        }),
       },
     });
     const thread = await createTestThread({ id: conversationId });
@@ -987,8 +975,8 @@ describe("bot handlers (integration)", () => {
     const ack = vi.fn();
     const { slackRuntime } = createRuntime({
       services: {
+        agentRunner: neverRunAgentRunner(),
         replyExecutor: {
-          agentRunner: neverRunAgentRunner(),
           wakePausedTurn: bindPausedTurnQueue(queue),
         },
       },
@@ -1035,9 +1023,7 @@ describe("bot handlers (integration)", () => {
     const ack = vi.fn();
     const { slackRuntime } = createRuntime({
       services: {
-        replyExecutor: {
-          agentRunner: neverRunAgentRunner(),
-        },
+        agentRunner: neverRunAgentRunner(),
       },
     });
     const thread = await createTestThread({ id: conversationId });
@@ -1096,12 +1082,10 @@ describe("bot handlers (integration)", () => {
     });
     const { slackRuntime } = createRuntime({
       services: {
-        replyExecutor: {
-          agentRunner: createModelAgentRunnerForRun(() => {
-            agentRunCount += 1;
-            return createModelStream([{ type: "text", text: "Recovered." }]);
-          }),
-        },
+        agentRunner: createModelAgentRunnerForRun(() => {
+          agentRunCount += 1;
+          return createModelStream([{ type: "text", text: "Recovered." }]);
+        }),
       },
     });
 
@@ -1155,8 +1139,8 @@ describe("bot handlers (integration)", () => {
     const queue = createConversationWorkQueueTestAdapter();
     const { slackRuntime } = createRuntime({
       services: {
+        agentRunner: neverRunAgentRunner(),
         replyExecutor: {
-          agentRunner: neverRunAgentRunner(),
           wakePausedTurn: bindPausedTurnQueue(queue),
         },
       },
@@ -1210,8 +1194,8 @@ describe("bot handlers (integration)", () => {
     const onTurnStatePersisted = vi.fn();
     const { slackRuntime } = createRuntime({
       services: {
+        agentRunner: neverRunAgentRunner(),
         replyExecutor: {
-          agentRunner: neverRunAgentRunner(),
           wakePausedTurn: bindPausedTurnQueue(queue),
         },
       },
@@ -1274,8 +1258,8 @@ describe("bot handlers (integration)", () => {
     queue.rejectSends();
     const { slackRuntime } = createRuntime({
       services: {
+        agentRunner: neverRunAgentRunner(),
         replyExecutor: {
-          agentRunner: neverRunAgentRunner(),
           wakePausedTurn: bindPausedTurnQueue(queue),
         },
       },
@@ -1313,11 +1297,9 @@ describe("bot handlers (integration)", () => {
     const { slackRuntime } = createRuntime({
       slackAdapter: fakeAdapter,
       services: {
-        replyExecutor: {
-          agentRunner: createModelAgentRunner(
-            createModelStream([{ type: "text", text: "Done." }]),
-          ),
-        },
+        agentRunner: createModelAgentRunner(
+          createModelStream([{ type: "text", text: "Done." }]),
+        ),
       },
     });
 
@@ -1385,19 +1367,17 @@ describe("bot handlers (integration)", () => {
         conversationMemory: {
           completeText: async () => ({ text: "Status thread" }) as never,
         },
-        replyExecutor: {
-          agentRunner: createModelAgentRunner(
-            createModelStream([
-              {
-                type: "text",
-                text: "Reply lands after the pending status is drained.",
-                onRequest: () => {
-                  replyStarted = true;
-                },
+        agentRunner: createModelAgentRunner(
+          createModelStream([
+            {
+              type: "text",
+              text: "Reply lands after the pending status is drained.",
+              onRequest: () => {
+                replyStarted = true;
               },
-            ]),
-          ),
-        },
+            },
+          ]),
+        ),
       },
     });
 
@@ -1444,13 +1424,11 @@ describe("bot handlers (integration)", () => {
     const { slackRuntime } = createRuntime({
       slackAdapter: fakeAdapter,
       services: {
-        replyExecutor: {
-          agentRunner: createModelAgentRunner(
-            createModelStream([
-              { type: "text", text: "Here is the updated answer." },
-            ]),
-          ),
-        },
+        agentRunner: createModelAgentRunner(
+          createModelStream([
+            { type: "text", text: "Here is the updated answer." },
+          ]),
+        ),
       },
     });
 
@@ -1502,13 +1480,11 @@ describe("bot handlers (integration)", () => {
     const { slackRuntime } = createRuntime({
       slackAdapter: fakeAdapter,
       services: {
-        replyExecutor: {
-          agentRunner: createModelAgentRunner(
-            createModelStream([
-              { type: "text", text: "Today is April 16, 2026." },
-            ]),
-          ),
-        },
+        agentRunner: createModelAgentRunner(
+          createModelStream([
+            { type: "text", text: "Today is April 16, 2026." },
+          ]),
+        ),
       },
     });
 
@@ -1567,17 +1543,15 @@ describe("bot handlers (integration)", () => {
     const { slackRuntime } = createRuntime({
       slackAdapter: fakeAdapter,
       services: {
-        replyExecutor: {
-          agentRunner: createModelAgentRunner(
-            createModelStream([
-              {
-                type: "text",
-                text: "Today is April 16, 2026.",
-                waitFor: titleReady.promise,
-              },
-            ]),
-          ),
-        },
+        agentRunner: createModelAgentRunner(
+          createModelStream([
+            {
+              type: "text",
+              text: "Today is April 16, 2026.",
+              waitFor: titleReady.promise,
+            },
+          ]),
+        ),
       },
     });
 
@@ -1606,14 +1580,12 @@ describe("bot handlers (integration)", () => {
     const { slackRuntime } = createRuntime({
       slackAdapter: fakeAdapter,
       services: {
-        replyExecutor: {
-          agentRunner: createModelAgentRunnerForRun(() => {
-            turnCount += 1;
-            return createModelStream([
-              { type: "text", text: `reply-${turnCount}` },
-            ]);
-          }),
-        },
+        agentRunner: createModelAgentRunnerForRun(() => {
+          turnCount += 1;
+          return createModelStream([
+            { type: "text", text: `reply-${turnCount}` },
+          ]);
+        }),
       },
     });
 
@@ -1674,13 +1646,11 @@ describe("bot handlers (integration)", () => {
     const { slackRuntime } = createRuntime({
       slackAdapter: fakeAdapter,
       services: {
-        replyExecutor: {
-          agentRunner: createModelAgentRunner(
-            createModelStream([
-              { type: "text", text: "This reply should still succeed." },
-            ]),
-          ),
-        },
+        agentRunner: createModelAgentRunner(
+          createModelStream([
+            { type: "text", text: "This reply should still succeed." },
+          ]),
+        ),
       },
     });
 
@@ -1725,13 +1695,9 @@ describe("bot handlers (integration)", () => {
     const { slackRuntime } = createRuntime({
       slackAdapter: fakeAdapter,
       services: {
-        replyExecutor: {
-          agentRunner: createModelAgentRunner(
-            createModelStream([
-              { type: "text", text: "Reply still succeeds." },
-            ]),
-          ),
-        },
+        agentRunner: createModelAgentRunner(
+          createModelStream([{ type: "text", text: "Reply still succeeds." }]),
+        ),
       },
     });
 
@@ -1767,12 +1733,10 @@ describe("bot handlers (integration)", () => {
     const capturedContexts: Array<string | undefined> = [];
     const { slackRuntime } = createRuntime({
       services: {
-        replyExecutor: {
-          agentRunner: createModelAgentRunnerForRun((run) => {
-            capturedContexts.push(run.instruction.context);
-            return createModelStream([{ type: "text", text: "First reply." }]);
-          }),
-        },
+        agentRunner: createModelAgentRunnerForRun((run) => {
+          capturedContexts.push(run.instruction.context);
+          return createModelStream([{ type: "text", text: "First reply." }]);
+        }),
       },
     });
 
@@ -1797,14 +1761,12 @@ describe("bot handlers (integration)", () => {
     const capturedContexts: Array<string | undefined> = [];
     const { slackRuntime } = createRuntime({
       services: {
-        replyExecutor: {
-          agentRunner: createModelAgentRunnerForRun((run) => {
-            capturedContexts.push(run.instruction.context);
-            return createModelStream([
-              { type: "text", text: "Follow-up reply." },
-            ]);
-          }),
-        },
+        agentRunner: createModelAgentRunnerForRun((run) => {
+          capturedContexts.push(run.instruction.context);
+          return createModelStream([
+            { type: "text", text: "Follow-up reply." },
+          ]);
+        }),
       },
     });
 
@@ -1893,14 +1855,12 @@ describe("bot handlers (integration)", () => {
               text: '{"should_reply":true,"should_unsubscribe":false,"confidence":1,"reason":"follow-up"}',
             }) as any,
         },
-        replyExecutor: {
-          agentRunner: createModelAgentRunnerForRun((run) => {
-            capturedContexts.push(run.instruction.context);
-            return createModelStream([
-              { type: "text", text: "Responding to first message only." },
-            ]);
-          }),
-        },
+        agentRunner: createModelAgentRunnerForRun((run) => {
+          capturedContexts.push(run.instruction.context);
+          return createModelStream([
+            { type: "text", text: "Responding to first message only." },
+          ]);
+        }),
       },
     });
 
@@ -1942,14 +1902,12 @@ describe("bot handlers (integration)", () => {
     let turnCount = 0;
     const { slackRuntime } = createRuntime({
       services: {
-        replyExecutor: {
-          agentRunner: createModelAgentRunnerForRun(() => {
-            turnCount += 1;
-            return createModelStream([
-              { type: "text", text: `reply-${turnCount}` },
-            ]);
-          }),
-        },
+        agentRunner: createModelAgentRunnerForRun(() => {
+          turnCount += 1;
+          return createModelStream([
+            { type: "text", text: `reply-${turnCount}` },
+          ]);
+        }),
       },
     });
 

--- a/packages/junior/tests/integration/slack/bot-image-hydration.test.ts
+++ b/packages/junior/tests/integration/slack/bot-image-hydration.test.ts
@@ -74,9 +74,7 @@ describe("bot image hydration", () => {
           visionContext: {
             listThreadReplies: listThreadRepliesMock,
           },
-          replyExecutor: {
-            agentRunner: createReplyAgentRunner(),
-          },
+          agentRunner: createReplyAgentRunner(),
         },
       },
       {
@@ -199,9 +197,7 @@ describe("bot image hydration", () => {
             downloadFile: downloadFileMock,
             completeText: completeTextMock,
           },
-          replyExecutor: {
-            agentRunner: createReplyAgentRunner(),
-          },
+          agentRunner: createReplyAgentRunner(),
         },
       },
       { AI_VISION_MODEL: "openai/gpt-5.4" },
@@ -261,9 +257,7 @@ describe("bot image hydration", () => {
         visionContext: {
           listThreadReplies: listThreadRepliesMock,
         },
-        replyExecutor: {
-          agentRunner: createReplyAgentRunner(),
-        },
+        agentRunner: createReplyAgentRunner(),
       },
     });
     const thread = await createTestThread({
@@ -340,9 +334,7 @@ describe("bot image hydration", () => {
         visionContext: {
           listThreadReplies: listThreadRepliesMock,
         },
-        replyExecutor: {
-          agentRunner: createReplyAgentRunner(),
-        },
+        agentRunner: createReplyAgentRunner(),
       },
     });
     const firstThread = await createTestThread({
@@ -415,9 +407,7 @@ describe("bot image hydration", () => {
             downloadFile: downloadFileMock,
             completeText: completeTextMock,
           },
-          replyExecutor: {
-            agentRunner: createReplyAgentRunner(),
-          },
+          agentRunner: createReplyAgentRunner(),
         },
       },
       {
@@ -519,9 +509,7 @@ describe("bot image hydration", () => {
             downloadFile: downloadFileMock,
             completeText: completeTextMock,
           },
-          replyExecutor: {
-            agentRunner: createModelAgentRunnerForRun(streamForRun),
-          },
+          agentRunner: createModelAgentRunnerForRun(streamForRun),
         },
       },
       {
@@ -659,9 +647,7 @@ describe("bot image hydration", () => {
             downloadFile: downloadFileMock,
             completeText: completeTextMock,
           },
-          replyExecutor: {
-            agentRunner: createModelAgentRunnerForRun(streamForRun),
-          },
+          agentRunner: createModelAgentRunnerForRun(streamForRun),
         },
       },
       {
@@ -796,9 +782,7 @@ describe("bot image hydration", () => {
             downloadFile: downloadFileMock,
             completeText: completeTextMock,
           },
-          replyExecutor: {
-            agentRunner: createModelAgentRunnerForRun(streamForRun),
-          },
+          agentRunner: createModelAgentRunnerForRun(streamForRun),
         },
       },
       {
@@ -897,9 +881,7 @@ describe("bot image hydration", () => {
             listThreadReplies: listThreadRepliesMock,
             completeText: completeTextMock,
           },
-          replyExecutor: {
-            agentRunner: createModelAgentRunnerForRun(streamForRun),
-          },
+          agentRunner: createModelAgentRunnerForRun(streamForRun),
         },
       },
       {

--- a/packages/junior/tests/integration/slack/conversation-turn-steering-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/conversation-turn-steering-behavior.test.ts
@@ -129,10 +129,7 @@ function createTurnHarness(args: {
     getSlackAdapter: () => adapter,
     services: {
       ...(args.services ?? {}),
-      replyExecutor: {
-        ...(args.services?.replyExecutor ?? {}),
-        agentRunner: args.agentRunner,
-      },
+      agentRunner: args.agentRunner,
       subscribedReplyPolicy: {
         completeObject:
           args.completeObject ??

--- a/packages/junior/tests/integration/slack/finalized-reply-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/finalized-reply-behavior.test.ts
@@ -50,11 +50,9 @@ describe("Slack behavior: finalized thread replies", () => {
   it("posts a completed assistant message", async () => {
     const { slackRuntime } = createTestChatRuntime({
       services: {
-        replyExecutor: {
-          agentRunner: createModelAgentRunner(
-            createModelStream([{ type: "text", text: "Hello world" }]),
-          ),
-        },
+        agentRunner: createModelAgentRunner(
+          createModelStream([{ type: "text", text: "Hello world" }]),
+        ),
       },
     });
 
@@ -97,11 +95,9 @@ describe("Slack behavior: finalized thread replies", () => {
     ).join("\n");
     const { slackRuntime } = createTestChatRuntime({
       services: {
-        replyExecutor: {
-          agentRunner: createModelAgentRunner(
-            createModelStream([{ type: "text", text: longReply }]),
-          ),
-        },
+        agentRunner: createModelAgentRunner(
+          createModelStream([{ type: "text", text: longReply }]),
+        ),
       },
     });
 
@@ -134,11 +130,9 @@ describe("Slack behavior: finalized thread replies", () => {
     const longReply = `Here is the script:\n\`\`\`ts\n${repeated}\`\`\``;
     const { slackRuntime } = createTestChatRuntime({
       services: {
-        replyExecutor: {
-          agentRunner: createModelAgentRunner(
-            createModelStream([{ type: "text", text: longReply }]),
-          ),
-        },
+        agentRunner: createModelAgentRunner(
+          createModelStream([{ type: "text", text: longReply }]),
+        ),
       },
     });
 
@@ -172,19 +166,17 @@ describe("Slack behavior: finalized thread replies", () => {
     const longReply = `${partialStart} ${"A".repeat(slackOutputPolicy.maxInlineChars)}\n\n${partialEnd}`;
     const { slackRuntime } = createTestChatRuntime({
       services: {
-        replyExecutor: {
-          agentRunner: createModelAgentRunner(
-            createModelStream([
-              {
-                type: "message",
-                message: fauxAssistantMessage(longReply, {
-                  stopReason: "error",
-                  errorMessage: "The model stream stopped.",
-                }),
-              },
-            ]),
-          ),
-        },
+        agentRunner: createModelAgentRunner(
+          createModelStream([
+            {
+              type: "message",
+              message: fauxAssistantMessage(longReply, {
+                stopReason: "error",
+                errorMessage: "The model stream stopped.",
+              }),
+            },
+          ]),
+        ),
       },
     });
 

--- a/packages/junior/tests/integration/slack/message-changed-reply-contract.test.ts
+++ b/packages/junior/tests/integration/slack/message-changed-reply-contract.test.ts
@@ -82,8 +82,8 @@ async function createEditedDmBot(args: {
   const slackRuntime = createSlackRuntime({
     getSlackAdapter: () => bot.getAdapter("slack"),
     services: {
+      agentRunner: args.agentRunner,
       replyExecutor: {
-        agentRunner: args.agentRunner,
         ...(args.queue
           ? {
               wakePausedTurn: async (request) => {

--- a/packages/junior/tests/integration/slack/message-content-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/message-content-behavior.test.ts
@@ -78,12 +78,10 @@ describe("Slack behavior: message content", () => {
             } as never;
           },
         },
-        replyExecutor: {
-          agentRunner: createModelAgentRunnerForRun((run) => {
-            captureAgentCall(calls, run);
-            return createModelStream([{ type: "text", text: "Summary sent." }]);
-          }),
-        },
+        agentRunner: createModelAgentRunnerForRun((run) => {
+          captureAgentCall(calls, run);
+          return createModelStream([{ type: "text", text: "Summary sent." }]);
+        }),
       },
     });
 
@@ -113,12 +111,10 @@ describe("Slack behavior: message content", () => {
 
     const { slackRuntime } = createTestChatRuntime({
       services: {
-        replyExecutor: {
-          agentRunner: createModelAgentRunnerForRun((run) => {
-            captureAgentCall(calls, run);
-            return createModelStream([{ type: "text", text: "Reviewed." }]);
-          }),
-        },
+        agentRunner: createModelAgentRunnerForRun((run) => {
+          captureAgentCall(calls, run);
+          return createModelStream([{ type: "text", text: "Reviewed." }]);
+        }),
       },
     });
 
@@ -158,12 +154,10 @@ describe("Slack behavior: message content", () => {
 
     const { slackRuntime } = createTestChatRuntime({
       services: {
-        replyExecutor: {
-          agentRunner: createModelAgentRunnerForRun((run) => {
-            captureAgentCall(calls, run);
-            return createModelStream([{ type: "text", text: "Done." }]);
-          }),
-        },
+        agentRunner: createModelAgentRunnerForRun((run) => {
+          captureAgentCall(calls, run);
+          return createModelStream([{ type: "text", text: "Done." }]);
+        }),
       },
     });
 
@@ -191,14 +185,10 @@ describe("Slack behavior: message content", () => {
 
     const { slackRuntime } = createTestChatRuntime({
       services: {
-        replyExecutor: {
-          agentRunner: createModelAgentRunnerForRun((run) => {
-            captureAgentCall(calls, run);
-            return createModelStream([
-              { type: "text", text: "Alert reviewed." },
-            ]);
-          }),
-        },
+        agentRunner: createModelAgentRunnerForRun((run) => {
+          captureAgentCall(calls, run);
+          return createModelStream([{ type: "text", text: "Alert reviewed." }]);
+        }),
       },
     });
 
@@ -242,12 +232,10 @@ describe("Slack behavior: message content", () => {
 
     const { slackRuntime } = createTestChatRuntime({
       services: {
-        replyExecutor: {
-          agentRunner: createModelAgentRunnerForRun((run) => {
-            captureAgentCall(calls, run);
-            return createModelStream([{ type: "text", text: "Review found." }]);
-          }),
-        },
+        agentRunner: createModelAgentRunnerForRun((run) => {
+          captureAgentCall(calls, run);
+          return createModelStream([{ type: "text", text: "Review found." }]);
+        }),
       },
     });
 
@@ -322,9 +310,7 @@ describe("Slack behavior: message content", () => {
   it("does not invoke the agent for self-authored mention messages", async () => {
     const { slackRuntime } = createTestChatRuntime({
       services: {
-        replyExecutor: {
-          agentRunner: neverRunAgentRunner(),
-        },
+        agentRunner: neverRunAgentRunner(),
       },
     });
 
@@ -365,18 +351,15 @@ describe("Slack behavior: message content", () => {
             } as never;
           },
         },
-        replyExecutor: {
-          agentRunner: createModelAgentRunnerForRun((run) => {
-            captureAgentCall(calls, run);
-            return createModelStream([
-              {
-                type: "text",
-                text:
-                  calls.length === 1 ? "First response." : "Second response.",
-              },
-            ]);
-          }),
-        },
+        agentRunner: createModelAgentRunnerForRun((run) => {
+          captureAgentCall(calls, run);
+          return createModelStream([
+            {
+              type: "text",
+              text: calls.length === 1 ? "First response." : "Second response.",
+            },
+          ]);
+        }),
       },
     });
 
@@ -458,12 +441,10 @@ describe("Slack behavior: message content", () => {
             }) as never,
           autoCompactionTriggerTokens: 100,
         },
-        replyExecutor: {
-          agentRunner: createModelAgentRunnerForRun((run) => {
-            captureAgentCall(calls, run);
-            return createModelStream([{ type: "text", text: "Done." }]);
-          }),
-        },
+        agentRunner: createModelAgentRunnerForRun((run) => {
+          captureAgentCall(calls, run);
+          return createModelStream([{ type: "text", text: "Done." }]);
+        }),
       },
     });
 
@@ -536,6 +517,9 @@ describe("Slack behavior: message content", () => {
 
     const { slackRuntime } = createTestChatRuntime({
       services: {
+        agentRunner: createModelAgentRunner(
+          createModelStream([{ type: "text", text: "Done." }]),
+        ),
         replyExecutor: {
           contextCompactor: {
             maybeCompact: async (args) => {
@@ -543,9 +527,6 @@ describe("Slack behavior: message content", () => {
               return { compacted: false, reason: "below_threshold" };
             },
           },
-          agentRunner: createModelAgentRunner(
-            createModelStream([{ type: "text", text: "Done." }]),
-          ),
         },
       },
     });
@@ -632,12 +613,10 @@ describe("Slack behavior: message content", () => {
           },
           autoCompactionTriggerTokens: 100,
         },
-        replyExecutor: {
-          agentRunner: createModelAgentRunnerForRun((run) => {
-            captureAgentCall(calls, run);
-            return createModelStream([{ type: "text", text: "Done." }]);
-          }),
-        },
+        agentRunner: createModelAgentRunnerForRun((run) => {
+          captureAgentCall(calls, run);
+          return createModelStream([{ type: "text", text: "Done." }]);
+        }),
       },
     });
 

--- a/packages/junior/tests/integration/slack/message-im-attachment-contract.test.ts
+++ b/packages/junior/tests/integration/slack/message-im-attachment-contract.test.ts
@@ -45,9 +45,7 @@ async function createDirectMessageBot(args: {
       visionContext: {
         completeText: args.completeText,
       },
-      replyExecutor: {
-        agentRunner: args.agentRunner,
-      },
+      agentRunner: args.agentRunner,
     },
   });
 

--- a/packages/junior/tests/integration/slack/new-mention-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/new-mention-behavior.test.ts
@@ -43,17 +43,15 @@ describe("Slack behavior: new mention", () => {
 
     const { slackRuntime } = createTestChatRuntime({
       services: {
-        replyExecutor: {
-          agentRunner: createModelAgentRunnerForRun((request) => {
-            agentRuns.push({
-              prompt: request.instruction.text,
-              piMessages: request.history ? [...request.history] : undefined,
-            });
-            return createModelStream([
-              { type: "text", text: "Handled both updates." },
-            ]);
-          }),
-        },
+        agentRunner: createModelAgentRunnerForRun((request) => {
+          agentRuns.push({
+            prompt: request.instruction.text,
+            piMessages: request.history ? [...request.history] : undefined,
+          });
+          return createModelStream([
+            { type: "text", text: "Handled both updates." },
+          ]);
+        }),
       },
     });
 
@@ -119,24 +117,21 @@ describe("Slack behavior: new mention", () => {
 
     const { slackRuntime } = createTestChatRuntime({
       services: {
-        replyExecutor: {
-          agentRunner: createModelAgentRunnerForRun((request) => {
-            const attachments = request.instruction.attachments ?? [];
-            agentRuns.push({
-              prompt: request.instruction.text,
-              inboundAttachmentCount:
-                request.instruction.inboundAttachmentCount,
-              filenames: attachments.map(
-                (attachment) => attachment.filename ?? "",
-              ),
-              attachmentText: attachments[0]?.data?.toString("utf8"),
-              piMessages: request.history ? [...request.history] : undefined,
-            });
-            return createModelStream([
-              { type: "text", text: "Handled queued attachment." },
-            ]);
-          }),
-        },
+        agentRunner: createModelAgentRunnerForRun((request) => {
+          const attachments = request.instruction.attachments ?? [];
+          agentRuns.push({
+            prompt: request.instruction.text,
+            inboundAttachmentCount: request.instruction.inboundAttachmentCount,
+            filenames: attachments.map(
+              (attachment) => attachment.filename ?? "",
+            ),
+            attachmentText: attachments[0]?.data?.toString("utf8"),
+            piMessages: request.history ? [...request.history] : undefined,
+          });
+          return createModelStream([
+            { type: "text", text: "Handled queued attachment." },
+          ]);
+        }),
       },
     });
 
@@ -194,13 +189,11 @@ describe("Slack behavior: new mention", () => {
     const { slackRuntime } = createTestChatRuntime({
       slackAdapter,
       services: {
-        replyExecutor: {
-          agentRunner: createModelAgentRunner(
-            createModelStream([
-              { type: "error", errorMessage: "model exploded" },
-            ]),
-          ),
-        },
+        agentRunner: createModelAgentRunner(
+          createModelStream([
+            { type: "error", errorMessage: "model exploded" },
+          ]),
+        ),
       },
     });
 

--- a/packages/junior/tests/integration/slack/processing-reaction-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/processing-reaction-behavior.test.ts
@@ -29,13 +29,11 @@ describe("Slack behavior: processing reaction", () => {
   it("adds eyes before mention work and marks the message complete after the reply", async () => {
     const { slackRuntime } = createTestChatRuntime({
       services: {
-        replyExecutor: {
-          agentRunner: createModelAgentRunnerForRun(() => {
-            expect(slackApiOutbox.reactionAdds()).toHaveLength(1);
-            expect(slackApiOutbox.reactionRemovals()).toHaveLength(0);
-            return createModelStream([{ type: "text", text: "Done." }]);
-          }),
-        },
+        agentRunner: createModelAgentRunnerForRun(() => {
+          expect(slackApiOutbox.reactionAdds()).toHaveLength(1);
+          expect(slackApiOutbox.reactionRemovals()).toHaveLength(0);
+          return createModelStream([{ type: "text", text: "Done." }]);
+        }),
       },
     });
 
@@ -84,9 +82,7 @@ describe("Slack behavior: processing reaction", () => {
             } as never;
           },
         },
-        replyExecutor: {
-          agentRunner: neverRunAgentRunner(),
-        },
+        agentRunner: neverRunAgentRunner(),
       },
     });
 
@@ -132,13 +128,11 @@ describe("Slack behavior: processing reaction", () => {
             } as never;
           },
         },
-        replyExecutor: {
-          agentRunner: createModelAgentRunnerForRun(() => {
-            expect(slackApiOutbox.reactionAdds()).toHaveLength(1);
-            expect(slackApiOutbox.reactionRemovals()).toHaveLength(0);
-            return createModelStream([{ type: "text", text: "Done." }]);
-          }),
-        },
+        agentRunner: createModelAgentRunnerForRun(() => {
+          expect(slackApiOutbox.reactionAdds()).toHaveLength(1);
+          expect(slackApiOutbox.reactionRemovals()).toHaveLength(0);
+          return createModelStream([{ type: "text", text: "Done." }]);
+        }),
       },
     });
 
@@ -173,13 +167,11 @@ describe("Slack behavior: processing reaction", () => {
   it("does not react to synthetic resource-event notifications", async () => {
     const { slackRuntime } = createTestChatRuntime({
       services: {
-        replyExecutor: {
-          agentRunner: createModelAgentRunnerForRun(() => {
-            expect(slackApiOutbox.reactionAdds()).toHaveLength(0);
-            expect(slackApiOutbox.reactionRemovals()).toHaveLength(0);
-            return createModelStream([{ type: "text", text: "Done." }]);
-          }),
-        },
+        agentRunner: createModelAgentRunnerForRun(() => {
+          expect(slackApiOutbox.reactionAdds()).toHaveLength(0);
+          expect(slackApiOutbox.reactionRemovals()).toHaveLength(0);
+          return createModelStream([{ type: "text", text: "Done." }]);
+        }),
       },
     });
 
@@ -221,18 +213,16 @@ describe("Slack behavior: processing reaction", () => {
   it("keeps eyes when the assistant explicitly adds an eyes reaction", async () => {
     const { slackRuntime } = createTestChatRuntime({
       services: {
-        replyExecutor: {
-          agentRunner: createModelAgentRunner(
-            createModelStream([
-              {
-                type: "toolCall",
-                name: "addReaction",
-                arguments: { emoji: ":eyes:" },
-              },
-              { type: "text", text: "Done." },
-            ]),
-          ),
-        },
+        agentRunner: createModelAgentRunner(
+          createModelStream([
+            {
+              type: "toolCall",
+              name: "addReaction",
+              arguments: { emoji: ":eyes:" },
+            },
+            { type: "text", text: "Done." },
+          ]),
+        ),
       },
     });
 
@@ -265,18 +255,16 @@ describe("Slack behavior: processing reaction", () => {
   it("clears eyes and marks complete for reaction-only no-reply turns", async () => {
     const { slackRuntime } = createTestChatRuntime({
       services: {
-        replyExecutor: {
-          agentRunner: createModelAgentRunner(
-            createModelStream([
-              {
-                type: "toolCall",
-                name: "addReaction",
-                arguments: { emoji: ":heart:" },
-              },
-              { type: "text", text: NO_REPLY_MARKER },
-            ]),
-          ),
-        },
+        agentRunner: createModelAgentRunner(
+          createModelStream([
+            {
+              type: "toolCall",
+              name: "addReaction",
+              arguments: { emoji: ":heart:" },
+            },
+            { type: "text", text: NO_REPLY_MARKER },
+          ]),
+        ),
       },
     });
 

--- a/packages/junior/tests/integration/slack/provider-default-config-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/provider-default-config-behavior.test.ts
@@ -29,9 +29,7 @@ describe("Slack behavior: provider default configuration", () => {
   it("sets an explicit default GitHub repo without starting an agent turn", async () => {
     const { slackRuntime } = createTestChatRuntime({
       services: {
-        replyExecutor: {
-          agentRunner: neverRunAgentRunner(),
-        },
+        agentRunner: neverRunAgentRunner(),
       },
     });
     const thread = await createTestThread({
@@ -66,14 +64,12 @@ describe("Slack behavior: provider default configuration", () => {
     let agentRunCount = 0;
     const { slackRuntime } = createTestChatRuntime({
       services: {
-        replyExecutor: {
-          agentRunner: createModelAgentRunnerForRun(() => {
-            agentRunCount += 1;
-            return createModelStream([
-              { type: "text", text: "Created the issue." },
-            ]);
-          }),
-        },
+        agentRunner: createModelAgentRunnerForRun(() => {
+          agentRunCount += 1;
+          return createModelStream([
+            { type: "text", text: "Created the issue." },
+          ]);
+        }),
       },
     });
     const thread = await createTestThread({

--- a/packages/junior/tests/integration/slack/subscribed-message-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/subscribed-message-behavior.test.ts
@@ -81,9 +81,7 @@ describe("Slack behavior: subscribed messages", () => {
             } as never;
           },
         },
-        replyExecutor: {
-          agentRunner: neverRunAgentRunner(),
-        },
+        agentRunner: neverRunAgentRunner(),
       },
     });
 
@@ -118,9 +116,7 @@ describe("Slack behavior: subscribed messages", () => {
             throw providerError;
           },
         },
-        replyExecutor: {
-          agentRunner: neverRunAgentRunner(),
-        },
+        agentRunner: neverRunAgentRunner(),
       },
     });
 
@@ -155,12 +151,10 @@ describe("Slack behavior: subscribed messages", () => {
             throw new Error("resource events bypass subscribed classifier");
           },
         },
-        replyExecutor: {
-          agentRunner: replyForRun((run) => {
-            agentRuns.push(run);
-            return "I checked the subscribed PR event.\nThe PR is merged.";
-          }),
-        },
+        agentRunner: replyForRun((run) => {
+          agentRuns.push(run);
+          return "I checked the subscribed PR event.\nThe PR is merged.";
+        }),
       },
     });
 
@@ -233,7 +227,7 @@ describe("Slack behavior: subscribed messages", () => {
     });
     const { slackRuntime } = createRuntime({
       services: {
-        replyExecutor: { agentRunner },
+        agentRunner,
       },
     });
     const thread = await createTestThread({
@@ -357,12 +351,10 @@ describe("Slack behavior: subscribed messages", () => {
             } as never;
           },
         },
-        replyExecutor: {
-          agentRunner: replyForRun((run) => {
-            replyCalls.push(run.instruction.text);
-            return "Action item captured: monitor dashboards for 30 minutes.";
-          }),
-        },
+        agentRunner: replyForRun((run) => {
+          replyCalls.push(run.instruction.text);
+          return "Action item captured: monitor dashboards for 30 minutes.";
+        }),
       },
     });
 
@@ -406,12 +398,10 @@ describe("Slack behavior: subscribed messages", () => {
             } as never;
           },
         },
-        replyExecutor: {
-          agentRunner: replyForRun((run) => {
-            replyCalls.push(run.instruction.text);
-            return "Yes. Shipping status is green.";
-          }),
-        },
+        agentRunner: replyForRun((run) => {
+          replyCalls.push(run.instruction.text);
+          return "Yes. Shipping status is green.";
+        }),
       },
     });
 
@@ -450,15 +440,13 @@ describe("Slack behavior: subscribed messages", () => {
             );
           },
         },
-        replyExecutor: {
-          agentRunner: replyForRun((run) => {
-            replyCalls.push({
-              prompt: run.instruction.text,
-              piMessages: run.history ? [...run.history] : undefined,
-            });
-            return "Handled queued subscribed turn.";
-          }),
-        },
+        agentRunner: replyForRun((run) => {
+          replyCalls.push({
+            prompt: run.instruction.text,
+            piMessages: run.history ? [...run.history] : undefined,
+          });
+          return "Handled queued subscribed turn.";
+        }),
       },
     });
     const thread = await createTestThread({
@@ -521,14 +509,12 @@ describe("Slack behavior: subscribed messages", () => {
             } as never;
           },
         },
-        replyExecutor: {
-          agentRunner: replyForRun((run) => {
-            replyCalls.push(run.instruction.text);
-            return replyCalls.length === 1
-              ? "I can help with this thread."
-              : "I'm back because you mentioned me again.";
-          }),
-        },
+        agentRunner: replyForRun((run) => {
+          replyCalls.push(run.instruction.text);
+          return replyCalls.length === 1
+            ? "I can help with this thread."
+            : "I'm back because you mentioned me again.";
+        }),
       },
     });
 
@@ -629,9 +615,7 @@ describe("Slack behavior: subscribed messages", () => {
             );
           },
         },
-        replyExecutor: {
-          agentRunner: neverRunAgentRunner(),
-        },
+        agentRunner: neverRunAgentRunner(),
       },
     });
 
@@ -672,9 +656,7 @@ describe("Slack behavior: subscribed messages", () => {
             } as never;
           },
         },
-        replyExecutor: {
-          agentRunner: neverRunAgentRunner(),
-        },
+        agentRunner: neverRunAgentRunner(),
       },
     });
 
@@ -721,9 +703,7 @@ describe("Slack behavior: subscribed messages", () => {
             } as never;
           },
         },
-        replyExecutor: {
-          agentRunner: neverRunAgentRunner(),
-        },
+        agentRunner: neverRunAgentRunner(),
       },
     });
 
@@ -772,9 +752,7 @@ describe("Slack behavior: subscribed messages", () => {
             } as never;
           },
         },
-        replyExecutor: {
-          agentRunner: neverRunAgentRunner(),
-        },
+        agentRunner: neverRunAgentRunner(),
       },
     });
 
@@ -827,12 +805,10 @@ describe("Slack behavior: subscribed messages", () => {
             } as never;
           },
         },
-        replyExecutor: {
-          agentRunner: replyForRun((run) => {
-            agentRuns.push(run);
-            return "Deploy summarized.";
-          }),
-        },
+        agentRunner: replyForRun((run) => {
+          agentRuns.push(run);
+          return "Deploy summarized.";
+        }),
       },
     });
 
@@ -887,12 +863,10 @@ describe("Slack behavior: subscribed messages", () => {
             } as never;
           },
         },
-        replyExecutor: {
-          agentRunner: replyForRun((run) => {
-            agentRuns.push(run);
-            return "Deploy summarized.";
-          }),
-        },
+        agentRunner: replyForRun((run) => {
+          agentRuns.push(run);
+          return "Deploy summarized.";
+        }),
       },
     });
 
@@ -947,9 +921,7 @@ describe("Slack behavior: subscribed messages", () => {
             );
           },
         },
-        replyExecutor: {
-          agentRunner: neverRunAgentRunner(),
-        },
+        agentRunner: neverRunAgentRunner(),
       },
     });
 
@@ -1013,12 +985,10 @@ describe("Slack behavior: subscribed messages", () => {
             } as never;
           },
         },
-        replyExecutor: {
-          agentRunner: replyForRun((run) => {
-            replyCalls.push(run.instruction.text);
-            return "You asked for the budget by Friday.";
-          }),
-        },
+        agentRunner: replyForRun((run) => {
+          replyCalls.push(run.instruction.text);
+          return "You asked for the budget by Friday.";
+        }),
       },
     });
 
@@ -1074,14 +1044,12 @@ describe("Slack behavior: subscribed messages", () => {
             } as never;
           },
         },
-        replyExecutor: {
-          agentRunner: replyForRun((run) => {
-            replyCalls.push(run.instruction.text);
-            return replyCalls.length === 1
-              ? "The deploy changed billing, auth, and the API gateway."
-              : "The three services were billing, auth, and the API gateway.";
-          }),
-        },
+        agentRunner: replyForRun((run) => {
+          replyCalls.push(run.instruction.text);
+          return replyCalls.length === 1
+            ? "The deploy changed billing, auth, and the API gateway."
+            : "The three services were billing, auth, and the API gateway.";
+        }),
       },
     });
 


### PR DESCRIPTION
Slack Turn and resume paths now receive the native `ExecuteTurn` capability instead of the lower-level `AgentRunner`. App construction binds the selected runner to native Turn execution, so Slack keeps provider behavior while the core runtime keeps timeout, result, and pause handling.

The override cutover is intentional: model execution now lives at the app construction boundary instead of inside Slack's `replyExecutor` services. There is no compatibility shape. Most of the test diff removes that old nesting; the affected behavior suite passes 151 tests in a clean worktree.

Refs #1563
