### PR TITLE
fix(api): resume turns as the user who started them

### DIFF
--- a/TERMINOLOGY.md
+++ b/TERMINOLOGY.md
@@ -18,8 +18,10 @@ Canonical words used across Junior's code and documentation.
 - **Source**: where an inbound event came from, such as Slack, local CLI, web
   (dashboard), scheduler, or plugin dispatch.
 - **Destination**: where Junior sends output or side effects.
-- **Location**: the optional provider container associated with a conversation,
-  identified by Junior and provider ids. Conversation visibility is separate.
+- **Location**: optional provider context for a conversation or input,
+  identified by Junior and provider ids. A run may keep this context when its
+  Source or Actor is not from that provider. Location does not grant delivery.
+  Conversation visibility is separate.
 - **publishExternally**: whether one turn also publishes assistant output to the
   conversation destination. The conversation log always stores the turn. Slack
   surfaces treat missing as publish; non-Slack work treats missing as
@@ -28,7 +30,8 @@ Canonical words used across Junior's code and documentation.
 - **Identity**: one provider account, such as a Slack account in one workspace,
   optionally linked to a user.
 - **Actor**: the runtime participant for one source invocation. Actor ids are
-  provider-scoped and are not canonical user ids.
+  provider-scoped and are not canonical user ids. An Actor may keep provider
+  fields that the agent or tools need. Those fields do not select the runtime.
 - **Resource event**: one normalized change identified by namespace, identifier,
   event type, and an idempotency key. Plugins and core can publish them.
   Delivery wakes the conversation; destination stays on that conversation.
@@ -90,6 +93,9 @@ Canonical words used across Junior's code and documentation.
 
 - Use `provider` on provider-owned references such as Identity and Location; it
   names the namespace that owns their provider ids.
+- Keep Source, Actor, Location, Destination, and `publishExternally`
+  independent. Do not infer one from another. Provider data may supply agent
+  context without selecting another runtime or granting delivery.
 - For new Source unions, use one discriminant for what produced the work. Keep
   provider-native identifiers inside that provider's Source branch rather than
   adding a second generic provider or thread field.

--- a/packages/junior/src/chat/README.md
+++ b/packages/junior/src/chat/README.md
@@ -131,8 +131,10 @@ delegation without becoming the execution actor or a general task owner.
   after delivery plus steering may still park so steered work can continue.
 - Unexpected failures propagate to the boundary that owns capture and fallback
   delivery.
-- Actor, execution destination, conversation, and credential context remain
-  explicit across asynchronous boundaries. A destinationless child
+- Source, Actor, Location, Destination, `publishExternally`, and credential
+  context remain explicit and independent across asynchronous boundaries.
+  Provider fields may reach the agent or its tools when needed. They do not
+  select another runtime or grant provider delivery. A destinationless child
   conversation receives its bounded execution destination from its durable
   agent invocation.
 - External publish is controlled per turn via `publishExternally`. Slack

--- a/packages/junior/src/chat/api-turns/work.ts
+++ b/packages/junior/src/chat/api-turns/work.ts
@@ -11,7 +11,12 @@ import {
 } from "@sentry/junior-plugin-api";
 import type { ConversationPrivacy } from "@/chat/conversation-privacy";
 import type { AssistantMessage } from "@earendil-works/pi-ai";
-import type { LocalActor, WebActor } from "@/chat/actor";
+import {
+  createActor,
+  type LocalActor,
+  type StoredSlackActor,
+  type WebActor,
+} from "@/chat/actor";
 import type { ConversationStore } from "@/chat/conversations/store";
 import { loadProjection } from "@/chat/conversations/projection";
 import {
@@ -73,7 +78,6 @@ import {
   scheduleSessionCompletedPluginTasks,
 } from "@/chat/plugins/task-runner";
 import type { SandboxRef } from "@/chat/sandbox/ref";
-import type { StoredSlackActor } from "@/chat/actor";
 import {
   createWebAuthorization,
   deleteWebAuthorization,
@@ -238,19 +242,6 @@ export function webActorFromEmail(
     ...(profile?.fullName ? { fullName: profile.fullName } : undefined),
     ...(profile?.userName ? { userName: profile.userName } : undefined),
   };
-}
-
-function actorFromStoredConversation(
-  stored?: StoredSlackActor,
-): WebActor | undefined {
-  const email = stored?.email?.trim().toLowerCase();
-  if (!email) {
-    return undefined;
-  }
-  return webActorFromEmail(
-    email,
-    stored?.fullName ? { fullName: stored.fullName } : undefined,
-  );
 }
 
 /** Build one API mailbox entry with conversation-only publish. */
@@ -516,7 +507,6 @@ export function createApiTurnWorker(
       );
     } else {
       turnId = resolved.turnId;
-      actor = actorFromStoredConversation(storedConversation?.actor);
     }
 
     const persisted = await getPersistedThreadState(context.conversationId);
