### PR TITLE
ref(chat): pass Conversation Location into agent runs

### DIFF
--- a/TERMINOLOGY.md
+++ b/TERMINOLOGY.md
@@ -102,8 +102,7 @@ Canonical words used across Junior's code and documentation.
 - Keep the current Source and Actor separate from the Conversation's Location.
   Source and Delivery may each contain Location when they need it. Do not infer
   Delivery from Source, Actor, or Location.
-- Use `Location`. Do not create another name such as `DeliveryLocation` or
-  `ProviderLocation` for the same value.
+- Use `Location`. Do not create another name for the same place.
 - For new Source unions, use one discriminant for what produced the work. Keep
   provider-native identifiers inside that provider's Source branch rather than
   adding a second generic provider or thread field.

--- a/TERMINOLOGY.md
+++ b/TERMINOLOGY.md
@@ -16,16 +16,18 @@ Canonical words used across Junior's code and documentation.
 - **Conversation**: the durable container for visible history and execution
   state, identified by a globally unique `conversationId`.
 - **Source**: the current input that caused a Turn, such as a Slack message,
-  local CLI input, dashboard input, scheduled task, or plugin dispatch. A
-  provider Source uses Location for provider coordinates.
+  local CLI input, dashboard input, scheduled task, or plugin dispatch. Source
+  may include the Conversation's Location so the agent can use that place even
+  when the input came through Junior's API or UI.
 - **Destination**: an explicit target for output or a side effect. Do not use
-  Destination as another name for a Conversation's provider context.
-- **Location**: provider coordinates shared by Conversation, Source, and
-  Delivery. A Conversation has zero or one Location. Location does not grant
-  delivery. Conversation visibility is separate.
-- **Delivery**: an optional capability that sends Run output. Provider Delivery
-  uses Location for its target coordinates. The Conversation log does not
-  depend on provider Delivery.
+  Destination as another name for a Conversation's Location.
+- **Location**: one place outside Junior where a Conversation can be delivered,
+  such as a Slack channel or thread. A Conversation has zero or one Location.
+  Source and Delivery may each contain that Location. Location does not allow
+  output to be sent. Conversation visibility is separate.
+- **Delivery**: an optional ability to send Run output. Delivery may include the
+  Location where it sends output. The Conversation log does not depend on
+  Delivery.
 - **publishExternally**: whether one turn also publishes assistant output to the
   provider through Delivery. The Conversation log always stores the Turn.
   Slack surfaces treat missing as publish; non-Slack work treats missing as
@@ -98,8 +100,10 @@ Canonical words used across Junior's code and documentation.
 - Use `provider` on provider-owned references such as Identity and Location; it
   names the namespace that owns their provider ids.
 - Keep the current Source and Actor separate from the Conversation's Location.
-  Provider Source and Delivery may use the same Location type for their own
-  coordinates. Do not infer Delivery from Source, Actor, or Location.
+  Source and Delivery may each contain Location when they need it. Do not infer
+  Delivery from Source, Actor, or Location.
+- Use `Location`. Do not create another name such as `DeliveryLocation` or
+  `ProviderLocation` for the same value.
 - For new Source unions, use one discriminant for what produced the work. Keep
   provider-native identifiers inside that provider's Source branch rather than
   adding a second generic provider or thread field.

--- a/TERMINOLOGY.md
+++ b/TERMINOLOGY.md
@@ -15,17 +15,21 @@ Canonical words used across Junior's code and documentation.
 - **Sandbox**: an isolated execution environment for a run or snapshot build.
 - **Conversation**: the durable container for visible history and execution
   state, identified by a globally unique `conversationId`.
-- **Source**: where an inbound event came from, such as Slack, local CLI, web
-  (dashboard), scheduler, or plugin dispatch.
-- **Destination**: where Junior sends output or side effects.
-- **Location**: optional provider context for a conversation or input,
-  identified by Junior and provider ids. A run may keep this context when its
-  Source or Actor is not from that provider. Location does not grant delivery.
-  Conversation visibility is separate.
+- **Source**: the current input that caused a Turn, such as a Slack message,
+  local CLI input, dashboard input, scheduled task, or plugin dispatch. A
+  provider Source uses Location for provider coordinates.
+- **Destination**: an explicit target for output or a side effect. Do not use
+  Destination as another name for a Conversation's provider context.
+- **Location**: provider coordinates shared by Conversation, Source, and
+  Delivery. A Conversation has zero or one Location. Location does not grant
+  delivery. Conversation visibility is separate.
+- **Delivery**: an optional capability that sends Run output. Provider Delivery
+  uses Location for its target coordinates. The Conversation log does not
+  depend on provider Delivery.
 - **publishExternally**: whether one turn also publishes assistant output to the
-  conversation destination. The conversation log always stores the turn. Slack
-  surfaces treat missing as publish; non-Slack work treats missing as
-  conversation-only. Explicit false always means conversation-only.
+  provider through Delivery. The Conversation log always stores the Turn.
+  Slack surfaces treat missing as publish; non-Slack work treats missing as
+  Conversation-only. Explicit false always means Conversation-only.
 - **User**: one person-level record. A user may have several linked identities.
 - **Identity**: one provider account, such as a Slack account in one workspace,
   optionally linked to a user.
@@ -34,7 +38,7 @@ Canonical words used across Junior's code and documentation.
   fields that the agent or tools need. Those fields do not select the runtime.
 - **Resource event**: one normalized change identified by namespace, identifier,
   event type, and an idempotency key. Plugins and core can publish them.
-  Delivery wakes the conversation; destination stays on that conversation.
+  Delivery wakes the Conversation; Location stays on that Conversation.
 - **Resource subscription**: a temporary conversation association that delivers
   matching resource events back into that conversation.
 - **Event task**: a durable instruction that dispatches when a matching
@@ -93,9 +97,9 @@ Canonical words used across Junior's code and documentation.
 
 - Use `provider` on provider-owned references such as Identity and Location; it
   names the namespace that owns their provider ids.
-- Keep Source, Actor, Location, Destination, and `publishExternally`
-  independent. Do not infer one from another. Provider data may supply agent
-  context without selecting another runtime or granting delivery.
+- Keep the current Source and Actor separate from the Conversation's Location.
+  Provider Source and Delivery may use the same Location type for their own
+  coordinates. Do not infer Delivery from Source, Actor, or Location.
 - For new Source unions, use one discriminant for what produced the work. Keep
   provider-native identifiers inside that provider's Source branch rather than
   adding a second generic provider or thread field.

--- a/packages/junior/src/chat/README.md
+++ b/packages/junior/src/chat/README.md
@@ -141,9 +141,12 @@ delegation without becoming the execution actor or a general task owner.
 - Source and Actor describe the current Turn. Location describes optional
   provider coordinates. Provider Source and Delivery may use that type, but
   Location does not select another runtime or grant provider delivery.
-- Junior resolves the Conversation's Location from `conversationId`. Callers do
-  not pass another copy into the core agent. Child Conversations store the
-  Location they need instead of searching parent lineage at Run time.
+- The final Run interface gets provider coordinates through Source and
+  Delivery. During the cutover, `AgentRun.location` may carry the stored
+  Conversation Location while consumers move away from Destination and session
+  Source. Its removal TODO defines the end of that transition.
+- Child Conversations store the Location they need instead of searching parent
+  lineage at Run time in the final model.
 - External publish is controlled per turn via `publishExternally`. Slack
   ingress/resume publish unless the flag is explicitly false. Non-Slack,
   destinationless, and dashboard/web work stay conversation-only unless the

