### PR TITLE
ref(chat): normalize resource events with local destinations

### DIFF
--- a/packages/junior/src/chat/README.md
+++ b/packages/junior/src/chat/README.md
@@ -39,9 +39,9 @@ with `publishExternally: false`. Continues keep the conversation destination
 - `runtime/`: native Turn orchestration and provider-neutral delivery ports.
 - `providers/`: source provider layers around the native runtime. Slack owns
   its provider runtime in `providers/slack/`.
-- `api-turns/`: mailbox enqueue and worker consumer for dashboard/API turns
-  that stay in the conversation log (`publishExternally: false`), including
-  continues of Slack-rooted conversations by verified participants.
+- `api-turns/`: Conversation API admission and conversation-only execution for
+  user messages and resource events with a local Destination. This includes
+  continues of Slack-associated Conversations by verified participants.
 - `agent-dispatch/`: durable task and plugin dispatch authority, mailbox
   adaptation, and plugin-facing outcome projection.
 - `agent-invocations/`: durable parent/child bindings, delegated work, and

--- a/packages/junior/src/chat/api-turns/assistant-message.ts
+++ b/packages/junior/src/chat/api-turns/assistant-message.ts
@@ -5,26 +5,29 @@ import { recordDeliveredAssistantMessage } from "@/chat/services/conversation-me
 import { persistWithRetry } from "@/chat/services/persist-retry";
 import type { ThreadConversationState } from "@/chat/state/conversation";
 
