### PR TITLE
ref(chat): keep Location on AgentRun

### DIFF
--- a/TERMINOLOGY.md
+++ b/TERMINOLOGY.md
@@ -16,23 +16,26 @@ Canonical words used across Junior's code and documentation.
 - **Conversation**: the durable container for visible history and execution
   state, identified by a globally unique `conversationId`. A Conversation may
   have one parent Conversation. Parent and Location are independent.
-- **Source**: the current input that caused a Turn, such as a Slack message,
-  local CLI input, dashboard input, scheduled task, or plugin dispatch. Source
-  may include the Conversation's Location so the agent can use that place even
-  when the input came through Junior's API or UI.
+- **Source**: the input that caused work, such as a Slack message, local CLI
+  input, dashboard input, resource event, scheduled task, plugin dispatch, or
+  Agent invocation. Every Inbound message has one Source. A Turn stores the
+  Source selected from the input that started it.
 - **Destination**: an explicit target for output or a side effect. Do not use
-  Destination as another name for a Conversation's Location.
+  Destination as another name for a Conversation's Location. A feature may use
+  Destination before a Conversation exists. If that target becomes the linked
+  place for a new Conversation, store it as the Conversation's Location.
 - **Location**: one place outside Junior where a Conversation can be delivered,
   such as a Slack channel or thread. A Conversation has zero or one Location.
-  Source and Delivery may each contain that Location. Location does not allow
-  output to be sent. Conversation visibility is separate.
-- **Delivery**: an optional ability to send Run output. Delivery may include the
-  Location where it sends output. The Conversation log does not depend on
-  Delivery.
-- **publishExternally**: whether one turn also publishes assistant output to the
-  provider through Delivery. The Conversation log always stores the Turn.
-  Slack surfaces treat missing as publish; non-Slack work treats missing as
-  Conversation-only. Explicit false always means Conversation-only.
+  A Run carries this same Location when the agent or tools need it. Location
+  does not allow output to be sent. Conversation visibility is separate.
+- **Delivery**: an optional function that sends Run output to the Conversation
+  Location. Only Delivery allows output to be sent there. Storing a completed
+  assistant Message in the Conversation does not depend on Delivery.
+- **publish**: whether one Turn also sends assistant output to the Conversation
+  Location through Delivery. The Conversation always stores each completed
+  assistant Message. `publishExternally` is the legacy mailbox, Turn checkpoint,
+  and Run field for this fact until those interfaces use `publish` or Delivery
+  alone.
 - **User**: one person-level record. A user may have several linked identities.
 - **Identity**: one provider account, such as a Slack account in one workspace,
   optionally linked to a user.
@@ -41,7 +44,8 @@ Canonical words used across Junior's code and documentation.
   fields that the agent or tools need. Those fields do not select the runtime.
 - **Resource event**: one normalized change identified by namespace, identifier,
   event type, and an idempotency key. Plugins and core can publish them.
-  Delivery wakes the Conversation; Location stays on that Conversation.
+  A Resource event can wake a Conversation. Location stays on that
+  Conversation.
 - **Resource subscription**: a temporary conversation association that delivers
   matching resource events back into that conversation.
 - **Event task**: a durable instruction that dispatches when a matching
@@ -100,13 +104,13 @@ Canonical words used across Junior's code and documentation.
 
 - Use `provider` on provider-owned references such as Identity and Location; it
   names the namespace that owns their provider ids.
-- Keep the current Source and Actor separate from the Conversation's Location.
-  Source and Delivery may each contain Location when they need it. Do not infer
-  Delivery from Source, Actor, or Location.
+- Keep Source and Actor separate from the Conversation's Location. Pass
+  Location once on the Run. Do not put Location inside Source or Delivery. Do
+  not infer Delivery from Source, Actor, or Location.
 - Use `Location`. Do not create another name for the same place.
-- For new Source unions, use one discriminant for what produced the work. Keep
-  provider-native identifiers inside that provider's Source branch rather than
-  adding a second generic provider or thread field.
+- Use `kind` on Source to state what produced the work. Keep provider
+  identifiers inside that Source kind. Do not use `platform` for this field
+  because many Source kinds are not providers.
 - Use `turn`, `run`, and `slice` only with the meanings above.
 - Use `agent invocation` for delegated child work; do not shorten it to
   `invocation` where it could be confused with a model or serverless