--- a/packages/junior/src/chat/README.md
+++ b/packages/junior/src/chat/README.md
@@ -28,8 +28,8 @@ file.
 The local CLI uses `local/runner.ts` directly rather than pretending to be a
 mailbox-backed provider. API-authored root Turns and dashboard continues of
 existing Conversations use the shared mailbox and worker through `api-turns/`.
-A dashboard continue may keep provider context from the Conversation without
-giving the Run provider delivery.
+A dashboard continue may keep the Conversation Location without giving the Run
+Delivery to that Location.
 
 ## Ownership
 
@@ -81,17 +81,18 @@ singleton.
 - **Reply**: one destination-visible assistant message owned by delivery code.
 - **Actor**: human or system principal associated with current work.
 - **Credential subject**: principal whose provider authority may be used.
-- **Source**: the current input that caused a Turn. Provider Source uses
-  Location for its provider coordinates.
-- **Location**: provider coordinates shared by Conversation, Source, and
-  Delivery. A Conversation has zero or one Location.
-- **Delivery**: optional capability that sends Run output. Provider Delivery
-  uses Location for its target coordinates.
+- **Source**: the current input that caused a Turn. Source may include the
+  Conversation's Location so the agent can use it for API and UI input too.
+- **Location**: one place outside Junior where a Conversation can be delivered.
+  A Conversation has zero or one Location. Source and Delivery may each contain
+  that Location.
+- **Delivery**: optional ability to send Run output. Delivery may include the
+  Location where it sends output.
 - **Destination**: explicit target for output or a side effect. Current uses as
-  Conversation provider context are migration debt.
+  a Conversation Location are migration debt.
 - **publishExternally**: per-turn side effect. When true, also publish assistant
-  output through provider Delivery. The Conversation log always stores the
-  Turn. Missing or false means Conversation-only.
+  output through Delivery. The Conversation log always stores the Turn. Missing
+  or false means Conversation-only.
 
 Attribution does not grant authority. `run.actors` records participating actors;
 credential issuance still requires the current actor or an explicit delegated
@@ -138,13 +139,20 @@ delegation without becoming the execution actor or a general task owner.
   after delivery plus steering may still park so steered work can continue.
 - Unexpected failures propagate to the boundary that owns capture and fallback
   delivery.
-- Source and Actor describe the current Turn. Location describes optional
-  provider coordinates. Provider Source and Delivery may use that type, but
-  Location does not select another runtime or grant provider delivery.
-- The final Run interface gets provider coordinates through Source and
-  Delivery. During the cutover, `AgentRun.location` may carry the stored
-  Conversation Location while consumers move away from Destination and session
-  Source. Its removal TODO defines the end of that transition.
+- Source and Actor describe the current Turn. Location names an optional place
+  outside Junior. Source and Delivery may each contain Location, but Location
+  does not select another runtime or allow output to be sent.
+- The final Run interface has Source and optional Delivery. It has no separate
+  Location field. Source carries the Conversation Location when the current
+  input needs it, including API or UI input. Delivery carries the Location where
+  it can send output. A dashboard continuation may therefore keep a Slack
+  Location in Source without getting Slack Delivery. During the cutover,
+  `AgentRun.location` may carry the stored Conversation Location while consumers
+  move away from Destination and session Source. Its removal TODO defines the
+  end of that transition.
+- The final interface uses Conversation, Source, Location, and Delivery. Do not
+  add `DeliveryLocation`, `ProviderSource`, a routing context, or another
+  wrapper for these values.
 - Child Conversations store the Location they need instead of searching parent
   lineage at Run time in the final model.
 - External publish is controlled per turn via `publishExternally`. Slack

--- a/packages/junior/src/chat/README.md
+++ b/packages/junior/src/chat/README.md
@@ -26,10 +26,10 @@ file.
    delivery or intentional no-reply completion commits the durable turn outcome.
 
 The local CLI uses `local/runner.ts` directly rather than pretending to be a
-mailbox-backed provider. API-authored root turns and dashboard continues of
-existing conversations use the shared mailbox and worker through `api-turns/`
-with `publishExternally: false`. Continues keep the conversation destination
-(including Slack) for location context and never copy replies to the provider.
+mailbox-backed provider. API-authored root Turns and dashboard continues of
+existing Conversations use the shared mailbox and worker through `api-turns/`.
+A dashboard continue may keep provider context from the Conversation without
+giving the Run provider delivery.
 
 ## Ownership
 
@@ -81,10 +81,17 @@ singleton.
 - **Reply**: one destination-visible assistant message owned by delivery code.
 - **Actor**: human or system principal associated with current work.
 - **Credential subject**: principal whose provider authority may be used.
-- **Destination**: platform location where output is delivered.
+- **Source**: the current input that caused a Turn. Provider Source uses
+  Location for its provider coordinates.
+- **Location**: provider coordinates shared by Conversation, Source, and
+  Delivery. A Conversation has zero or one Location.
+- **Delivery**: optional capability that sends Run output. Provider Delivery
+  uses Location for its target coordinates.
+- **Destination**: explicit target for output or a side effect. Current uses as
+  Conversation provider context are migration debt.
 - **publishExternally**: per-turn side effect. When true, also publish assistant
-  output to the conversation destination. The conversation log always stores the
-  turn. Missing or false means conversation-only.
+  output through provider Delivery. The Conversation log always stores the
+  Turn. Missing or false means Conversation-only.
 
 Attribution does not grant authority. `run.actors` records participating actors;
 credential issuance still requires the current actor or an explicit delegated
@@ -131,17 +138,18 @@ delegation without becoming the execution actor or a general task owner.
   after delivery plus steering may still park so steered work can continue.
 - Unexpected failures propagate to the boundary that owns capture and fallback
   delivery.
-- Source, Actor, Location, Destination, `publishExternally`, and credential
-  context remain explicit and independent across asynchronous boundaries.
-  Provider fields may reach the agent or its tools when needed. They do not
-  select another runtime or grant provider delivery. A destinationless child
-  conversation receives its bounded execution destination from its durable
-  agent invocation.
+- Source and Actor describe the current Turn. Location describes optional
+  provider coordinates. Provider Source and Delivery may use that type, but
+  Location does not select another runtime or grant provider delivery.
+- Junior resolves the Conversation's Location from `conversationId`. Callers do
+  not pass another copy into the core agent. Child Conversations store the
+  Location they need instead of searching parent lineage at Run time.
 - External publish is controlled per turn via `publishExternally`. Slack
   ingress/resume publish unless the flag is explicitly false. Non-Slack,
   destinationless, and dashboard/web work stay conversation-only unless the
-  flag is true. Destination presence must not invent publish. A web Source may
-  keep a Slack Destination when `publishExternally` is false.
+  flag is true. This flag remains at provider, mailbox, and resume boundaries
+  while they need it to restore Delivery. Destination or Location presence
+  must not invent publish.
 - Host-owned runtime context and the actor's current instruction are separate
   user messages. The context message immediately precedes the instruction,
   remains context-authority on resume, and may be replaced before a later model

