### PR TITLE
ref(chat): store complete Conversation Location

### DIFF
--- a/packages/junior-plugin-api/src/context.ts
+++ b/packages/junior-plugin-api/src/context.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import type { ZodTypeAny } from "zod";
 import {
+  baseLocationSchema,
   destinationSchema,
   identitySchema,
   locationSchema,
@@ -11,6 +12,7 @@ import {
   slackActorSchema,
   systemActorSchema,
   sourceSchema,
+  slackLocationSchema,
   userSchema,
 } from "./schemas";
 
@@ -24,8 +26,12 @@ export type SystemActor = z.output<typeof systemActorSchema>;
 export type Identity = z.output<typeof identitySchema>;
 export type User = z.output<typeof userSchema>;
 export type Source = z.output<typeof sourceSchema>;
+/** Fields shared by every provider Location. */
+export type BaseLocation = z.output<typeof baseLocationSchema>;
 /** Validated Location associated with a Conversation. */
 export type Location = z.output<typeof locationSchema>;
+/** Complete Slack Location associated with a Conversation. */
+export type SlackLocation = z.output<typeof slackLocationSchema>;
 export type SlackSource = Extract<Source, { platform: "slack" }>;
 export type LocalSource = Extract<Source, { platform: "local" }>;
 export type WebSource = Extract<Source, { platform: "web" }>;

--- a/packages/junior-plugin-api/src/context.ts
+++ b/packages/junior-plugin-api/src/context.ts
@@ -1,7 +1,6 @@
 import { z } from "zod";
 import type { ZodTypeAny } from "zod";
 import {
-  baseLocationSchema,
   destinationSchema,
   identitySchema,
   locationSchema,
@@ -26,8 +25,6 @@ export type SystemActor = z.output<typeof systemActorSchema>;
 export type Identity = z.output<typeof identitySchema>;
 export type User = z.output<typeof userSchema>;
 export type Source = z.output<typeof sourceSchema>;
-/** Fields shared by every provider Location. */
-export type BaseLocation = z.output<typeof baseLocationSchema>;
 /** Validated Location associated with a Conversation. */
 export type Location = z.output<typeof locationSchema>;
 /** Complete Slack Location associated with a Conversation. */

--- a/packages/junior-plugin-api/src/schemas.ts
+++ b/packages/junior-plugin-api/src/schemas.ts
@@ -21,21 +21,29 @@ const exactNonBlankStringSchema = nonBlankStringSchema.refine(
   (value) => value === value.trim(),
 );
 
-/** One place outside Junior where a Conversation can be delivered. */
-// TODO(dcramer): Add the fields Location needs to identify the exact provider
-// Conversation. For Slack, this includes threadTs.
-export const locationSchema = z
+/** Fields shared by every Location. */
+export const baseLocationSchema = z
   .object({
-    /** Junior-owned stable identity for this location. */
+    /** Stable SQL identity used by Location configuration and reporting. */
     id: nonBlankStringSchema,
-    /** Provider namespace that owns the provider and tenant identifiers. */
-    provider: nonBlankStringSchema,
-    /** Optional provider-native workspace, account, or tenant scope. */
-    tenantId: nonBlankStringSchema.optional(),
-    /** Provider-native identifier for the container within its tenant scope. */
-    providerId: nonBlankStringSchema,
+    provider: exactNonBlankStringSchema,
   })
   .strict();
+
+/** Complete Slack Location associated with a Conversation. */
+export const slackLocationSchema = baseLocationSchema
+  .extend({
+    provider: z.literal("slack"),
+    teamId: slackTeamIdSchema,
+    channelId: slackConversationIdSchema,
+    threadTs: exactNonBlankStringSchema.optional(),
+  })
+  .strict();
+
+/** Complete Location types supported by Junior. */
+export const locationSchema = z.discriminatedUnion("provider", [
+  slackLocationSchema,
+]);
 
 /** Runtime platform names supported by plugin public contracts. */
 export const platformSchema = z.enum(["slack", "local"]);

--- a/packages/junior-plugin-api/src/schemas.ts
+++ b/packages/junior-plugin-api/src/schemas.ts
@@ -22,7 +22,7 @@ const exactNonBlankStringSchema = nonBlankStringSchema.refine(
 );
 
 /** Fields shared by every Location. */
-export const baseLocationSchema = z
+const baseLocationSchema = z
   .object({
     /** Stable SQL identity used by Location configuration and reporting. */
     id: nonBlankStringSchema,

--- a/packages/junior/migrations/0037_conversation_location.sql
+++ b/packages/junior/migrations/0037_conversation_location.sql
@@ -1,0 +1,23 @@
+ALTER TABLE "junior_conversations" ADD COLUMN "location_json" jsonb;
+--> statement-breakpoint
+UPDATE "junior_conversations" AS "conversation"
+SET "location_json" =
+  jsonb_build_object(
+    'id', "location"."id",
+    'provider', 'slack',
+    'teamId', "location"."provider_tenant_id",
+    'channelId', "location"."provider_destination_id"
+  ) ||
+  CASE
+    WHEN "conversation"."source_json"->>'platform' = 'slack'
+      AND "conversation"."source_json"->>'teamId' = "location"."provider_tenant_id"
+      AND "conversation"."source_json"->>'channelId' = "location"."provider_destination_id"
+      AND nullif(btrim("conversation"."source_json"->>'threadTs'), '') IS NOT NULL
+    THEN jsonb_build_object(
+      'threadTs', btrim("conversation"."source_json"->>'threadTs')
+    )
+    ELSE '{}'::jsonb
+  END
+FROM "junior_destinations" AS "location"
+WHERE "conversation"."destination_id" = "location"."id"
+  AND "location"."provider" = 'slack';

--- a/packages/junior/migrations/meta/0037_snapshot.json
+++ b/packages/junior/migrations/meta/0037_snapshot.json
@@ -1,0 +1,3192 @@
+{
+  "id": "0987fcdb-05e2-44d9-889c-4eea8bbf6101",
+  "prevId": "7afb21c1-f6f3-4369-a7bb-7a29e0af3226",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.junior_agent_bindings": {
+      "name": "junior_agent_bindings",
+      "schema": "",
+      "columns": {
+        "parent_conversation_id": {
+          "name": "parent_conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_conversation_id": {
+          "name": "child_conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "junior_agent_bindings_child_idx": {
+          "name": "junior_agent_bindings_child_idx",
+          "columns": [
+            {
+              "expression": "child_conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "junior_agent_bindings_parent_conversation_id_junior_conversations_conversation_id_fk": {
+          "name": "junior_agent_bindings_parent_conversation_id_junior_conversations_conversation_id_fk",
+          "tableFrom": "junior_agent_bindings",
+          "tableTo": "junior_conversations",
+          "columnsFrom": ["parent_conversation_id"],
+          "columnsTo": ["conversation_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "junior_agent_bindings_child_conversation_id_junior_conversations_conversation_id_fk": {
+          "name": "junior_agent_bindings_child_conversation_id_junior_conversations_conversation_id_fk",
+          "tableFrom": "junior_agent_bindings",
+          "tableTo": "junior_conversations",
+          "columnsFrom": ["child_conversation_id"],
+          "columnsTo": ["conversation_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "junior_agent_bindings_parent_conversation_id_name_pk": {
+          "name": "junior_agent_bindings_parent_conversation_id_name_pk",
+          "columns": ["parent_conversation_id", "name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_agent_invocations": {
+      "name": "junior_agent_invocations",
+      "schema": "",
+      "columns": {
+        "invocation_id": {
+          "name": "invocation_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "parent_conversation_id": {
+          "name": "parent_conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_conversation_id": {
+          "name": "child_conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input": {
+          "name": "input",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_json": {
+          "name": "actor_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_context_json": {
+          "name": "credential_context_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_json": {
+          "name": "source_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination_json": {
+          "name": "destination_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination_visibility": {
+          "name": "destination_visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasoning_level": {
+          "name": "reasoning_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mailbox_status": {
+          "name": "mailbox_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "terminal_at": {
+          "name": "terminal_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "junior_agent_invocations_child_idx": {
+          "name": "junior_agent_invocations_child_idx",
+          "columns": [
+            {
+              "expression": "child_conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_agent_invocations_mailbox_idx": {
+          "name": "junior_agent_invocations_mailbox_idx",
+          "columns": [
+            {
+              "expression": "mailbox_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "junior_agent_invocations_parent_conversation_id_junior_conversations_conversation_id_fk": {
+          "name": "junior_agent_invocations_parent_conversation_id_junior_conversations_conversation_id_fk",
+          "tableFrom": "junior_agent_invocations",
+          "tableTo": "junior_conversations",
+          "columnsFrom": ["parent_conversation_id"],
+          "columnsTo": ["conversation_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "junior_agent_invocations_child_conversation_id_junior_conversations_conversation_id_fk": {
+          "name": "junior_agent_invocations_child_conversation_id_junior_conversations_conversation_id_fk",
+          "tableFrom": "junior_agent_invocations",
+          "tableTo": "junior_conversations",
+          "columnsFrom": ["child_conversation_id"],
+          "columnsTo": ["conversation_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_api_tokens": {
+      "name": "junior_api_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_email_normalized": {
+          "name": "owner_email_normalized",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_suffix": {
+          "name": "token_suffix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "junior_api_tokens_token_hash_uidx": {
+          "name": "junior_api_tokens_token_hash_uidx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_api_tokens_owner_email_idx": {
+          "name": "junior_api_tokens_owner_email_idx",
+          "columns": [
+            {
+              "expression": "owner_email_normalized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_artifacts": {
+      "name": "junior_artifacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ext": {
+          "name": "ext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delete_requested_at": {
+          "name": "delete_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "junior_artifacts_conversation_sha_uidx": {
+          "name": "junior_artifacts_conversation_sha_uidx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_artifacts_gc_idx": {
+          "name": "junior_artifacts_gc_idx",
+          "columns": [
+            {
+              "expression": "delete_requested_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_artifacts_conversation_idx": {
+          "name": "junior_artifacts_conversation_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_attachments": {
+      "name": "junior_attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delete_requested_at": {
+          "name": "delete_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "junior_attachments_conversation_idx": {
+          "name": "junior_attachments_conversation_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_attachments_gc_idx": {
+          "name": "junior_attachments_gc_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "delete_requested_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "junior_attachments_conversation_id_junior_conversations_conversation_id_fk": {
+          "name": "junior_attachments_conversation_id_junior_conversations_conversation_id_fk",
+          "tableFrom": "junior_attachments",
+          "tableTo": "junior_conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["conversation_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_code_changes": {
+      "name": "junior_code_changes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversation_ids": {
+          "name": "conversation_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "merged_at": {
+          "name": "merged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "junior_code_changes_provider_id_idx": {
+          "name": "junior_code_changes_provider_id_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_code_changes_opened_at_idx": {
+          "name": "junior_code_changes_opened_at_idx",
+          "columns": [
+            {
+              "expression": "opened_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_code_changes_merged_at_idx": {
+          "name": "junior_code_changes_merged_at_idx",
+          "columns": [
+            {
+              "expression": "merged_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_code_changes_closed_at_idx": {
+          "name": "junior_code_changes_closed_at_idx",
+          "columns": [
+            {
+              "expression": "closed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_code_changes_open_idx": {
+          "name": "junior_code_changes_open_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"junior_code_changes\".\"state\" = 'open'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "junior_code_changes_repository_id_junior_code_repositories_id_fk": {
+          "name": "junior_code_changes_repository_id_junior_code_repositories_id_fk",
+          "tableFrom": "junior_code_changes",
+          "tableTo": "junior_code_repositories",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_code_repositories": {
+      "name": "junior_code_repositories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "junior_code_repositories_provider_id_idx": {
+          "name": "junior_code_repositories_provider_id_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_conversation_annotations": {
+      "name": "junior_conversation_annotations",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plugin": {
+          "name": "plugin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "annotation_json": {
+          "name": "annotation_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "junior_conversation_annotations_conversation_id_fk": {
+          "name": "junior_conversation_annotations_conversation_id_fk",
+          "tableFrom": "junior_conversation_annotations",
+          "tableTo": "junior_conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["conversation_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "junior_conversation_annotations_pk": {
+          "name": "junior_conversation_annotations_pk",
+          "columns": ["conversation_id", "plugin", "kind", "key"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_conversation_bindings": {
+      "name": "junior_conversation_bindings",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_tenant_id": {
+          "name": "provider_tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "provider_destination_id": {
+          "name": "provider_destination_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_conversation_id": {
+          "name": "provider_conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "junior_conversation_bindings_conversation_idx": {
+          "name": "junior_conversation_bindings_conversation_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "junior_conversation_bindings_conversation_id_junior_conversations_conversation_id_fk": {
+          "name": "junior_conversation_bindings_conversation_id_junior_conversations_conversation_id_fk",
+          "tableFrom": "junior_conversation_bindings",
+          "tableTo": "junior_conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["conversation_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "junior_conversation_bindings_provider_conversation_pk": {
+          "name": "junior_conversation_bindings_provider_conversation_pk",
+          "columns": [
+            "provider",
+            "provider_tenant_id",
+            "provider_destination_id",
+            "provider_conversation_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_conversation_events": {
+      "name": "junior_conversation_events",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "history_version": {
+          "name": "history_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_identity_id": {
+          "name": "actor_identity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "junior_conversation_events_history_version_idx": {
+          "name": "junior_conversation_events_history_version_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "history_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_conversation_events_type_idx": {
+          "name": "junior_conversation_events_type_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_conversation_events_actor_identity_idx": {
+          "name": "junior_conversation_events_actor_identity_idx",
+          "columns": [
+            {
+              "expression": "actor_identity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_conversation_events_message_search_idx": {
+          "name": "junior_conversation_events_message_search_idx",
+          "columns": [
+            {
+              "expression": "to_tsvector('english', \"payload\"->>'text')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"junior_conversation_events\".\"type\" = 'message'",
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "junior_conversation_events_idempotency_idx": {
+          "name": "junior_conversation_events_idempotency_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "junior_conversation_events_actor_identity_id_junior_identities_id_fk": {
+          "name": "junior_conversation_events_actor_identity_id_junior_identities_id_fk",
+          "tableFrom": "junior_conversation_events",
+          "tableTo": "junior_identities",
+          "columnsFrom": ["actor_identity_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "junior_conversation_events_conversation_id_junior_conversations_conversation_id_fk": {
+          "name": "junior_conversation_events_conversation_id_junior_conversations_conversation_id_fk",
+          "tableFrom": "junior_conversation_events",
+          "tableTo": "junior_conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["conversation_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "junior_conversation_events_conversation_id_seq_pk": {
+          "name": "junior_conversation_events_conversation_id_seq_pk",
+          "columns": ["conversation_id", "seq"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_conversation_participants": {
+      "name": "junior_conversation_participants",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_conversation_id": {
+          "name": "root_conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "junior_conversation_participants_user_activity_idx": {
+          "name": "junior_conversation_participants_user_activity_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_message_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_conversation_participants_root_idx": {
+          "name": "junior_conversation_participants_root_idx",
+          "columns": [
+            {
+              "expression": "root_conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "junior_conversation_participants_user_id_junior_users_id_fk": {
+          "name": "junior_conversation_participants_user_id_junior_users_id_fk",
+          "tableFrom": "junior_conversation_participants",
+          "tableTo": "junior_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "junior_conversation_participants_root_conversation_id_junior_conversations_conversation_id_fk": {
+          "name": "junior_conversation_participants_root_conversation_id_junior_conversations_conversation_id_fk",
+          "tableFrom": "junior_conversation_participants",
+          "tableTo": "junior_conversations",
+          "columnsFrom": ["root_conversation_id"],
+          "columnsTo": ["conversation_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "junior_conversation_participants_user_root_pk": {
+          "name": "junior_conversation_participants_user_root_pk",
+          "columns": ["user_id", "root_conversation_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_conversations": {
+      "name": "junior_conversations",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_json": {
+          "name": "source_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin_type": {
+          "name": "origin_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin_id": {
+          "name": "origin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin_run_id": {
+          "name": "origin_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_json": {
+          "name": "location_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destination_id": {
+          "name": "destination_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destination_json": {
+          "name": "destination_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_identity_id": {
+          "name": "actor_identity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_identity_id": {
+          "name": "creator_identity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_subject_identity_id": {
+          "name": "credential_subject_identity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_json": {
+          "name": "actor_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_name": {
+          "name": "channel_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "execution_updated_at": {
+          "name": "execution_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_status": {
+          "name": "execution_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_checkpoint_at": {
+          "name": "last_checkpoint_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_enqueued_at": {
+          "name": "last_enqueued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_conversation_id": {
+          "name": "parent_conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_conversation_id": {
+          "name": "root_conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcript_purged_at": {
+          "name": "transcript_purged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "usage_json": {
+          "name": "usage_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_duration_ms": {
+          "name": "execution_duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "execution_usage_json": {
+          "name": "execution_usage_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metric_run_id": {
+          "name": "metric_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "junior_conversations_last_activity_idx": {
+          "name": "junior_conversations_last_activity_idx",
+          "columns": [
+            {
+              "expression": "last_activity_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_conversations_active_idx": {
+          "name": "junior_conversations_active_idx",
+          "columns": [
+            {
+              "expression": "coalesce(\"execution_updated_at\", \"updated_at\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"junior_conversations\".\"execution_status\" <> 'idle'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_conversations_destination_activity_idx": {
+          "name": "junior_conversations_destination_activity_idx",
+          "columns": [
+            {
+              "expression": "destination_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_activity_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_conversations_actor_activity_idx": {
+          "name": "junior_conversations_actor_activity_idx",
+          "columns": [
+            {
+              "expression": "actor_identity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_activity_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_conversations_origin_idx": {
+          "name": "junior_conversations_origin_idx",
+          "columns": [
+            {
+              "expression": "origin_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "origin_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_activity_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_conversations_parent_idx": {
+          "name": "junior_conversations_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_conversations_root_idx": {
+          "name": "junior_conversations_root_idx",
+          "columns": [
+            {
+              "expression": "root_conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "junior_conversations_destination_id_junior_destinations_id_fk": {
+          "name": "junior_conversations_destination_id_junior_destinations_id_fk",
+          "tableFrom": "junior_conversations",
+          "tableTo": "junior_destinations",
+          "columnsFrom": ["destination_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "junior_conversations_actor_identity_id_junior_identities_id_fk": {
+          "name": "junior_conversations_actor_identity_id_junior_identities_id_fk",
+          "tableFrom": "junior_conversations",
+          "tableTo": "junior_identities",
+          "columnsFrom": ["actor_identity_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "junior_conversations_creator_identity_id_junior_identities_id_fk": {
+          "name": "junior_conversations_creator_identity_id_junior_identities_id_fk",
+          "tableFrom": "junior_conversations",
+          "tableTo": "junior_identities",
+          "columnsFrom": ["creator_identity_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "junior_conversations_credential_subject_identity_id_junior_identities_id_fk": {
+          "name": "junior_conversations_credential_subject_identity_id_junior_identities_id_fk",
+          "tableFrom": "junior_conversations",
+          "tableTo": "junior_identities",
+          "columnsFrom": ["credential_subject_identity_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "junior_conversations_parent_conversation_id_junior_conversations_conversation_id_fk": {
+          "name": "junior_conversations_parent_conversation_id_junior_conversations_conversation_id_fk",
+          "tableFrom": "junior_conversations",
+          "tableTo": "junior_conversations",
+          "columnsFrom": ["parent_conversation_id"],
+          "columnsTo": ["conversation_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "junior_conversations_root_conversation_id_junior_conversations_conversation_id_fk": {
+          "name": "junior_conversations_root_conversation_id_junior_conversations_conversation_id_fk",
+          "tableFrom": "junior_conversations",
+          "tableTo": "junior_conversations",
+          "columnsFrom": ["root_conversation_id"],
+          "columnsTo": ["conversation_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_destinations": {
+      "name": "junior_destinations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_tenant_id": {
+          "name": "provider_tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "provider_destination_id": {
+          "name": "provider_destination_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_destination_id": {
+          "name": "parent_destination_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "junior_destinations_provider_destination_uidx": {
+          "name": "junior_destinations_provider_destination_uidx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_destination_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_destinations_provider_kind_idx": {
+          "name": "junior_destinations_provider_kind_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_event_tasks": {
+      "name": "junior_event_tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at_ms": {
+          "name": "created_at_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_json": {
+          "name": "task_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "junior_event_tasks_team_idx": {
+          "name": "junior_event_tasks_team_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at_ms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_event_tasks_match_idx": {
+          "name": "junior_event_tasks_match_idx",
+          "columns": [
+            {
+              "expression": "namespace",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at_ms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_identities": {
+      "name": "junior_identities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_tenant_id": {
+          "name": "provider_tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "provider_subject_id": {
+          "name": "provider_subject_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_normalized": {
+          "name": "email_normalized",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "junior_identities_provider_subject_uidx": {
+          "name": "junior_identities_provider_subject_uidx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_identities_user_idx": {
+          "name": "junior_identities_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_identities_verified_email_idx": {
+          "name": "junior_identities_verified_email_idx",
+          "columns": [
+            {
+              "expression": "email_normalized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"junior_identities\".\"email_verified\" = true AND \"junior_identities\".\"email_normalized\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_identities_kind_provider_idx": {
+          "name": "junior_identities_kind_provider_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "junior_identities_user_id_junior_users_id_fk": {
+          "name": "junior_identities_user_id_junior_users_id_fk",
+          "tableFrom": "junior_identities",
+          "tableTo": "junior_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_location_configurations": {
+      "name": "junior_location_configurations",
+      "schema": "",
+      "columns": {
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "junior_location_configurations_location_id_junior_destinations_id_fk": {
+          "name": "junior_location_configurations_location_id_junior_destinations_id_fk",
+          "tableFrom": "junior_location_configurations",
+          "tableTo": "junior_destinations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "junior_location_configurations_location_id_key_pk": {
+          "name": "junior_location_configurations_location_id_key_pk",
+          "columns": ["location_id", "key"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_scheduler_runs": {
+      "name": "junior_scheduler_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduled_for_ms": {
+          "name": "scheduled_for_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record": {
+          "name": "record",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "junior_scheduler_runs_task_status_idx": {
+          "name": "junior_scheduler_runs_task_status_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduled_for_ms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_scheduler_runs_status_idx": {
+          "name": "junior_scheduler_runs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduled_for_ms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_scheduler_tasks": {
+      "name": "junior_scheduler_tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_slack_user_id": {
+          "name": "creator_slack_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_identity_id": {
+          "name": "creator_identity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_run_at_ms": {
+          "name": "next_run_at_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_now_at_ms": {
+          "name": "run_now_at_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at_ms": {
+          "name": "created_at_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "record": {
+          "name": "record",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "junior_scheduler_tasks_creator_idx": {
+          "name": "junior_scheduler_tasks_creator_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "creator_slack_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at_ms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"junior_scheduler_tasks\".\"status\" <> 'deleted'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_scheduler_tasks_creator_identity_idx": {
+          "name": "junior_scheduler_tasks_creator_identity_idx",
+          "columns": [
+            {
+              "expression": "creator_identity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at_ms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"junior_scheduler_tasks\".\"status\" <> 'deleted' AND \"junior_scheduler_tasks\".\"creator_identity_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_scheduler_tasks_team_status_idx": {
+          "name": "junior_scheduler_tasks_team_status_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at_ms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"junior_scheduler_tasks\".\"status\" <> 'deleted'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_scheduler_tasks_run_now_due_idx": {
+          "name": "junior_scheduler_tasks_run_now_due_idx",
+          "columns": [
+            {
+              "expression": "run_now_at_ms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at_ms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"junior_scheduler_tasks\".\"status\" = 'active' AND \"junior_scheduler_tasks\".\"run_now_at_ms\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_scheduler_tasks_next_run_due_idx": {
+          "name": "junior_scheduler_tasks_next_run_due_idx",
+          "columns": [
+            {
+              "expression": "next_run_at_ms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at_ms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"junior_scheduler_tasks\".\"status\" = 'active' AND \"junior_scheduler_tasks\".\"next_run_at_ms\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_snapshots": {
+      "name": "junior_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_hash": {
+          "name": "profile_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "build_duration_ms": {
+          "name": "build_duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "build_started_at": {
+          "name": "build_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "build_phase": {
+          "name": "build_phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "build_sandbox_name": {
+          "name": "build_sandbox_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "build_command_id": {
+          "name": "build_command_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "build_error": {
+          "name": "build_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "junior_snapshots_snapshot_id_uidx": {
+          "name": "junior_snapshots_snapshot_id_uidx",
+          "columns": [
+            {
+              "expression": "snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_snapshots_workspace_idx": {
+          "name": "junior_snapshots_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_snapshots_workspace_profile_status_idx": {
+          "name": "junior_snapshots_workspace_profile_status_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "profile_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_snapshots_active_build_uidx": {
+          "name": "junior_snapshots_active_build_uidx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "profile_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"junior_snapshots\".\"status\" = 'building'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_snapshots_workspace_status_idx": {
+          "name": "junior_snapshots_workspace_status_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "junior_snapshots_workspace_id_junior_workspaces_id_fk": {
+          "name": "junior_snapshots_workspace_id_junior_workspaces_id_fk",
+          "tableFrom": "junior_snapshots",
+          "tableTo": "junior_workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "junior_snapshots_status_check": {
+          "name": "junior_snapshots_status_check",
+          "value": "\"junior_snapshots\".\"status\" in ('building', 'failed', 'ready')"
+        },
+        "junior_snapshots_build_phase_check": {
+          "name": "junior_snapshots_build_phase_check",
+          "value": "\"junior_snapshots\".\"build_phase\" is null or \"junior_snapshots\".\"build_phase\" in ('created', 'dependencies_installed', 'repositories_prepared')"
+        },
+        "junior_snapshots_ready_fields_check": {
+          "name": "junior_snapshots_ready_fields_check",
+          "value": "\"junior_snapshots\".\"status\" <> 'ready' or (\"junior_snapshots\".\"snapshot_id\" is not null and \"junior_snapshots\".\"build_duration_ms\" is not null and \"junior_snapshots\".\"generated_at\" is not null)"
+        },
+        "junior_snapshots_build_fields_check": {
+          "name": "junior_snapshots_build_fields_check",
+          "value": "\"junior_snapshots\".\"status\" = 'ready' or (\"junior_snapshots\".\"build_started_at\" is not null and \"junior_snapshots\".\"build_phase\" is not null)"
+        },
+        "junior_snapshots_build_duration_check": {
+          "name": "junior_snapshots_build_duration_check",
+          "value": "\"junior_snapshots\".\"build_duration_ms\" is null or \"junior_snapshots\".\"build_duration_ms\" >= 0"
+        },
+        "junior_snapshots_size_bytes_check": {
+          "name": "junior_snapshots_size_bytes_check",
+          "value": "\"junior_snapshots\".\"size_bytes\" is null or \"junior_snapshots\".\"size_bytes\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.junior_stats": {
+      "name": "junior_stats",
+      "schema": "",
+      "columns": {
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metric": {
+          "name": "metric",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "junior_stats_date_namespace_metric_name_pk": {
+          "name": "junior_stats_date_namespace_metric_name_pk",
+          "columns": ["date", "namespace", "metric", "name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_task_executions": {
+      "name": "junior_task_executions",
+      "schema": "",
+      "columns": {
+        "execution_id": {
+          "name": "execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executed_at_ms": {
+          "name": "executed_at_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "junior_task_executions_task_time_idx": {
+          "name": "junior_task_executions_task_time_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "namespace",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "executed_at_ms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_task_executions_time_kind_idx": {
+          "name": "junior_task_executions_time_kind_idx",
+          "columns": [
+            {
+              "expression": "executed_at_ms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_task_executions_conversation_time_idx": {
+          "name": "junior_task_executions_conversation_time_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "executed_at_ms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "junior_task_executions_conversation_id_junior_conversations_conversation_id_fk": {
+          "name": "junior_task_executions_conversation_id_junior_conversations_conversation_id_fk",
+          "tableFrom": "junior_task_executions",
+          "tableTo": "junior_conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["conversation_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "junior_task_executions_kind_namespace_execution_id_pk": {
+          "name": "junior_task_executions_kind_namespace_execution_id_pk",
+          "columns": ["kind", "namespace", "execution_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "junior_task_executions_kind_check": {
+          "name": "junior_task_executions_kind_check",
+          "value": "\"junior_task_executions\".\"kind\" in ('scheduled', 'event')"
+        },
+        "junior_task_executions_status_check": {
+          "name": "junior_task_executions_status_check",
+          "value": "\"junior_task_executions\".\"status\" in ('blocked', 'completed', 'failed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.junior_users": {
+      "name": "junior_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "primary_email": {
+          "name": "primary_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "primary_email_normalized": {
+          "name": "primary_email_normalized",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "junior_users_primary_email_normalized_uidx": {
+          "name": "junior_users_primary_email_normalized_uidx",
+          "columns": [
+            {
+              "expression": "primary_email_normalized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_workspace_repos": {
+      "name": "junior_workspace_repos",
+      "schema": "",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "junior_workspace_repos_workspace_id_junior_workspaces_id_fk": {
+          "name": "junior_workspace_repos_workspace_id_junior_workspaces_id_fk",
+          "tableFrom": "junior_workspace_repos",
+          "tableTo": "junior_workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "junior_workspace_repos_workspace_id_provider_repo_pk": {
+          "name": "junior_workspace_repos_workspace_id_provider_repo_pk",
+          "columns": ["workspace_id", "provider", "repo"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_workspaces": {
+      "name": "junior_workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "setup_script": {
+          "name": "setup_script",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "junior_workspaces_name_idx": {
+          "name": "junior_workspaces_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/junior/migrations/meta/_journal.json
+++ b/packages/junior/migrations/meta/_journal.json
@@ -260,6 +260,13 @@
       "when": 1787598193137,
       "tag": "0036_complex_rage",
       "breakpoints": true
+    },
+    {
+      "idx": 37,
+      "version": "7",
+      "when": 1787873831749,
+      "tag": "0037_conversation_location",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/junior/src/api/conversations/list.ts
+++ b/packages/junior/src/api/conversations/list.ts
@@ -133,11 +133,19 @@ function conversationFromRow(row: ConversationRow): Conversation {
           ...(row.identitySubjectId
             ? { slackUserId: row.identitySubjectId }
             : undefined),
-          ...(row.identityHandle ? { slackUserName: row.identityHandle } : undefined),
-          ...(row.identityTenantId ? { teamId: row.identityTenantId } : undefined),
+          ...(row.identityHandle
+            ? { slackUserName: row.identityHandle }
+            : undefined),
+          ...(row.identityTenantId
+            ? { teamId: row.identityTenantId }
+            : undefined),
         }
       : undefined;
-  const location = locationFromRow(row.destination);
+  const location = locationFromRow(
+    value.location,
+    row.destination,
+    sessionSource,
+  );
   return {
     schemaVersion: 1,
     conversationId: value.conversationId,

--- a/packages/junior/src/chat/conversations/README.md
+++ b/packages/junior/src/chat/conversations/README.md
@@ -10,13 +10,15 @@ outside Junior where a provider can deliver the Conversation. For Slack, a
 complete Location identifies the workspace, channel, and thread. Conversation
 privacy remains in `Conversation.visibility`.
 
-The current Location projection does not yet include every Slack field.
+The Conversation row stores the complete Location in `location_json`. Local
+Conversations have no Location.
 
-TODO(dcramer): Remove `sessionSource` after Location stores and reads `threadTs`
-and every reader uses the complete Location.
+TODO(dcramer): Remove `sessionSource` after resume reads the saved Turn Source
+and every Conversation place reader uses Location.
 
-During this change, the linked destination row remains the stored data used to
-build Location. Local Conversations have no Location.
+TODO(dcramer): Remove the `destination_id` and `source_json` Location read
+fallback after no deployed writer can omit `location_json` and a backfill has
+populated rows that those writers created during deployment.
 
 ## Storage Model
 

--- a/packages/junior/src/chat/conversations/sql/location.ts
+++ b/packages/junior/src/chat/conversations/sql/location.ts
@@ -1,19 +1,78 @@
+import type { Destination } from "@sentry/junior-plugin-api";
 import type { ConversationPrivacy } from "@/chat/conversation-privacy";
 import { locationSchema, type Location } from "@/chat/conversations/location";
+import type { SessionSource } from "@/chat/source";
 import type { juniorDestinations } from "@/db/schema";
 
 type LocationRow = typeof juniorDestinations.$inferSelect;
 
-/** Project one supported provider location from its linked SQL row. */
-export function locationFromRow(row: LocationRow | null): Location | undefined {
-  if (!row || row.provider === "local") {
+/** Build the complete Location for one Conversation SQL write. */
+export function conversationLocationForWrite(args: {
+  destination: Destination | undefined;
+  destinationId: string | undefined;
+  location: Location | undefined;
+  sessionSource: SessionSource | undefined;
+}): Location | undefined {
+  if (args.location) {
+    return locationSchema.parse(args.location);
+  }
+  const destination =
+    args.destination?.platform === "slack" ? args.destination : undefined;
+  const source =
+    args.sessionSource?.platform === "slack" ? args.sessionSource : undefined;
+  if (
+    destination &&
+    source &&
+    (destination.teamId !== source.teamId ||
+      destination.channelId !== source.channelId)
+  ) {
+    throw new Error("Conversation Location does not match its session Source");
+  }
+  if (!destination || !args.destinationId) {
     return undefined;
   }
   return locationSchema.parse({
+    id: args.destinationId,
+    provider: "slack",
+    teamId: destination.teamId,
+    channelId: destination.channelId,
+    ...(source?.threadTs ? { threadTs: source.threadTs } : undefined),
+  });
+}
+
+/** Read one complete Location from SQL. */
+export function locationFromRow(
+  value: unknown,
+  row: LocationRow | null,
+  sessionSource: SessionSource | undefined,
+): Location | undefined {
+  if (value !== undefined && value !== null) {
+    return locationSchema.parse(value);
+  }
+  if (!row || row.provider === "local") {
+    return undefined;
+  }
+  if (row.provider !== "slack") {
+    throw new Error("Conversation Location provider is not supported");
+  }
+  // TODO(dcramer): Remove this destination_id and source_json fallback after no
+  // deployed writer can omit location_json and a backfill has populated rows
+  // that those writers created during deployment.
+  const slackSource =
+    sessionSource?.platform === "slack" ? sessionSource : undefined;
+  if (
+    slackSource &&
+    (slackSource.teamId !== row.providerTenantId ||
+      slackSource.channelId !== row.providerDestinationId)
+  ) {
+    throw new Error("Conversation Location does not match its session Source");
+  }
+  return locationSchema.parse({
     id: row.id,
-    provider: row.provider,
-    ...(row.providerTenantId ? { tenantId: row.providerTenantId } : undefined),
-    providerId: row.providerDestinationId,
+    provider: "slack",
+    teamId: row.providerTenantId,
+    channelId: row.providerDestinationId,
+    ...(slackSource?.threadTs ? { threadTs: slackSource.threadTs } : undefined),
   });
 }
 

--- a/packages/junior/src/chat/conversations/sql/location.ts
+++ b/packages/junior/src/chat/conversations/sql/location.ts
@@ -7,19 +7,37 @@ import type { juniorDestinations } from "@/db/schema";
 type LocationRow = typeof juniorDestinations.$inferSelect;
 
 /** Build the complete Location for one Conversation SQL write. */
-export function conversationLocationForWrite(args: {
+// TODO(dcramer): Remove Destination and SessionSource inputs after every
+// Conversation writer supplies Location directly.
+export function locationForWrite(args: {
   destination: Destination | undefined;
   destinationId: string | undefined;
   location: Location | undefined;
   sessionSource: SessionSource | undefined;
 }): Location | undefined {
-  if (args.location) {
-    return locationSchema.parse(args.location);
-  }
+  const location = args.location
+    ? locationSchema.parse(args.location)
+    : undefined;
   const destination =
     args.destination?.platform === "slack" ? args.destination : undefined;
   const source =
     args.sessionSource?.platform === "slack" ? args.sessionSource : undefined;
+  if (location) {
+    if (
+      (destination &&
+        (location.id !== args.destinationId ||
+          location.teamId !== destination.teamId ||
+          location.channelId !== destination.channelId)) ||
+      (source &&
+        (location.teamId !== source.teamId ||
+          location.channelId !== source.channelId))
+    ) {
+      throw new Error("Conversation Location changed");
+    }
+    return source?.threadTs && !location.threadTs
+      ? { ...location, threadTs: source.threadTs }
+      : location;
+  }
   if (
     destination &&
     source &&
@@ -59,14 +77,11 @@ export function locationFromRow(
   // deployed writer can omit location_json and a backfill has populated rows
   // that those writers created during deployment.
   const slackSource =
-    sessionSource?.platform === "slack" ? sessionSource : undefined;
-  if (
-    slackSource &&
-    (slackSource.teamId !== row.providerTenantId ||
-      slackSource.channelId !== row.providerDestinationId)
-  ) {
-    throw new Error("Conversation Location does not match its session Source");
-  }
+    sessionSource?.platform === "slack" &&
+    sessionSource.teamId === row.providerTenantId &&
+    sessionSource.channelId === row.providerDestinationId
+      ? sessionSource
+      : undefined;
   return locationSchema.parse({
     id: row.id,
     provider: "slack",

--- a/packages/junior/src/chat/conversations/sql/store.ts
+++ b/packages/junior/src/chat/conversations/sql/store.ts
@@ -43,7 +43,7 @@ import {
   mergeActor,
 } from "./actor-identity";
 import {
-  conversationLocationForWrite,
+  locationForWrite,
   locationFromRow,
   privacyFromLocationRow,
 } from "./location";
@@ -807,7 +807,7 @@ export class SqlStore implements ConversationStore {
       }),
       conversation.updatedAtMs,
     );
-    const location = conversationLocationForWrite({
+    const location = locationForWrite({
       destination: conversation.destination,
       destinationId,
       location: conversation.location,

--- a/packages/junior/src/chat/conversations/sql/store.ts
+++ b/packages/junior/src/chat/conversations/sql/store.ts
@@ -42,7 +42,11 @@ import {
   actorIdentityForConversation,
   mergeActor,
 } from "./actor-identity";
-import { locationFromRow, privacyFromLocationRow } from "./location";
+import {
+  conversationLocationForWrite,
+  locationFromRow,
+  privacyFromLocationRow,
+} from "./location";
 type ConversationRow = Omit<
   typeof juniorConversations.$inferSelect,
   "legacyArchivedAt"
@@ -267,7 +271,11 @@ function conversationFromRow(readRow: ConversationReadRow): Conversation {
     updatedAtMs:
       msFromDate(row.executionUpdatedAt) ?? requiredMsFromDate(row.updatedAt),
   };
-  const location = locationFromRow(readRow.destination);
+  const location = locationFromRow(
+    row.location,
+    readRow.destination,
+    sessionSource,
+  );
 
   return {
     schemaVersion: 1,
@@ -424,9 +432,7 @@ export class SqlStore implements ConversationStore {
             conversationId: args.childConversationId,
           });
           if (existing) {
-            if (
-              existing.parentConversationId !== args.parentConversationId
-            ) {
+            if (existing.parentConversationId !== args.parentConversationId) {
               throw new Error(
                 `Conversation parent changed for ${args.childConversationId}`,
               );
@@ -578,6 +584,7 @@ export class SqlStore implements ConversationStore {
           ...(existing?.parentConversationId
             ? { parentConversationId: existing.parentConversationId }
             : undefined),
+          ...(existing?.location ? { location: existing.location } : undefined),
           ...(args.channelName ? { channelName: args.channelName } : undefined),
           ...(args.destination ? { destination: args.destination } : undefined),
           ...(args.actor ? { actor: args.actor } : undefined),
@@ -800,6 +807,12 @@ export class SqlStore implements ConversationStore {
       }),
       conversation.updatedAtMs,
     );
+    const location = conversationLocationForWrite({
+      destination: conversation.destination,
+      destinationId,
+      location: conversation.location,
+      sessionSource: conversation.sessionSource,
+    });
     const actorIdentityObservation = actorIdentityForConversation(conversation);
     const actorIdentity = actorIdentityObservation
       ? await upsertIdentity(
@@ -826,6 +839,7 @@ export class SqlStore implements ConversationStore {
         originType: originTypeFromSource(conversation.source) ?? null,
         originId: null,
         originRunId: null,
+        location: location ?? null,
         destinationId: destinationId ?? null,
         destination: null,
         actorIdentityId: actorIdentity?.id ?? null,
@@ -863,6 +877,7 @@ export class SqlStore implements ConversationStore {
           originType: sql`coalesce(excluded.origin_type, ${juniorConversations.originType})`,
           originId: sql`coalesce(excluded.origin_id, ${juniorConversations.originId})`,
           originRunId: sql`coalesce(excluded.origin_run_id, ${juniorConversations.originRunId})`,
+          location: sql`coalesce(excluded.location_json, ${juniorConversations.location})`,
           destinationId: sql`coalesce(excluded.destination_id, ${juniorConversations.destinationId})`,
           actorIdentityId: sql`coalesce(excluded.actor_identity_id, ${juniorConversations.actorIdentityId})`,
           creatorIdentityId: sql`coalesce(excluded.creator_identity_id, ${juniorConversations.creatorIdentityId})`,

--- a/packages/junior/src/chat/conversations/store.ts
+++ b/packages/junior/src/chat/conversations/store.ts
@@ -76,8 +76,8 @@ export interface Conversation {
    * Session-stable (threaded Slack keeps threadTs; channel-level turns omit
    * it; never stores per-message ts). Set-once.
    */
-  // TODO(dcramer): Remove this locator after every stored Conversation has a
-  // complete Location and all readers use Location instead.
+  // TODO(dcramer): Remove sessionSource after resume reads the saved Turn Source
+  // and all Conversation place readers use Location.
   sessionSource?: SessionSource;
   title?: string;
   updatedAtMs: number;

--- a/packages/junior/src/db/schema/conversations.ts
+++ b/packages/junior/src/db/schema/conversations.ts
@@ -12,6 +12,7 @@ import { juniorIdentities } from "./identities";
 import { timestamptz } from "./timestamps";
 import type { Destination } from "@sentry/junior-plugin-api";
 import type { StoredSlackActor } from "@/chat/actor";
+import type { Location } from "@/chat/conversations/location";
 import type { SessionSource } from "@/chat/source";
 import type { AgentTurnUsage } from "@/chat/usage";
 import type {
@@ -26,12 +27,14 @@ export const juniorConversations = pgTable(
     schemaVersion: integer("schema_version").notNull().default(1),
     source: text("source").$type<ConversationSource>(),
     /** Structured session Source locator; set-once on the conversation root. */
-    // TODO(dcramer): Remove source_json after every stored Conversation has a
-    // complete Location and all readers use it for provider context.
+    // TODO(dcramer): Remove source_json after resume reads the saved Turn Source
+    // and all provider context readers use Conversation Location.
     sessionSource: jsonb("source_json").$type<SessionSource>(),
     originType: text("origin_type"),
     originId: text("origin_id"),
     originRunId: text("origin_run_id"),
+    /** Complete Location associated with this Conversation. */
+    location: jsonb("location_json").$type<Location>(),
     // TODO(dcramer): Rename destination_id to location_id after all deployed
     // readers and writers use the singular Conversation Location contract.
     destinationId: text("destination_id").references(

--- a/packages/junior/tests/component/conversation-sql-store.test.ts
+++ b/packages/junior/tests/component/conversation-sql-store.test.ts
@@ -193,11 +193,22 @@ describe("conversation SQL store", () => {
     try {
       const store = createSqlStore(fixture.sql);
       await migrateSchema(fixture.sql);
+      const destination = inboundMessage("activity").destination;
+
+      await store.recordExecution({
+        conversationId: CONVERSATION_ID,
+        createdAtMs: 2_000,
+        destination,
+        execution: { status: "idle", updatedAtMs: 2_000 },
+        lastActivityAtMs: 2_000,
+        metrics: null,
+        updatedAtMs: 2_000,
+      });
 
       await store.recordActivity({
         conversationId: CONVERSATION_ID,
         channelName: "eng-runtime",
-        destination: inboundMessage("activity").destination,
+        destination,
         actor: {
           email: "user@example.com",
           fullName: "Runtime User",

--- a/packages/junior/tests/component/conversation-sql-store.test.ts
+++ b/packages/junior/tests/component/conversation-sql-store.test.ts
@@ -1,10 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { migrateSchema } from "@/chat/conversations/sql/migrations";
 import { createSqlStore } from "@/chat/conversations/sql/store";
-import {
-  upsertIdentity,
-  upsertLinkedIdentity,
-} from "@/chat/identities/sql";
+import { upsertIdentity, upsertLinkedIdentity } from "@/chat/identities/sql";
 import {
   appendInboundMessage,
   drainConversationMailbox,
@@ -237,8 +234,9 @@ describe("conversation SQL store", () => {
           location: {
             id: expect.any(String),
             provider: "slack",
-            tenantId: "T123",
-            providerId: "C123",
+            teamId: "T123",
+            channelId: "C123",
+            threadTs: "1700000000.000100",
           },
           actor: {
             platform: "slack",
@@ -259,6 +257,7 @@ describe("conversation SQL store", () => {
         .select({
           actorIdentityId: juniorConversations.actorIdentityId,
           actorJson: juniorConversations.actor,
+          location: juniorConversations.location,
           destinationId: juniorConversations.destinationId,
           destinationJson: juniorConversations.destination,
           destinationKind: juniorDestinations.kind,
@@ -286,6 +285,13 @@ describe("conversation SQL store", () => {
         {
           actorIdentityId: linkedRows[0]?.actorIdentityId,
           actorJson: null,
+          location: {
+            id: linkedRows[0]?.destinationId,
+            provider: "slack",
+            teamId: "T123",
+            channelId: "C123",
+            threadTs: "1700000000.000100",
+          },
           destinationId: linkedRows[0]?.destinationId,
           destinationJson: null,
           destinationKind: "channel",
@@ -329,8 +335,9 @@ describe("conversation SQL store", () => {
         location: {
           id: expect.any(String),
           provider: "slack",
-          tenantId: "T123",
-          providerId: "C123",
+          teamId: "T123",
+          channelId: "C123",
+          threadTs: "1700000000.000100",
         },
         actor: {
           platform: "slack",

--- a/packages/junior/tests/integration/agent-continue-slack.test.ts
+++ b/packages/junior/tests/integration/agent-continue-slack.test.ts
@@ -264,8 +264,9 @@ describe("paused turn Slack integration", () => {
       ...storedSource,
       location: expect.objectContaining({
         provider: "slack",
-        tenantId: "T123",
-        providerId: "C123",
+        teamId: "T123",
+        channelId: "C123",
+        threadTs: "1712345.0001",
       }),
     });
     expect(resumedRun.delivery?.location).toEqual(resumedRun.source.location);

--- a/packages/junior/tests/integration/agent-invocation-work.test.ts
+++ b/packages/junior/tests/integration/agent-invocation-work.test.ts
@@ -414,8 +414,9 @@ describe("agent invocation conversation work", () => {
           location: {
             id: expect.any(String),
             provider: "slack",
-            tenantId: "T123",
-            providerId: "C123",
+            teamId: "T123",
+            channelId: "C123",
+            threadTs: "1712345.0001",
           },
         },
         surface: "internal",

--- a/packages/junior/tests/integration/api-turn-work.test.ts
+++ b/packages/junior/tests/integration/api-turn-work.test.ts
@@ -635,8 +635,9 @@ describe("Conversation API work", () => {
       destination: slackDestination,
       location: {
         provider: "slack",
-        tenantId: "T1200",
-        providerId: "C1200",
+        teamId: "T1200",
+        channelId: "C1200",
+        threadTs: "1712345.1200",
       },
       visibility: "public",
       sessionSource: {

--- a/packages/junior/tests/integration/api/conversations/list.test.ts
+++ b/packages/junior/tests/integration/api/conversations/list.test.ts
@@ -276,7 +276,7 @@ describe("conversation list API", () => {
       const fixture = createConfiguredJuniorSqlFixture();
       const store = createSqlStore(fixture.sql);
       const conversationId = `slack:C123:${visibility}-visibility`;
-      const channelId = `C-${visibility}`;
+      const channelId = `C${visibility.toUpperCase()}`;
       try {
         await migrateSchema(fixture.sql);
         await store.recordActivity({

--- a/packages/junior/tests/integration/oauth-callback.test.ts
+++ b/packages/junior/tests/integration/oauth-callback.test.ts
@@ -390,8 +390,9 @@ describe("oauth callback integration", () => {
       ...slackSource("1700000000.009"),
       location: expect.objectContaining({
         provider: "slack",
-        providerId: "C123",
-        tenantId: "T123",
+        teamId: "T123",
+        channelId: "C123",
+        threadTs: "1700000000.009",
       }),
     });
     expect(resumeContext.delivery?.location).toEqual(

--- a/packages/junior/tests/unit/services/turn-session-routing.test.ts
+++ b/packages/junior/tests/unit/services/turn-session-routing.test.ts
@@ -118,8 +118,9 @@ describe("resolveConversationRouting", () => {
             location: {
               id: "location-123",
               provider: "slack",
-              tenantId: "T123",
-              providerId: "C123",
+              teamId: "T123",
+              channelId: "C123",
+              threadTs: "1712345.0001",
             },
             sessionSource: SOURCE,
           });
@@ -138,16 +139,18 @@ describe("resolveConversationRouting", () => {
       location: {
         id: "location-123",
         provider: "slack",
-        tenantId: "T123",
-        providerId: "C123",
+        teamId: "T123",
+        channelId: "C123",
+        threadTs: "1712345.0001",
       },
       source: {
         ...SOURCE,
         location: {
           id: "location-123",
           provider: "slack",
-          tenantId: "T123",
-          providerId: "C123",
+          teamId: "T123",
+          channelId: "C123",
+          threadTs: "1712345.0001",
         },
       },
     });


### PR DESCRIPTION
Conversation records now store one complete optional Location in `location_json`. Location keeps a provider-neutral base with `id` and `provider`; Slack extends that base with `teamId`, `channelId`, and optional `threadTs`. Source and Delivery now receive the exact Slack Location instead of the earlier generic tenant and provider id fields.

The migration backfills current Slack Conversations from their linked destination and saved session Source. A marked read fallback covers rows written during deployment until old writers are gone and a post-deploy backfill runs. Junior-only and local Conversations continue to have no Location, and Location still does not grant Delivery.

Refs #1563
