### PR TITLE
ref(chat): Store parent on Conversation directly

### DIFF
--- a/TERMINOLOGY.md
+++ b/TERMINOLOGY.md
@@ -14,7 +14,8 @@ Canonical words used across Junior's code and documentation.
   commit identifier.
 - **Sandbox**: an isolated execution environment for a run or snapshot build.
 - **Conversation**: the durable container for visible history and execution
-  state, identified by a globally unique `conversationId`.
+  state, identified by a globally unique `conversationId`. A Conversation may
+  have one parent Conversation. Parent and Location are independent.
 - **Source**: the current input that caused a Turn, such as a Slack message,
   local CLI input, dashboard input, scheduled task, or plugin dispatch. Source
   may include the Conversation's Location so the agent can use that place even

--- a/packages/junior/src/chat/README.md
+++ b/packages/junior/src/chat/README.md
@@ -154,8 +154,9 @@ delegation without becoming the execution actor or a general task owner.
   end of that transition.
 - The final interface uses Conversation, Source, Location, and Delivery. Do not
   add another type, routing object, or wrapper for the same values.
-- Child Conversations store the Location they need instead of searching parent
-  lineage at Run time in the final model.
+- A Conversation may have one parent Conversation. It stores that relation as
+  `parentConversationId`. Location is independent and is not copied from the
+  parent. A Run may read the parent Conversation when it needs that Location.
 - External publish is controlled per turn via `publishExternally`. Slack
   ingress/resume publish unless the flag is explicitly false. Non-Slack,
   destinationless, and dashboard/web work stay conversation-only unless the

--- a/packages/junior/src/chat/agent-invocations/README.md
+++ b/packages/junior/src/chat/agent-invocations/README.md
@@ -15,8 +15,8 @@ stores the terminal result for its parent to read later.
   idempotency key. Optional reasoning level is per-invocation policy, not
   binding state.
 - An invocation without a name gets an invocation-scoped child conversation.
-- Child conversation lineage is immutable. Bindings and invocation content are
-  purged with their root conversation tree. Recursive delegation is disabled
+- `parentConversationId` is immutable. Bindings and invocation content are
+  purged with their root Conversation tree. Recursive delegation is disabled
   until depth, cancellation, and authority rules are defined. Children cannot
   spawn, hand off model profiles, or otherwise override their run policy.
 - Each parent may keep at most
@@ -46,10 +46,12 @@ conversation tree.
    result or error onto the invocation.
 7. The heartbeat repairs invocations left in `mailboxStatus: "pending"`.
 
-The child conversation has no provider destination. Each invocation carries
-the actor, credential context, source, and destination that bound its tool
-execution. Child output is an internal result; provider delivery remains owned
-by the parent-facing runtime.
+A Conversation created for an Agent invocation stores `parentConversationId`.
+It uses the same Conversation type as all other work. It does not copy the
+parent Conversation's Location or receive Delivery. Its Run reads the parent
+Conversation's Location when tools need it. Output stays inside Junior. Agent
+invocation fields still carry the Actor, credentials, Source, and Destination
+until the final Run interface removes these older fields.
 
 ## Current Boundary
 

--- a/packages/junior/src/chat/agent-invocations/work.ts
+++ b/packages/junior/src/chat/agent-invocations/work.ts
@@ -4,7 +4,7 @@ import type { Location } from "@/chat/conversations/location";
 import type { ConversationStore } from "@/chat/conversations/store";
 import { openConversationProjection } from "@/chat/conversations/projection";
 import { ConversationTurnLifecycleService } from "@/chat/conversations/turn-lifecycle";