--- a/packages/junior/src/chat/README.md
+++ b/packages/junior/src/chat/README.md
@@ -151,8 +151,7 @@ delegation without becoming the execution actor or a general task owner.
   move away from Destination and session Source. Its removal TODO defines the
   end of that transition.
 - The final interface uses Conversation, Source, Location, and Delivery. Do not
-  add `DeliveryLocation`, `ProviderSource`, a routing context, or another
-  wrapper for these values.
+  add another type, routing object, or wrapper for the same values.
 - Child Conversations store the Location they need instead of searching parent
   lineage at Run time in the final model.
 - External publish is controlled per turn via `publishExternally`. Slack

--- a/packages/junior/src/chat/agent-invocations/README.md
+++ b/packages/junior/src/chat/agent-invocations/README.md
@@ -64,8 +64,8 @@ visibility, source, parent conversation, and idempotency from the active tool
 call. Child runs set
 `disabledFeatures: ["handoff", "interactive-auth", "subagents"]` so they cannot
 hand off models, start interactive OAuth pauses, or spawn further children.
-TODO(#881, #883): children may still need a way to force interactive auth when a
-delegated tool requires credentials the parent can already request.
+TODO(dcramer): Issues #881 and #883 track a way for children to force interactive
+auth when a delegated tool requires credentials the parent can already request.
 
 This slice does not yet expose result recovery, inject child results into a
 parent turn, support recursive children, or implement cancellation. Those

--- a/packages/junior/src/chat/agent-invocations/work.ts
+++ b/packages/junior/src/chat/agent-invocations/work.ts
@@ -1,5 +1,6 @@
 import type { StateAdapter } from "chat";
 import { z } from "zod";
+import type { Location } from "@/chat/conversations/location";
 import type { ConversationStore } from "@/chat/conversations/store";
 import { openConversationProjection } from "@/chat/conversations/projection";
 import { ConversationTurnLifecycleService } from "@/chat/conversations/turn-lifecycle";
@@ -28,6 +29,7 @@ import { getTerminalAssistantMessages } from "@/chat/pi/transcript";
 import type { PiMessage } from "@/chat/pi/messages";
 import type { SandboxRef } from "@/chat/sandbox/ref";
 import type { AgentRunResult } from "@/chat/services/turn-result";
+import { resolveConversationRouting } from "@/chat/services/turn-session-routing";
 import {
   appendAndEnqueueInboundMessage,
   type InboundMessage,
@@ -356,6 +358,7 @@ export function createAgentInvocationWorker(agentRunner: AgentRunner) {
     );
     let sandboxRef: SandboxRef | undefined;
     let history: PiMessage[];
+    let location: Location | undefined;
     try {
       if (invocation.childConversationId !== context.conversationId) {
         throw new Error(
@@ -396,6 +399,11 @@ export function createAgentInvocationWorker(agentRunner: AgentRunner) {
       ]);
       sandboxRef = getPersistedSandboxState(persisted);
       history = projection.messages;
+      location = (
+        await resolveConversationRouting({
+          conversationId: invocation.childConversationId,
+        })
+      )?.location;
     } catch (error) {
       if (isInvocationInputCommitLost(error)) {
         return { status: "lost_lease" };
@@ -431,6 +439,7 @@ export function createAgentInvocationWorker(agentRunner: AgentRunner) {
           actor: invocation.actor,
           credentialContext: invocation.credentialContext,
           destination: invocation.destination,
+          ...(location ? { location } : undefined),
           destinationVisibility: invocation.destinationVisibility,
           publishExternally: context.publishExternally,
           source: invocation.source,

--- a/packages/junior/src/chat/agent-invocations/work.ts
+++ b/packages/junior/src/chat/agent-invocations/work.ts
@@ -435,10 +435,10 @@ export function createAgentInvocationWorker(agentRunner: AgentRunner) {
           publishExternally: context.publishExternally,
           source: invocation.source,
           surface: "internal",
-          // TODO(#881, #883): Child runs may still need a path to force
-          // interactive auth when a delegated tool requires credentials the
-          // parent already has authority to request. Today background children
-          // hard-fail instead of pausing for an OAuth link.
+          // TODO(dcramer): Issues #881 and #883 track a path for child runs to
+          // force interactive auth when a delegated tool requires credentials
+          // the parent can request. Today background children hard-fail instead
+          // of pausing for an OAuth link.
           disabledFeatures: ["handoff", "interactive-auth", "subagents"],
           reasoning: invocation.reasoningLevel,
           state: {

--- a/packages/junior/src/chat/agent/tools.ts
+++ b/packages/junior/src/chat/agent/tools.ts
@@ -39,7 +39,7 @@ import { createPiAgentTools } from "@/chat/tool-support/pi-tool-adapter";
 import { planToolExposure } from "@/chat/tool-exposure";
 import type { SandboxRef } from "@/chat/sandbox/ref";
 import { getWorkspace } from "@/chat/workspaces/store";
-import { getConversationStore, getDb } from "@/chat/db";
+import { getDb } from "@/chat/db";
 import type { RepositoryInstructions } from "@/chat/repository-instructions";
 import { createMcpAuthOrchestration } from "@/chat/services/mcp-auth-orchestration";
 import { createPluginAuthOrchestration } from "@/chat/services/plugin-auth-orchestration";
@@ -219,9 +219,6 @@ export async function wireAgentTools(
     ? credentialUserSubjectId(args.run.credentialContext)
     : undefined;
   const userTokenStore = createUserTokenStore();
-  const conversation = await getConversationStore().get({
-    conversationId: args.run.conversationId,
-  });
   const pluginHooks = createPluginHookRunner({
     actor: args.currentActor,
     actors: args.currentActors,
@@ -328,9 +325,7 @@ export async function wireAgentTools(
   );
   const commonToolRuntimeContext = {
     conversationId: args.run.conversationId,
-    ...(conversation?.location
-      ? { locationId: conversation.location.id }
-      : undefined),
+    ...(args.run.location ? { locationId: args.run.location.id } : undefined),
     userText: args.userInput,
     configuration: args.configurationValues,
     egress: createPluginEgress({

--- a/packages/junior/src/chat/agent/types.ts
+++ b/packages/junior/src/chat/agent/types.ts
@@ -7,6 +7,7 @@ import type {
 } from "@sentry/junior-plugin-api";
 import type { LocationConfigurationService } from "@/chat/configuration/types";
 import type { ConversationPrivacy } from "@/chat/conversation-privacy";
+import type { Location } from "@/chat/conversations/location";
 import type { CredentialContext } from "@/chat/credentials/context";
 import type { PiMessage } from "@/chat/pi/messages";
 import type { Actor } from "@/chat/actor";
@@ -209,6 +210,14 @@ export type AgentRun = {
   /** Credential authority projected from actor (plus optional subject). */
   credentialContext?: CredentialContext;
   source: Source;
+  /**
+   * Transitional provider context for this Run.
+   * TODO(dcramer): Remove top-level Location, Destination, and
+   * publishExternally after provider Source contains its inbound Location and
+   * Delivery contains its target Location and authority across new, resumed,
+   * and child Runs.
+   */
+  location?: Location;
   destination: Destination;
   /** When true, also publish assistant output to the conversation destination. */
   publishExternally?: boolean;

--- a/packages/junior/src/chat/agent/types.ts
+++ b/packages/junior/src/chat/agent/types.ts
@@ -1,10 +1,4 @@
-/**
- * Public agent-run launch contract.
- *
- * Providers build one flat `AgentRun` and call `AgentRunner.run`. Delivery and
- * durability are capabilities that affect the run. `onEvent` is best-effort UI
- * only. Stable composition binds stream, spawn, and tracing outside this type.
- */
+/** Input for one Run through Junior's agent. */
 import type {
   Destination,
   ReplyAttribution,
@@ -50,7 +44,8 @@ export type AgentInstructionActor = {
   authorName?: string;
   /**
    * Slack message ts for the instruction when known.
-   * TODO: generalize to a provider-neutral message id once prompt attrs are neutral.
+   * TODO(dcramer): Use a provider-neutral message id after prompt attributes no
+   * longer require the Slack timestamp.
    */
   slackTs?: string;
 };
@@ -132,9 +127,7 @@ export type AgentRunState = {
  * The runner must commit the preceding agent boundary before invoking this
  * port; the accepted reply transaction appends only this message.
  */
-export type AgentDelivery = (
-  message: AssistantMessage,
-) => void | Promise<void>;
+export type AgentDelivery = (message: AssistantMessage) => void | Promise<void>;
 
 /** Resume the agent turn after a transient or ambiguous delivery failure. */
 export class RetryableDeliveryError extends Error {
@@ -190,7 +183,7 @@ export type AgentEnvironment = {
 };
 
 /**
- * One provider-launched agent-run slice.
+ * One bounded attempt to advance a Turn.
  *
  * Build identity, instruction, history, delivery, and durability here. Bind
  * stable model/stream composition when creating the runner, not on each run.
@@ -225,7 +218,7 @@ export type AgentRun = {
   dispatch?: AgentDispatch;
 
   /**
-   * TODO: Move ephemeral Slack credentials and conversation labels into
+   * TODO(dcramer): Move ephemeral Slack credentials and conversation labels into
    * provider-owned tool/prompt context so the shared run edge stays neutral.
    */
   slackConversation?: SlackConversationContext;
@@ -239,9 +232,9 @@ export type AgentRun = {
    * Optional agent capabilities disabled for this run slice.
    * `interactive-auth` blocks pausing to send an OAuth link; missing credentials
    * hard-fail instead. Default is enabled when omitted.
-   * TODO(#881, #883): child invocations currently disable interactive-auth, but
-   * may later need a path to force the auth flow when a delegated tool requires
-   * credentials the parent can already request.
+   * TODO(dcramer): Issues #881 and #883 track a path for child invocations to
+   * force interactive auth when a delegated tool requires credentials the
+   * parent can already request. Children currently disable it.
    */
   disabledFeatures?: readonly AgentFeature[];
   /** Absolute wall-clock deadline for this host request, in milliseconds. */
@@ -303,7 +296,9 @@ export function assertRunConsistency(
   switch (source.platform) {
     case "slack": {
       if (destination.platform !== "slack") {
-        throw new TypeError("Run source and destination platforms do not match");
+        throw new TypeError(
+          "Run source and destination platforms do not match",
+        );
       }
       if (source.teamId !== destination.teamId) {
         throw new TypeError("Slack source and destination teams do not match");
@@ -312,7 +307,9 @@ export function assertRunConsistency(
     }
     case "local": {
       if (destination.platform !== "local") {
-        throw new TypeError("Run source and destination platforms do not match");
+        throw new TypeError(
+          "Run source and destination platforms do not match",
+        );
       }
       if (source.conversationId !== destination.conversationId) {
         throw new TypeError(

--- a/packages/junior/src/chat/agent/types.ts
+++ b/packages/junior/src/chat/agent/types.ts
@@ -211,11 +211,10 @@ export type AgentRun = {
   credentialContext?: CredentialContext;
   source: Source;
   /**
-   * Transitional provider context for this Run.
+   * Transitional Conversation Location for this Run.
    * TODO(dcramer): Remove top-level Location, Destination, and
-   * publishExternally after provider Source contains its inbound Location and
-   * Delivery contains its target Location and authority across new, resumed,
-   * and child Runs.
+   * publishExternally after Source and Delivery contain Location across new,
+   * resumed, and child Runs.
    */
   location?: Location;
   destination: Destination;

--- a/packages/junior/src/chat/api-turns/work.ts
+++ b/packages/junior/src/chat/api-turns/work.ts
@@ -699,6 +699,9 @@ export function createApiTurnWorker(
               actor,
               credentialContext: credentialContextForActor(actor),
               destination,
+              ...(storedConversation?.location
+                ? { location: storedConversation.location }
+                : undefined),
               publishExternally: false,
               source,
               surface: "api",

--- a/packages/junior/src/chat/config.ts
+++ b/packages/junior/src/chat/config.ts
@@ -265,7 +265,8 @@ function parseProfileMap(
   return profiles;
 }
 
-// TODO(v0.180.0): Remove env profile settings after the deprecation window.
+// TODO(dcramer): Remove env profile settings after supported deployments no
+// longer use AI_MODEL, AI_HANDOFF_MODEL, or AI_MODEL_PROFILES.
 function parseProfiles(
   rawValue: string | undefined,
   standardModelId: string,

--- a/packages/junior/src/chat/configuration/sql.ts
+++ b/packages/junior/src/chat/configuration/sql.ts
@@ -175,14 +175,18 @@ export function createDurableLocationConfigurationService(args: {
   db: JuniorDatabase;
   loadLegacy: () => Promise<unknown>;
 }): LocationConfigurationService {
-  const storage = createSqlLocationConfigurationStorage(args.db, args.destination);
+  const storage = createSqlLocationConfigurationStorage(
+    args.db,
+    args.destination,
+  );
   let cutover: Promise<void> | undefined;
   const ensureCutover = () =>
     (cutover ??= (async () => {
       if ((await storage.list()).length > 0) {
         return;
       }
-      // TODO(v0.147.0): Remove the 7-day Redis Location configuration import.
+      // TODO(dcramer): Remove this import after no supported deployment can
+      // retain Redis Location configuration from before the SQL cutover.
       const legacy = coerceLegacyLocationConfig(await args.loadLegacy());
       await storage.insertLegacy(legacy);
     })());

--- a/packages/junior/src/chat/conversation-privacy.ts
+++ b/packages/junior/src/chat/conversation-privacy.ts
@@ -9,6 +9,8 @@ import type {
 } from "@earendil-works/pi-ai";
 import { logWarn } from "@/chat/logging";
 
+// TODO(dcramer): Use ConversationVisibility after the Location cutover makes
+// visibility independent from the legacy destination record.
 export type ConversationPrivacy = "public" | "private";
 type TraceAttributeValue = string | number | boolean | string[];
 const SAFE_METADATA_KEY_LIMIT = 20;
@@ -268,6 +270,8 @@ export function toGenAiMessagesTraceAttributes(
     [`${prefix}.content_chars`]: contentChars,
     [`${prefix}.messages.size`]: contentChars,
     ...(roles.size > 0 ? { [`${prefix}.roles`]: [...roles] } : undefined),
-    ...(partTypes.size > 0 ? { [`${prefix}.part_types`]: [...partTypes] } : undefined),
+    ...(partTypes.size > 0
+      ? { [`${prefix}.part_types`]: [...partTypes] }
+      : undefined),
   };
 }

--- a/packages/junior/src/chat/conversations/README.md
+++ b/packages/junior/src/chat/conversations/README.md
@@ -4,14 +4,19 @@ This module owns Junior's durable conversation record, search, and retention.
 
 ## Location Read Model
 
-`Conversation.location` is the provider-location read model for new code. A
-location keeps Junior's id plus the provider's tenant and location identifiers.
-Conversation privacy remains in `Conversation.visibility`. Provider-specific
-event attribution, such as Slack `threadTs` and `messageTs`, remains in
-`sessionSource`.
+`Conversation.location` is the single Location field for new code. No Location
+means the Conversation stays in Junior's API and UI. A Location names the place
+outside Junior where a provider can deliver the Conversation. For Slack, a
+complete Location identifies the workspace, channel, and thread. Conversation
+privacy remains in `Conversation.visibility`.
 
-During the destination cutover, the linked destination row remains the durable
-location authority. Local conversations have no provider location.
+The current Location projection does not yet include every Slack field.
+
+TODO(dcramer): Remove `sessionSource` after Location stores and reads `threadTs`
+and every reader uses the complete Location.
+
+During this change, the linked destination row remains the stored data used to
+build Location. Local Conversations have no Location.
 
 ## Storage Model
 

--- a/packages/junior/src/chat/conversations/location.ts
+++ b/packages/junior/src/chat/conversations/location.ts
@@ -1,9 +1,9 @@
 import { nonBlankStringSchema } from "@sentry/junior-plugin-api";
 import { z } from "zod";
 
-/** Provider-neutral container associated with a conversation. */
-// TODO(dcramer): Add the provider fields needed by Source and Delivery to
-// identify the exact Conversation. For Slack, this includes threadTs.
+/** One place outside Junior where a Conversation can be delivered. */
+// TODO(dcramer): Add the fields Location needs to identify the exact provider
+// Conversation. For Slack, this includes threadTs.
 export const locationSchema = z
   .object({
     /** Junior-owned stable identity for this location. */
@@ -17,5 +17,5 @@ export const locationSchema = z
   })
   .strict();
 
-/** Validated provider location associated with a conversation. */
+/** Validated Location associated with a Conversation. */
 export type Location = z.output<typeof locationSchema>;

--- a/packages/junior/src/chat/conversations/location.ts
+++ b/packages/junior/src/chat/conversations/location.ts
@@ -2,6 +2,8 @@ import { nonBlankStringSchema } from "@sentry/junior-plugin-api";
 import { z } from "zod";
 
 /** Provider-neutral container associated with a conversation. */
+// TODO(dcramer): Add the provider fields needed by Source and Delivery to
+// identify the exact Conversation. For Slack, this includes threadTs.
 export const locationSchema = z
   .object({
     /** Junior-owned stable identity for this location. */

--- a/packages/junior/src/chat/conversations/sql/store.ts
+++ b/packages/junior/src/chat/conversations/sql/store.ts
@@ -181,7 +181,8 @@ function destinationUpsertFromDestination(args: {
     metadata: { platform: "local" },
   };
 }
-// TODO(v0.145.0): Migrate SQL execution_status from awaiting_resume to paused, then remove this mapping.
+// TODO(dcramer): Remove awaiting_resume mapping after every SQL row uses paused
+// and no supported worker writes the legacy status.
 function executionStatusFromValue(value: unknown): ConversationStatus {
   if (value === "awaiting_resume" || value === "paused") return "paused";
   if (

--- a/packages/junior/src/chat/conversations/store.ts
+++ b/packages/junior/src/chat/conversations/store.ts
@@ -35,6 +35,17 @@ export interface ConversationLineage {
   parentConversationId: string;
 }
 
+/**
+ * Durable Conversation owned by Junior.
+ *
+ * The final interface has zero or one complete Location. Location contains the
+ * provider coordinates shared by provider Source and Delivery. Source still
+ * describes the current input. Delivery still grants the authority to send
+ * output. Location alone grants neither.
+ *
+ * `destination` and `sessionSource` temporarily duplicate parts of that model.
+ * Their field TODOs state when each legacy copy can be removed.
+ */
 export interface Conversation {
   // TODO(dcramer): Move this provider label into Location after stored
   // Conversation reads no longer need the legacy destination projection.
@@ -54,6 +65,7 @@ export interface Conversation {
   // TODO(dcramer): Flatten this one-field wrapper to parentConversationId
   // after stored Conversation callers complete the same hard cutover.
   lineage?: ConversationLineage;
+  /** Optional provider coordinates associated with this Conversation. */
   location?: Location;
   // TODO(dcramer): Replace this creation-time Actor projection with the
   // stored creator Identity after creator identity writes are complete.

--- a/packages/junior/src/chat/conversations/store.ts
+++ b/packages/junior/src/chat/conversations/store.ts
@@ -36,9 +36,13 @@ export interface ConversationLineage {
 }
 
 export interface Conversation {
+  // TODO(dcramer): Move this provider label into Location after stored
+  // Conversation reads no longer need the legacy destination projection.
   channelName?: string;
   conversationId: string;
   createdAtMs: number;
+  // TODO(dcramer): Remove this legacy Conversation routing field after core
+  // reads use Location and provider output uses Delivery.
   destination?: Destination;
   execution: ConversationExecution;
   executionMetrics?: {
@@ -47,16 +51,26 @@ export interface Conversation {
     usage?: AgentTurnUsage;
   };
   lastActivityAtMs: number;
+  // TODO(dcramer): Flatten this one-field wrapper to parentConversationId
+  // after stored Conversation callers complete the same hard cutover.
   lineage?: ConversationLineage;
   location?: Location;
+  // TODO(dcramer): Replace this creation-time Actor projection with the
+  // stored creator Identity after creator identity writes are complete.
   actor?: StoredSlackActor;
+  // TODO(dcramer): Keep schemaVersion inside the SQL decoder after callers
+  // stop constructing stored Conversation values directly.
   schemaVersion: 1;
+  // TODO(dcramer): Rename this creation Source after SQL origin fields become
+  // the only stored authority. It is not the Source for the current Turn.
   source?: ConversationSource;
   /**
    * Structured inbound Source locator for this conversation session.
    * Session-stable (threaded Slack keeps threadTs; channel-level turns omit
    * it; never stores per-message ts). Set-once.
    */
+  // TODO(dcramer): Remove this locator after every stored Conversation has a
+  // complete Location and all readers use it for provider context.
   sessionSource?: SessionSource;
   title?: string;
   updatedAtMs: number;

--- a/packages/junior/src/chat/conversations/store.ts
+++ b/packages/junior/src/chat/conversations/store.ts
@@ -38,10 +38,11 @@ export interface ConversationLineage {
 /**
  * Durable Conversation owned by Junior.
  *
- * The final interface has zero or one complete Location. Location contains the
- * provider coordinates shared by provider Source and Delivery. Source still
- * describes the current input. Delivery still grants the authority to send
- * output. Location alone grants neither.
+ * The final interface stores zero or one complete Location here. No Location
+ * means the Conversation stays in Junior's API and UI. A Location names the
+ * outside place where a provider can deliver the Conversation. Source may also
+ * contain this Location so the agent can use it. Delivery contains it when
+ * output may be sent there. Only Delivery allows output to be sent.
  *
  * `destination` and `sessionSource` temporarily duplicate parts of that model.
  * Their field TODOs state when each legacy copy can be removed.
@@ -82,7 +83,7 @@ export interface Conversation {
    * it; never stores per-message ts). Set-once.
    */
   // TODO(dcramer): Remove this locator after every stored Conversation has a
-  // complete Location and all readers use it for provider context.
+  // complete Location and all readers use Location instead.
   sessionSource?: SessionSource;
   title?: string;
   updatedAtMs: number;

--- a/packages/junior/src/chat/plugins/task-runner.ts
+++ b/packages/junior/src/chat/plugins/task-runner.ts
@@ -381,7 +381,7 @@ async function loadPluginRun(
     completedAtMs: record.updatedAtMs,
     conversationId: record.conversationId,
     destination: routing.destination,
-    ...(routing.locationId ? { locationId: routing.locationId } : undefined),
+    ...(routing.location ? { locationId: routing.location.id } : undefined),
     // Read Actors from the full run record, not the shorter transcript.
     // This includes every Actor that supplied an instruction.
     actors: record.actors,

--- a/packages/junior/src/chat/providers/slack/turn.ts
+++ b/packages/junior/src/chat/providers/slack/turn.ts
@@ -68,6 +68,7 @@ import { buildDeliveredTurnStatePatch } from "@/chat/runtime/delivered-turn-stat
 import { getTurnRequestDeadline } from "@/chat/runtime/request-deadline";
 import { completeAuthPauseTurn } from "@/chat/runtime/auth-pause-state";
 import type { PreparedTurnState } from "@/chat/runtime/turn-preparation";
+import { getConversationStore } from "@/chat/db";
 import {
   type PrepareTurnStateInput,
   type QueuedTurnMessage,
@@ -1073,6 +1074,9 @@ export function createSlackTurn(deps: SlackTurnDeps) {
                 );
               }
             : undefined;
+          const location = (
+            await getConversationStore().get({ conversationId })
+          )?.location;
           const run: AgentRun = {
             conversationId,
             turnId,
@@ -1101,6 +1105,7 @@ export function createSlackTurn(deps: SlackTurnDeps) {
             actor: executionActor,
             slackConversation,
             source,
+            ...(location ? { location } : undefined),
             destination,
             publishExternally: shouldPublishExternally(
               options.publishExternally,

--- a/packages/junior/src/chat/scheduled-tasks/tasks.ts
+++ b/packages/junior/src/chat/scheduled-tasks/tasks.ts
@@ -16,8 +16,8 @@ const SCHEDULER_KEY_PREFIX = "junior:scheduler";
 const retainedScheduledTaskSchema = scheduledTaskSchema
   .omit({ creatorIdentityId: true, title: true })
   .extend({
-    // TODO(v0.131.0): Remove paused decoding and SQL list filtering after
-    // v0.129.x workers can no longer overlap upgrades.
+    // TODO(dcramer): Remove paused decoding and SQL list filtering after
+    // v0.129.x workers are unsupported and cannot overlap an upgrade.
     status: z.enum(["active", "blocked", "completed", "deleted", "paused"]),
     version: z.number().optional(),
   })
@@ -115,7 +115,10 @@ function requireStoredTask(task: ScheduledTask): ScheduledTask {
   }
   const { title, ...current } = parsed.data;
   const normalizedTitle = title?.trim() || undefined;
-  return { ...current, ...(normalizedTitle ? { title: normalizedTitle } : undefined) };
+  return {
+    ...current,
+    ...(normalizedTitle ? { title: normalizedTitle } : undefined),
+  };
 }
 
 function scheduledTaskJsonRecord(task: ScheduledTask): ScheduledTaskRecord {
@@ -133,7 +136,8 @@ async function upsertScheduledTask(
     .values({
       createdAtMs: task.createdAtMs,
       creatorIdentityId: task.creatorIdentityId,
-      // TODO(v0.128.0): Remove after v0.127.x runtimes no longer read this column.
+      // TODO(dcramer): Stop writing this column after v0.127.x runtimes are
+      // unsupported and no supported runtime reads it.
       creatorSlackUserId: task.createdBy.slackUserId,
       id: task.id,
       nextRunAtMs: task.nextRunAtMs,

--- a/packages/junior/src/chat/services/turn-session-routing.ts
+++ b/packages/junior/src/chat/services/turn-session-routing.ts
@@ -1,5 +1,5 @@
 /**
- * Load destination and session source from the conversation record.
+ * Load Location, Destination, and session Source from the Conversation record.
  *
  * Destination is set once on the root conversation. Child conversations
  * inherit through parent lineage. Later turns and mailbox wakes use that
@@ -14,16 +14,17 @@ import type {
   Conversation,
   ConversationStore,
 } from "@/chat/conversations/store";
+import type { Location } from "@/chat/conversations/location";
 import type { SessionSource } from "@/chat/source";
 
 export interface TurnSessionRouting {
   destination: Destination;
-  locationId?: string;
+  location?: Location;
   /** Present when the conversation already stores a session source. */
   source?: Source;
 }
 
-/** Full turn routing: destination plus a completed session source. */
+/** Conversation data with a required Destination and Source. */
 export type RequiredTurnSessionRouting = TurnSessionRouting & {
   source: Source;
 };
@@ -76,7 +77,7 @@ function slackSourceForDestination(args: {
 }
 
 /**
- * Resolve the conversation's destination and session source.
+ * Resolve the Conversation's Location, Destination, and session Source.
  *
  * Walks parent lineage when the conversation has no destination of its own.
  */
@@ -94,12 +95,12 @@ export async function resolveConversationRouting(args: {
 
   let destination: Destination | undefined;
   let source: SessionSource | undefined;
-  let locationId: string | undefined;
+  let location: Location | undefined;
 
   for (const conversation of chain) {
     destination ??= conversation.destination;
     source ??= conversation.sessionSource;
-    locationId ??= conversation.location?.id;
+    location ??= conversation.location;
     if (destination && source) {
       break;
     }
@@ -113,19 +114,19 @@ export async function resolveConversationRouting(args: {
     const slackSource = slackSourceForDestination({ destination, source });
     return {
       destination,
-      ...(locationId ? { locationId } : undefined),
+      ...(location ? { location } : undefined),
       ...(slackSource ? { source: slackSource } : undefined),
     };
   }
 
   return {
     destination,
-    ...(locationId ? { locationId } : undefined),
+    ...(location ? { location } : undefined),
     ...(source ? { source } : undefined),
   };
 }
 
-/** Require conversation destination and session source from SQL. */
+/** Require the Conversation Destination and Source from SQL. */
 export async function resolveTurnSessionRouting(args: {
   conversationId: string;
   conversationStore?: ConversationStore;
@@ -139,6 +140,6 @@ export async function resolveTurnSessionRouting(args: {
   return {
     destination: routing.destination,
     source: routing.source,
-    ...(routing.locationId ? { locationId: routing.locationId } : undefined),
+    ...(routing.location ? { location: routing.location } : undefined),
   };
 }

--- a/packages/junior/src/chat/services/turn-session-routing.ts
+++ b/packages/junior/src/chat/services/turn-session-routing.ts
@@ -37,7 +37,9 @@ async function loadConversationChain(
   let cursor: string | undefined = conversationId;
   while (cursor && !seen.has(cursor)) {
     seen.add(cursor);
-    const conversation = await conversationStore.get({ conversationId: cursor });
+    const conversation = await conversationStore.get({
+      conversationId: cursor,
+    });
     if (!conversation) {
       break;
     }

--- a/packages/junior/src/chat/task-execution/paused-turn.ts
+++ b/packages/junior/src/chat/task-execution/paused-turn.ts
@@ -537,6 +537,7 @@ async function runPausedTurnInContext(
             credentialContext,
             actor,
             destination: routingDestination,
+            ...(routing.location ? { location: routing.location } : undefined),
             // Slack resume publishes unless the checkpoint opted out.
             // Missing means legacy/in-flight Slack turns still post.
             publishExternally: activeTurn.publishExternally !== false,

--- a/packages/junior/src/chat/task-execution/state.ts
+++ b/packages/junior/src/chat/task-execution/state.ts
@@ -153,6 +153,8 @@ export interface ConversationExecution {
   updatedAtMs?: number;
 }
 
+// TODO(dcramer): Rename this Redis-only shape to ConversationExecutionState
+// without changing the v2 wire format. SQL owns the durable Conversation.
 export interface Conversation {
   channelName?: string;
   conversationId: string;

--- a/packages/junior/src/chat/tools/skill/call-mcp-tool.ts
+++ b/packages/junior/src/chat/tools/skill/call-mcp-tool.ts
@@ -52,7 +52,7 @@ function missingToolMessage(toolName: string, provider: string | undefined) {
 }
 
 /** Create the stable dispatcher for active MCP provider tools. */
-// TODO(future): Fold MCP execution into executeTool once searchTools can
+// TODO(dcramer): Fold MCP execution into executeTool once searchTools can
 // disclose MCP tool schemas and the execution catalog keeps them active.
 export function createCallMcpToolTool(mcpToolManager: CallMcpToolManager) {
   return zodTool({
@@ -111,7 +111,9 @@ export function createCallMcpToolTool(mcpToolManager: CallMcpToolManager) {
           : [];
         setSpanAttributes({
           "app.mcp.requested_tool_name": tool_name,
-          ...(provider ? { "app.mcp.requested_provider": provider } : undefined),
+          ...(provider
+            ? { "app.mcp.requested_provider": provider }
+            : undefined),
           "app.mcp.active_provider_names": activeProviderNames(activeTools),
           "app.mcp.active_tool_count": activeTools.length,
           ...(provider
@@ -129,7 +131,9 @@ export function createCallMcpToolTool(mcpToolManager: CallMcpToolManager) {
         resolveMcpArguments(input as Record<string, unknown>),
         {
           conversationPrivacy: options?.conversationPrivacy ?? "private",
-          ...(options?.toolCallId ? { toolCallId: options.toolCallId } : undefined),
+          ...(options?.toolCallId
+            ? { toolCallId: options.toolCallId }
+            : undefined),
         },
       );
       return { content: result.content };

--- a/packages/junior/src/chat/tools/skill/search-mcp-tools.ts
+++ b/packages/junior/src/chat/tools/skill/search-mcp-tools.ts
@@ -218,7 +218,7 @@ function searchProviderCatalog(
 }
 
 /** Create the progressive MCP catalog search tool used before callMcpTool. */
-// TODO(future): Fold MCP discovery into searchTools once the shared catalog can
+// TODO(dcramer): Fold MCP discovery into searchTools once the shared catalog can
 // connect a selected provider and return its full tool schemas.
 export function createSearchMcpToolsTool(mcpToolManager: SearchMcpToolManager) {
   return zodTool({

--- a/packages/junior/src/db/schema/agent-invocations.ts
+++ b/packages/junior/src/db/schema/agent-invocations.ts
@@ -13,8 +13,8 @@ import type { TurnReasoningLevel } from "@/chat/reasoning-level";
 import { juniorConversations } from "./conversations";
 import { timestamptz } from "./timestamps";
 
-// TODO(v0.145.0): Migrate SQL agent invocation status from awaiting_resume to
-// paused, then remove awaiting_resume from this schema and its store queries.
+// TODO(dcramer): Remove awaiting_resume after every SQL row uses paused and no
+// supported worker writes the legacy status.
 export const AGENT_INVOCATION_STATUSES = [
   "pending",
   "running",

--- a/packages/junior/src/db/schema/conversation-bindings.ts
+++ b/packages/junior/src/db/schema/conversation-bindings.ts
@@ -11,6 +11,8 @@ export const juniorConversationBindings = pgTable(
       .references(() => juniorConversations.conversationId),
     provider: text("provider").notNull(),
     providerTenantId: text("provider_tenant_id").notNull().default(""),
+    // TODO(dcramer): Rename provider_destination_id with the Location SQL
+    // migration. It identifies the provider place that contains the thread.
     providerDestinationId: text("provider_destination_id").notNull(),
     providerConversationId: text("provider_conversation_id").notNull(),
     createdAt: timestamptz("created_at").notNull(),

--- a/packages/junior/src/db/schema/conversations.ts
+++ b/packages/junior/src/db/schema/conversations.ts
@@ -26,13 +26,19 @@ export const juniorConversations = pgTable(
     schemaVersion: integer("schema_version").notNull().default(1),
     source: text("source").$type<ConversationSource>(),
     /** Structured session Source locator; set-once on the conversation root. */
+    // TODO(dcramer): Remove source_json after every stored Conversation has a
+    // complete Location and all readers use it for provider context.
     sessionSource: jsonb("source_json").$type<SessionSource>(),
     originType: text("origin_type"),
     originId: text("origin_id"),
     originRunId: text("origin_run_id"),
+    // TODO(dcramer): Rename destination_id to location_id after all deployed
+    // readers and writers use the singular Conversation Location contract.
     destinationId: text("destination_id").references(
       () => juniorDestinations.id,
     ),
+    // TODO(dcramer): Drop destination_json after every row uses location_id and
+    // no supported worker writes the legacy JSON value.
     destination: jsonb("destination_json").$type<Destination>(),
     actorIdentityId: text("actor_identity_id").references(
       () => juniorIdentities.id,

--- a/packages/junior/src/db/schema/destinations.ts
+++ b/packages/junior/src/db/schema/destinations.ts
@@ -19,6 +19,8 @@ export type JuniorDestinationVisibility =
   | "public"
   | "unknown";
 
+// TODO(dcramer): Rename this legacy destination table and its provider fields
+// to Location terms after the SQL migration and deployed reader cutover.
 export const juniorDestinations = pgTable(
   "junior_destinations",
   {

--- a/packages/junior/src/db/schema/scheduled-tasks.ts
+++ b/packages/junior/src/db/schema/scheduled-tasks.ts
@@ -10,7 +10,8 @@ export const juniorSchedulerTasks = pgTable(
   {
     id: text("id").primaryKey(),
     teamId: text("team_id").notNull(),
-    // TODO(v0.128.0): Remove after v0.127.x runtimes no longer write this column.
+    // TODO(dcramer): Remove after v0.127.x runtimes are unsupported and no
+    // supported runtime writes this column.
     creatorSlackUserId: text("creator_slack_user_id"),
     creatorIdentityId: text("creator_identity_id"),
     status: text("status").notNull(),
@@ -22,7 +23,8 @@ export const juniorSchedulerTasks = pgTable(
     record: jsonb("record").$type<ScheduledTaskRecord>().notNull(),
   },
   (table) => [
-    // TODO(v0.128.0): Remove with creatorSlackUserId.
+    // TODO(dcramer): Remove after no supported runtime reads or writes the
+    // legacy creatorSlackUserId column.
     index("junior_scheduler_tasks_creator_idx")
       .on(table.teamId, table.creatorSlackUserId, table.createdAtMs, table.id)
       .where(sql`${table.status} <> 'deleted'`),

--- a/packages/junior/src/handlers/mcp-oauth-callback.ts
+++ b/packages/junior/src/handlers/mcp-oauth-callback.ts
@@ -409,6 +409,7 @@ async function resumeAuthorizedMcpTurn(args: {
           },
           actor,
           destination,
+          ...(routing.location ? { location: routing.location } : undefined),
           source: routing.source,
           toolChannelId: authSession.toolChannelId ?? authSession.channelId,
           environment: {

--- a/packages/junior/src/handlers/oauth-callback.ts
+++ b/packages/junior/src/handlers/oauth-callback.ts
@@ -441,6 +441,7 @@ async function resumeOAuthSessionRecordTurn(
           },
           actor,
           destination,
+          ...(routing.location ? { location: routing.location } : undefined),
           source: routing.source,
           toolChannelId: stored.channelId!,
           environment: {

--- a/packages/junior/tests/integration/agent-continue-slack.test.ts
+++ b/packages/junior/tests/integration/agent-continue-slack.test.ts
@@ -253,6 +253,11 @@ describe("paused turn Slack integration", () => {
         userId: "U123",
       },
       destination: SLACK_DESTINATION,
+      location: {
+        provider: "slack",
+        tenantId: "T123",
+        providerId: "C123",
+      },
       publishExternally: true,
       source: storedSource,
       toolChannelId: "C123",

--- a/packages/junior/tests/integration/api-turn-work.test.ts
+++ b/packages/junior/tests/integration/api-turn-work.test.ts
@@ -629,11 +629,15 @@ describe("Conversation API work", () => {
       status: "accepted",
     });
 
-    await expect(
-      conversationStore.get({ conversationId }),
-    ).resolves.toMatchObject({
+    const storedConversation = await conversationStore.get({ conversationId });
+    expect(storedConversation).toMatchObject({
       source: "slack",
       destination: slackDestination,
+      location: {
+        provider: "slack",
+        tenantId: "T1200",
+        providerId: "C1200",
+      },
       visibility: "public",
       sessionSource: {
         platform: "slack",
@@ -685,6 +689,7 @@ describe("Conversation API work", () => {
     expect(agentRuns[0]).toEqual(
       expect.objectContaining({
         destination: expect.objectContaining({ platform: "slack" }),
+        location: storedConversation?.location,
         publishExternally: false,
         source: expect.objectContaining({ platform: "web" }),
       }),

--- a/packages/junior/tests/unit/services/turn-session-routing.test.ts
+++ b/packages/junior/tests/unit/services/turn-session-routing.test.ts
@@ -9,6 +9,7 @@ import {
   resolveTurnSessionRouting,
 } from "@/chat/services/turn-session-routing";
 import type { SessionSource } from "@/chat/source";
+import type { Location } from "@/chat/conversations/location";
 
 const DESTINATION = {
   platform: "slack",
@@ -28,6 +29,7 @@ function conversation(args: {
   conversationId?: string;
   destination?: Destination;
   lineage?: { parentConversationId: string };
+  location?: Location;
   sessionSource?: SessionSource;
 }): Conversation {
   return {
@@ -39,6 +41,7 @@ function conversation(args: {
     execution: { status: "paused" },
     ...(args.destination ? { destination: args.destination } : undefined),
     ...(args.lineage ? { lineage: args.lineage } : undefined),
+    ...(args.location ? { location: args.location } : undefined),
     ...(args.sessionSource ? { sessionSource: args.sessionSource } : undefined),
   };
 }
@@ -111,6 +114,12 @@ describe("resolveConversationRouting", () => {
         if (conversationId === "slack:C123:1712345.0001") {
           return conversation({
             destination: DESTINATION,
+            location: {
+              id: "location-123",
+              provider: "slack",
+              tenantId: "T123",
+              providerId: "C123",
+            },
             sessionSource: SOURCE,
           });
         }
@@ -125,6 +134,12 @@ describe("resolveConversationRouting", () => {
       }),
     ).resolves.toEqual({
       destination: DESTINATION,
+      location: {
+        id: "location-123",
+        provider: "slack",
+        tenantId: "T123",
+        providerId: "C123",
+      },
       source: SOURCE,
     });
   });

--- a/policies/code-comments.md
+++ b/policies/code-comments.md
@@ -20,10 +20,10 @@ They are not there to narrate obvious code.
 - When an owning edge intentionally omits behavior a maintainer would
   reasonably expect, document that absence when it affects correctness,
   security, privacy, delivery, or recovery.
-- Transitional compatibility branches and fallbacks require a removal TODO in
-  the form `TODO(vX.Y.Z): Remove ...` where `vX.Y.Z` is the next release after
-  the compatibility path is introduced. The comment must name the legacy state
-  or behavior being tolerated. Do not only say "cleanup later".
+- Every TODO must name an owner in the form `TODO(owner): ...`.
+- A removal TODO must name what will be removed and the condition that makes
+  removal safe. Use a version only when support for that version is the real
+  condition. Do not invent a release deadline.
 - Keep comments short, concrete, and current.
 
 ## Exceptions
@@ -31,5 +31,5 @@ They are not there to narrate obvious code.
 - Do not comment obvious transformations or control flow.
 - Do not add comments that simply restate the code in English.
 - Small obvious leaf helpers do not need comments.
-- If there is no concrete release or condition for removing a compatibility
-  path, prefer a hard cutover instead of adding the path.
+- If there is no concrete condition for removing a compatibility path, prefer
+  a hard cutover instead of adding the path.


### PR DESCRIPTION
Agent Runs now receive the stored Conversation Location for Conversation API and Slack work, paused and authorization resumes, and child work. Tool setup uses that Location instead of loading the Conversation again. An API or UI continuation keeps its Slack Location without sending its answer to Slack.

This is a bounded migration step. A Conversation owns zero or one Location. Source may carry that Location into the core agent, while only Delivery lets a Run send output there. The final `AgentRun` has Source and optional Delivery, with no separate Location, Destination, or `publishExternally`. The temporary `AgentRun.location` field has an owned removal condition.

Issue #1563 defines the final interface and the ordered removal of duplicate fields. The branch also requires owned TODOs with concrete removal conditions so the remaining migration work does not become permanent compatibility code.

Refs #1563