--- a/packages/junior-plugin-api/src/schemas.ts
+++ b/packages/junior-plugin-api/src/schemas.ts
@@ -82,7 +82,6 @@ export const destinationSchema = z.discriminatedUnion("platform", [
 /** Runtime-owned Slack coordinates for the inbound invocation. */
 export const slackSourceSchema = slackAddressSchema
   .extend({
-    location: locationSchema.optional(),
     visibility: sourceVisibilitySchema,
     messageTs: nonBlankStringSchema.optional(),
     threadTs: nonBlankStringSchema.optional(),
@@ -92,7 +91,6 @@ export const slackSourceSchema = slackAddressSchema
 /** Runtime-owned local CLI coordinates for the inbound invocation. */
 export const localSourceSchema = z
   .object({
-    location: locationSchema.optional(),
     platform: z.literal("local"),
     visibility: z.literal("private"),
     conversationId: localConversationIdSchema,
@@ -102,7 +100,6 @@ export const localSourceSchema = z
 /** Runtime-owned dashboard/web coordinates for the inbound invocation. */
 export const webSourceSchema = z
   .object({
-    location: locationSchema.optional(),
     platform: z.literal("web"),
     visibility: sourceVisibilitySchema,
     // Web can continue any existing conversation id, including Slack roots.
@@ -110,12 +107,20 @@ export const webSourceSchema = z
   })
   .strict();
 
-/** Runtime-owned provider-neutral coordinates for the inbound invocation. */
-export const sourceSchema = z.discriminatedUnion("platform", [
-  slackSourceSchema,
-  localSourceSchema,
-  webSourceSchema,
+// TODO(dcramer): Replace Source.platform with Source.kind after every input
+// owner emits a first-class Source kind and deployed readers accept it.
+const sourceWithLegacyLocationSchema = z.discriminatedUnion("platform", [
+  slackSourceSchema.extend({ location: locationSchema.optional() }).strict(),
+  localSourceSchema.extend({ location: locationSchema.optional() }).strict(),
+  webSourceSchema.extend({ location: locationSchema.optional() }).strict(),
 ]);
+
+/** Runtime-owned input Source. Legacy stored Location is accepted and removed. */
+// TODO(dcramer): Parse sourceSchema directly from the three Source schemas after
+// no stored SQL, Redis, queue, or public Source can contain Location.
+export const sourceSchema = sourceWithLegacyLocationSchema.transform(
+  ({ location: _legacyLocation, ...source }) => source,
+);
 
 /** Stable user credential subject shape accepted from plugins. */
 export const pluginCredentialSubjectSchema = z.discriminatedUnion(

--- a/packages/junior/src/chat/README.md
+++ b/packages/junior/src/chat/README.md
@@ -83,18 +83,76 @@ singleton.
 - **Reply**: one destination-visible assistant message owned by delivery code.
 - **Actor**: human or system principal associated with current work.
 - **Credential subject**: principal whose provider authority may be used.
-- **Source**: the current input that caused a Turn. Source may include the
-  Conversation's Location so the agent can use it for API and UI input too.
+- **Source**: the input that caused work. Every Inbound message has one Source.
+  A Turn stores the Source selected from the input that started it.
 - **Location**: one place outside Junior where a Conversation can be delivered.
-  A Conversation has zero or one Location. Source and Delivery may each contain
-  that Location.
-- **Delivery**: optional ability to send Run output. Delivery may include the
-  Location where it sends output.
+  A Conversation has zero or one Location. A Run carries that same Location
+  when the agent or tools need it.
+- **Delivery**: optional function created for a Location that sends Run output
+  there.
 - **Destination**: explicit target for output or a side effect. Current uses as
-  a Conversation Location are migration debt.
-- **publishExternally**: per-turn side effect. When true, also publish assistant
-  output through Delivery. The Conversation log always stores the Turn. Missing
-  or false means Conversation-only.
+  a Conversation Location are migration debt. A feature may use Destination
+  before it creates a Conversation at that target.
+- **publish**: Turn fact that says whether assistant output is also sent to the
+  Conversation Location through Delivery. The Conversation always stores each
+  completed assistant Message. `publishExternally` is the legacy field for this
+  fact.
+
+## Target Interface
+
+These types show the relevant fields. Source kinds keep the data that identifies
+their input. A provider Source may keep provider message identifiers. It does
+not contain the Conversation Location.
+
+```ts
+type Source =
+  | SlackSource
+  | WebSource
+  | LocalSource
+  | ResourceEventSource
+  | ScheduledTaskSource
+  | EventTaskSource
+  | PluginDispatchSource
+  | AgentInvocationSource;
+
+type Conversation = {
+  conversationId: string;
+  parentConversationId?: string;
+  location?: Location;
+  visibility?: ConversationPrivacy;
+};
+
+type InboundMessage = {
+  source: Source;
+  actor?: Actor;
+  input: AgentInput;
+  publish: boolean;
+};
+
+type Turn = {
+  turnId: string;
+  source: Source;
+  actor?: Actor;
+  publish: boolean;
+};
+
+type Delivery = (message: AssistantMessage) => void | Promise<void>;
+
+type AgentRun = {
+  conversationId: string;
+  turnId: string;
+  source: Source;
+  actor?: Actor;
+  location?: Location;
+  delivery?: Delivery;
+};
+```
+
+`Source.kind` states what produced the input. The worker copies Source and
+publish from the selected input to the Turn. It loads Location from the
+Conversation. Before every new or resumed Run, the provider supplies Delivery
+when the Turn publishes. A feature may use Destination to select a target before
+it creates a Conversation. That target becomes the new Conversation Location.
 
 Attribution does not grant authority. `run.actors` records participating actors;
 credential issuance still requires the current actor or an explicit delegated
@@ -141,25 +199,24 @@ delegation without becoming the execution actor or a general task owner.
   after delivery plus steering may still park so steered work can continue.
 - Unexpected failures propagate to the boundary that owns capture and fallback
   delivery.
-- Source and Actor describe the current Turn. Location names an optional place
-  outside Junior. Source and Delivery may each contain Location, but Location
-  does not select another runtime or allow output to be sent.
-- The final Run interface has Source and optional Delivery. It has no separate
-  Location field. Source carries the Conversation Location when the current
-  input needs it, including API or UI input. Delivery carries the Location where
-  it can send output. A dashboard continuation may therefore keep a Slack
-  Location in Source without getting Slack Delivery.
+- Source and Actor describe the current Turn. Location names the Conversation's
+  optional place outside Junior. Delivery sends output there. These facts stay
+  separate.
+- The final Run interface has Source, optional Location, and optional Delivery.
+  Source does not contain Location. Delivery is created for the Location and
+  does not repeat it. A dashboard continuation may therefore carry a Slack
+  Location without getting Slack Delivery.
 - The final interface uses Conversation, Source, Location, and Delivery. Do not
   add another type, routing object, or wrapper for the same values.
 - A Conversation may have one parent Conversation. It stores that relation as
   `parentConversationId`. Location is independent and is not copied from the
   parent. A Run may read the parent Conversation when it needs that Location.
-- External publish is controlled per turn via `publishExternally`. Slack
-  ingress/resume publish unless the flag is explicitly false. Non-Slack,
-  destinationless, and dashboard/web work stay conversation-only unless the
-  flag is true. This flag remains at provider, mailbox, and resume boundaries
-  while they need it to restore Delivery. Destination or Location presence
-  must not invent publish.
+- Each Turn stores `publish`. The worker gets Source from the selected input and
+  Location from the Conversation. Before every new or resumed Run, the owning
+  provider supplies Delivery only when the Turn publishes. Source, Actor,
+  Destination, and Location do not invent Delivery. The legacy
+  `publishExternally` field remains only until mailbox and Turn checkpoint data
+  use the final fact.
 - Host-owned runtime context and the actor's current instruction are separate
   user messages. The context message immediately precedes the instruction,
   remains context-authority on resume, and may be replaced before a later model

--- a/packages/junior/src/chat/agent-invocations/README.md
+++ b/packages/junior/src/chat/agent-invocations/README.md
@@ -51,7 +51,8 @@ It uses the same Conversation type as all other work. It does not copy the
 parent Conversation's Location or receive Delivery. Its Run reads the parent
 Conversation's Location when tools need it. Output stays inside Junior. Agent
 invocation fields still carry the Actor, credentials, Source, and Destination
-until the final Run interface removes these older fields.
+until the final Run interface removes Destination. The final Run carries the
+parent Location once, separate from Source and Delivery.
 
 ## Current Boundary
 

--- a/packages/junior/src/chat/agent-invocations/work.ts
+++ b/packages/junior/src/chat/agent-invocations/work.ts
@@ -397,9 +397,6 @@ export function createAgentInvocationWorker(agentRunner: AgentRunner) {
       ]);
       sandboxRef = getPersistedSandboxState(persisted);
       history = projection.messages;
-      // TODO(dcramer): Remove this parent Location lookup and use
-      // invocation.source after no runnable Agent invocation from before the
-      // Source Location cutover remains.
       location = (
         await getConversationStore().get({
           conversationId: invocation.parentConversationId,
@@ -441,9 +438,8 @@ export function createAgentInvocationWorker(agentRunner: AgentRunner) {
           credentialContext: invocation.credentialContext,
           destination: invocation.destination,
           publishExternally: context.publishExternally,
-          source: location
-            ? { ...invocation.source, location }
-            : invocation.source,
+          source: invocation.source,
+          ...(location ? { location } : undefined),
           surface: "internal",
           // TODO(dcramer): Issues #881 and #883 track a path for child runs to
           // force interactive auth when a delegated tool requires credentials

--- a/packages/junior/src/chat/agent/index.ts
+++ b/packages/junior/src/chat/agent/index.ts
@@ -233,9 +233,10 @@ export async function executeAgentRun(
         ? run.conversationId
         : run.source.conversationId,
     destinationName:
-      run.destination.platform === "slack"
-        ? run.destination.channelId
-        : run.destination.conversationId,
+      run.location?.channelId ??
+      (run.source.platform === "slack"
+        ? run.source.channelId
+        : run.source.conversationId),
     userId: userActor?.userId,
     userName: userActor?.userName,
     userEmail: userActor?.email,
@@ -391,8 +392,7 @@ async function executeAgentRunInPrivacyContext(
   const surface = surfaceFromRun(run);
   const runSource = routing.source;
   const slackSource = runSource.platform === "slack" ? runSource : undefined;
-  const slackDestination =
-    routing.destination.platform === "slack" ? routing.destination : undefined;
+  const slackChannelId = run.location?.channelId ?? slackSource?.channelId;
   const slackActor = actor?.platform === "slack" ? actor : undefined;
   const userInput = input.messageText;
   const credentialUserId = run.credentialContext
@@ -624,7 +624,7 @@ async function executeAgentRunInPrivacyContext(
         conversationContext: input.conversationContext,
         context: {
           threadId: conversationId,
-          channelId: slackDestination?.channelId,
+          channelId: slackChannelId,
           actorId: slackActor?.userId,
           runId,
         },
@@ -775,7 +775,7 @@ async function executeAgentRunInPrivacyContext(
           target,
           metadata: {
             threadId: conversationId,
-            channelId: slackDestination?.channelId,
+            channelId: slackChannelId,
             actorId: slackActor?.userId,
             runId,
           },
@@ -1025,7 +1025,7 @@ async function executeAgentRunInPrivacyContext(
           conversationId,
           metadata: {
             threadId: conversationId,
-            channelId: slackDestination?.channelId,
+            channelId: slackChannelId,
             actorId: slackActor?.userId,
             runId,
           },
@@ -1087,7 +1087,7 @@ async function executeAgentRunInPrivacyContext(
         return;
       }
       try {
-        await delivery.send(message);
+        await delivery(message);
         acceptedToolFreeAssistant = true;
       } catch (error) {
         assistantMessageDeliveryError = new AssistantMessageDeliveryError(

--- a/packages/junior/src/chat/agent/tools.ts
+++ b/packages/junior/src/chat/agent/tools.ts
@@ -325,9 +325,7 @@ export async function wireAgentTools(
   );
   const commonToolRuntimeContext = {
     conversationId: args.run.conversationId,
-    ...(args.run.source.location
-      ? { locationId: args.run.source.location.id }
-      : undefined),
+    ...(args.run.location ? { locationId: args.run.location.id } : undefined),
     userText: args.userInput,
     configuration: args.configurationValues,
     egress: createPluginEgress({

--- a/packages/junior/src/chat/agent/types.ts
+++ b/packages/junior/src/chat/agent/types.ts
@@ -126,13 +126,12 @@ export type AgentRunState = {
  *
  * The runner must commit the preceding agent boundary before invoking this
  * port; the accepted reply transaction appends only this message.
+ *
+ * TODO(dcramer): Remove Conversation Message persistence from Delivery
+ * implementations after the core Turn lifecycle stores each completed
+ * assistant Message.
  */
-export type Delivery = {
-  /** Location where this capability can send output, when outside Junior. */
-  location?: Location;
-  /** Send one accepted assistant message. */
-  send(message: AssistantMessage): void | Promise<void>;
-};
+export type Delivery = (message: AssistantMessage) => void | Promise<void>;
 
 /** Resume the agent turn after a transient or ambiguous delivery failure. */
 export class RetryableDeliveryError extends Error {
@@ -214,11 +213,13 @@ export type AgentRun = {
   /** Credential authority projected from actor (plus optional subject). */
   credentialContext?: CredentialContext;
   source: Source;
+  /** Conversation Location available to this Run. */
+  location?: Location;
   // TODO(dcramer): Remove AgentRun.destination after tool side effects use
-  // feature-owned targets and place context comes from Source or Delivery.
+  // feature-owned targets and place context comes from Location.
   destination: Destination;
-  // TODO(dcramer): Remove AgentRun.publishExternally after each provider builds
-  // the correct Delivery before every new or resumed Run.
+  // TODO(dcramer): Remove AgentRun.publishExternally after Turn checkpoints
+  // store publish and each provider uses it to supply Delivery before every Run.
   publishExternally?: boolean;
   surface?: AgentTurnSurface;
   dispatch?: AgentDispatch;
@@ -288,17 +289,14 @@ export function assertRunConsistency(
     AgentRun,
     | "conversationId"
     | "source"
+    | "location"
     | "destination"
     | "surface"
-    | "publishExternally"
     | "actor"
     | "dispatch"
   >,
 ): void {
   const { destination, source } = run;
-  // Source records what produced the work. Destination is the conversation's
-  // reply container and may already be Slack when a dashboard turn continues a
-  // Slack-rooted conversation without publishing externally.
   switch (source.platform) {
     case "slack": {
       if (destination.platform !== "slack") {
@@ -356,16 +354,8 @@ export function assertRunConsistency(
           }
           break;
         }
-        case "slack": {
-          // Dashboard continues keep the Slack destination for location/context
-          // but must stay conversation-log only.
-          if (run.publishExternally) {
-            throw new TypeError(
-              "Web turns on Slack destinations must not publish externally",
-            );
-          }
+        case "slack":
           break;
-        }
       }
       break;
     }
@@ -375,32 +365,17 @@ export function assertRunConsistency(
   if (!actor || actor.platform === "system") {
     return;
   }
-  const actorMatchesDestination = (() => {
-    switch (actor.platform) {
-      case "slack":
-        return destination.platform === "slack";
-      case "local":
-        return destination.platform === "local";
-      case "web":
-        // Web actors may write on local roots or continue Slack-rooted
-        // conversations without publishing externally.
-        return (
-          destination.platform === "local" ||
-          (destination.platform === "slack" && run.publishExternally !== true)
-        );
-    }
-  })();
-  if (!actorMatchesDestination) {
+  if (actor.platform !== source.platform) {
     throw new TypeError(
-      `Actor platform "${actor.platform}" does not match destination platform "${destination.platform}"`,
+      `Actor platform "${actor.platform}" does not match Source platform "${source.platform}"`,
     );
   }
   if (
     actor.platform === "slack" &&
-    destination.platform === "slack" &&
-    actor.teamId !== destination.teamId
+    source.platform === "slack" &&
+    actor.teamId !== source.teamId
   ) {
-    throw new TypeError("Slack actor team does not match destination team");
+    throw new TypeError("Slack Actor team does not match Source team");
   }
 }
 

--- a/packages/junior/src/chat/api-turns/work.ts
+++ b/packages/junior/src/chat/api-turns/work.ts
@@ -700,9 +700,10 @@ export function createApiTurnWorker(
               credentialContext: credentialContextForActor(actor),
               destination,
               publishExternally: false,
-              source: storedConversation?.location
-                ? { ...source, location: storedConversation.location }
-                : source,
+              source,
+              ...(storedConversation?.location
+                ? { location: storedConversation.location }
+                : undefined),
               surface: "api",
               ...(cancellationSignal
                 ? { signal: cancellationSignal }
@@ -719,7 +720,7 @@ export function createApiTurnWorker(
                 pendingAuth: conversation.processing.pendingAuth,
                 sandboxRef,
               },
-              delivery: { send: deliverAssistantMessage },
+              delivery: deliverAssistantMessage,
               durability: {
                 onInputCommitted: acknowledge,
                 shouldYield: context.shouldYield,

--- a/packages/junior/src/chat/conversations/README.md
+++ b/packages/junior/src/chat/conversations/README.md
@@ -10,6 +10,10 @@ outside Junior where a provider can deliver the Conversation. For Slack, a
 complete Location identifies the workspace, channel, and thread. Conversation
 privacy remains in `Conversation.visibility`.
 
+A Run carries the Conversation Location when the agent or tools need it.
+Source describes the input and does not contain Location. Delivery is created
+for the Location and does not repeat it.
+
 The Conversation row stores the complete Location in `location_json`. Local
 Conversations have no Location.
 

--- a/packages/junior/src/chat/conversations/store.ts
+++ b/packages/junior/src/chat/conversations/store.ts
@@ -35,9 +35,9 @@ export interface ConversationExecution {
  *
  * The final interface stores zero or one complete Location here. No Location
  * means the Conversation stays in Junior's API and UI. A Location names the
- * outside place where a provider can deliver the Conversation. Source may also
- * contain this Location so the agent can use it. Delivery contains it when
- * output may be sent there. Only Delivery allows output to be sent.
+ * outside place where a provider can deliver the Conversation. A Run carries
+ * this Location when the agent or tools need it. Source stays about the input.
+ * Delivery is created for the Location and allows output to be sent there.
  *
  * `destination` and `sessionSource` temporarily duplicate parts of that model.
  * Their field TODOs state when each legacy copy can be removed.

--- a/packages/junior/src/chat/local/runner.ts
+++ b/packages/junior/src/chat/local/runner.ts
@@ -357,7 +357,7 @@ async function runLocalAgentTurnInContext(
             await deps.onToolResult?.(event.report);
           }
         },
-        delivery: { send: deliverAssistantMessage },
+        delivery: deliverAssistantMessage,
         durability: {
           onSandboxRefChanged: async (nextSandboxRef) => {
             sandboxRef = nextSandboxRef;

--- a/packages/junior/src/chat/providers/slack/resume.ts
+++ b/packages/junior/src/chat/providers/slack/resume.ts
@@ -565,6 +565,8 @@ async function resumeSlackTurnInContext(
       const deliveryState = await getDeliveryConversation();
       let slackMessageTs: string[] = [];
       try {
+        // TODO(dcramer): Remove this missing-as-publish fallback after no stored
+        // Turn checkpoint can omit publishExternally.
         if (runArgs.run?.publishExternally !== false) {
           slackMessageTs = await sendSlackReply({
             channelId: runArgs.channelId,
@@ -657,13 +659,7 @@ async function resumeSlackTurnInContext(
       deliveryState.conversation,
       sessionId,
     );
-    const run = buildResumedRun(runArgs, status, {
-      ...(runArgs.run?.publishExternally !== false &&
-      runArgs.run?.source.location
-        ? { location: runArgs.run.source.location }
-        : undefined),
-      send: deliverAssistantMessage,
-    });
+    const run = buildResumedRun(runArgs, status, deliverAssistantMessage);
     if (runArgs.inputMessageIds?.length) {
       await turnLifecycle.start({
         conversationId: runArgs.conversationId,

--- a/packages/junior/src/chat/providers/slack/turn.ts
+++ b/packages/junior/src/chat/providers/slack/turn.ts
@@ -1112,7 +1112,8 @@ export function createSlackTurn(deps: SlackTurnDeps) {
             // carry the system principal; interactive turns carry the Slack user.
             actor: executionActor,
             slackConversation,
-            source: location ? { ...source, location } : source,
+            source,
+            ...(location ? { location } : undefined),
             destination,
             publishExternally: shouldPublishExternally(
               options.publishExternally,
@@ -1147,12 +1148,7 @@ export function createSlackTurn(deps: SlackTurnDeps) {
                 });
               }
             },
-            delivery: {
-              ...(location && shouldPublishExternally(options.publishExternally)
-                ? { location }
-                : undefined),
-              send: deliverAssistantMessage,
-            },
+            delivery: deliverAssistantMessage,
             durability: {
               onInputCommitted: options.ack,
               drainSteeringMessages,

--- a/packages/junior/src/chat/services/turn-session-routing.ts
+++ b/packages/junior/src/chat/services/turn-session-routing.ts
@@ -10,15 +10,16 @@ import type {
   SlackDestination,
   Source,
 } from "@sentry/junior-plugin-api";
-import type { Location } from "@/chat/conversations/location";
 import type {
   Conversation,
   ConversationStore,
 } from "@/chat/conversations/store";
+import type { Location } from "@/chat/conversations/location";
 import type { SessionSource } from "@/chat/source";
 
-// TODO(dcramer): Remove TurnSessionRouting and this module after callers read
-// Source, Conversation Location, and provider Delivery from their owners.
+// TODO(dcramer): Remove TurnSessionRouting and this module after every resume
+// reads Source from its Turn and Location from its Conversation, and no caller
+// uses Destination as the Conversation place.
 export interface TurnSessionRouting {
   destination: Destination;
   location?: Location;
@@ -79,7 +80,7 @@ function slackSourceForDestination(args: {
 }
 
 /**
- * Resolve the Conversation's Location, Destination, and session Source.
+ * Resolve the Conversation Location, Destination, and session Source.
  *
  * Reads parent Conversations when this Conversation has no Destination.
  */
@@ -97,7 +98,7 @@ export async function resolveConversationRouting(args: {
 
   let destination: Destination | undefined;
   let source: SessionSource | undefined;
-  let location: Location | undefined;
+  let location: Conversation["location"];
 
   for (const conversation of chain) {
     destination ??= conversation.destination;
@@ -117,20 +118,14 @@ export async function resolveConversationRouting(args: {
     return {
       destination,
       ...(location ? { location } : undefined),
-      ...(slackSource
-        ? {
-            source: location ? { ...slackSource, location } : slackSource,
-          }
-        : undefined),
+      ...(slackSource ? { source: slackSource } : undefined),
     };
   }
 
   return {
     destination,
     ...(location ? { location } : undefined),
-    ...(source
-      ? { source: location ? { ...source, location } : source }
-      : undefined),
+    ...(source ? { source } : undefined),
   };
 }
 
@@ -147,7 +142,7 @@ export async function resolveTurnSessionRouting(args: {
   }
   return {
     destination: routing.destination,
-    source: routing.source,
     ...(routing.location ? { location: routing.location } : undefined),
+    source: routing.source,
   };
 }

--- a/packages/junior/src/chat/task-execution/README.md
+++ b/packages/junior/src/chat/task-execution/README.md
@@ -38,26 +38,27 @@ Runtime and Redis status is `paused`. SQL free-text / enum rows may still say
 
 ## State Model
 
-- A conversation mailbox contains pending work. Each item has an `interrupt`
-  or `defer` mailbox delivery and a `publishExternally` flag. The worker keeps
-  different publish choices in separate turns.
+- A Conversation mailbox contains pending work. Each item has a Source, an
+  `interrupt` or `defer` mailbox delivery, and the legacy
+  `publishExternally` field. The worker keeps different publish choices in
+  separate Turns and saves the selected choice as the Turn's `publish` fact.
 - A queue message identifies the conversation to wake. The stored work controls
   delivery. A provider conversation stores its destination. Child work without
   a destination gets its authority from its stored agent invocation.
-- `publishExternally` means the turn also publishes assistant output to the
-  conversation destination. The conversation log always stores the turn.
-  Dashboard and destinationless work leave the flag false. Slack ingress and
-  Slack resume default to publish when the flag is unset. Destination presence
-  must not invent publish.
+- `publish` means the Turn also sends assistant output to the Conversation
+  Location. The Conversation always stores each completed assistant Message.
+  Dashboard and destinationless work do not publish. A resource event can
+  publish to a Slack Location without becoming a Slack Source. Destination or
+  Location presence must not invent publish.
 - A lease grants one worker temporary execution ownership.
 - Dispatch projection updates take a short dispatch lock only while the
   conversation lease is already held. They never wait for conversation work,
   which keeps lock ordering one-way.
 - Check-ins extend active ownership and allow heartbeat recovery to distinguish
   slow work from abandoned work.
-- Delivery state prevents a completed turn from being posted twice. The turn
-  checkpoint keeps `publishExternally` across pause and yield; worker execution
-  state does not duplicate it.
+- Delivery state prevents a completed Turn from being posted twice. The Turn
+  checkpoint keeps the publish choice across pause and yield. Its stored field
+  remains `publishExternally` until the durable data contract is migrated.
 
 Redis execution state uses the new v2 keys. This release does not read or move
 old Redis state. Old mailbox, lease, and turn-cursor state can be lost.

--- a/packages/junior/src/chat/task-execution/paused-turn.ts
+++ b/packages/junior/src/chat/task-execution/paused-turn.ts
@@ -530,8 +530,11 @@ async function runPausedTurnInContext(
             credentialContext,
             destination: routingDestination,
             ...(dispatch ? { dispatch } : undefined),
+            ...(routing.location ? { location: routing.location } : undefined),
             // Slack resume publishes unless the checkpoint opted out.
             // Missing means legacy/in-flight Slack turns still post.
+            // TODO(dcramer): Remove this missing-as-publish fallback after no
+            // stored Turn checkpoint can omit publishExternally.
             publishExternally: activeTurn.publishExternally !== false,
             source,
             ...(surface ? { surface } : undefined),

--- a/packages/junior/src/handlers/mcp-oauth-callback.ts
+++ b/packages/junior/src/handlers/mcp-oauth-callback.ts
@@ -409,6 +409,7 @@ async function resumeAuthorizedMcpTurn(args: {
           },
           actor,
           destination,
+          ...(routing.location ? { location: routing.location } : undefined),
           source: routing.source,
           toolChannelId: authSession.toolChannelId ?? authSession.channelId,
           environment: {

--- a/packages/junior/src/handlers/oauth-callback.ts
+++ b/packages/junior/src/handlers/oauth-callback.ts
@@ -441,6 +441,7 @@ async function resumeOAuthSessionRecordTurn(
           },
           actor,
           destination,
+          ...(routing.location ? { location: routing.location } : undefined),
           source: routing.source,
           toolChannelId: stored.channelId!,
           environment: {

--- a/packages/junior/tests/component/plugins/plugin-tasks.test.ts
+++ b/packages/junior/tests/component/plugins/plugin-tasks.test.ts
@@ -474,6 +474,7 @@ describe("plugin background tasks", () => {
     );
     await processPluginTask(queue.queuedMessages()[0]!);
 
+    expect(loadedRuns[0]!.locationId).toEqual(expect.any(String));
     const transcript = loadedRuns[0]!.transcript;
     expect(transcript).toContainEqual({
       type: "message",

--- a/packages/junior/tests/component/runtime/agent-run-error-path.test.ts
+++ b/packages/junior/tests/component/runtime/agent-run-error-path.test.ts
@@ -141,7 +141,7 @@ describe("executeAgentRun error path", () => {
     ).rejects.toThrow("Assistant reply generation requires a destination");
   });
 
-  it("hard-fails actor and destination platform mismatches", async () => {
+  it("hard-fails Actor and Source platform mismatches", async () => {
     await expect(
       executeAgentRun({
         conversationId: LOCAL_DESTINATION.conversationId,
@@ -156,7 +156,7 @@ describe("executeAgentRun error path", () => {
         },
       }),
     ).rejects.toThrow(
-      'Actor platform "slack" does not match destination platform "local"',
+      'Actor platform "slack" does not match Source platform "local"',
     );
   });
 

--- a/packages/junior/tests/component/runtime/agent-run-model-handoff.test.ts
+++ b/packages/junior/tests/component/runtime/agent-run-model-handoff.test.ts
@@ -655,7 +655,7 @@ describe("model handoff composition", () => {
       instruction: { text: "Check the details." },
       destination: { platform: "local", conversationId },
       source: createLocalSource(conversationId),
-      delivery: { send: (message) => void delivered.push(message) },
+      delivery: (message) => void delivered.push(message),
     });
 
     expect(outcome.status).toBe("completed");
@@ -679,10 +679,8 @@ describe("model handoff composition", () => {
         instruction: { text: "Check the details." },
         destination: { platform: "local", conversationId },
         source: createLocalSource(conversationId),
-        delivery: {
-          send: () => {
-            throw deliveryError;
-          },
+        delivery: () => {
+          throw deliveryError;
         },
         onEvent: async (event) => {
           if (event.type === "status") {
@@ -710,15 +708,13 @@ describe("model handoff composition", () => {
       instruction: { text: "Check the details." },
       destination: { platform: "local" as const, conversationId },
       source: createLocalSource(conversationId),
-      delivery: {
-        send: (message) => {
-          deliveryAttempts += 1;
-          if (deliveryAttempts === 1) {
-            throw new RetryableDeliveryError(new Error("Slack unavailable"));
-          }
-          const text = getAssistantReplyText(message);
-          if (text) delivered.push({ text });
-        },
+      delivery: (message) => {
+        deliveryAttempts += 1;
+        if (deliveryAttempts === 1) {
+          throw new RetryableDeliveryError(new Error("Slack unavailable"));
+        }
+        const text = getAssistantReplyText(message);
+        if (text) delivered.push({ text });
       },
     };
 

--- a/packages/junior/tests/component/runtime/agent-run-provider-retry.test.ts
+++ b/packages/junior/tests/component/runtime/agent-run-provider-retry.test.ts
@@ -969,10 +969,8 @@ describe("agent run continuation", () => {
       destination: TEST_DESTINATION,
       source: TEST_SOURCE,
       actor: { platform: "slack", teamId: "T123", userId: "U123" },
-      delivery: {
-        send(message) {
-          delivered.push({ text: extractAssistantText(message) });
-        },
+      delivery(message) {
+        delivered.push({ text: extractAssistantText(message) });
       },
       durability: {
         drainSteeringMessages: async (inject) => {
@@ -1009,10 +1007,8 @@ describe("agent run continuation", () => {
       destination: TEST_DESTINATION,
       source: TEST_SOURCE,
       actor: { platform: "slack", teamId: "T123", userId: "U123" },
-      delivery: {
-        send(message) {
-          delivered.push({ text: extractAssistantText(message) });
-        },
+      delivery(message) {
+        delivered.push({ text: extractAssistantText(message) });
       },
       durability: { shouldYield: () => true },
     });
@@ -1034,10 +1030,8 @@ describe("agent run continuation", () => {
       destination: TEST_DESTINATION,
       source: TEST_SOURCE,
       actor: { platform: "slack", teamId: "T123", userId: "U123" },
-      delivery: {
-        send(message) {
-          delivered.push({ text: extractAssistantText(message) });
-        },
+      delivery(message) {
+        delivered.push({ text: extractAssistantText(message) });
       },
       durability: {
         drainSteeringMessages: async (inject) => {
@@ -1197,10 +1191,8 @@ describe("agent run continuation", () => {
         destination: TEST_DESTINATION,
         source: TEST_SOURCE,
         actor: { platform: "slack", teamId: "T123", userId: "U123" },
-        delivery: {
-          send(message) {
-            delivered.push({ text: extractAssistantText(message) });
-          },
+        delivery(message) {
+          delivered.push({ text: extractAssistantText(message) });
         },
       }),
     );

--- a/packages/junior/tests/fixtures/agent-runner.ts
+++ b/packages/junior/tests/fixtures/agent-runner.ts
@@ -87,7 +87,7 @@ export async function deliverAssistantMessagesForTest(
       );
     }
     history.push(message);
-    await run.delivery.send(message);
+    await run.delivery(message);
   }
   return history;
 }

--- a/packages/junior/tests/integration/agent-continue-slack.test.ts
+++ b/packages/junior/tests/integration/agent-continue-slack.test.ts
@@ -254,22 +254,19 @@ describe("paused turn Slack integration", () => {
         userId: "U123",
       },
       destination: SLACK_DESTINATION,
+      location: {
+        provider: "slack",
+        teamId: "T123",
+        channelId: "C123",
+        threadTs: "1712345.0001",
+      },
       publishExternally: true,
+      source: storedSource,
       toolChannelId: "C123",
       state: expect.objectContaining({
         sandboxRef: undefined,
       }),
     });
-    expect(resumedRun.source).toEqual({
-      ...storedSource,
-      location: expect.objectContaining({
-        provider: "slack",
-        teamId: "T123",
-        channelId: "C123",
-        threadTs: "1712345.0001",
-      }),
-    });
-    expect(resumedRun.delivery?.location).toEqual(resumedRun.source.location);
     const resumeContext = resumedRun as {
       deadlineAtMs?: number;
       environment?: {

--- a/packages/junior/tests/integration/agent-invocation-work.test.ts
+++ b/packages/junior/tests/integration/agent-invocation-work.test.ts
@@ -415,17 +415,15 @@ describe("agent invocation conversation work", () => {
         reasoning: "medium",
         actor: slackInvocationInput.actor,
         destination: slackDestination,
-        publishExternally: false,
-        source: {
-          ...slackInvocationInput.source,
-          location: {
-            id: expect.any(String),
-            provider: "slack",
-            teamId: "T123",
-            channelId: "C123",
-            threadTs: "1712345.0001",
-          },
+        location: {
+          id: expect.any(String),
+          provider: "slack",
+          teamId: "T123",
+          channelId: "C123",
+          threadTs: "1712345.0001",
         },
+        publishExternally: false,
+        source: slackInvocationInput.source,
         surface: "internal",
         runId: created.invocationId,
       });

--- a/packages/junior/tests/integration/api-turn-work.test.ts
+++ b/packages/junior/tests/integration/api-turn-work.test.ts
@@ -690,14 +690,11 @@ describe("Conversation API work", () => {
     expect(agentRuns[0]).toEqual(
       expect.objectContaining({
         destination: expect.objectContaining({ platform: "slack" }),
+        location: storedConversation?.location,
         publishExternally: false,
-        source: expect.objectContaining({
-          location: storedConversation?.location,
-          platform: "web",
-        }),
+        source: expect.objectContaining({ platform: "web" }),
       }),
     );
-    expect(agentRuns[0]?.delivery?.location).toBeUndefined();
 
     const messages = (
       await getConversationEventStore().loadMessageHistory(conversationId)

--- a/packages/junior/tests/integration/mcp-oauth-callback.test.ts
+++ b/packages/junior/tests/integration/mcp-oauth-callback.test.ts
@@ -509,7 +509,12 @@ describe("mcp oauth callback integration", () => {
           userId: "U123",
         },
         destination: SLACK_DESTINATION,
-        source: expect.objectContaining(storedSource),
+        location: expect.objectContaining({
+          provider: "slack",
+          teamId: "T123",
+          channelId: "C123",
+        }),
+        source: storedSource,
         toolChannelId: "C123",
         state: expect.objectContaining({}),
       }),
@@ -729,7 +734,7 @@ describe("mcp oauth callback integration", () => {
       }),
     );
     const resumeContext = agentRuns[0]!;
-    expect(resumeContext.source).toMatchObject(slackSource("1700000000.005"));
+    expect(resumeContext.source).toEqual(slackSource("1700000000.005"));
     expect(resumeContext.instruction.context).not.toContain(
       "Old MCP context that should not be used.",
     );

--- a/packages/junior/tests/integration/oauth-callback.test.ts
+++ b/packages/junior/tests/integration/oauth-callback.test.ts
@@ -382,22 +382,18 @@ describe("oauth callback integration", () => {
           userId: "U123",
         },
         destination: SLACK_DESTINATION,
+        location: expect.objectContaining({
+          provider: "slack",
+          teamId: "T123",
+          channelId: "C123",
+          threadTs: "1700000000.009",
+        }),
+        source: storedSource,
         toolChannelId: "C123",
       }),
     );
     const resumeContext = agentRuns[0]!;
-    expect(resumeContext.source).toEqual({
-      ...slackSource("1700000000.009"),
-      location: expect.objectContaining({
-        provider: "slack",
-        teamId: "T123",
-        channelId: "C123",
-        threadTs: "1700000000.009",
-      }),
-    });
-    expect(resumeContext.delivery?.location).toEqual(
-      resumeContext.source.location,
-    );
+    expect(resumeContext.source).toEqual(slackSource("1700000000.009"));
     expect(resumeContext.instruction.context).not.toContain(
       "list my sentry issues",
     );

--- a/packages/junior/tests/unit/agent-request.test.ts
+++ b/packages/junior/tests/unit/agent-request.test.ts
@@ -2,17 +2,25 @@ import { describe, expect, it } from "vitest";
 import { createLocalSource, createWebSource } from "@sentry/junior-plugin-api";
 import { assertRunConsistency } from "@/chat/agent/types";
 
+const SLACK_LOCATION = {
+  id: "location-123",
+  provider: "slack" as const,
+  teamId: "T123",
+  channelId: "C123",
+  threadTs: "1712345.0001",
+};
+
 describe("agent run routing", () => {
   it("allows an internal child run to borrow its parent's local route", () => {
     expect(() =>
       assertRunConsistency({
         conversationId: "local:test:child",
         destination: {
-            conversationId: "local:test:parent",
-            platform: "local",
-          },
-          source: createLocalSource("local:test:parent"),
-          surface: "internal"
+          conversationId: "local:test:parent",
+          platform: "local",
+        },
+        source: createLocalSource("local:test:parent"),
+        surface: "internal",
       }),
     ).not.toThrow();
   });
@@ -22,11 +30,11 @@ describe("agent run routing", () => {
       assertRunConsistency({
         conversationId: "local:test:child",
         destination: {
-            conversationId: "local:web:parent",
-            platform: "local",
-          },
-          source: createWebSource("local:web:parent"),
-          surface: "internal"
+          conversationId: "local:web:parent",
+          platform: "local",
+        },
+        source: createWebSource("local:web:parent"),
+        surface: "internal",
       }),
     ).not.toThrow();
   });
@@ -36,10 +44,10 @@ describe("agent run routing", () => {
       assertRunConsistency({
         conversationId: "local:test:child",
         destination: {
-            conversationId: "local:test:parent",
-            platform: "local",
-          },
-          source: createLocalSource("local:test:parent")
+          conversationId: "local:test:parent",
+          platform: "local",
+        },
+        source: createLocalSource("local:test:parent"),
       }),
     ).toThrow("Source, destination, and run conversation IDs do not match");
   });
@@ -49,54 +57,33 @@ describe("agent run routing", () => {
       assertRunConsistency({
         conversationId: "local:test:child",
         destination: {
-            conversationId: "local:test:other-parent",
-            platform: "local",
-          },
-          source: createLocalSource("local:test:parent"),
-          surface: "internal"
+          conversationId: "local:test:other-parent",
+          platform: "local",
+        },
+        source: createLocalSource("local:test:parent"),
+        surface: "internal",
       }),
     ).toThrow("Source and destination conversation IDs do not match");
   });
 
-  it("allows a web continue on a Slack destination without external publish", () => {
+  it("allows a web continue on a Slack Location without external Delivery", () => {
     expect(() =>
       assertRunConsistency({
         conversationId: "slack:C123:1712345.0001",
         actor: {
-            platform: "web",
-            userId: "dashboard:alice",
-            email: "alice@example.com",
-          },
-          destination: {
-            platform: "slack",
-            teamId: "T123",
-            channelId: "C123",
-          },
-          publishExternally: false,
-          source: createWebSource("slack:C123:1712345.0001", "public"),
-          surface: "api"
+          platform: "web",
+          userId: "dashboard:alice",
+          email: "alice@example.com",
+        },
+        destination: {
+          platform: "slack",
+          teamId: "T123",
+          channelId: "C123",
+        },
+        location: SLACK_LOCATION,
+        source: createWebSource("slack:C123:1712345.0001", "public"),
+        surface: "api",
       }),
     ).not.toThrow();
-  });
-
-  it("rejects a web continue that would publish to Slack", () => {
-    expect(() =>
-      assertRunConsistency({
-        conversationId: "slack:C123:1712345.0001",
-        actor: {
-            platform: "web",
-            userId: "dashboard:alice",
-            email: "alice@example.com",
-          },
-          destination: {
-            platform: "slack",
-            teamId: "T123",
-            channelId: "C123",
-          },
-          publishExternally: true,
-          source: createWebSource("slack:C123:1712345.0001", "public"),
-          surface: "api"
-      }),
-    ).toThrow("Web turns on Slack destinations must not publish externally");
   });
 });

--- a/packages/junior/tests/unit/plugin-api-source.test.ts
+++ b/packages/junior/tests/unit/plugin-api-source.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { createSlackSource } from "@sentry/junior-plugin-api";
+import { createSlackSource, sourceSchema } from "@sentry/junior-plugin-api";
 
 describe("plugin source helpers", () => {
   it("accepts Slack source visibility from the runtime boundary", () => {
@@ -42,5 +42,30 @@ describe("plugin source helpers", () => {
         visibility: "private",
       }),
     ).toMatchObject({ visibility: "private" });
+  });
+
+  it("removes Location from a stored legacy Source", () => {
+    expect(
+      sourceSchema.parse({
+        platform: "slack",
+        teamId: "T123",
+        channelId: "C123",
+        threadTs: "1712345.0001",
+        visibility: "private",
+        location: {
+          id: "location-123",
+          provider: "slack",
+          teamId: "T123",
+          channelId: "C123",
+          threadTs: "1712345.0001",
+        },
+      }),
+    ).toEqual({
+      platform: "slack",
+      teamId: "T123",
+      channelId: "C123",
+      threadTs: "1712345.0001",
+      visibility: "private",
+    });
   });
 });

--- a/packages/junior/tests/unit/services/turn-session-routing.test.ts
+++ b/packages/junior/tests/unit/services/turn-session-routing.test.ts
@@ -143,16 +143,7 @@ describe("resolveConversationRouting", () => {
         channelId: "C123",
         threadTs: "1712345.0001",
       },
-      source: {
-        ...SOURCE,
-        location: {
-          id: "location-123",
-          provider: "slack",
-          teamId: "T123",
-          channelId: "C123",
-          threadTs: "1712345.0001",
-        },
-      },
+      source: SOURCE,
     });
   });
 


### PR DESCRIPTION
Agent runs now carry the Conversation Location once on `AgentRun.location`. Source records only the input that caused the work, and Delivery is a callable capability without another Location copy. Slack turns, web turns, child work, paused turns, and OAuth resumes now use the same shape.

The Source schema still accepts old persisted values with a nested Location and removes that field at the read boundary. This keeps stored and public data compatible during deployment without preserving a second live TypeScript interface. Reviewers should start with the `AgentRun` type and the Source schema; the remaining files update their direct producers, consumers, tests, and owning documentation.

Refs #1563