-import { getConversationEventStore } from "@/chat/db";
+import { getConversationEventStore, getConversationStore } from "@/chat/db";
 import type { AgentRunner } from "@/chat/runtime/agent-runner";
 import { AgentRunError, executeTurn } from "@/chat/runtime/turn-execution";
 import {
@@ -29,7 +29,6 @@ import { getTerminalAssistantMessages } from "@/chat/pi/transcript";
 import type { PiMessage } from "@/chat/pi/messages";
 import type { SandboxRef } from "@/chat/sandbox/ref";
 import type { AgentRunResult } from "@/chat/services/turn-result";
-import { resolveConversationRouting } from "@/chat/services/turn-session-routing";
 import {
   appendAndEnqueueInboundMessage,
   type InboundMessage,
@@ -400,8 +399,8 @@ export function createAgentInvocationWorker(agentRunner: AgentRunner) {
       sandboxRef = getPersistedSandboxState(persisted);
       history = projection.messages;
       location = (
-        await resolveConversationRouting({
-          conversationId: invocation.childConversationId,
+        await getConversationStore().get({
+          conversationId: invocation.parentConversationId,
         })
       )?.location;
     } catch (error) {

--- a/packages/junior/src/chat/conversations/sql/store.ts
+++ b/packages/junior/src/chat/conversations/sql/store.ts
@@ -282,11 +282,7 @@ function conversationFromRow(readRow: ConversationReadRow): Conversation {
       ...(row.executionUsage ? { usage: row.executionUsage } : undefined),
     },
     ...(row.parentConversationId
-      ? {
-          lineage: {
-            parentConversationId: row.parentConversationId,
-          },
-        }
+      ? { parentConversationId: row.parentConversationId }
       : undefined),
     ...(destination ? { destination } : undefined),
     ...(location ? { location } : undefined),
@@ -429,11 +425,10 @@ export class SqlStore implements ConversationStore {
           });
           if (existing) {
             if (
-              existing.lineage?.parentConversationId !==
-              args.parentConversationId
+              existing.parentConversationId !== args.parentConversationId
             ) {
               throw new Error(
-                `Conversation lineage changed for ${args.childConversationId}`,
+                `Conversation parent changed for ${args.childConversationId}`,
               );
             }
             return;
@@ -446,7 +441,7 @@ export class SqlStore implements ConversationStore {
               `Conversation parent is missing for ${args.childConversationId}`,
             );
           }
-          if (parent.lineage) {
+          if (parent.parentConversationId) {
             throw new Error("Recursive agent delegation is not enabled");
           }
           const child: Conversation = {
@@ -455,9 +450,7 @@ export class SqlStore implements ConversationStore {
               nowMs,
               source: args.source,
             }),
-            lineage: {
-              parentConversationId: args.parentConversationId,
-            },
+            parentConversationId: args.parentConversationId,
           };
           await this.upsertConversation({ conversation: child });
         },
@@ -582,7 +575,9 @@ export class SqlStore implements ConversationStore {
           createdAtMs: args.createdAtMs,
           lastActivityAtMs: args.lastActivityAtMs,
           updatedAtMs: args.updatedAtMs,
-          ...(existing?.lineage ? { lineage: existing.lineage } : undefined),
+          ...(existing?.parentConversationId
+            ? { parentConversationId: existing.parentConversationId }
+            : undefined),
           ...(args.channelName ? { channelName: args.channelName } : undefined),
           ...(args.destination ? { destination: args.destination } : undefined),
           ...(args.actor ? { actor: args.actor } : undefined),
@@ -646,7 +641,7 @@ export class SqlStore implements ConversationStore {
         eq(juniorIdentities.id, juniorConversations.actorIdentityId),
       )
       .leftJoin(juniorUsers, eq(juniorUsers.id, juniorIdentities.userId))
-      // Subagent child conversations are excluded from top-level listings and
+      // Conversations with a parent are excluded from top-level listings and
       // purge with their root on the root's visibility window.
       .where(isNull(juniorConversations.parentConversationId))
       .orderBy(
@@ -778,10 +773,10 @@ export class SqlStore implements ConversationStore {
     conversation: Conversation;
   }): Promise<void> {
     const { conversation } = args;
-    // Root conversations set destination on first write. Children keep no
-    // destination and inherit through parent lineage. Later updates may omit
-    // destination because onConflict keeps the existing destination_id.
-    if (!conversation.lineage && !conversation.destination) {
+    // Root Conversations set Destination on first write. A Conversation with a
+    // parent can omit Destination. Later updates may omit Destination because
+    // onConflict keeps the existing destination_id.
+    if (!conversation.parentConversationId && !conversation.destination) {
       const existing = await this.get({
         conversationId: conversation.conversationId,
       });
@@ -813,11 +808,11 @@ export class SqlStore implements ConversationStore {
           conversation.updatedAtMs,
         )
       : undefined;
-    const rootConversationId = conversation.lineage
+    const rootConversationId = conversation.parentConversationId
       ? sql<string | null>`(
           select parent.root_conversation_id
           from junior_conversations parent
-          where parent.conversation_id = ${conversation.lineage.parentConversationId}
+          where parent.conversation_id = ${conversation.parentConversationId}
         )`
       : conversation.conversationId;
     const rows = await this.executor
@@ -856,8 +851,7 @@ export class SqlStore implements ConversationStore {
           conversation.execution.lastEnqueuedAtMs === undefined
             ? null
             : dateFromMs(conversation.execution.lastEnqueuedAtMs),
-        parentConversationId:
-          conversation.lineage?.parentConversationId ?? null,
+        parentConversationId: conversation.parentConversationId ?? null,
         rootConversationId,
       })
       .onConflictDoUpdate({

--- a/packages/junior/src/chat/conversations/store.ts
+++ b/packages/junior/src/chat/conversations/store.ts
@@ -30,11 +30,6 @@ export interface ConversationExecution {
   updatedAtMs?: number;
 }
 
-/** Immutable parent correlation for a child conversation. */
-export interface ConversationLineage {
-  parentConversationId: string;
-}
-
 /**
  * Durable Conversation owned by Junior.
  *
@@ -63,9 +58,8 @@ export interface Conversation {
     usage?: AgentTurnUsage;
   };
   lastActivityAtMs: number;
-  // TODO(dcramer): Flatten this one-field wrapper to parentConversationId
-  // after stored Conversation callers complete the same hard cutover.
-  lineage?: ConversationLineage;
+  /** Immutable parent Conversation. */
+  parentConversationId?: string;
   /** Optional provider coordinates associated with this Conversation. */
   location?: Location;
   // TODO(dcramer): Replace this creation-time Actor projection with the
@@ -99,7 +93,7 @@ export interface Conversation {
 
 /** Persist and read durable conversation metadata for reporting surfaces. */
 export interface ConversationStore {
-  /** Create one destinationless child with immutable parent lineage. */
+  /** Create one Conversation with an immutable parent. */
   createChild(args: {
     childConversationId: string;
     parentConversationId: string;

--- a/packages/junior/src/chat/services/conversation-title.ts
+++ b/packages/junior/src/chat/services/conversation-title.ts
@@ -62,8 +62,8 @@ async function ensureConversationTitleOnce(args: {
     if (stored?.title?.trim()) {
       return undefined;
     }
-    // Child conversations are execution machinery, not listable threads.
-    if (stored?.lineage) {
+    // Conversations with a parent are execution machinery, not listable threads.
+    if (stored?.parentConversationId) {
       return undefined;
     }
 

--- a/packages/junior/src/chat/services/turn-session-routing.ts
+++ b/packages/junior/src/chat/services/turn-session-routing.ts
@@ -1,9 +1,9 @@
 /**
  * Load Location, Destination, and session Source from the Conversation record.
  *
- * Destination is set once on the root conversation. Child conversations
- * inherit through parent lineage. Later turns and mailbox wakes use that
- * same destination so tools stay consistent for the whole conversation.
+ * Destination is set once on the root Conversation. A Conversation with a
+ * parent reads through that relation. Later Turns and mailbox wakes use the
+ * same Destination so tools stay consistent for the whole Conversation.
  */
 import type {
   Destination,
@@ -45,7 +45,7 @@ async function loadConversationChain(
       break;
     }
     chain.push(conversation);
-    cursor = conversation.lineage?.parentConversationId;
+    cursor = conversation.parentConversationId;
   }
   return chain;
 }
@@ -79,7 +79,7 @@ function slackSourceForDestination(args: {
 /**
  * Resolve the Conversation's Location, Destination, and session Source.
  *
- * Walks parent lineage when the conversation has no destination of its own.
+ * Reads parent Conversations when this Conversation has no Destination.
  */
 export async function resolveConversationRouting(args: {
   conversationId: string;

--- a/packages/junior/src/chat/task-execution/turn-cursor.ts
+++ b/packages/junior/src/chat/task-execution/turn-cursor.ts
@@ -344,14 +344,14 @@ async function recordConversationActivityMetadata(args: {
   const conversation = await conversationStore.get({
     conversationId: args.summary.conversationId,
   });
-  const isChild = Boolean(conversation?.lineage);
-  // Nested destination/source/actor stay off Redis cursor payloads; callers
-  // pass live routing/identity here for SQL dual-write. Child conversations keep
-  // no destination.
-  const destination = isChild ? undefined : args.destination;
+  const hasParent = Boolean(conversation?.parentConversationId);
+  // Nested Destination, Source, and Actor stay off Redis cursor payloads.
+  // Callers pass live values here for the SQL write. Conversations with a
+  // parent keep no Destination.
+  const destination = hasParent ? undefined : args.destination;
   // Root dual-write requires a destination on first create. Cursor-only writes
   // without destination stay Redis-only until a real root upsert lands.
-  if (!isChild && !destination && !conversation) {
+  if (!hasParent && !destination && !conversation) {
     return;
   }
   // Only derive ConversationSource when routing is known. Abandon/fail no longer
@@ -359,7 +359,7 @@ async function recordConversationActivityMetadata(args: {
   // overwrite a durable `local` source with surface `internal`.
   // Prefer the typed session Source branch when present so web/dashboard turns
   // are not collapsed to local just because delivery uses a local destination.
-  const activitySource = isChild
+  const activitySource = hasParent
     ? "internal"
     : args.source?.platform === "web"
       ? "web"
@@ -377,7 +377,7 @@ async function recordConversationActivityMetadata(args: {
     actor: sessionLogActor(args.actor),
     ...definedProps({ source: activitySource }),
     ...(args.source ? { sessionSource: args.source } : undefined),
-    visibility: isChild ? undefined : args.destinationVisibility,
+    visibility: hasParent ? undefined : args.destinationVisibility,
   });
   await conversationStore.recordExecution({
     channelName: args.summary.channelName,
@@ -395,7 +395,7 @@ async function recordConversationActivityMetadata(args: {
     actor: sessionLogActor(args.actor),
     ...definedProps({ source: activitySource }),
     updatedAtMs: args.nowMs,
-    visibility: isChild ? undefined : args.destinationVisibility,
+    visibility: hasParent ? undefined : args.destinationVisibility,
   });
 }
 

--- a/packages/junior/src/chat/task-execution/worker.ts
+++ b/packages/junior/src/chat/task-execution/worker.ts
@@ -402,13 +402,13 @@ async function processConversationWorkInContext(
     }
     return { status: "no_work" };
   }
-  // Mailbox wakes may omit destination. Read it from this root conversation
-  // only. Children keep no destination so invocation and dispatch workers stay
-  // free of provider destinations.
+  // Mailbox wakes may omit Destination. Read it from this root Conversation
+  // only. Conversations with a parent keep no Destination, so invocation and
+  // dispatch workers stay free of provider Destinations.
   let destination = initial.destination;
   if (!destination && options.conversationStore) {
     const stored = await options.conversationStore.get({ conversationId });
-    if (stored && !stored.lineage) {
+    if (stored && !stored.parentConversationId) {
       destination = stored.destination;
     }
   }

--- a/packages/junior/src/chat/tools/search-conversation-events.ts
+++ b/packages/junior/src/chat/tools/search-conversation-events.ts
@@ -161,11 +161,11 @@ export function createSearchConversationEventsTool(
         context,
         currentConversationId,
       );
-      // Child conversations inherit the root destination privacy boundary.
+      // A Conversation with a parent uses the root privacy boundary.
       const targetRootConversationId = await resolveRootConversationId(
         conversationStore,
         conversationId,
-        target.lineage?.parentConversationId,
+        target.parentConversationId,
       );
       const targetRoot =
         targetRootConversationId === conversationId
@@ -218,7 +218,7 @@ async function resolveAccessScope(
     ? await resolveRootConversationId(
         conversationStore,
         currentConversationId,
-        current.lineage?.parentConversationId,
+        current.parentConversationId,
       )
     : currentConversationId;
 
@@ -270,10 +270,10 @@ async function resolveRootConversationId(
     if (!parent) {
       return conversationId;
     }
-    if (!parent.lineage?.parentConversationId) {
+    if (!parent.parentConversationId) {
       return parent.conversationId;
     }
-    cursor = parent.lineage.parentConversationId;
+    cursor = parent.parentConversationId;
   }
   return conversationId;
 }

--- a/packages/junior/tests/component/conversation-sql-store.test.ts
+++ b/packages/junior/tests/component/conversation-sql-store.test.ts
@@ -163,7 +163,7 @@ describe("conversation SQL store", () => {
       ).resolves.toMatchObject({
         conversationId: "child:missing-parent",
         lastActivityAtMs: 1,
-        lineage: { parentConversationId: "parent-without-root" },
+        parentConversationId: "parent-without-root",
       });
     } finally {
       await fixture.close();

--- a/packages/junior/tests/integration/agent-invocation-work.test.ts
+++ b/packages/junior/tests/integration/agent-invocation-work.test.ts
@@ -35,6 +35,7 @@ import {
 import { createModelStream } from "../fixtures/model-stream";
 import {
   createLocalSource,
+  createSlackSource,
 } from "@sentry/junior-plugin-api";
 const parentConversationId = "local:test:parent-agent";
 const destination = {
@@ -50,6 +51,24 @@ const invocationInput = {
   reasoningLevel: "medium" as const,
   source: createLocalSource(parentConversationId),
 };
+const slackParentConversationId = "slack:C123:1712345.0001";
+const slackDestination = {
+  platform: "slack",
+  teamId: "T123",
+  channelId: "C123",
+} as const;
+const slackSource = createSlackSource({
+  channelId: "C123",
+  teamId: "T123",
+  threadTs: "1712345.0001",
+  visibility: "private",
+});
+const slackInvocationInput = {
+  ...invocationInput,
+  destination: slackDestination,
+  parentConversationId: slackParentConversationId,
+  source: slackSource,
+};
 
 async function prepareParentConversation() {
   const fixture = createConfiguredJuniorSqlFixture();
@@ -60,6 +79,21 @@ async function prepareParentConversation() {
     destination,
     nowMs: 1_000,
     source: "local",
+  });
+  return { conversationStore, fixture };
+}
+
+async function prepareSlackParentConversation() {
+  const fixture = createConfiguredJuniorSqlFixture();
+  await migrateSchema(fixture.sql);
+  const conversationStore = createSqlStore(fixture.sql);
+  await conversationStore.recordActivity({
+    conversationId: slackParentConversationId,
+    destination: slackDestination,
+    nowMs: 1_000,
+    sessionSource: slackSource,
+    source: "slack",
+    visibility: "private",
   });
   return { conversationStore, fixture };
 }
@@ -146,7 +180,7 @@ describe("agent invocation conversation work", () => {
         conversationId: first.childConversationId,
       });
       expect(child).toMatchObject({
-        lineage: { parentConversationId },
+        parentConversationId,
         source: "internal",
       });
       expect(child).not.toHaveProperty("destination");
@@ -253,15 +287,16 @@ describe("agent invocation conversation work", () => {
     }
   });
 
-  it("runs child work once without external delivery and saves its result", async () => {
-    const { conversationStore, fixture } = await prepareParentConversation();
+  it("reads the parent Location without delivering child output", async () => {
+    const { conversationStore, fixture } =
+      await prepareSlackParentConversation();
     const queue = createConversationWorkQueueTestAdapter();
     const state = getStateAdapter();
     await state.connect();
     try {
       const created = await createAndEnqueueAgentInvocation(
         {
-          ...invocationInput,
+          ...slackInvocationInput,
           idempotencyKey: "execute-1",
         },
         {
@@ -271,6 +306,15 @@ describe("agent invocation conversation work", () => {
           state,
         },
       );
+      const child = await conversationStore.get({
+        conversationId: created.childConversationId,
+      });
+      expect(child).toMatchObject({
+        parentConversationId: slackParentConversationId,
+      });
+      expect(child).not.toHaveProperty("destination");
+      expect(child).not.toHaveProperty("location");
+      expect(child).not.toHaveProperty("sessionSource");
       const agentRunner = createModelAgentRunner(
         createModelStream([{ type: "text", text: "Durable child result" }]),
       );
@@ -358,13 +402,20 @@ describe("agent invocation conversation work", () => {
       expect(run).toHaveBeenCalledOnce();
       expect(run.mock.calls[0]?.[0]).toMatchObject({
         conversationId: created.childConversationId,
-        instruction: { text: invocationInput.input },
+        instruction: { text: slackInvocationInput.input },
         disabledFeatures: ["handoff", "interactive-auth", "subagents"],
         reasoning: "medium",
-        actor: invocationInput.actor,
-        destination,
+        actor: slackInvocationInput.actor,
+        destination: slackDestination,
         destinationVisibility: "private",
-        source: invocationInput.source,
+        location: {
+          id: expect.any(String),
+          provider: "slack",
+          tenantId: "T123",
+          providerId: "C123",
+        },
+        publishExternally: false,
+        source: slackInvocationInput.source,
         surface: "internal",
         runId: created.invocationId,
       });

--- a/packages/junior/tests/unit/services/turn-session-routing.test.ts
+++ b/packages/junior/tests/unit/services/turn-session-routing.test.ts
@@ -28,7 +28,7 @@ const SOURCE = {
 function conversation(args: {
   conversationId?: string;
   destination?: Destination;
-  lineage?: { parentConversationId: string };
+  parentConversationId?: string;
   location?: Location;
   sessionSource?: SessionSource;
 }): Conversation {
@@ -40,7 +40,9 @@ function conversation(args: {
     schemaVersion: 1,
     execution: { status: "paused" },
     ...(args.destination ? { destination: args.destination } : undefined),
-    ...(args.lineage ? { lineage: args.lineage } : undefined),
+    ...(args.parentConversationId
+      ? { parentConversationId: args.parentConversationId }
+      : undefined),
     ...(args.location ? { location: args.location } : undefined),
     ...(args.sessionSource ? { sessionSource: args.sessionSource } : undefined),
   };
@@ -108,7 +110,7 @@ describe("resolveConversationRouting", () => {
         if (conversationId === "agent:child") {
           return conversation({
             conversationId: "agent:child",
-            lineage: { parentConversationId: "slack:C123:1712345.0001" },
+            parentConversationId: "slack:C123:1712345.0001",
           });
         }
         if (conversationId === "slack:C123:1712345.0001") {
@@ -273,7 +275,7 @@ describe("resolveConversationRouting", () => {
         if (conversationId === "agent:child") {
           return conversation({
             conversationId: "agent:child",
-            lineage: { parentConversationId: "agent-dispatch:task" },
+            parentConversationId: "agent-dispatch:task",
           });
         }
         if (conversationId === "agent-dispatch:task") {


### PR DESCRIPTION
Conversation now has an optional `parentConversationId` field. Location is a
separate optional field. Setting a parent does not create or copy Location. A
Conversation used for an Agent invocation uses the same type as every other
Conversation. Its Run reads the parent Conversation when tools need that
Location, and its output stays inside Junior.

This removes the one-field `ConversationLineage` wrapper and the shared lookup
that mixed Location, Source, and Destination. SQL already stores
`parent_conversation_id` directly, so the change needs no migration. Agent
invocations are not enabled in production, so this is an internal hard cutover
with no compatibility path.

Refs #1563