@@ -532,11 +522,19 @@ export function createApiTurnWorker(
           `Unable to locate the persisted user message for Turn "${turnId}"`,
         );
       }
-      // Empty resume wakes lose mailbox kind; rebuild identity from the turn input.
+      // Empty resume wakes lose mailbox kind; restore the Actor from the Turn input.
       if (isResourceEventConversationMessage(userMessage)) {
         isResourceEvent = true;
         actor = localResourceEventActor();
         source = sourceFor(true);
+      } else {
+        const resumedActor = createActor(userMessage.author, {
+          platform: "web",
+          userId: userMessage.author?.userId,
+        });
+        if (resumedActor?.platform === "web") {
+          actor = resumedActor;
+        }
       }
       userMessageId = userMessage.id;
       text = userMessage.text;

--- a/packages/junior/tests/integration/web-auth-orchestration.test.ts
+++ b/packages/junior/tests/integration/web-auth-orchestration.test.ts
@@ -11,6 +11,7 @@ import {
 } from "../fixtures/api-turn";
 import {
   completeLatestMcpAuth,
+  expectMcpAuthParked,
   expectMcpAuthCleared,
   expectMcpAuthCredentialsStored,
   expectWebMcpAuthParked,
@@ -100,6 +101,48 @@ describe("web auth orchestration", () => {
         expect.objectContaining({ state: "completed", surface: "api" }),
       ]),
     );
+  });
+
+  it("resumes an API Turn as the user who started it", async () => {
+    const q = await createConversationWorkWebHarness(
+      streamMcpSearchAndCall("Eval Auth tool completed."),
+    );
+    const conversationId = "slack:CAPI123:1787718000.000001";
+    await q.conversationStore.recordActivity({
+      actor: {
+        email: "root@example.com",
+        platform: "slack",
+        slackUserId: "UAPIROOT",
+        teamId: "TAPIROOT",
+      },
+      conversationId,
+      destination: {
+        channelId: "CAPI123",
+        platform: "slack",
+        teamId: "TAPIROOT",
+      },
+      source: "slack",
+      visibility: "private",
+    });
+    await q.continue({
+      conversationId,
+      idempotencyKey: "web-auth-park-resume-1",
+      message: "use eval-auth and confirm the connection",
+    });
+    await q.drain();
+    await expectMcpAuthParked({
+      actorId: q.actor.userId,
+      conversationId,
+    });
+
+    await completeLatestMcpAuth({
+      userId: q.actor.userId,
+      agentRunner: q.agentRunner,
+      conversationWorkQueue: q.queue,
+    });
+    await q.drain();
+
+    expect(q.agentRuns.map((run) => run.actor)).toEqual([q.actor, q.actor]);
   });
 
   it("supersedes an auth-parked Turn from the Conversation API and clears the prompt", async () => {

--- a/policies/provider-boundaries.md
+++ b/policies/provider-boundaries.md
@@ -20,6 +20,10 @@ runtime and the provider-neutral contracts that plugins use.
   reviewers must apply this rule to values and control flow as well as imports.
 - Shared code must use Junior-owned types. Examples include `Destination`,
   `Source`, actor identity, a local interface, or a feature-owned view.
+- A Junior-owned runtime contract may carry provider fields in Source, Actor,
+  or Location when the agent or its tools need them. Their presence must not
+  select another runtime or grant provider delivery. Keep provider decisions
+  with the provider owner.
 - Tests for one provider may use its SDK types. Tests outside that provider
   must use its public adapter or a Junior runtime contract.
 


### PR DESCRIPTION
Conversation API Turns now resume as the user who started them. Previously, resume rebuilt the Actor from the Conversation's first stored Actor. On a Conversation connected to Slack, authorization could therefore resume the Turn as the Slack user instead of the API user.

Resume now rebuilds the Actor from the stored user Message for that Turn. The durable user ID is required; email and profile fields remain optional. This adds no state, schema, provider type, or compatibility path. The existing API authorization test remains unchanged. A separate integration test connects a Conversation to Slack with one user, starts an API Turn with another user, completes authorization, and checks that both Runs preserve the complete API Actor.

The runtime vocabulary and provider-boundary policy now state that Source, Actor, Location, Destination, and external publishing are independent. Provider fields may reach the agent and its tools when needed, but they do not select another runtime or grant delivery.

Refs #1563