-/** Record a web-accepted assistant reply with agent history before the visible message. */
-export async function commitWebAcceptedReply(args: {
+/** Store one assistant Message and its Agent history. */
+export async function commitAssistantMessage(args: {
   agentMessage?: AssistantMessage;
   conversation: ThreadConversationState;
   conversationId: string;
   sessionId: string;
+  source?: "web";
   text: string;
   userMessageId: string;
 }): Promise<void> {
   const conversationMessageId = recordDeliveredAssistantMessage({
     conversation: args.conversation,
     sessionId: args.sessionId,
-    source: "web",
+    source: args.source,
     text: args.text,
     userMessageId: args.userMessageId,
   });
   try {
     await persistWithRetry(() =>
       commitAcceptedReply({
-        ...(args.agentMessage ? { agentMessage: args.agentMessage } : undefined),
+        ...(args.agentMessage
+          ? { agentMessage: args.agentMessage }
+          : undefined),
         conversation: args.conversation,
         conversationMessageId,
         conversationId: args.conversationId,
@@ -32,8 +35,8 @@ export async function commitWebAcceptedReply(args: {
     );
   } catch (error) {
     logException(
-      new Error("Accepted assistant message persistence failed"),
-      "api.assistant.message_post_delivery_persist.failed",
+      new Error("Assistant message persistence failed"),
+      "conversation.assistant.message_persist.failed",
       {
         "error.type": error instanceof Error ? error.name : typeof error,
       },

--- a/packages/junior/src/chat/api-turns/cancellation.ts
+++ b/packages/junior/src/chat/api-turns/cancellation.ts
@@ -74,7 +74,6 @@ export function createApiTurnCancellation(): ApiTurnCancellation {
 /** Close one cancelled Turn without a failure reply or retry. */
 export async function completeCancelledApiTurn(args: {
   acknowledge(): Promise<void>;
-  actorId: string;
   cancellation?: ApiTurnCancellation;
   conversation: ThreadConversationState;
   conversationId: string;
@@ -84,8 +83,10 @@ export async function completeCancelledApiTurn(args: {
   userMessageId: string;
 }): Promise<void> {
   try {
-    const ownsPendingAuthorization =
-      args.conversation.processing.pendingAuth?.sessionId === args.turnId;
+    const pendingAuthorization =
+      args.conversation.processing.pendingAuth?.sessionId === args.turnId
+        ? args.conversation.processing.pendingAuth
+        : undefined;
     await abandonTurnRecord({
       conversationId: args.conversationId,
       turnId: args.turnId,
@@ -101,9 +102,9 @@ export async function completeCancelledApiTurn(args: {
       nowMs: Date.now(),
       sessionId: args.turnId,
     });
-    if (ownsPendingAuthorization) {
+    if (pendingAuthorization) {
       await deleteWebAuthorization({
-        actorId: args.actorId,
+        actorId: pendingAuthorization.actorId,
         conversationId: args.conversationId,
       });
     }

--- a/packages/junior/src/chat/api-turns/mailbox-input.ts
+++ b/packages/junior/src/chat/api-turns/mailbox-input.ts
@@ -1,6 +1,4 @@
 /** Shared mailbox helpers for conversation-only turns. */
-import type { LocalActor } from "@/chat/actor";
-import { RESOURCE_EVENT_AUTHOR_ID } from "@/chat/resource-events/actor";
 import type { InboundMessage } from "@/chat/task-execution/store";
 
 /** Join non-empty mailbox texts for one conversation-only turn. */
@@ -9,14 +7,4 @@ export function joinMailboxText(messages: readonly InboundMessage[]): string {
     .map((message) => message.input.text.trim())
     .filter(Boolean)
     .join("\n\n");
-}
-
-/** Local actor stamped on resource-event conversation-only turns. */
-export function localResourceEventActor(): LocalActor {
-  return {
-    platform: "local",
-    userId: RESOURCE_EVENT_AUTHOR_ID,
-    userName: "junior-event",
-    fullName: "Junior event",
-  };
 }

--- a/packages/junior/src/chat/api-turns/routing.ts
+++ b/packages/junior/src/chat/api-turns/routing.ts
@@ -3,7 +3,10 @@ import {
   getTurnRecord,
   listTurnSummaries,
 } from "@/chat/task-execution/checkpoint";
-import { isResourceEventMailboxMetadata } from "@/chat/resource-events/notification";
+import {
+  isResourceEventMailboxMetadata,
+  type ResourceEventMailboxMetadata,
+} from "@/chat/resource-events/notification";
 import type { InboundMessage } from "@/chat/task-execution/store";
 import type { ConversationWorkerContext } from "@/chat/task-execution/worker";
 
@@ -22,17 +25,10 @@ export type ApiTurnMailboxMetadata = z.output<
   typeof apiTurnMailboxMetadataSchema
 >;
 
-/**
- * Local destination resource-event mailbox rows share the conversation-only runner.
- *
- * TODO(resource-events): Remove the dedicated `resource_event` work kind once
- * local/web destinations run plain mailbox system wakes the same way as any
- * other deferred conversation turn (no special batch/actor fork).
- */
-export type LocalResourceEventMailboxEntry = {
-  message: InboundMessage;
-  kind: "resource_event";
-};
+/** One validated mailbox entry owned by the conversation-only runner. */
+type ConversationMailboxEntry =
+  | { message: InboundMessage; metadata: ApiTurnMailboxMetadata }
+  | { message: InboundMessage; metadata: ResourceEventMailboxMetadata };
 
 /** Return the active root API Turn for one Conversation, if it has one. */
 export async function getActiveApiTurnId(
@@ -101,7 +97,10 @@ function parseApiTurnMessages(
 
 function parseLocalResourceEventMessages(
   messages: readonly InboundMessage[],
-): LocalResourceEventMailboxEntry[] {
+): Array<{
+  message: InboundMessage;
+  metadata: ResourceEventMailboxMetadata;
+}> {
   if (messages.length === 0) {
     return [];
   }
@@ -114,10 +113,12 @@ function parseLocalResourceEventMessages(
   ) {
     return [];
   }
-  return messages.map((message) => ({
-    message,
-    kind: "resource_event" as const,
-  }));
+  return messages.map((message) => {
+    if (!isResourceEventMailboxMetadata(message.input.metadata)) {
+      throw new Error("Resource-event mailbox metadata failed validation");
+    }
+    return { message, metadata: message.input.metadata };
+  });
 }
 
 /**
@@ -132,14 +133,7 @@ export async function resolveApiTurnWork(
 ): Promise<
   | {
       kind: "mailbox";
-      batch: Array<{
-        message: InboundMessage;
-        metadata: ApiTurnMailboxMetadata;
-      }>;
-    }
-  | {
-      kind: "resource_event";
-      batch: LocalResourceEventMailboxEntry[];
+      batch: ConversationMailboxEntry[];
     }
   | { kind: "resume"; turnId: string }
   | undefined
@@ -148,15 +142,14 @@ export async function resolveApiTurnWork(
   if (batch.length > 0) {
     return { kind: "mailbox", batch };
   }
-  // Local destination resource events share the conversation-only runner. Slack
-  // destination resource events stay on the Slack worker for thread metadata.
-  // TODO(resource-events): Fold into normal mailbox work; see LocalResourceEventMailboxEntry.
+  // Local resource events are ordinary conversation-only mailbox work. Slack
+  // resource events stay on the Slack worker until it has a plain Turn entry.
   if (context.destination?.platform === "local") {
     const resourceBatch = parseLocalResourceEventMessages(
       context.attempt.messages,
     );
     if (resourceBatch.length > 0) {
-      return { kind: "resource_event", batch: resourceBatch };
+      return { kind: "mailbox", batch: resourceBatch };
     }
   }
   if (context.attempt.messages.length > 0) {

--- a/packages/junior/src/chat/api-turns/routing.ts
+++ b/packages/junior/src/chat/api-turns/routing.ts
@@ -84,17 +84,17 @@ function parseApiTurnMessages(
     return [];
   }
   if (parsed.some((entry) => !entry.metadata.success)) {
-    throw new Error("Conversation input mixes user messages and other input");
+    throw new Error("A Turn cannot combine different kinds of input");
   }
   return parsed.map((entry) => {
     if (!entry.metadata.success) {
-      throw new Error("Conversation message metadata failed validation");
+      throw new Error("Conversation message has invalid metadata");
     }
     return { message: entry.message, metadata: entry.metadata.data };
   });
 }
 
-function parseLocalResourceEventMessages(
+function parseResourceEventMessages(
   messages: readonly InboundMessage[],
 ): Array<{
   message: InboundMessage;
@@ -114,17 +114,18 @@ function parseLocalResourceEventMessages(
   }
   return messages.map((message) => {
     if (!isResourceEventMailboxMetadata(message.input.metadata)) {
-      throw new Error("Resource event metadata failed validation");
+      throw new Error("Resource event has invalid metadata");
     }
     return { message, metadata: message.input.metadata };
   });
 }
 
 /**
- * Find a direct Junior Turn from new input or a saved active Turn.
+ * Find a Junior Turn from new input or saved Turn state.
  *
- * User messages and local resource events run directly in Junior. A resumed
- * Turn has no new input, so saved Turn state identifies it.
+ * User messages from the Conversation API run here. Resource events for
+ * Conversations without the Slack provider run here too. Saved state
+ * identifies a resumed Turn.
  */
 export async function resolveApiTurnWork(
   context: ConversationWorkerContext,
@@ -140,12 +141,10 @@ export async function resolveApiTurnWork(
   if (batch.length > 0) {
     return { kind: "mailbox", batch };
   }
-  // Local resource events run through Junior directly. Slack resource events
-  // stay with Slack because they still need thread context.
+  // Resource events for Conversations without the Slack provider run here. The
+  // provider supplies thread context for events on Conversations that use Slack.
   if (context.destination?.platform === "local") {
-    const resourceBatch = parseLocalResourceEventMessages(
-      context.attempt.messages,
-    );
+    const resourceBatch = parseResourceEventMessages(context.attempt.messages);
     if (resourceBatch.length > 0) {
       return { kind: "mailbox", batch: resourceBatch };
     }

--- a/packages/junior/src/chat/api-turns/routing.ts
+++ b/packages/junior/src/chat/api-turns/routing.ts
@@ -84,13 +84,11 @@ function parseApiTurnMessages(
     return [];
   }
   if (parsed.some((entry) => !entry.metadata.success)) {
-    throw new Error(
-      "Conversation input mixes dashboard messages and other input",
-    );
+    throw new Error("Conversation input mixes user messages and other input");
   }
   return parsed.map((entry) => {
     if (!entry.metadata.success) {
-      throw new Error("Dashboard message metadata failed validation");
+      throw new Error("Conversation message metadata failed validation");
     }
     return { message: entry.message, metadata: entry.metadata.data };
   });
@@ -125,8 +123,8 @@ function parseLocalResourceEventMessages(
 /**
  * Find a direct Junior Turn from new input or a saved active Turn.
  *
- * Dashboard messages and local resource events run directly in Junior. A
- * resumed Turn has no new input, so saved Turn state identifies it.
+ * User messages and local resource events run directly in Junior. A resumed
+ * Turn has no new input, so saved Turn state identifies it.
  */
 export async function resolveApiTurnWork(
   context: ConversationWorkerContext,

--- a/packages/junior/src/chat/api-turns/routing.ts
+++ b/packages/junior/src/chat/api-turns/routing.ts
@@ -25,7 +25,7 @@ export type ApiTurnMailboxMetadata = z.output<
   typeof apiTurnMailboxMetadataSchema
 >;
 
-type ConversationInput =
+type TurnInput =
   | { message: InboundMessage; metadata: ApiTurnMailboxMetadata }
   | { message: InboundMessage; metadata: ResourceEventMailboxMetadata };
 
@@ -88,7 +88,7 @@ function parseApiTurnMessages(
   }
   return parsed.map((entry) => {
     if (!entry.metadata.success) {
-      throw new Error("Conversation message has invalid metadata");
+      throw new Error("User message has invalid metadata");
     }
     return { message: entry.message, metadata: entry.metadata.data };
   });
@@ -121,18 +121,17 @@ function parseResourceEventMessages(
 }
 
 /**
- * Find a Junior Turn from new input or saved Turn state.
+ * Resolve conversation-only work from new input or a saved Turn.
  *
- * User messages from the Conversation API run here. Resource events for
- * Conversations without the Slack provider run here too. Saved state
- * identifies a resumed Turn.
+ * User messages from the Conversation API run here. Resource events with a
+ * local Destination run here too. Saved state identifies a resumed Turn.
  */
 export async function resolveApiTurnWork(
   context: ConversationWorkerContext,
 ): Promise<
   | {
       kind: "mailbox";
-      batch: ConversationInput[];
+      batch: TurnInput[];
     }
   | { kind: "resume"; turnId: string }
   | undefined
@@ -141,8 +140,8 @@ export async function resolveApiTurnWork(
   if (batch.length > 0) {
     return { kind: "mailbox", batch };
   }
-  // Resource events for Conversations without the Slack provider run here. The
-  // provider supplies thread context for events on Conversations that use Slack.
+  // The Slack provider owns its thread context. Resource events with a local
+  // Destination need no provider work and run here.
   if (context.destination?.platform === "local") {
     const resourceBatch = parseResourceEventMessages(context.attempt.messages);
     if (resourceBatch.length > 0) {

--- a/packages/junior/src/chat/api-turns/routing.ts
+++ b/packages/junior/src/chat/api-turns/routing.ts
@@ -1,12 +1,25 @@
 import { z } from "zod";
 import {
+  createLocalSource,
+  createWebSource,
+  type Source,
+} from "@sentry/junior-plugin-api";
+import { createActor, type Actor, type WebActor } from "@/chat/actor";
+import type { ConversationPrivacy } from "@/chat/conversation-privacy";
+import type {
+  ConversationAuthor,
+  ConversationMessage,
+} from "@/chat/state/conversation";
+import {
   getTurnRecord,
   listTurnSummaries,
 } from "@/chat/task-execution/checkpoint";
 import {
-  isResourceEventMailboxMetadata,
-  type ResourceEventMailboxMetadata,
-} from "@/chat/resource-events/notification";
+  isResourceEventConversationMessage,
+  RESOURCE_EVENT_MESSAGE_AUTHOR,
+  RESOURCE_EVENT_SYSTEM_ACTOR,
+} from "@/chat/resource-events/actor";
+import { isResourceEventMailboxMetadata } from "@/chat/resource-events/notification";
 import type { InboundMessage } from "@/chat/task-execution/store";
 import type { ConversationWorkerContext } from "@/chat/task-execution/worker";
 
@@ -25,9 +38,56 @@ export type ApiTurnMailboxMetadata = z.output<
   typeof apiTurnMailboxMetadataSchema
 >;
 
-type TurnInput =
-  | { message: InboundMessage; metadata: ApiTurnMailboxMetadata }
-  | { message: InboundMessage; metadata: ResourceEventMailboxMetadata };
+export interface TurnInput {
+  actor: Actor;
+  author: ConversationAuthor;
+  message: InboundMessage;
+  source: "resource_event" | "web";
+}
+
+export type TurnIdentity = Pick<TurnInput, "actor" | "author" | "source">;
+
+/** Restore normalized Turn identity from one saved Message. */
+export function turnIdentityFromConversationMessage(
+  message: ConversationMessage,
+): TurnIdentity | undefined {
+  if (isResourceEventConversationMessage(message)) {
+    return {
+      actor: RESOURCE_EVENT_SYSTEM_ACTOR,
+      author: message.author ?? RESOURCE_EVENT_MESSAGE_AUTHOR,
+      source: "resource_event",
+    };
+  }
+  const actor = createActor(message.author, {
+    platform: "web",
+    userId: message.author?.userId,
+  });
+  if (actor?.platform !== "web") {
+    return undefined;
+  }
+  return {
+    actor,
+    author: message.author ?? { userId: actor.userId },
+    source: "web",
+  };
+}
+
+/** Build the AgentRun Source for one Turn input. */
+export function sourceFromTurnInput(args: {
+  conversationId: string;
+  source: TurnInput["source"];
+  visibility?: ConversationPrivacy;
+}): Source {
+  switch (args.source) {
+    case "resource_event":
+      return createLocalSource(args.conversationId);
+    case "web":
+      return createWebSource(
+        args.conversationId,
+        args.visibility === "private" ? "private" : "public",
+      );
+  }
+}
 
 /** Return the active root API Turn for one Conversation, if it has one. */
 export async function getActiveApiTurnId(
@@ -72,7 +132,7 @@ export async function getAuthPausedApiTurnId(
 
 function parseApiTurnMessages(
   messages: readonly InboundMessage[],
-): Array<{ message: InboundMessage; metadata: ApiTurnMailboxMetadata }> {
+): TurnInput[] {
   if (messages.length === 0) {
     return [];
   }
@@ -90,16 +150,35 @@ function parseApiTurnMessages(
     if (!entry.metadata.success) {
       throw new Error("User message has invalid metadata");
     }
-    return { message: entry.message, metadata: entry.metadata.data };
+    const metadata = entry.metadata.data;
+    const actor: WebActor = {
+      platform: "web",
+      userId: metadata.authorUserId,
+      email: metadata.authorEmail.trim().toLowerCase(),
+      ...(metadata.authorFullName
+        ? { fullName: metadata.authorFullName }
+        : undefined),
+      ...(metadata.authorUserName
+        ? { userName: metadata.authorUserName }
+        : undefined),
+    };
+    return {
+      actor,
+      author: {
+        email: actor.email,
+        ...(actor.fullName ? { fullName: actor.fullName } : undefined),
+        userId: actor.userId,
+        ...(actor.userName ? { userName: actor.userName } : undefined),
+      },
+      message: entry.message,
+      source: "web" as const,
+    };
   });
 }
 
 function parseResourceEventMessages(
   messages: readonly InboundMessage[],
-): Array<{
-  message: InboundMessage;
-  metadata: ResourceEventMailboxMetadata;
-}> {
+): TurnInput[] {
   if (messages.length === 0) {
     return [];
   }
@@ -116,7 +195,12 @@ function parseResourceEventMessages(
     if (!isResourceEventMailboxMetadata(message.input.metadata)) {
       throw new Error("Resource event has invalid metadata");
     }
-    return { message, metadata: message.input.metadata };
+    return {
+      actor: RESOURCE_EVENT_SYSTEM_ACTOR,
+      author: RESOURCE_EVENT_MESSAGE_AUTHOR,
+      message,
+      source: "resource_event" as const,
+    };
   });
 }
 

--- a/packages/junior/src/chat/api-turns/routing.ts
+++ b/packages/junior/src/chat/api-turns/routing.ts
@@ -25,8 +25,7 @@ export type ApiTurnMailboxMetadata = z.output<
   typeof apiTurnMailboxMetadataSchema
 >;
 
-/** One validated mailbox entry owned by the conversation-only runner. */
-type ConversationMailboxEntry =
+type ConversationInput =
   | { message: InboundMessage; metadata: ApiTurnMailboxMetadata }
   | { message: InboundMessage; metadata: ResourceEventMailboxMetadata };
 
@@ -85,11 +84,13 @@ function parseApiTurnMessages(
     return [];
   }
   if (parsed.some((entry) => !entry.metadata.success)) {
-    throw new Error("Conversation mailbox mixes web turns and other input");
+    throw new Error(
+      "Conversation input mixes dashboard messages and other input",
+    );
   }
   return parsed.map((entry) => {
     if (!entry.metadata.success) {
-      throw new Error("API turn mailbox metadata failed validation");
+      throw new Error("Dashboard message metadata failed validation");
     }
     return { message: entry.message, metadata: entry.metadata.data };
   });
@@ -115,25 +116,24 @@ function parseLocalResourceEventMessages(
   }
   return messages.map((message) => {
     if (!isResourceEventMailboxMetadata(message.input.metadata)) {
-      throw new Error("Resource-event mailbox metadata failed validation");
+      throw new Error("Resource event metadata failed validation");
     }
     return { message, metadata: message.input.metadata };
   });
 }
 
 /**
- * Resolve conversation-only work from mailbox metadata or an active checkpoint.
+ * Find a direct Junior Turn from new input or a saved active Turn.
  *
- * Covers dashboard API turns and local destination resource-event wakes. Empty
- * resume wakes after yield carry no mailbox rows; durable active Turn state keeps
- * those wakes on this runner instead of falling through to Slack.
+ * Dashboard messages and local resource events run directly in Junior. A
+ * resumed Turn has no new input, so saved Turn state identifies it.
  */
 export async function resolveApiTurnWork(
   context: ConversationWorkerContext,
 ): Promise<
   | {
       kind: "mailbox";
-      batch: ConversationMailboxEntry[];
+      batch: ConversationInput[];
     }
   | { kind: "resume"; turnId: string }
   | undefined
@@ -142,8 +142,8 @@ export async function resolveApiTurnWork(
   if (batch.length > 0) {
     return { kind: "mailbox", batch };
   }
-  // Local resource events are ordinary conversation-only mailbox work. Slack
-  // resource events stay on the Slack worker until it has a plain Turn entry.
+  // Local resource events run through Junior directly. Slack resource events
+  // stay with Slack because they still need thread context.
   if (context.destination?.platform === "local") {
     const resourceBatch = parseLocalResourceEventMessages(
       context.attempt.messages,

--- a/packages/junior/src/chat/api-turns/work.ts
+++ b/packages/junior/src/chat/api-turns/work.ts
@@ -518,7 +518,7 @@ export function createApiTurnWorker(
           `Unable to locate the persisted user message for Turn "${turnId}"`,
         );
       }
-      // Empty resume wakes lose mailbox kind; restore the Actor from the Turn input.
+      // Resume has no new input. Restore the Actor from the saved Turn input.
       if (isResourceEventConversationMessage(userMessage)) {
         isResourceEvent = true;
         actor = localResourceEventActor();

--- a/packages/junior/src/chat/api-turns/work.ts
+++ b/packages/junior/src/chat/api-turns/work.ts
@@ -1,4 +1,4 @@
-/** Conversation API work runs a native Turn and keeps replies in the Conversation. */
+/** Conversation-only work runs a native Turn and stores assistant Messages. */
 import { createHash } from "node:crypto";
 import type { StateAdapter } from "chat";
 import {
@@ -15,7 +15,7 @@ import {
   hydrateConversationMessages,
   persistConversationMessages,
 } from "@/chat/conversations/messages";
-import { commitWebAcceptedReply } from "@/chat/api-turns/accepted-reply";
+import { commitAssistantMessage } from "@/chat/api-turns/assistant-message";
 import { ConversationTurnLifecycleService } from "@/chat/conversations/turn-lifecycle";
 import type { ConversationTurnFailureCode } from "@/chat/conversations/history";
 import { credentialContextForActor } from "@/chat/credentials/context";
@@ -612,11 +612,12 @@ export function createApiTurnWorker(
           }
           failureCode = "delivery_failed";
           assistantMessageDelivered = true;
-          await commitWebAcceptedReply({
+          await commitAssistantMessage({
             ...(agentMessage ? { agentMessage } : undefined),
             conversation,
             conversationId: context.conversationId,
             sessionId: turnId,
+            ...(turnIdentity.source === "web" ? { source: "web" } : undefined),
             text: replyText,
             userMessageId,
           });

--- a/packages/junior/src/chat/api-turns/work.ts
+++ b/packages/junior/src/chat/api-turns/work.ts
@@ -2,21 +2,13 @@
 import { createHash } from "node:crypto";
 import type { StateAdapter } from "chat";
 import {
-  createLocalSource,
-  createWebSource,
   localDestinationSchema,
   type Destination,
   type LocalDestination,
-  type Source,
 } from "@sentry/junior-plugin-api";
 import type { ConversationPrivacy } from "@/chat/conversation-privacy";
 import type { AssistantMessage } from "@earendil-works/pi-ai";
-import {
-  createActor,
-  type LocalActor,
-  type StoredSlackActor,
-  type WebActor,
-} from "@/chat/actor";
+import { type StoredSlackActor, type WebActor } from "@/chat/actor";
 import type { ConversationStore } from "@/chat/conversations/store";
 import { loadProjection } from "@/chat/conversations/projection";
 import {
@@ -89,13 +81,12 @@ import {
 import {
   isApiTurnWork,
   resolveApiTurnWork,
+  sourceFromTurnInput,
+  turnIdentityFromConversationMessage,
   type ApiTurnMailboxMetadata,
+  type TurnIdentity,
 } from "@/chat/api-turns/routing";
-import {
-  joinMailboxText,
-  localResourceEventActor,
-} from "@/chat/api-turns/mailbox-input";
-import { isResourceEventConversationMessage } from "@/chat/resource-events/actor";
+import { joinMailboxText } from "@/chat/api-turns/mailbox-input";
 
 export { resolveApiTurnWork } from "@/chat/api-turns/routing";
 
@@ -196,31 +187,6 @@ function resolveApiTurnDestination(args: {
   return requireLocalDestination(args.conversationId);
 }
 
-/** Build the web Source for one dashboard turn, inheriting conversation privacy. */
-function webSourceForConversation(args: {
-  conversationId: string;
-  visibility?: ConversationPrivacy;
-}): Source {
-  return createWebSource(
-    args.conversationId,
-    args.visibility === "private" ? "private" : "public",
-  );
-}
-
-function actorFromMetadata(metadata: ApiTurnMailboxMetadata): WebActor {
-  return {
-    platform: "web",
-    userId: metadata.authorUserId,
-    email: normalizeEmail(metadata.authorEmail),
-    ...(metadata.authorFullName
-      ? { fullName: metadata.authorFullName }
-      : undefined),
-    ...(metadata.authorUserName
-      ? { userName: metadata.authorUserName }
-      : undefined),
-  };
-}
-
 /** Durable conversation actor fields for web/dashboard participants. */
 function storedActorFromApi(actor: WebActor): StoredSlackActor {
   return {
@@ -311,8 +277,9 @@ export async function recordApiConversationActivity(args: {
   const isNewRoot = !existing;
   const visibility = args.rootVisibility === "private" ? "private" : "public";
   const source = isNewRoot
-    ? webSourceForConversation({
+    ? sourceFromTurnInput({
         conversationId: args.conversationId,
+        source: "web",
         visibility,
       })
     : undefined;
@@ -455,10 +422,7 @@ export function createApiTurnWorker(
     );
 
     const isResume = resolved.kind === "resume";
-    let isResourceEvent =
-      resolved.kind === "mailbox" &&
-      resolved.batch[0]?.metadata.kind === "resource_event";
-    let actor: WebActor | LocalActor | undefined;
+    let turnIdentity: TurnIdentity | undefined;
     let text = "";
     let turnId = "";
     let userMessageId = "";
@@ -479,15 +443,6 @@ export function createApiTurnWorker(
         mailboxDestination ??
         storedConversation?.destination,
     });
-    const sourceFor = (resourceEvent: boolean): Source =>
-      resourceEvent
-        ? createLocalSource(context.conversationId)
-        : webSourceForConversation({
-            conversationId: context.conversationId,
-            visibility: storedConversation?.visibility,
-          });
-    let source = sourceFor(isResourceEvent);
-
     if (resolved.kind === "mailbox") {
       const first = resolved.batch[0]!;
       text = joinMailboxText(resolved.batch.map((entry) => entry.message));
@@ -497,10 +452,7 @@ export function createApiTurnWorker(
       inputMessageIds = resolved.batch.map(
         (entry) => entry.message.inboundMessageId,
       );
-      actor =
-        first.metadata.kind === "resource_event"
-          ? localResourceEventActor()
-          : actorFromMetadata(first.metadata);
+      turnIdentity = first;
     } else {
       turnId = resolved.turnId;
     }
@@ -519,36 +471,37 @@ export function createApiTurnWorker(
         );
       }
       // Resume has no new input. Restore the Actor from the saved Turn input.
-      if (isResourceEventConversationMessage(userMessage)) {
-        isResourceEvent = true;
-        actor = localResourceEventActor();
-        source = sourceFor(true);
-      } else {
-        const resumedActor = createActor(userMessage.author, {
-          platform: "web",
-          userId: userMessage.author?.userId,
-        });
-        if (resumedActor?.platform === "web") {
-          actor = resumedActor;
-        }
-      }
+      turnIdentity = turnIdentityFromConversationMessage(userMessage);
       userMessageId = userMessage.id;
       text = userMessage.text;
       startedAtMs = userMessage.createdAtMs;
       inputMessageIds = [userMessageId];
     }
-    if (!actor) {
+    if (!turnIdentity) {
       throw new Error(
         `Resumed Turn is missing an Actor for Conversation ${context.conversationId}`,
       );
     }
+    const { actor, author } = turnIdentity;
+    const source = sourceFromTurnInput({
+      conversationId: context.conversationId,
+      source: turnIdentity.source,
+      visibility: storedConversation?.visibility,
+    });
+    const webActor = actor.platform === "web" ? actor : undefined;
 
     return await withLogContext(
       {
         conversationId: context.conversationId,
-        platform: isResourceEvent ? "local" : "web",
-        userId: actor.userId,
-        ...(actor.userName ? { userName: actor.userName } : undefined),
+        platform: actor.platform,
+        ...(webActor
+          ? {
+              userId: webActor.userId,
+              ...(webActor.userName
+                ? { userName: webActor.userName }
+                : undefined),
+            }
+          : undefined),
       },
       async () => {
         let acknowledged = isResume || context.attempt.messages.length === 0;
@@ -585,7 +538,6 @@ export function createApiTurnWorker(
             try {
               await completeCancelledApiTurn({
                 acknowledge,
-                actorId: actor.userId,
                 cancellation,
                 conversation,
                 conversationId: context.conversationId,
@@ -613,16 +565,13 @@ export function createApiTurnWorker(
             role: "user",
             text: normalizeConversationText(text),
             createdAtMs: startedAtMs,
-            author: {
-              ...(actor.email ? { email: actor.email } : undefined),
-              ...(actor.fullName ? { fullName: actor.fullName } : undefined),
-              userId: actor.userId,
-              ...(actor.userName ? { userName: actor.userName } : undefined),
-            },
+            author,
             meta: {
               explicitMention: true,
               replied: false,
-              ...(isResourceEvent ? undefined : { source: "web" as const }),
+              ...(turnIdentity.source === "web"
+                ? { source: "web" as const }
+                : undefined),
             },
           });
           await persistConversationMessages({
@@ -679,9 +628,11 @@ export function createApiTurnWorker(
             return await completeCancelledTurn();
           }
           if (!isResume) {
-            // Match Slack: a newer user message supersedes an auth-parked turn
+            // Match Slack: new input supersedes an auth-paused Turn
             // instead of leaving two active Turns or letting a late OAuth
             // wake resume stale work.
+            const pendingAuthorizationActorId =
+              conversation.processing.pendingAuth?.actorId;
             const authParked = (
               await listTurnSummaries(context.conversationId)
             ).filter(
@@ -698,8 +649,7 @@ export function createApiTurnWorker(
               await abandonTurnRecord({
                 conversationId: context.conversationId,
                 turnId: parked.turnId,
-                errorMessage:
-                  "Auth-parked session superseded by a new user message",
+                errorMessage: "Auth-paused Turn superseded by new input",
               });
               // Keep pendingAuth: MCP OAuth still needs it to accept an in-flight
               // connect and store credentials. The abandoned turn record makes a
@@ -710,11 +660,11 @@ export function createApiTurnWorker(
                 sessionId: parked.turnId,
               });
             }
-            if (authParked.length > 0) {
+            if (authParked.length > 0 && pendingAuthorizationActorId) {
               // Drop the dashboard connect prompt so a superseded OAuth flow
               // cannot leave a stale banner after the user moves on.
               await deleteWebAuthorization({
-                actorId: actor.userId,
+                actorId: pendingAuthorizationActorId,
                 conversationId: context.conversationId,
               });
             }
@@ -754,10 +704,14 @@ export function createApiTurnWorker(
               ...(cancellationSignal
                 ? { signal: cancellationSignal }
                 : undefined),
-              authorization: createWebAuthorization({
-                actorId: actor.userId,
-                conversationId: context.conversationId,
-              }),
+              ...(webActor
+                ? {
+                    authorization: createWebAuthorization({
+                      actorId: webActor.userId,
+                      conversationId: context.conversationId,
+                    }),
+                  }
+                : { disabledFeatures: ["interactive-auth"] as const }),
               state: {
                 pendingAuth: conversation.processing.pendingAuth,
                 sandboxRef,

--- a/packages/junior/src/chat/api-turns/work.ts
+++ b/packages/junior/src/chat/api-turns/work.ts
@@ -455,7 +455,9 @@ export function createApiTurnWorker(
     );
 
     const isResume = resolved.kind === "resume";
-    let isResourceEvent = resolved.kind === "resource_event";
+    let isResourceEvent =
+      resolved.kind === "mailbox" &&
+      resolved.batch[0]?.metadata.kind === "resource_event";
     let actor: WebActor | LocalActor | undefined;
     let text = "";
     let turnId = "";
@@ -467,7 +469,7 @@ export function createApiTurnWorker(
       conversationId: context.conversationId,
     });
     const mailboxDestination =
-      resolved.kind === "mailbox" || resolved.kind === "resource_event"
+      resolved.kind === "mailbox"
         ? resolved.batch[0]?.message.destination
         : undefined;
     const destination = resolveApiTurnDestination({
@@ -489,22 +491,16 @@ export function createApiTurnWorker(
     if (resolved.kind === "mailbox") {
       const first = resolved.batch[0]!;
       text = joinMailboxText(resolved.batch.map((entry) => entry.message));
-      actor = actorFromMetadata(first.metadata);
-      turnId = apiTurnIdForMessage(first.metadata.messageId);
-      userMessageId = first.metadata.messageId;
       startedAtMs = first.message.createdAtMs;
-      inputMessageIds = resolved.batch.map((entry) => entry.metadata.messageId);
-    } else if (resolved.kind === "resource_event") {
-      // TODO(resource-events): Remove this fork; plain mailbox wakes need no special actor/id path.
-      const first = resolved.batch[0]!;
-      text = joinMailboxText(resolved.batch.map((entry) => entry.message));
-      actor = localResourceEventActor();
-      turnId = apiTurnIdForMessage(first.message.inboundMessageId);
       userMessageId = first.message.inboundMessageId;
-      startedAtMs = first.message.createdAtMs;
+      turnId = apiTurnIdForMessage(userMessageId);
       inputMessageIds = resolved.batch.map(
         (entry) => entry.message.inboundMessageId,
       );
+      actor =
+        first.metadata.kind === "resource_event"
+          ? localResourceEventActor()
+          : actorFromMetadata(first.metadata);
     } else {
       turnId = resolved.turnId;
     }

--- a/packages/junior/src/chat/api-turns/work.ts
+++ b/packages/junior/src/chat/api-turns/work.ts
@@ -430,7 +430,7 @@ function hasLostTurnInputCommit(error: unknown): boolean {
   return isTurnInputCommitLostError(error) || isTurnInputCommitLostError(cause);
 }
 
-/** Create the worker for messages from the Conversation API. */
+/** Create the worker for Turns that need no provider delivery. */
 export function createApiTurnWorker(
   agentRunner: AgentRunner,
   cancellation?: ApiTurnCancellation,
@@ -441,12 +441,12 @@ export function createApiTurnWorker(
     const resolved = await resolveApiTurnWork(context);
     if (!resolved) {
       throw new Error(
-        `Conversation API worker received other work for ${context.conversationId}`,
+        `Unsupported input for Conversation ${context.conversationId}`,
       );
     }
     if (context.publishExternally) {
       throw new Error(
-        `Conversation API work cannot publish to a provider for ${context.conversationId}`,
+        `publishExternally must be false for Conversation ${context.conversationId}`,
       );
     }
 
@@ -539,7 +539,7 @@ export function createApiTurnWorker(
     }
     if (!actor) {
       throw new Error(
-        `Conversation API resume missing actor for ${context.conversationId}`,
+        `Resumed Turn is missing an Actor for Conversation ${context.conversationId}`,
       );
     }
 

--- a/packages/junior/src/chat/resource-events/README.md
+++ b/packages/junior/src/chat/resource-events/README.md
@@ -48,8 +48,6 @@ conversation.
   worker edge so `handleSubscribedMessage` can run. Replace with a plain turn
   entry from conversation destination + session source, then delete
   `slack-resource-event.ts`.
-- TODO(resource-events): Local destinations still use a dedicated
-  `resource_event` api-turns work kind. Fold into normal deferred mailbox turns.
 - TODO(subagents): child conversations still store watches on their own id.
   When subagents matter, store the parent root id or give children the parent's
   destination and worker path.

--- a/packages/junior/src/chat/resource-events/actor.ts
+++ b/packages/junior/src/chat/resource-events/actor.ts
@@ -16,6 +16,14 @@ import type { Actor } from "@/chat/actor";
  */
 export const RESOURCE_EVENT_AUTHOR_ID = "UJRNEVENT";
 
+/** Synthetic Message author for resource-event input. */
+export const RESOURCE_EVENT_MESSAGE_AUTHOR = {
+  fullName: "Junior event",
+  isBot: true,
+  userId: RESOURCE_EVENT_AUTHOR_ID,
+  userName: "junior-event",
+} as const;
+
 /** System execution actor for every resource-event turn. */
 export const RESOURCE_EVENT_SYSTEM_ACTOR = {
   platform: "system",

--- a/packages/junior/src/chat/task-execution/slack-resource-event.ts
+++ b/packages/junior/src/chat/task-execution/slack-resource-event.ts
@@ -20,7 +20,10 @@ import {
   normalizeIncomingSlackThreadId,
   withNormalizedThreadId,
 } from "@/chat/ingress/message-router";
-import { RESOURCE_EVENT_AUTHOR_ID } from "@/chat/resource-events/actor";
+import {
+  RESOURCE_EVENT_AUTHOR_ID,
+  RESOURCE_EVENT_MESSAGE_AUTHOR,
+} from "@/chat/resource-events/actor";
 import { isResourceEventMailboxMetadata } from "@/chat/resource-events/notification";
 import { resolveConversationRouting } from "@/chat/services/turn-session-routing";
 import type { InboundMessage } from "@/chat/task-execution/store";
@@ -97,10 +100,7 @@ export function buildResourceEventSlackMessage(args: {
     threadId,
     text: args.record.input.text,
     author: {
-      userId: RESOURCE_EVENT_AUTHOR_ID,
-      userName: "junior-event",
-      fullName: "Junior event",
-      isBot: true,
+      ...RESOURCE_EVENT_MESSAGE_AUTHOR,
       isMe: false,
     },
     isMention: false,

--- a/packages/junior/tests/integration/api-turn-work.test.ts
+++ b/packages/junior/tests/integration/api-turn-work.test.ts
@@ -405,7 +405,7 @@ describe("Conversation API work", () => {
     expect(resolved).toEqual({ kind: "resume", turnId });
   });
 
-  it("runs and resumes a local resource event through Junior", async () => {
+  it("runs and resumes a resource event without the Slack provider", async () => {
     const { actor, conversationStore, queue, state } =
       await createApiTurnWorkFixture();
     const conversationId = createApiConversationId({
@@ -422,7 +422,7 @@ describe("Conversation API work", () => {
       activityAtMs: 1,
       conversationId,
       nowMs: 1,
-      title: "Resource watch",
+      title: "Resource events",
     });
     const message = createResourceEventInboundMessage({
       event: {
@@ -431,14 +431,14 @@ describe("Conversation API work", () => {
         identifier: "getsentry/junior#1563",
         namespace: "github",
         occurredAtMs: 2,
-        trustedSummary: "PR checks failed",
+        trustedSummary: "Code change checks failed",
       },
       receivedAtMs: 2,
       subscription: {
         conversationId,
-        id: "resource-watch-1",
+        id: "resource-subscription-1",
       },
-      text: "PR checks failed",
+      text: "Code change checks failed",
     });
     await appendAndEnqueueInboundMessage({
       conversationStore,
@@ -470,7 +470,7 @@ describe("Conversation API work", () => {
     const route = routeApiTurnWork({
       apiTurnWorker: worker,
       fallbackWorker: async () => {
-        throw new Error("Slack must not handle local resource events");
+        throw new Error("Slack provider must not receive this resource event");
       },
     });
 
@@ -524,7 +524,7 @@ describe("Conversation API work", () => {
         : [],
     );
     expect(transcript).toEqual([
-      { role: "user", text: "PR checks failed" },
+      { role: "user", text: "Code change checks failed" },
       { role: "assistant", text: "Handled the resource event." },
     ]);
   }, 10_000);

--- a/packages/junior/tests/integration/api-turn-work.test.ts
+++ b/packages/junior/tests/integration/api-turn-work.test.ts
@@ -405,7 +405,7 @@ describe("Conversation API work", () => {
     expect(resolved).toEqual({ kind: "resume", turnId });
   });
 
-  it("runs and resumes a resource event without the Slack provider", async () => {
+  it("runs and resumes a resource event with a local Destination", async () => {
     const { actor, conversationStore, queue, state } =
       await createApiTurnWorkFixture();
     const conversationId = createApiConversationId({
@@ -470,7 +470,7 @@ describe("Conversation API work", () => {
     const route = routeApiTurnWork({
       apiTurnWorker: worker,
       fallbackWorker: async () => {
-        throw new Error("Slack provider must not receive this resource event");
+        throw new Error("Provider must not receive this resource event");
       },
     });
 

--- a/packages/junior/tests/integration/api-turn-work.test.ts
+++ b/packages/junior/tests/integration/api-turn-work.test.ts
@@ -405,7 +405,7 @@ describe("Conversation API work", () => {
     expect(resolved).toEqual({ kind: "resume", turnId });
   });
 
-  it("runs and resumes resource-event mailbox work as one conversation-only Turn", async () => {
+  it("runs and resumes a local resource event through Junior", async () => {
     const { actor, conversationStore, queue, state } =
       await createApiTurnWorkFixture();
     const conversationId = createApiConversationId({
@@ -470,7 +470,7 @@ describe("Conversation API work", () => {
     const route = routeApiTurnWork({
       apiTurnWorker: worker,
       fallbackWorker: async () => {
-        throw new Error("fallback worker must not run for resource events");
+        throw new Error("Slack must not handle local resource events");
       },
     });
 

--- a/packages/junior/tests/integration/api-turn-work.test.ts
+++ b/packages/junior/tests/integration/api-turn-work.test.ts
@@ -9,13 +9,14 @@ import {
   createAndEnqueueApiConversation,
   createApiConversationId,
   createApiTurnWorker,
+  recordApiConversationActivity,
   resolveApiTurnWork,
   routeApiTurnWork,
 } from "@/chat/api-turns/work";
 import type { AgentRun } from "@/chat/agent/types";
 import { getConversationEventStore } from "@/chat/db";
-import { RESOURCE_EVENT_AUTHOR_ID } from "@/chat/resource-events/actor";
-import { persistThreadStateById } from "@/chat/runtime/thread-state";
+import { createResourceEventInboundMessage } from "@/chat/resource-events/notification";
+import { appendAndEnqueueInboundMessage } from "@/chat/task-execution/store";
 import { processConversationQueueMessage } from "@/chat/task-execution/vercel-callback";
 import {
   getTurnRecord,
@@ -404,101 +405,129 @@ describe("Conversation API work", () => {
     expect(resolved).toEqual({ kind: "resume", turnId });
   });
 
-  it("resumes a resource-event turn with the resource-event actor and local source", async () => {
+  it("runs and resumes resource-event mailbox work as one conversation-only Turn", async () => {
     const { actor, conversationStore, queue, state } =
       await createApiTurnWorkFixture();
-    const accepted = await createAndEnqueueApiConversation(
-      {
-        actor,
-        idempotencyKey: "resource-event-resume-1",
-        message: "Seed conversation for resource-event resume.",
+    const conversationId = createApiConversationId({
+      actorEmail: actor.email,
+      idempotencyKey: "resource-event-root-1",
+    });
+    const destination = await recordApiConversationActivity({
+      actor,
+      conversationId,
+      conversationStore,
+      nowMs: 1,
+    });
+    await conversationStore.recordActivity({
+      activityAtMs: 1,
+      conversationId,
+      nowMs: 1,
+      title: "Resource watch",
+    });
+    const message = createResourceEventInboundMessage({
+      event: {
+        eventKey: "checks-failed-1",
+        eventType: "check_suite.completed",
+        identifier: "getsentry/junior#1563",
+        namespace: "github",
+        occurredAtMs: 2,
+        trustedSummary: "PR checks failed",
       },
-      { conversationStore, queue, state },
-    );
-    // Drop the seed mailbox wake; this case drives an empty resume attempt.
-    queue.takeMessage();
+      receivedAtMs: 2,
+      subscription: {
+        conversationId,
+        id: "resource-watch-1",
+      },
+      text: "PR checks failed",
+    });
+    await appendAndEnqueueInboundMessage({
+      conversationStore,
+      message,
+      queue,
+      state,
+    });
 
-    const messageId = "resource-event-msg.resume-1";
+    const messageId = message.inboundMessageId;
     const turnId = apiTurnIdForMessage(messageId);
-    const destination = {
-      platform: "local" as const,
-      conversationId: accepted.conversationId,
-    };
     const eventActor = localResourceEventActor();
-    await persistThreadStateById(accepted.conversationId, {
-      conversation: {
-        schemaVersion: 1,
-        compactions: [],
-        messages: [
-          {
-            id: messageId,
-            role: "user",
-            text: "PR checks failed",
-            createdAtMs: 10,
-            author: {
-              userId: RESOURCE_EVENT_AUTHOR_ID,
-              userName: eventActor.userName,
-              fullName: eventActor.fullName,
-            },
-          },
-        ],
-        processing: { activeTurnId: turnId },
-        vision: { byFileId: {} },
-      },
-    });
-    await saveTurnCheckpoint({
-      mode: "paused",
-      conversationId: accepted.conversationId,
-      turnId,
-      sliceId: 1,
-      reason: "yield",
-      messages: [
-        {
-          role: "user",
-          content: [{ type: "text", text: "PR checks failed" }],
-          timestamp: 10,
-        },
-      ],
-      destination,
-      publishExternally: false,
-      source: createLocalSource(accepted.conversationId),
-      actor: eventActor,
-      surface: "api",
-    });
-
     const agentRuns: AgentRun[] = [];
+    let firstRun = true;
     const worker = createApiTurnWorker(
       createModelAgentRunnerForRun((run) => {
         agentRuns.push(run);
+        if (firstRun) {
+          firstRun = false;
+          return createModelStream([
+            { type: "toolCall", name: "systemTime", arguments: {} },
+            { type: "text", text: "Handled the resource event." },
+          ]);
+        }
         return createModelStream([
-          { type: "text", text: "Handled the resource event resume." },
+          { type: "text", text: "Handled the resource event." },
         ]);
       }),
     );
+    const route = routeApiTurnWork({
+      apiTurnWorker: worker,
+      fallbackWorker: async () => {
+        throw new Error("fallback worker must not run for resource events");
+      },
+    });
 
     await expect(
-      worker({
-        attempt: emptyApiTurnAttempt({
-          conversationId: accepted.conversationId,
-          destination,
-        }),
-        checkIn: async () => true,
-        conversationId: accepted.conversationId,
-        destination,
-        publishExternally: false,
-        shouldYield: () => false,
+      processConversationQueueMessage(queue.takeMessage(), {
+        conversationStore,
+        nowMs: () => 10,
+        queue,
+        run: route,
+        softYieldAfterMs: 0,
+        state,
+      }),
+    ).resolves.toEqual({ status: "yielded" });
+    await expect(getTurnRecord(conversationId, turnId)).resolves.toMatchObject({
+      publishExternally: false,
+      resumeReason: "yield",
+      state: "paused",
+    });
+
+    await expect(
+      processConversationQueueMessage(queue.takeMessage(), {
+        conversationStore,
+        nowMs: () => 20,
+        queue,
+        run: route,
+        state,
       }),
     ).resolves.toEqual({ status: "completed" });
 
-    expect(agentRuns).toHaveLength(1);
-    expect(agentRuns[0]).toEqual(
-      expect.objectContaining({
-        actor: eventActor,
-        publishExternally: false,
-        source: createLocalSource(accepted.conversationId),
-      }),
+    expect(agentRuns).toHaveLength(2);
+    for (const run of agentRuns) {
+      expect(run).toEqual(
+        expect.objectContaining({
+          actor: eventActor,
+          destination,
+          publishExternally: false,
+          source: createLocalSource(conversationId),
+          turnId,
+        }),
+      );
+    }
+    await expect(getTurnRecord(conversationId, turnId)).resolves.toMatchObject({
+      publishExternally: false,
+      state: "completed",
+    });
+    const transcript = (
+      await getConversationEventStore().loadHistory(conversationId)
+    ).flatMap((event) =>
+      event.data.type === "message"
+        ? [{ role: event.data.role, text: event.data.text }]
+        : [],
     );
-  });
+    expect(transcript).toEqual([
+      { role: "user", text: "PR checks failed" },
+      { role: "assistant", text: "Handled the resource event." },
+    ]);
+  }, 10_000);
 
   it("does not claim dispatch resume wakes that share surface api", async () => {
     await createApiTurnWorkFixture();

--- a/packages/junior/tests/integration/api-turn-work.test.ts
+++ b/packages/junior/tests/integration/api-turn-work.test.ts
@@ -1,7 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createLocalSource, createWebSource } from "@sentry/junior-plugin-api";
 import { createApiTurnCancellation } from "@/chat/api-turns/cancellation";
-import { localResourceEventActor } from "@/chat/api-turns/mailbox-input";
 import {
   appendAndEnqueueApiConversationMessage,
   apiTurnIdForMessage,
@@ -15,6 +14,7 @@ import {
 } from "@/chat/api-turns/work";
 import type { AgentRun } from "@/chat/agent/types";
 import { getConversationEventStore } from "@/chat/db";
+import { RESOURCE_EVENT_SYSTEM_ACTOR } from "@/chat/resource-events/actor";
 import { createResourceEventInboundMessage } from "@/chat/resource-events/notification";
 import { appendAndEnqueueInboundMessage } from "@/chat/task-execution/store";
 import { processConversationQueueMessage } from "@/chat/task-execution/vercel-callback";
@@ -449,7 +449,6 @@ describe("Conversation API work", () => {
 
     const messageId = message.inboundMessageId;
     const turnId = apiTurnIdForMessage(messageId);
-    const eventActor = localResourceEventActor();
     const agentRuns: AgentRun[] = [];
     let firstRun = true;
     const worker = createApiTurnWorker(
@@ -504,13 +503,16 @@ describe("Conversation API work", () => {
     for (const run of agentRuns) {
       expect(run).toEqual(
         expect.objectContaining({
-          actor: eventActor,
+          actor: RESOURCE_EVENT_SYSTEM_ACTOR,
+          credentialContext: { actor: RESOURCE_EVENT_SYSTEM_ACTOR },
           destination,
+          disabledFeatures: ["interactive-auth"],
           publishExternally: false,
           source: createLocalSource(conversationId),
           turnId,
         }),
       );
+      expect(run.authorization).toBeUndefined();
     }
     await expect(getTurnRecord(conversationId, turnId)).resolves.toMatchObject({
       publishExternally: false,

--- a/packages/junior/tests/integration/api-turn-work.test.ts
+++ b/packages/junior/tests/integration/api-turn-work.test.ts
@@ -522,12 +522,26 @@ describe("Conversation API work", () => {
       await getConversationEventStore().loadHistory(conversationId)
     ).flatMap((event) =>
       event.data.type === "message"
-        ? [{ role: event.data.role, text: event.data.text }]
+        ? [
+            {
+              role: event.data.role,
+              source: event.data.meta?.source,
+              text: event.data.text,
+            },
+          ]
         : [],
     );
     expect(transcript).toEqual([
-      { role: "user", text: "Code change checks failed" },
-      { role: "assistant", text: "Handled the resource event." },
+      {
+        role: "user",
+        source: undefined,
+        text: "Code change checks failed",
+      },
+      {
+        role: "assistant",
+        source: undefined,
+        text: "Handled the resource event.",
+      },
     ]);
   }, 10_000);
 


### PR DESCRIPTION
Routing now converts Conversation API messages and resource events into one Turn input with an Actor, Message author, Source, and Inbound message. The worker consumes that input without checking message metadata kinds. Resource events with a local Destination use the same mailbox path as Conversation API messages.

Resource events now use the canonical system Actor for both new and resumed Runs. Slack and core share the same synthetic Message author. System input cannot start interactive authorization. Authorization cleanup reads the Actor from the saved authorization request instead of assuming it matches the current input.

The integration test starts with a real resource event, pauses and resumes the Turn, and confirms the same system Actor, credential context, Destination, and Turn. It also confirms that Junior stores one assistant Message without falsely labeling either Message as web input. The full owning integration file passes.

The current `AgentRun` Source union still represents this resource-event path as local. Issue #1563 now documents the target input contract and concrete API, Slack, and resource-event examples. Changing the shared Source contract remains a separate slice.

Refs #1563
