### PR TITLE
ref(slack): move turn lifecycle setup

### DIFF
--- a/packages/junior/src/chat/conversations/turn-lifecycle.ts
+++ b/packages/junior/src/chat/conversations/turn-lifecycle.ts
@@ -3,6 +3,7 @@ import type {
   ConversationTurnFailureCode,
   ConversationTurnFailureReason,
 } from "./history";
+import { getConversationEventStore } from "@/chat/db";
 
 /** Product-owned inputs for opening one correlated conversation turn. */
 export interface StartConversationTurnInput {
@@ -91,4 +92,9 @@ export class ConversationTurnLifecycleService implements ConversationTurnLifecyc
       },
     ]);
   }
+}
+
+/** Return the Turn lifecycle that records Conversation events. */
+export function getTurnLifecycle(): ConversationTurnLifecycle {
+  return new ConversationTurnLifecycleService(getConversationEventStore());
 }

--- a/packages/junior/src/chat/providers/slack/resume.ts
+++ b/packages/junior/src/chat/providers/slack/resume.ts
@@ -36,11 +36,10 @@ import {
   requireTurnFailureEventId,
 } from "@/chat/services/turn-failure-response";
 import {
-  ConversationTurnLifecycleService,
+  getTurnLifecycle,
   type ConversationTurnLifecycle,
 } from "@/chat/conversations/turn-lifecycle";
 import type { ConversationTurnFailureCode } from "@/chat/conversations/history";
-import { getConversationEventStore } from "@/chat/db";
 import {
   recordTurnSummary,
   saveTurnCheckpoint,
@@ -457,9 +456,7 @@ async function resumeSlackTurnInContext(
   let assistantMessageDelivered = false;
   let shouldScheduleCompletedPluginTasks = false;
   let postDeliveryCommitError: unknown;
-  const turnLifecycle = new ConversationTurnLifecycleService(
-    getConversationEventStore(),
-  );
+  const turnLifecycle = getTurnLifecycle();
   let failureCode: ConversationTurnFailureCode = "agent_run_failed";
   let runArgs = args;
   try {


### PR DESCRIPTION
Slack resume now gets the Turn lifecycle from the Conversation owner instead of constructing it from the event store. This keeps storage setup out of the Slack provider without passing another service through its callers, and resume behavior remains unchanged.

Refs #1563.
