### PR TITLE
ref(chat)!: add Resource event Source

### DIFF
--- a/packages/junior-evals/evals/agent/subscriptions.eval.ts
+++ b/packages/junior-evals/evals/agent/subscriptions.eval.ts
@@ -3,7 +3,7 @@ import { expect } from "vitest";
 import {
   githubWebhook,
   mention,
-  resourceEventNotification,
+  resourceEvent,
   rubric,
   slackEvals,
   visibleAssistantText,
@@ -177,7 +177,7 @@ describeEval("Resource Event Subscriptions", slackEvals, (it) => {
   }) => {
     const result = await run({
       initialEvents: [
-        resourceEventNotification({
+        resourceEvent({
           eventKey: "github-delivery-checks-failed",
           eventType: "pull_request.checks.failed",
           intent:
@@ -234,7 +234,7 @@ describeEval("Resource Event Subscriptions", slackEvals, (it) => {
   }) => {
     const result = await run({
       initialEvents: [
-        resourceEventNotification({
+        resourceEvent({
           eventKey: "github-delivery-pr-merged",
           eventType: "pull_request.merged",
           intent:

--- a/packages/junior-evals/evals/conversation/routing.eval.ts
+++ b/packages/junior-evals/evals/conversation/routing.eval.ts
@@ -2,7 +2,7 @@ import { describeEval } from "vitest-evals";
 import { expect } from "vitest";
 import {
   mention,
-  resourceEventNotification,
+  resourceEvent,
   rubric,
   slackEvals,
   steer,
@@ -22,7 +22,7 @@ describeEval("Conversation Routing", slackEvals, (it) => {
   }) => {
     const result = await run({
       initialEvents: [
-        resourceEventNotification({
+        resourceEvent({
           eventKey: "linear-issue-linked",
           eventType: "issue.linked",
           intent: "Track linked infrastructure work in this Slack thread.",

--- a/packages/junior-evals/evals/github/skills.eval.ts
+++ b/packages/junior-evals/evals/github/skills.eval.ts
@@ -2,7 +2,7 @@ import { describeEval, toolCalls } from "vitest-evals";
 import { beforeAll, expect } from "vitest";
 import {
   mention,
-  resourceEventNotification,
+  resourceEvent,
   rubric,
   slackEvals,
   threadMessage,
@@ -25,7 +25,7 @@ describeEval("GitHub Skill Workflows", slackEvals, (it) => {
         skill_dirs: ["fixtures/github-headless-skills"],
       },
       initialEvents: [
-        resourceEventNotification({
+        resourceEvent({
           eventType: "pull_request.checks.failed",
           intent:
             "Fix failing checks on this pull request and push the update.",

--- a/packages/junior-evals/evals/guardian/helpers.ts
+++ b/packages/junior-evals/evals/guardian/helpers.ts
@@ -14,7 +14,7 @@ import type { ToolActionPriorRejection } from "@/chat/tool-support/action-review
 const LOCAL_CONVERSATION_ID = "local:guardian-eval";
 
 const LOCAL_SOURCE = {
-  platform: "local" as const,
+  kind: "local" as const,
   visibility: "private" as const,
   conversationId: LOCAL_CONVERSATION_ID,
 };
@@ -25,7 +25,7 @@ const LOCAL_DESTINATION = {
 };
 
 const SLACK_SOURCE = {
-  platform: "slack" as const,
+  kind: "slack" as const,
   teamId: "TGUARDIAN",
   channelId: "CGUARDIAN",
   visibility: "public" as const,
@@ -101,7 +101,10 @@ export function proposal(input: {
 
 /** Chronological visible-conversation evidence without author identity. */
 export function evidence(
-  entries: Array<{ role: ToolActionEvidence["entries"][number]["role"]; text: string }>,
+  entries: Array<{
+    role: ToolActionEvidence["entries"][number]["role"];
+    text: string;
+  }>,
   omittedEntries = 0,
 ): ToolActionEvidence {
   return { entries, omittedEntries };

--- a/packages/junior-evals/src/behavior-harness.ts
+++ b/packages/junior-evals/src/behavior-harness.ts
@@ -5,9 +5,10 @@ import { fileURLToPath } from "node:url";
 import { vi } from "vitest";
 import type { SlackAdapter } from "@chat-adapter/slack";
 import { Message as ChatMessage, ThreadImpl, type Message } from "chat";
-import type {
-  Destination,
-  PluginRegistration,
+import {
+  createSlackSource,
+  type Destination,
+  type PluginRegistration,
 } from "@sentry/junior-plugin-api";
 import { executeWithReplay } from "vitest-evals/replay";
 import type { JsonValue } from "vitest-evals/harness";
@@ -17,7 +18,11 @@ import {
 } from "@earendil-works/pi-ai/providers/faux";
 import { createConversationWork } from "@/chat/app/conversation-work";
 import { botConfig } from "@/chat/config";
-import { getConversationEventStore, getConversationStore, getDb } from "@/chat/db";
+import {
+  getConversationEventStore,
+  getConversationStore,
+  getDb,
+} from "@/chat/db";
 import type { AssistantLifecycleEvent } from "@/chat/providers/slack/runtime";
 import type { JuniorRuntimeServiceOverrides } from "@/chat/app/services";
 import { createUserTokenStore } from "@/chat/capabilities/factory";
@@ -266,6 +271,20 @@ interface EventTaskMatchedEvent extends EvalBaseEvent {
   untrusted_text?: string;
 }
 
+interface ResourceEventFixture extends EvalBaseEvent {
+  type: "resource_event";
+  data?: Record<string, unknown>;
+  event_key: string;
+  event_type: string;
+  intent: string;
+  label: string;
+  namespace: string;
+  identifier: string;
+  resource_type: string;
+  trusted_summary: string;
+  untrusted_text?: string;
+}
+
 interface GitHubWebhookEvent extends EvalBaseEvent {
   body: unknown;
   delivery_id: string;
@@ -287,6 +306,7 @@ export type EvalEvent =
   | AssistantContextChangedEvent
   | ScheduledTaskDueEvent
   | EventTaskMatchedEvent
+  | ResourceEventFixture
   | GitHubWebhookEvent;
 
 type SlackMessageEvent = MentionEvent | SubscribedMessageEvent;
@@ -2305,6 +2325,63 @@ async function processEvents(args: {
     await drainQueuedConversationWork();
   };
 
+  const runResourceEvent = async (
+    event: ResourceEventFixture,
+  ): Promise<void> => {
+    const { thread } = await getThreadRecord(event.thread);
+    const nowMs = Date.now();
+    const destination = createEvalDestination(thread);
+    await getConversationStore().recordActivity({
+      conversationId: thread.id,
+      destination,
+      nowMs,
+      sessionSource: createSlackSource({
+        channelId: destination.channelId,
+        teamId: destination.teamId,
+        ...(thread.threadTs ? { threadTs: thread.threadTs } : undefined),
+        visibility: "public",
+      }),
+      source: "slack",
+      visibility: "public",
+    });
+    await createResourceEventSubscription(
+      {
+        conversationId: thread.id,
+        events: [event.event_type],
+        expiresAtMs: nowMs + 14 * 24 * 60 * 60 * 1000,
+        intent: event.intent,
+        label: event.label,
+        namespace: event.namespace,
+        identifier: event.identifier,
+        resourceType: event.resource_type,
+      },
+      { nowMs, state: env.stateAdapter },
+    );
+    const result = await ingestResourceEvent(
+      {
+        data: event.data,
+        eventKey: event.event_key,
+        eventType: event.event_type,
+        identifier: event.identifier,
+        namespace: event.namespace,
+        occurredAtMs: nowMs,
+        trustedSummary: event.trusted_summary,
+        untrustedText: event.untrusted_text,
+      },
+      {
+        nowMs,
+        queue: conversationWorkQueue,
+        state: env.stateAdapter,
+      },
+    );
+    if (result.enqueued !== 1) {
+      throw new Error(
+        `Resource event eval expected one queued input, got ${result.enqueued}`,
+      );
+    }
+    await drainQueuedConversationWork();
+  };
+
   const runEventTaskMatched = async (
     event: EventTaskMatchedEvent,
   ): Promise<void> => {
@@ -2361,6 +2438,8 @@ async function processEvents(args: {
       await runScheduledTaskDue(event);
     } else if (event.type === "event_task_matched") {
       await runEventTaskMatched(event);
+    } else if (event.type === "resource_event") {
+      await runResourceEvent(event);
     } else if (event.type === "github_webhook") {
       await runGitHubWebhook(event);
     } else {
@@ -2373,24 +2452,31 @@ async function processEvents(args: {
     }
   };
 
+  const stageSteering = (
+    preceding: readonly EvalBaseEvent[],
+    steering: SteerEvent,
+  ): void => {
+    const conversationIds = new Set(
+      [...preceding, ...steering.events].map((event) =>
+        buildRuntimeThreadId(event.thread),
+      ),
+    );
+    if (conversationIds.size !== 1) {
+      throw new Error(
+        "steer() messages must target the preceding Conversation",
+      );
+    }
+    steeringDelivery.deliver = async () => {
+      await appendMailboxMessages(steering.events);
+    };
+  };
+
   const processMessageGroup = async (
     messages: Array<MentionEvent | SubscribedMessageEvent>,
     steering?: SteerEvent,
   ): Promise<void> => {
     if (steering) {
-      const conversationIds = new Set(
-        [...messages, ...steering.events].map((event) =>
-          buildRuntimeThreadId(event.thread),
-        ),
-      );
-      if (conversationIds.size !== 1) {
-        throw new Error(
-          "steer() messages must target the preceding Slack conversation",
-        );
-      }
-      steeringDelivery.deliver = async () => {
-        await appendMailboxMessages(steering.events);
-      };
+      stageSteering(messages, steering);
     }
     await appendMailboxMessages(messages);
     await maybeAutoCompleteAuth();
@@ -2403,12 +2489,31 @@ async function processEvents(args: {
     }
   };
 
+  const processResourceEvent = async (
+    event: ResourceEventFixture,
+    steering?: SteerEvent,
+  ): Promise<void> => {
+    if (steering) {
+      stageSteering([event], steering);
+    }
+    await processSettledEvent(event);
+    if (steeringDelivery.deliver) {
+      steeringDelivery.deliver = undefined;
+      throw new Error(
+        "steer() requires the preceding Resource event to start an agent run",
+      );
+    }
+  };
+
   const remainingEvents = scenario.events ?? [];
   let nextIndex = 0;
   const initialSteering =
     remainingEvents[0]?.type === "steer" ? remainingEvents[0] : undefined;
   if (initialSteering) {
     nextIndex = 1;
+  }
+  if (initialSteering && scenario.initialEvents.length === 0) {
+    throw new Error("steer() requires a preceding event");
   }
 
   const initialMessages = Array.from(scenario.initialEvents).filter(
@@ -2421,14 +2526,23 @@ async function processEvents(args: {
   ) {
     await processMessageGroup(initialMessages, initialSteering);
   } else {
-    if (scenario.initialEvents.length > 1 || initialSteering !== undefined) {
+    if (scenario.initialEvents.length > 1) {
       throw new Error(
         "Multiple initialEvents and steer() require Slack message events",
       );
     }
     const initialEvent = scenario.initialEvents[0];
     if (initialEvent) {
-      await processSettledEvent(initialEvent);
+      if (initialSteering) {
+        if (initialEvent.type !== "resource_event") {
+          throw new Error(
+            "steer() must follow a Slack message or Resource event",
+          );
+        }
+        await processResourceEvent(initialEvent, initialSteering);
+      } else {
+        await processSettledEvent(initialEvent);
+      }
     }
   }
 
@@ -2438,15 +2552,23 @@ async function processEvents(args: {
       break;
     }
     if (event.type === "steer") {
-      throw new Error("steer() must follow a Slack message event");
+      throw new Error("steer() requires a preceding event");
     }
     const nextEvent = remainingEvents[nextIndex + 1];
     const steering = nextEvent?.type === "steer" ? nextEvent : undefined;
     if (steering) {
-      if (event.type !== "new_mention" && event.type !== "subscribed_message") {
-        throw new Error("steer() must follow a Slack message event");
+      if (event.type === "resource_event") {
+        await processResourceEvent(event, steering);
+      } else if (
+        event.type === "new_mention" ||
+        event.type === "subscribed_message"
+      ) {
+        await processMessageGroup([event], steering);
+      } else {
+        throw new Error(
+          "steer() must follow a Slack message or Resource event",
+        );
       }
-      await processMessageGroup([event], steering);
       nextIndex += 2;
       continue;
     }

--- a/packages/junior-evals/src/helpers.ts
+++ b/packages/junior-evals/src/helpers.ts
@@ -20,7 +20,6 @@ import {
   type TranscriptEvent,
 } from "vitest-evals/harness";
 import { registerLogRecordSink, type EmittedLogRecord } from "@/chat/logging";
-import { renderResourceEventNotificationText } from "@/chat/resource-events/notification";
 import {
   slackEventThread,
   slackMentionEvent,
@@ -1011,7 +1010,7 @@ export function steer(
   };
 }
 
-interface ResourceEventNotificationOptions {
+interface ResourceEventOptions {
   eventKey?: string;
   eventType: string;
   intent: string;
@@ -1019,7 +1018,6 @@ interface ResourceEventNotificationOptions {
   namespace?: string;
   identifier: string;
   resourceType: string;
-  subscriptionId?: string;
   thread?: ThreadOverrides;
   trustedSummary: string;
   data?: Record<string, unknown>;
@@ -1064,60 +1062,28 @@ export function githubWebhook(opts: GitHubWebhookOptions) {
   };
 }
 
-function resourceEventNotificationText(
-  opts: ResourceEventNotificationOptions,
-): string {
-  return renderResourceEventNotificationText(
-    {
-      intent: opts.intent,
-      label: opts.label,
-      resourceType: opts.resourceType,
-    },
-    {
-      namespace: opts.namespace ?? "github",
-      eventType: opts.eventType,
-      trustedSummary: opts.trustedSummary,
-      data: opts.data,
-      untrustedText: opts.untrustedText,
-    },
-  );
-}
-
-/** Builds a runtime-owned subscribed resource-event notification for Slack evals. */
-export function resourceEventNotification(
-  opts: ResourceEventNotificationOptions,
-) {
+/** Builds a Resource event for the production mailbox path. */
+export function resourceEvent(opts: ResourceEventOptions) {
   const seq = nextId();
   const eventKey = opts.eventKey ?? `eval-resource-event-${seq}`;
-  const subscriptionId = opts.subscriptionId ?? `eval-subscription-${seq}`;
   return {
-    type: "subscribed_message" as const,
+    type: "resource_event" as const,
     thread: {
       id: `thread-${seq}`,
       channel_id: `C${seq}`,
       thread_ts: `17000000.${seq}`,
       ...opts.thread,
     },
-    message: {
-      id: `resource-event-${subscriptionId}-${eventKey}`,
-      text: resourceEventNotificationText(opts),
-      is_mention: false,
-      author: {
-        user_id: "UJRNEVENT",
-        user_name: "junior-event",
-        full_name: "Junior event",
-        is_me: false,
-        is_bot: true,
-      },
-      raw: {
-        event_type: "resource_event",
-        namespace: opts.namespace ?? "github",
-        identifier: opts.identifier,
-        subscription_id: subscriptionId,
-        type: "message",
-        user: "UJRNEVENT",
-      },
-    },
+    event_key: eventKey,
+    event_type: opts.eventType,
+    intent: opts.intent,
+    label: opts.label,
+    namespace: opts.namespace ?? "github",
+    identifier: opts.identifier,
+    resource_type: opts.resourceType,
+    trusted_summary: opts.trustedSummary,
+    ...(opts.data ? { data: opts.data } : {}),
+    ...(opts.untrustedText ? { untrusted_text: opts.untrustedText } : {}),
   };
 }
 

--- a/packages/junior-evals/tests/unit/guardian-helpers.test.ts
+++ b/packages/junior-evals/tests/unit/guardian-helpers.test.ts
@@ -27,7 +27,7 @@ describe("guardian eval helpers", () => {
           conversationId: "local:guardian-eval",
         },
         source: {
-          platform: "local",
+          kind: "local",
           visibility: "private",
           conversationId: "local:guardian-eval",
         },
@@ -50,7 +50,9 @@ describe("guardian eval helpers", () => {
     };
     const snapshot = proposal({
       context: slackContext("Clean up preview-42 if needed."),
-      evidence: evidence([{ role: "user", text: "Clean up preview-42 if needed." }]),
+      evidence: evidence([
+        { role: "user", text: "Clean up preview-42 if needed." },
+      ]),
       input: { workspace: "preview-42" },
       priorRejectedActions: [
         priorRejection({

--- a/packages/junior-evals/tests/unit/harness/behavior-harness.test.ts
+++ b/packages/junior-evals/tests/unit/harness/behavior-harness.test.ts
@@ -406,6 +406,118 @@ describe("behavior harness", () => {
     ]);
   });
 
+  it("routes Resource event fixtures through Conversation work", async () => {
+    executeAgentRunMock.mockImplementationOnce(async (request) => {
+      await (
+        request as {
+          durability?: { onInputCommitted?: () => Promise<void> };
+        }
+      ).durability?.onInputCommitted?.();
+      return {
+        status: "completed",
+        result: {
+          text: "",
+          diagnostics: {
+            assistantMessageCount: 0,
+            modelId: "fake-resource-event",
+            outcome: "success",
+            toolCalls: [],
+            toolErrorCount: 0,
+            toolResultCount: 0,
+            usedPrimaryText: false,
+          },
+        },
+      } as never;
+    });
+
+    const result = await runEvalScenario({
+      initialEvents: [],
+      events: [
+        {
+          type: "resource_event",
+          thread: {
+            id: "fixture-resource-event",
+            channel_id: "CRESOURCE",
+            thread_ts: "1700000000.0005",
+          },
+          event_key: "resource-event-1",
+          event_type: "pull_request.merged",
+          intent: "Report when the pull request merges.",
+          label: "GitHub PR getsentry/junior#1730",
+          namespace: "github",
+          identifier: "getsentry/junior#1730",
+          resource_type: "pull_request",
+          trusted_summary: "GitHub PR getsentry/junior#1730 was merged.",
+        },
+        {
+          type: "steer",
+          events: [
+            {
+              type: "new_mention",
+              thread: {
+                id: "fixture-resource-event",
+                channel_id: "CRESOURCE",
+                thread_ts: "1700000000.0005",
+              },
+              message: {
+                id: "resource-event-steer-1",
+                text: "The owner is Alice. Tell the thread.",
+                is_mention: true,
+                author: { user_id: "URESOURCE" },
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(handleSubscribedMessageMock).not.toHaveBeenCalled();
+    expect(executeAgentRunMock).toHaveBeenCalledTimes(1);
+    expect(result.posts).toEqual([
+      {
+        channel: "CRESOURCE",
+        files: [],
+        text: "observed",
+        thread_ts: "1700000000.0005",
+      },
+    ]);
+    expect(executeAgentRunMock.mock.calls[0]?.[0]).toMatchObject({
+      location: {
+        provider: "slack",
+        teamId: "TEVAL",
+        channelId: "CRESOURCE",
+        threadTs: "1700000000.0005",
+      },
+      source: {
+        kind: "resource_event",
+        eventKey: "resource-event-1",
+        eventType: "pull_request.merged",
+        namespace: "github",
+        identifier: "getsentry/junior#1730",
+      },
+    });
+  });
+
+  it("rejects steering without a preceding event", async () => {
+    await expect(
+      runEvalScenario({
+        initialEvents: [],
+        events: [
+          {
+            type: "steer",
+            events: [
+              {
+                type: "new_mention",
+                thread: { id: "fixture-leading-steer" },
+                message: { text: "This has no preceding event." },
+              },
+            ],
+          },
+        ],
+      }),
+    ).rejects.toThrow("steer() requires a preceding event");
+  });
+
   it("preserves attached file metadata on assistant thread posts", async () => {
     handleNewMentionMock.mockImplementationOnce(
       async (

--- a/packages/junior-github/tests/github-plugin.test.ts
+++ b/packages/junior-github/tests/github-plugin.test.ts
@@ -281,7 +281,9 @@ async function grantForEgress(input: {
     log: pluginLog,
     plugin: { name: "github" },
     request: {
-      ...(input.bodyText !== undefined ? { bodyText: input.bodyText } : undefined),
+      ...(input.bodyText !== undefined
+        ? { bodyText: input.bodyText }
+        : undefined),
       method: input.method,
       ...(input.operation ? { operation: input.operation } : undefined),
       url: input.url,
@@ -327,7 +329,7 @@ function githubToolsContext(input?: {
     conversationId,
     destination: { platform: "local" as const, conversationId },
     source: {
-      platform: "local" as const,
+      kind: "local" as const,
       visibility: "private" as const,
       conversationId,
     },

--- a/packages/junior-memory/src/agent.ts
+++ b/packages/junior-memory/src/agent.ts
@@ -294,12 +294,14 @@ function actorLabel(actor: z.output<typeof actorSchema> | undefined): string {
 }
 
 function sourceLabel(source: z.output<typeof sourceSchema>): string {
-  switch (source.platform) {
+  switch (source.kind) {
     case "slack":
       return `slack:${source.teamId}:${source.channelId}`;
     case "web":
     case "local":
-      return `${source.platform}:${source.conversationId}`;
+      return `${source.kind}:${source.conversationId}`;
+    case "resource_event":
+      return `resource-event:${source.namespace}:${source.eventKey}`;
   }
 }
 

--- a/packages/junior-memory/src/process-session.ts
+++ b/packages/junior-memory/src/process-session.ts
@@ -223,7 +223,7 @@ export async function processMemorySession(
   context: PluginTaskContext,
 ): Promise<void> {
   const run = await context.run.load();
-  if (run.source.platform === "local") {
+  if (run.source.kind === "local" || run.source.kind === "resource_event") {
     return;
   }
   // Memory tool turns already own memory management or recall; do not reinterpret

--- a/packages/junior-memory/src/scope.ts
+++ b/packages/junior-memory/src/scope.ts
@@ -32,7 +32,7 @@ function privateMemoryScope(userId: string): ResolvedMemoryScope {
 export function deriveMemoryScope(
   ctx: MemoryRuntimeContext,
 ): ResolvedMemoryScope {
-  if (ctx.source.visibility === "public") {
+  if ("visibility" in ctx.source && ctx.source.visibility === "public") {
     return publicMemoryScope;
   }
   if (!ctx.userId) {

--- a/packages/junior-memory/src/store.ts
+++ b/packages/junior-memory/src/store.ts
@@ -37,6 +37,7 @@ import {
   MEMORY_KINDS,
   memoryRuntimeContextSchema,
   type MemoryRuntimeContext,
+  type MemorySourcePlatform,
 } from "./types";
 import {
   deriveMemoryScope,
@@ -182,6 +183,15 @@ const memoryRowSchema = z
       });
     }
   });
+
+function storedMemorySource(
+  source: MemoryRuntimeContext["source"],
+): MemorySourcePlatform {
+  if (source.kind === "resource_event") {
+    throw new Error("Resource event Source cannot own a Memory.");
+  }
+  return source.kind;
+}
 
 const memoryRecordSchema = z
   .object({
@@ -772,7 +782,7 @@ async function rememberDuplicateIdempotency(args: {
       scope: args.scope.scope,
       scopeKey: args.scope.scopeKey,
       sourceKey: sourceKey(args.runtimeContext),
-      sourcePlatform: args.runtimeContext.source.platform,
+      sourcePlatform: storedMemorySource(args.runtimeContext.source),
       subjectKey: args.subject.subjectKey,
       subjectType: args.subject.subjectType,
       supersededAtMs: args.nowMs,
@@ -1288,7 +1298,7 @@ export function createMemoryStore(
           scope: scope.scope,
           scopeKey: scope.scopeKey,
           sourceKey: sourceKey(runtimeContext),
-          sourcePlatform: runtimeContext.source.platform,
+          sourcePlatform: storedMemorySource(runtimeContext.source),
           subjectKey: subject.subjectKey,
           subjectType: subject.subjectType,
           kind: input.kind,

--- a/packages/junior-memory/src/types.ts
+++ b/packages/junior-memory/src/types.ts
@@ -9,7 +9,7 @@ export const MEMORY_SUBJECT_TYPES = [
   "conversation",
   "general",
 ] as const;
-// Durable attribution follows Source platform, including dashboard/web roots.
+// Durable attribution follows Source kind, including dashboard roots.
 export const MEMORY_SOURCE_PLATFORMS = ["slack", "local", "web"] as const;
 export const MEMORY_EMBEDDING_METRICS = ["cosine"] as const;
 export const MEMORY_EMBEDDING_DIMENSIONS = 1536;

--- a/packages/junior-memory/tests/storage.test.ts
+++ b/packages/junior-memory/tests/storage.test.ts
@@ -8,6 +8,7 @@ import {
   type LocalPgliteFixture,
 } from "@sentry/junior-testing/pglite";
 import {
+  createResourceEventSource,
   createWebSource,
   createLocalSource,
   createSlackSource,
@@ -1003,6 +1004,32 @@ describe("memory plugin storage", () => {
     } finally {
       await fixture.close();
     }
+  });
+
+  it("does not extract Memory from Resource event Turns", async () => {
+    const actor = { platform: "system", name: "resource-event" } as const;
+    await expect(
+      processMemorySession(
+        processSessionContext({
+          model: throwingExtractionModel,
+          run: {
+            async load() {
+              return completedRun({
+                actor,
+                actorUserId: undefined,
+                actors: [actor],
+                source: createResourceEventSource({
+                  eventKey: "event-1",
+                  eventType: "issue.updated",
+                  identifier: "PROJ-123",
+                  namespace: "sentry",
+                }),
+              });
+            },
+          },
+        }),
+      ),
+    ).resolves.toBeUndefined();
   });
 
   it("supersedes old preferences from passive completed-session extraction", async () => {
@@ -3574,7 +3601,7 @@ WHERE id = '${superseded.memory.id}'
             userId: "U123",
           },
           source: {
-            platform: "slack",
+            kind: "slack",
             visibility: "private",
             teamId: "T123",
             channelId: "D123",

--- a/packages/junior-plugin-api/README.md
+++ b/packages/junior-plugin-api/README.md
@@ -42,6 +42,9 @@ reports, and other typed hook surfaces exported by this package.
 
 - Hook context carries the active source, actor, conversation, plugin metadata,
   database, logging, and only the host capabilities required by that hook.
+- Source uses `kind` to state what produced the input, including input such as
+  a Resource event that has no provider platform. Actor and Destination keep
+  `platform` for their provider scope.
 - Prompt hooks return bounded structured prompt messages rather than mutate the
   core prompt.
 - `formatMarkdown` is a pure text rewrite into ordinary Markdown before delivery.

--- a/packages/junior-plugin-api/src/context.ts
+++ b/packages/junior-plugin-api/src/context.ts
@@ -11,6 +11,7 @@ import {
   slackActorSchema,
   systemActorSchema,
   sourceSchema,
+  sourceVisibilitySchema,
   slackLocationSchema,
   userSchema,
 } from "./schemas";
@@ -29,10 +30,11 @@ export type Source = z.output<typeof sourceSchema>;
 export type Location = z.output<typeof locationSchema>;
 /** Complete Slack Location associated with a Conversation. */
 export type SlackLocation = z.output<typeof slackLocationSchema>;
-export type SlackSource = Extract<Source, { platform: "slack" }>;
-export type LocalSource = Extract<Source, { platform: "local" }>;
-export type WebSource = Extract<Source, { platform: "web" }>;
-export type SourceVisibility = Source["visibility"];
+export type SlackSource = Extract<Source, { kind: "slack" }>;
+export type LocalSource = Extract<Source, { kind: "local" }>;
+export type WebSource = Extract<Source, { kind: "web" }>;
+export type ResourceEventSource = Extract<Source, { kind: "resource_event" }>;
+export type SourceVisibility = z.output<typeof sourceVisibilitySchema>;
 
 export type Destination = z.output<typeof destinationSchema>;
 
@@ -117,8 +119,17 @@ export interface WebInvocationContext extends BaseInvocationContext {
   source: WebSource;
 }
 
+export interface ResourceEventInvocationContext extends BaseInvocationContext {
+  /** Existing conversation destination used for tool context. */
+  destination: Destination;
+  actor?: SystemActor;
+  /** Runtime-owned Resource event Source for this invocation. */
+  source: ResourceEventSource;
+}
+
 export type InvocationContext =
   | LocalInvocationContext
+  | ResourceEventInvocationContext
   | SlackInvocationContext
   | WebInvocationContext;
 
@@ -132,7 +143,7 @@ export function createSlackSource(input: {
   visibility: SourceVisibility;
 }): SlackSource {
   return {
-    platform: "slack",
+    kind: "slack",
     visibility: input.visibility,
     teamId: input.teamId,
     channelId: input.channelId,
@@ -144,7 +155,7 @@ export function createSlackSource(input: {
 /** Build a normalized local source from a local conversation id. */
 export function createLocalSource(conversationId: string): LocalSource {
   return {
-    platform: "local",
+    kind: "local",
     visibility: "private",
     conversationId,
   };
@@ -156,20 +167,36 @@ export function createWebSource(
   visibility: SourceVisibility = "public",
 ): WebSource {
   return {
-    platform: "web",
+    kind: "web",
     visibility,
     conversationId,
   };
 }
 
+/** Build a normalized Resource event Source from one matched event. */
+export function createResourceEventSource(input: {
+  eventKey: string;
+  eventType: string;
+  identifier: string;
+  namespace: string;
+}): ResourceEventSource {
+  return {
+    kind: "resource_event",
+    eventKey: input.eventKey,
+    eventType: input.eventType,
+    identifier: input.identifier,
+    namespace: input.namespace,
+  };
+}
+
 /** Return whether a source is private to a person or restricted group. */
 export function isPrivateSource(source: Source): boolean {
-  return source.visibility === "private";
+  return "visibility" in source && source.visibility === "private";
 }
 
 /** Return the stable source identity used for idempotency and attribution. */
 export function getSourceKey(source: Source): string | undefined {
-  switch (source.platform) {
+  switch (source.kind) {
     case "web":
     case "local":
       return source.conversationId;
@@ -180,6 +207,8 @@ export function getSourceKey(source: Source): string | undefined {
       }
       return `slack:${source.teamId}:${source.channelId}:${messageKey}`;
     }
+    case "resource_event":
+      return `resource-event:${source.namespace}:${source.eventKey}`;
   }
 }
 

--- a/packages/junior-plugin-api/src/schemas.ts
+++ b/packages/junior-plugin-api/src/schemas.ts
@@ -79,47 +79,80 @@ export const destinationSchema = z.discriminatedUnion("platform", [
   localDestinationSchema,
 ]);
 
-/** Runtime-owned Slack coordinates for the inbound invocation. */
-export const slackSourceSchema = slackAddressSchema
-  .extend({
+/** Runtime-owned Slack input Source. */
+export const slackSourceSchema = z
+  .object({
+    kind: z.literal("slack"),
+    teamId: slackTeamIdSchema,
+    channelId: slackConversationIdSchema,
     visibility: sourceVisibilitySchema,
     messageTs: nonBlankStringSchema.optional(),
     threadTs: nonBlankStringSchema.optional(),
   })
   .strict();
 
-/** Runtime-owned local CLI coordinates for the inbound invocation. */
+/** Runtime-owned local CLI input Source. */
 export const localSourceSchema = z
   .object({
-    platform: z.literal("local"),
+    kind: z.literal("local"),
     visibility: z.literal("private"),
     conversationId: localConversationIdSchema,
   })
   .strict();
 
-/** Runtime-owned dashboard/web coordinates for the inbound invocation. */
+/** Runtime-owned dashboard input Source. */
 export const webSourceSchema = z
   .object({
-    platform: z.literal("web"),
+    kind: z.literal("web"),
     visibility: sourceVisibilitySchema,
     // Web can continue any existing conversation id, including Slack roots.
     conversationId: exactNonBlankStringSchema,
   })
   .strict();
 
-// TODO(dcramer): Replace Source.platform with Source.kind after every input
-// owner emits a first-class Source kind and deployed readers accept it.
-const sourceWithLegacyLocationSchema = z.discriminatedUnion("platform", [
-  slackSourceSchema.extend({ location: locationSchema.optional() }).strict(),
-  localSourceSchema.extend({ location: locationSchema.optional() }).strict(),
-  webSourceSchema.extend({ location: locationSchema.optional() }).strict(),
+/** Runtime-owned Resource event input Source. */
+export const resourceEventSourceSchema = z
+  .object({
+    kind: z.literal("resource_event"),
+    eventKey: exactNonBlankStringSchema,
+    eventType: exactNonBlankStringSchema,
+    identifier: exactNonBlankStringSchema,
+    namespace: exactNonBlankStringSchema,
+  })
+  .strict();
+
+const currentSourceSchema = z.discriminatedUnion("kind", [
+  slackSourceSchema,
+  localSourceSchema,
+  webSourceSchema,
+  resourceEventSourceSchema,
 ]);
 
-/** Runtime-owned input Source. Legacy stored Location is accepted and removed. */
-// TODO(dcramer): Parse sourceSchema directly from the three Source schemas after
-// no stored SQL, Redis, queue, or public Source can contain Location.
-export const sourceSchema = sourceWithLegacyLocationSchema.transform(
-  ({ location: _legacyLocation, ...source }) => source,
+function normalizeStoredSource(value: unknown): unknown {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return value;
+  }
+  const source = value as Record<string, unknown>;
+  if ("kind" in source || !("platform" in source)) {
+    return value;
+  }
+  if (
+    source.platform !== "slack" &&
+    source.platform !== "local" &&
+    source.platform !== "web"
+  ) {
+    return value;
+  }
+  const { location: _location, platform: kind, ...fields } = source;
+  return { ...fields, kind };
+}
+
+/** Runtime-owned input Source. Stored `platform` and Location fields normalize on read. */
+// TODO(dcramer): Remove stored Source normalization after deployed SQL, Redis,
+// queue, and OAuth values can only contain `kind` and no Location copy.
+export const sourceSchema = z.preprocess(
+  normalizeStoredSource,
+  currentSourceSchema,
 );
 
 /** Stable user credential subject shape accepted from plugins. */

--- a/packages/junior-plugin-api/src/tools.ts
+++ b/packages/junior-plugin-api/src/tools.ts
@@ -2,6 +2,7 @@ import type {
   Actor,
   Identity,
   LocalInvocationContext,
+  ResourceEventInvocationContext,
   PluginContext,
   PluginEmbedder,
   PluginModel,
@@ -582,7 +583,13 @@ interface WebToolRegistrationContext
   slack?: never;
 }
 
+interface ResourceEventToolRegistrationContext
+  extends BaseToolRegistrationHookContext, ResourceEventInvocationContext {
+  slack?: never;
+}
+
 export type ToolRegistrationHookContext =
   | LocalToolRegistrationContext
+  | ResourceEventToolRegistrationContext
   | SlackToolRegistrationContext
   | WebToolRegistrationContext;

--- a/packages/junior/src/api/conversations/detail.ts
+++ b/packages/junior/src/api/conversations/detail.ts
@@ -74,7 +74,9 @@ function projectConversationDetail(args: {
     ...(modelUsage.length > 0 ? { modelUsage } : undefined),
     eventHistory: conversationEventHistory({
       canExposePayload,
-      ...(transcriptPurgedAtMs === undefined ? undefined : { transcriptPurgedAtMs }),
+      ...(transcriptPurgedAtMs === undefined
+        ? undefined
+        : { transcriptPurgedAtMs }),
     }),
     generatedAt: new Date().toISOString(),
     ...(sentryConversationUrl ? { sentryConversationUrl } : undefined),
@@ -126,7 +128,7 @@ async function readConversationDetailFromSql(
       ...(options.viewer ? { viewer: options.viewer } : undefined),
     }),
     resolveSlackTeamDomains(
-      record.conversation.sessionSource?.platform === "slack"
+      record.conversation.sessionSource?.kind === "slack"
         ? [record.conversation.sessionSource.teamId]
         : [],
     ),

--- a/packages/junior/src/api/conversations/list.ts
+++ b/packages/junior/src/api/conversations/list.ts
@@ -296,7 +296,7 @@ export async function readConversationFeedFromSql(
     readRootConversationMetricsFromSql(db, conversationIds),
     resolveSlackTeamDomains(
       conversations.flatMap((conversation) =>
-        conversation.sessionSource?.platform === "slack"
+        conversation.sessionSource?.kind === "slack"
           ? [conversation.sessionSource.teamId]
           : [],
       ),

--- a/packages/junior/src/api/conversations/projection.ts
+++ b/packages/junior/src/api/conversations/projection.ts
@@ -83,7 +83,7 @@ function sourceUrlFromConversation(args: {
   const { conversation } = args;
   if (
     !args.canViewPrivateContent ||
-    conversation.sessionSource?.platform !== "slack"
+    conversation.sessionSource?.kind !== "slack"
   ) {
     return undefined;
   }
@@ -105,7 +105,9 @@ function actorIdentityReport(
   if (!actor) return undefined;
   const identity: ActorIdentity = {
     ...(actor.email !== undefined ? { email: actor.email } : undefined),
-    ...(actor.fullName !== undefined ? { fullName: actor.fullName } : undefined),
+    ...(actor.fullName !== undefined
+      ? { fullName: actor.fullName }
+      : undefined),
     ...(actor.slackUserId !== undefined
       ? { slackUserId: actor.slackUserId }
       : undefined),
@@ -262,7 +264,9 @@ export function conversationSummaryFromStoredConversation(args: {
     startedAt: new Date(conversation.createdAtMs).toISOString(),
     status: statusFromConversation(conversation),
     surface,
-    ...(args.auxiliaryCosts ? { auxiliaryCosts: args.auxiliaryCosts } : undefined),
+    ...(args.auxiliaryCosts
+      ? { auxiliaryCosts: args.auxiliaryCosts }
+      : undefined),
     ...(usage ? { cumulativeUsage: usage } : undefined),
     ...(actorIdentity ? { actorIdentity } : undefined),
     ...(sourceUrl ? { sourceUrl } : undefined),

--- a/packages/junior/src/chat/agent-dispatch/validation.ts
+++ b/packages/junior/src/chat/agent-dispatch/validation.ts
@@ -76,7 +76,7 @@ function dispatchOptionsErrorMessage(
     return "Dispatch source must not include unknown fields";
   }
   if (hasIssueAtPath(issues, ["source"])) {
-    return "Dispatch source platform is required";
+    return "Dispatch Source kind is required";
   }
   if (hasIssueUnderPath(issues, ["source", "teamId"])) {
     return "Dispatch source teamId must be a Slack team id";

--- a/packages/junior/src/chat/agent/index.ts
+++ b/packages/junior/src/chat/agent/index.ts
@@ -227,16 +227,20 @@ export async function executeAgentRun(
   const userActor = actor && "userId" in actor ? actor : undefined;
   const runLogContext: LogContext = {
     conversationId: run.conversationId,
-    platform: run.source.platform,
+    platform: run.source.kind,
     messageConversationId:
-      run.source.platform === "slack"
+      run.source.kind === "slack"
         ? run.conversationId
-        : run.source.conversationId,
+        : run.source.kind === "web" || run.source.kind === "local"
+          ? run.source.conversationId
+          : run.conversationId,
     destinationName:
       run.location?.channelId ??
-      (run.source.platform === "slack"
+      (run.source.kind === "slack"
         ? run.source.channelId
-        : run.source.conversationId),
+        : run.source.kind === "web" || run.source.kind === "local"
+          ? run.source.conversationId
+          : run.conversationId),
     userId: userActor?.userId,
     userName: userActor?.userName,
     userEmail: userActor?.email,
@@ -391,7 +395,7 @@ async function executeAgentRunInPrivacyContext(
   const actor = actorFromRun(run);
   const surface = surfaceFromRun(run);
   const runSource = routing.source;
-  const slackSource = runSource.platform === "slack" ? runSource : undefined;
+  const slackSource = runSource.kind === "slack" ? runSource : undefined;
   const slackChannelId = run.location?.channelId ?? slackSource?.channelId;
   const slackActor = actor?.platform === "slack" ? actor : undefined;
   const userInput = input.messageText;

--- a/packages/junior/src/chat/agent/tools.ts
+++ b/packages/junior/src/chat/agent/tools.ts
@@ -131,15 +131,19 @@ async function tryRecordSkillLoadStat(skill: Skill) {
 
 type ToolRuntimeRoute =
   | Pick<
-      Extract<ToolRuntimeContext, { source: { platform: "slack" } }>,
+      Extract<ToolRuntimeContext, { source: { kind: "slack" } }>,
       "actor" | "destination" | "source" | "slackActionToken"
     >
   | Pick<
-      Extract<ToolRuntimeContext, { source: { platform: "local" } }>,
+      Extract<ToolRuntimeContext, { source: { kind: "local" } }>,
       "actor" | "destination" | "source"
     >
   | Pick<
-      Extract<ToolRuntimeContext, { source: { platform: "web" } }>,
+      Extract<ToolRuntimeContext, { source: { kind: "web" } }>,
+      "actor" | "destination" | "source"
+    >
+  | Pick<
+      Extract<ToolRuntimeContext, { source: { kind: "resource_event" } }>,
       "actor" | "destination" | "source"
     >;
 
@@ -152,7 +156,7 @@ function resolveToolRuntimeRoute(args: {
   >;
 }): ToolRuntimeRoute {
   const destination = toolInvocationDestination(args.run);
-  switch (args.run.source.platform) {
+  switch (args.run.source.kind) {
     case "slack": {
       if (destination.platform !== "slack") {
         throw new TypeError("Slack tool runtime requires a Slack destination");
@@ -178,6 +182,12 @@ function resolveToolRuntimeRoute(args: {
       return {
         destination,
         actor: args.actor?.platform === "web" ? args.actor : undefined,
+        source: args.run.source,
+      };
+    case "resource_event":
+      return {
+        destination,
+        actor: args.actor?.platform === "system" ? args.actor : undefined,
         source: args.run.source,
       };
   }
@@ -260,9 +270,7 @@ export async function wireAgentTools(
     destination: args.run.destination,
     source: runSource,
     threadTs:
-      args.run.source.platform === "slack"
-        ? args.run.source.threadTs
-        : undefined,
+      args.run.source.kind === "slack" ? args.run.source.threadTs : undefined,
     toolChannelId: args.run.toolChannelId,
     userMessage: args.userInput,
     pendingAuth: args.state.pendingAuth,
@@ -284,9 +292,7 @@ export async function wireAgentTools(
     destination: args.run.destination,
     source: runSource,
     threadTs:
-      args.run.source.platform === "slack"
-        ? args.run.source.threadTs
-        : undefined,
+      args.run.source.kind === "slack" ? args.run.source.threadTs : undefined,
     userMessage: args.userInput,
     pendingAuth: args.state.pendingAuth,
     recordPendingAuth: args.durability.recordPendingAuth,

--- a/packages/junior/src/chat/agent/types.ts
+++ b/packages/junior/src/chat/agent/types.ts
@@ -297,7 +297,7 @@ export function assertRunConsistency(
   >,
 ): void {
   const { destination, source } = run;
-  switch (source.platform) {
+  switch (source.kind) {
     case "slack": {
       if (destination.platform !== "slack") {
         throw new TypeError(
@@ -359,20 +359,22 @@ export function assertRunConsistency(
       }
       break;
     }
+    case "resource_event":
+      break;
   }
 
   const actor = run.dispatch?.actor ?? run.actor;
   if (!actor || actor.platform === "system") {
     return;
   }
-  if (actor.platform !== source.platform) {
+  if (actor.platform !== source.kind) {
     throw new TypeError(
-      `Actor platform "${actor.platform}" does not match Source platform "${source.platform}"`,
+      `Actor platform "${actor.platform}" does not match Source kind "${source.kind}"`,
     );
   }
   if (
     actor.platform === "slack" &&
-    source.platform === "slack" &&
+    source.kind === "slack" &&
     actor.teamId !== source.teamId
   ) {
     throw new TypeError("Slack Actor team does not match Source team");
@@ -400,10 +402,10 @@ export function surfaceFromRun(
   if (run.surface) {
     return run.surface;
   }
-  if (run.source.platform === "slack") {
+  if (run.source.kind === "slack") {
     return "slack";
   }
-  if (run.source.platform === "web") {
+  if (run.source.kind === "web") {
     // Web/dashboard turns share the non-Slack api surface with agent-dispatch.
     return "api";
   }

--- a/packages/junior/src/chat/conversations/sql/event-actor.ts
+++ b/packages/junior/src/chat/conversations/sql/event-actor.ts
@@ -1,5 +1,6 @@
 import { and, eq, or, sql } from "drizzle-orm";
 import { parseActorUserId } from "@/chat/actor";
+import { parseSessionSource } from "@/chat/source";
 import type { IdentityUpsert } from "@/chat/identities/identity";
 import { upsertIdentity } from "@/chat/identities/sql";
 import type { JuniorSqlDatabase } from "@/db/db";
@@ -32,8 +33,12 @@ function readAuthor(meta: unknown): {
     ...(typeof author.fullName === "string"
       ? { fullName: author.fullName }
       : undefined),
-    ...(typeof author.isBot === "boolean" ? { isBot: author.isBot } : undefined),
-    ...(typeof author.userId === "string" ? { userId: author.userId } : undefined),
+    ...(typeof author.isBot === "boolean"
+      ? { isBot: author.isBot }
+      : undefined),
+    ...(typeof author.userId === "string"
+      ? { userId: author.userId }
+      : undefined),
     ...(typeof author.userName === "string"
       ? { userName: author.userName }
       : undefined),
@@ -61,14 +66,9 @@ async function loadConversationSlackTenantId(
   if (destinationTenant) {
     return destinationTenant;
   }
-  const sessionSource = row?.sessionSource;
-  if (
-    isRecord(sessionSource) &&
-    sessionSource.platform === "slack" &&
-    typeof sessionSource.teamId === "string" &&
-    sessionSource.teamId.trim()
-  ) {
-    return sessionSource.teamId.trim();
+  const sessionSource = parseSessionSource(row?.sessionSource);
+  if (sessionSource?.kind === "slack") {
+    return sessionSource.teamId;
   }
   return undefined;
 }

--- a/packages/junior/src/chat/conversations/sql/location.ts
+++ b/packages/junior/src/chat/conversations/sql/location.ts
@@ -21,7 +21,7 @@ export function locationForWrite(args: {
   const destination =
     args.destination?.platform === "slack" ? args.destination : undefined;
   const source =
-    args.sessionSource?.platform === "slack" ? args.sessionSource : undefined;
+    args.sessionSource?.kind === "slack" ? args.sessionSource : undefined;
   if (location) {
     if (
       (destination &&
@@ -77,7 +77,7 @@ export function locationFromRow(
   // deployed writer can omit location_json and a backfill has populated rows
   // that those writers created during deployment.
   const slackSource =
-    sessionSource?.platform === "slack" &&
+    sessionSource?.kind === "slack" &&
     sessionSource.teamId === row.providerTenantId &&
     sessionSource.channelId === row.providerDestinationId
       ? sessionSource

--- a/packages/junior/src/chat/event-tasks/tool-support.ts
+++ b/packages/junior/src/chat/event-tasks/tool-support.ts
@@ -107,7 +107,7 @@ export function requireSupportedEventTaskTrigger(
 /** Require the active Slack authority used for event-task management. */
 export function requireEventTaskSlackContext(context: ToolRuntimeContext) {
   if (
-    context.source.platform !== "slack" ||
+    context.source.kind !== "slack" ||
     context.destination.platform !== "slack" ||
     context.actor?.platform !== "slack" ||
     context.actor.teamId !== context.source.teamId
@@ -159,9 +159,8 @@ export function eventTaskTriggerAvailable(
 ): boolean {
   // resourceType is presentation metadata; runtime matching uses namespace,
   // identifier, and event type. Core snapshot events never dispatch tasks.
-  const registration = pluginResourceEventCatalog(catalog)[
-    task.trigger.namespace
-  ];
+  const registration =
+    pluginResourceEventCatalog(catalog)[task.trigger.namespace];
   return Boolean(
     registration &&
     task.trigger.events.every((eventType) =>

--- a/packages/junior/src/chat/plugins/agent-hooks.ts
+++ b/packages/junior/src/chat/plugins/agent-hooks.ts
@@ -173,7 +173,7 @@ function pluginInvocationContext(
     conversationId: context.conversationId,
     locationId: context.locationId,
   };
-  switch (context.source.platform) {
+  switch (context.source.kind) {
     case "slack": {
       if (context.destination.platform !== "slack") {
         throw new TypeError("Slack plugin context requires Slack destination");
@@ -200,6 +200,13 @@ function pluginInvocationContext(
       return {
         ...common,
         actor: context.actor?.platform === "web" ? context.actor : undefined,
+        destination: context.destination,
+        source: context.source,
+      };
+    case "resource_event":
+      return {
+        ...common,
+        actor: context.actor?.platform === "system" ? context.actor : undefined,
         destination: context.destination,
         source: context.source,
       };
@@ -458,7 +465,7 @@ export async function getPluginSystemPromptContributions(
       const pluginContributions = await hook({
         ...systemPromptPluginContext(plugin),
         // Plugin system prompts only distinguish Slack vs non-Slack surfaces.
-        platform: source.platform === "slack" ? "slack" : "local",
+        platform: source.kind === "slack" ? "slack" : "local",
       });
       const result =
         systemPromptMessageArraySchema.safeParse(pluginContributions);
@@ -703,7 +710,7 @@ export function getPluginTools(
       },
     };
     let pluginContext: ToolRegistrationHookContext;
-    switch (context.source.platform) {
+    switch (context.source.kind) {
       case "slack":
         if (context.destination.platform !== "slack") {
           throw new TypeError(
@@ -737,6 +744,15 @@ export function getPluginTools(
         pluginContext = {
           ...common,
           actor: context.actor?.platform === "web" ? context.actor : undefined,
+          destination: context.destination,
+          source: context.source,
+        };
+        break;
+      case "resource_event":
+        pluginContext = {
+          ...common,
+          actor:
+            context.actor?.platform === "system" ? context.actor : undefined,
           destination: context.destination,
           source: context.source,
         };

--- a/packages/junior/src/chat/plugins/task-runner.ts
+++ b/packages/junior/src/chat/plugins/task-runner.ts
@@ -268,7 +268,7 @@ async function loadConversationContextTranscriptEntries(
   runActor: Actor | undefined,
 ): Promise<PluginRunTranscriptEntry[]> {
   // Prior conversation evidence is a Slack public-channel concern only.
-  switch (source.platform) {
+  switch (source.kind) {
     case "slack":
       if (source.visibility === "private") {
         return [];
@@ -276,6 +276,7 @@ async function loadConversationContextTranscriptEntries(
       break;
     case "web":
     case "local":
+    case "resource_event":
       return [];
   }
   const state = await getPersistedThreadState(record.conversationId);

--- a/packages/junior/src/chat/prompt.ts
+++ b/packages/junior/src/chat/prompt.ts
@@ -442,16 +442,16 @@ function buildRuntimeSection(params: {
 }
 
 function formatSourceLines(source: Source): string[] {
-  switch (source.platform) {
+  switch (source.kind) {
     case "web":
     case "local":
       return [
-        `- source.platform: ${source.platform}`,
+        `- source.kind: ${source.kind}`,
         `- source.conversation_id: ${escapeXml(source.conversationId)}`,
       ];
     case "slack":
       return [
-        "- source.platform: slack",
+        "- source.kind: slack",
         `- source.team_id: ${escapeXml(source.teamId)}`,
         `- source.channel_id: ${escapeXml(source.channelId)}`,
         ...(source.messageTs
@@ -460,6 +460,13 @@ function formatSourceLines(source: Source): string[] {
         ...(source.threadTs
           ? [`- source.thread_ts: ${escapeXml(source.threadTs)}`]
           : []),
+      ];
+    case "resource_event":
+      return [
+        "- source.kind: resource_event",
+        `- source.namespace: ${escapeXml(source.namespace)}`,
+        `- source.identifier: ${escapeXml(source.identifier)}`,
+        `- source.event_type: ${escapeXml(source.eventType)}`,
       ];
   }
 }
@@ -694,7 +701,7 @@ const STATIC_SYSTEM_PROMPTS: Record<PromptPlatform, string> = {
 export function buildSystemPrompt(params: { source: Source }): string {
   // web/dashboard turns use the local (non-Slack) instruction surface.
   const platform: PromptPlatform =
-    params.source.platform === "slack" ? "slack" : "local";
+    params.source.kind === "slack" ? "slack" : "local";
   return STATIC_SYSTEM_PROMPTS[platform];
 }
 

--- a/packages/junior/src/chat/providers/slack/resume.ts
+++ b/packages/junior/src/chat/providers/slack/resume.ts
@@ -369,7 +369,7 @@ function buildResumedRun(
       text: args.messageText,
     },
     source:
-      source.platform === "slack"
+      source.kind === "slack"
         ? {
             ...source,
             channelId: args.channelId,

--- a/packages/junior/src/chat/resource-events/README.md
+++ b/packages/junior/src/chat/resource-events/README.md
@@ -55,7 +55,9 @@ conversation.
 - Ingestion appends a system-authored conversation message and sends a normal
   task-execution wake-up. Resource-event identity constants and detection live
   in `actor.ts` (`RESOURCE_EVENT_SYSTEM_ACTOR`, synthetic author id, and message
-  markers). Live and resume paths both execute as that system actor.
+  markers). The mailbox worker builds a Resource event Source from the stored
+  event identity. The Turn stores that Source, and resume restores it. Live and
+  resume paths both execute as the system actor.
 - Notification text stays short and uses plain language: what the update is
   about, the instructions for this update, a verified summary and details, and
   external text. When the agent replies, it should summarize what it was acting

--- a/packages/junior/src/chat/scheduled-tasks/tool-support.ts
+++ b/packages/junior/src/chat/scheduled-tasks/tool-support.ts
@@ -98,7 +98,7 @@ export function requireActiveConversation(
   if (!parsed.success) {
     const source = context.source as Partial<SlackSource> | undefined;
     const issues = parsed.error.issues as readonly SchemaIssue[];
-    if (!source || source.platform !== "slack") {
+    if (!source || source.kind !== "slack") {
       throwToolInputError("No active Slack conversation is available.");
     }
     if (issues.some((issue) => issue.code === "unrecognized_keys")) {
@@ -115,7 +115,7 @@ export function requireActiveConversation(
     throwToolInputError("No active Slack conversation is available.");
   }
 
-  if (parsed.data.platform !== "slack") {
+  if (parsed.data.kind !== "slack") {
     throwToolInputError("No active Slack conversation is available.");
   }
 
@@ -144,8 +144,12 @@ export function requireActor(
 
   return sanitizeScheduledTaskPrincipal({
     slackUserId: userId,
-    ...(context.actor?.userName ? { userName: context.actor.userName } : undefined),
-    ...(context.actor?.fullName ? { fullName: context.actor.fullName } : undefined),
+    ...(context.actor?.userName
+      ? { userName: context.actor.userName }
+      : undefined),
+    ...(context.actor?.fullName
+      ? { fullName: context.actor.fullName }
+      : undefined),
   });
 }
 

--- a/packages/junior/src/chat/services/turn-session-routing.ts
+++ b/packages/junior/src/chat/services/turn-session-routing.ts
@@ -63,7 +63,7 @@ function slackSourceForDestination(args: {
   source?: SessionSource;
 }): SessionSource | undefined {
   if (
-    args.source?.platform !== "slack" ||
+    args.source?.kind !== "slack" ||
     args.source.channelId !== args.destination.channelId
   ) {
     return undefined;
@@ -71,7 +71,7 @@ function slackSourceForDestination(args: {
 
   const threadTs = args.source.threadTs?.trim();
   return {
-    platform: "slack",
+    kind: "slack",
     visibility: args.source.visibility ?? "public",
     teamId: args.source.teamId?.trim() || args.destination.teamId,
     channelId: args.source.channelId,

--- a/packages/junior/src/chat/slack/tool-support/context.ts
+++ b/packages/junior/src/chat/slack/tool-support/context.ts
@@ -28,7 +28,7 @@ export interface SlackToolContext {
 export function getSlackToolContext(
   context: ToolRuntimeContext,
 ): SlackToolContext | undefined {
-  if (context.source.platform !== "slack") {
+  if (context.source.kind !== "slack") {
     return undefined;
   }
   if (context.destination.platform !== "slack") {

--- a/packages/junior/src/chat/source.ts
+++ b/packages/junior/src/chat/source.ts
@@ -2,9 +2,9 @@ import { sourceSchema, type Source } from "@sentry/junior-plugin-api";
 
 /** Source coordinates reduced to the stable locator for one conversation. */
 export type SessionSource =
-  | Extract<Source, { platform: "web" }>
-  | Extract<Source, { platform: "local" }>
-  | Omit<Extract<Source, { platform: "slack" }>, "messageTs">;
+  | Extract<Source, { kind: "web" }>
+  | Extract<Source, { kind: "local" }>
+  | Omit<Extract<Source, { kind: "slack" }>, "messageTs">;
 
 /**
  * Normalize a turn Source into the session-stable locator persisted on a
@@ -18,23 +18,26 @@ export function normalizeSessionSource(
   if (!value) {
     return undefined;
   }
-  if (value.platform === "local") {
+  if (value.kind === "local") {
     return {
-      platform: "local",
+      kind: "local",
       visibility: value.visibility,
       conversationId: value.conversationId,
     };
   }
-  if (value.platform === "web") {
+  if (value.kind === "web") {
     return {
-      platform: "web",
+      kind: "web",
       visibility: value.visibility,
       conversationId: value.conversationId,
     };
+  }
+  if (value.kind === "resource_event") {
+    return undefined;
   }
   const threadTs = value.threadTs?.trim();
   return {
-    platform: "slack",
+    kind: "slack",
     visibility: value.visibility,
     teamId: value.teamId,
     channelId: value.channelId,

--- a/packages/junior/src/chat/task-execution/README.md
+++ b/packages/junior/src/chat/task-execution/README.md
@@ -13,7 +13,8 @@ checkpoint and is private to this module.
 
 `turn-wake.ts` wakes paused turns. `paused-turn.ts` runs them under the
 conversation lease. SQL conversation events store history. The Redis turn
-cursor stores only the data that is needed to resume a turn.
+cursor stores only the data that is needed to resume a turn, including the
+Source that started it.
 
 The reliability rules are small:
 

--- a/packages/junior/src/chat/task-execution/conversation-turn.ts
+++ b/packages/junior/src/chat/task-execution/conversation-turn.ts
@@ -74,6 +74,7 @@ import {
 } from "@/chat/task-execution/mailbox-turn";
 import { joinMailboxText } from "@/chat/task-execution/mailbox-input";
 import { resolveConversationDestination } from "@/chat/conversations/destination";
+import { isResourceEventConversationMessage } from "@/chat/resource-events/actor";
 
 function stableHex(...parts: string[]): string {
   return createHash("sha256")
@@ -211,6 +212,10 @@ export function createConversationTurnWorker(
       conversation,
       conversationId: context.conversationId,
     });
+    const savedTurn = isResume
+      ? await getTurnRecord(context.conversationId, turnId)
+      : undefined;
+    let resumedResourceEvent = false;
     if (isResume) {
       const userMessage = getTurnUserMessage(conversation, turnId);
       if (!userMessage) {
@@ -218,8 +223,15 @@ export function createConversationTurnWorker(
           `Unable to locate the persisted user message for Turn "${turnId}"`,
         );
       }
-      // Resume has no new input. Restore the Actor from the saved Turn input.
-      turnInputFacts = turnInputFactsFromConversationMessage(userMessage);
+      resumedResourceEvent = isResourceEventConversationMessage(userMessage);
+      // Resume has no new input. Restore Source from the Turn and Actor from
+      // the saved instruction until Actor is also a first-class Turn field.
+      turnInputFacts = turnInputFactsFromConversationMessage(userMessage, {
+        conversationId: context.conversationId,
+        location: storedConversation?.location,
+        savedSource: savedTurn?.source,
+        visibility: storedConversation?.visibility,
+      });
       userMessageId = userMessage.id;
       text = userMessage.text;
       startedAtMs = userMessage.createdAtMs;
@@ -233,21 +245,19 @@ export function createConversationTurnWorker(
     const { actor, author } = turnInputFacts;
     const source = sourceFromTurnInput({
       conversationId: context.conversationId,
-      location: storedConversation?.location,
       source: turnInputFacts.source,
       visibility: storedConversation?.visibility,
     });
     const webActor = actor.platform === "web" ? actor : undefined;
-    const savedTurn = isResume
-      ? await getTurnRecord(context.conversationId, turnId)
-      : undefined;
     // TODO(dcramer): Copy publish from the selected Inbound message after
     // resource-event input stores the final publish fact. Then remove this
     // Location default and the checkpoint fallback.
     const publish =
-      turnInputFacts.source === "resource_event" && storedConversation?.location
-        ? (savedTurn?.publishExternally ?? true)
-        : false;
+      savedTurn?.publishExternally ??
+      Boolean(
+        storedConversation?.location &&
+        (source.kind === "resource_event" || resumedResourceEvent),
+      );
     // TODO(dcramer): Remove this legacy surface choice after Turn checkpoints
     // store Source.kind and publish, and resume reads both fields.
     const surface = publish ? ("slack" as const) : ("api" as const);
@@ -319,7 +329,7 @@ export function createConversationTurnWorker(
             meta: {
               explicitMention: true,
               replied: false,
-              ...(turnInputFacts.source === "web"
+              ...(source.kind === "web"
                 ? { source: "web" as const }
                 : undefined),
             },
@@ -383,7 +393,7 @@ export function createConversationTurnWorker(
             sessionId: turnId,
             ...(publishedMessage
               ? { source: "slack" as const }
-              : turnInputFacts.source === "web"
+              : source.kind === "web"
                 ? { source: "web" as const }
                 : undefined),
             text: replyText,

--- a/packages/junior/src/chat/task-execution/mailbox-turn.ts
+++ b/packages/junior/src/chat/task-execution/mailbox-turn.ts
@@ -1,4 +1,5 @@
 import {
+  createResourceEventSource,
   createLocalSource,
   createWebSource,
   type Source,
@@ -29,9 +30,7 @@ export type MailboxTurnInput = {
   actor: Actor;
   author: ConversationAuthor;
   message: InboundMessage;
-  // TODO(dcramer): Replace this legacy source name with Source after mailbox
-  // Inbound messages store Source.kind.
-  source: "resource_event" | "web";
+  source: Source;
 };
 
 /** Actor and Source facts saved for one Turn. */
@@ -43,12 +42,27 @@ export type TurnInputFacts = Pick<
 /** Restore the Turn input facts kept on one saved Message. */
 export function turnInputFactsFromConversationMessage(
   message: ConversationMessage,
+  args: {
+    conversationId: string;
+    location?: Location;
+    savedSource?: Source;
+    visibility?: ConversationPrivacy;
+  },
 ): TurnInputFacts | undefined {
   if (isResourceEventConversationMessage(message)) {
     return {
       actor: RESOURCE_EVENT_SYSTEM_ACTOR,
       author: message.author ?? RESOURCE_EVENT_MESSAGE_AUTHOR,
-      source: "resource_event",
+      // Stored Turns written before Source was saved can only restore the old
+      // provider stand-in from the Conversation.
+      source:
+        args.savedSource ??
+        (args.location
+          ? createWebSource(
+              args.conversationId,
+              args.visibility === "private" ? "private" : "public",
+            )
+          : createLocalSource(args.conversationId)),
     };
   }
   const actor = createActor(message.author, {
@@ -61,33 +75,29 @@ export function turnInputFactsFromConversationMessage(
   return {
     actor,
     author: message.author ?? { userId: actor.userId },
-    source: "web",
+    source:
+      args.savedSource?.kind === "web"
+        ? args.savedSource
+        : createWebSource(
+            args.conversationId,
+            args.visibility === "private" ? "private" : "public",
+          ),
   };
 }
 
-/** Build the AgentRun Source for one Turn input. */
+/** Normalize the selected mailbox Source with current Conversation visibility. */
 export function sourceFromTurnInput(args: {
   conversationId: string;
-  location?: Location;
-  source: MailboxTurnInput["source"];
+  source: Source;
   visibility?: ConversationPrivacy;
 }): Source {
-  switch (args.source) {
-    case "resource_event":
-      // TODO(dcramer): Remove this temporary web Source after Turn checkpoints
-      // can store a resource-event Source.kind.
-      return args.location
-        ? createWebSource(
-            args.conversationId,
-            args.visibility === "private" ? "private" : "public",
-          )
-        : createLocalSource(args.conversationId);
-    case "web":
-      return createWebSource(
-        args.conversationId,
-        args.visibility === "private" ? "private" : "public",
-      );
+  if (args.source.kind === "web") {
+    return createWebSource(
+      args.conversationId,
+      args.visibility === "private" ? "private" : "public",
+    );
   }
+  return args.source;
 }
 
 function hasResourceEventActor(actors: readonly Actor[] | undefined): boolean {
@@ -123,7 +133,8 @@ export async function getActiveConversationTurnId(
   if (!turnId) return undefined;
   const record = await getTurnRecord(conversationId, turnId);
   return record &&
-    record.surface === "api" &&
+    (record.source?.kind === "web" ||
+      (!record.source && record.surface === "api")) &&
     !record.dispatchId &&
     (record.state === "paused" || record.state === "running")
     ? turnId
@@ -149,7 +160,11 @@ async function getActiveMailboxTurnId(
     (record) =>
       record &&
       !record.dispatchId &&
-      (record.surface === "api" || hasResourceEventActor(record.actors)) &&
+      (record.source?.kind === "web" ||
+        record.source?.kind === "resource_event" ||
+        (!record.source &&
+          (record.surface === "api" ||
+            hasResourceEventActor(record.actors)))) &&
       (record.state === "paused" || record.state === "running"),
   );
   if (active.length > 1) {
@@ -157,8 +172,8 @@ async function getActiveMailboxTurnId(
       `Conversation ${conversationId} has multiple active mailbox Turns`,
     );
   }
-  // TODO(dcramer): Remove Actor-based resource-event selection after Turn
-  // checkpoints store Source.kind and resume reads it.
+  // TODO(dcramer): Remove the legacy surface and Actor checks after deployed
+  // Turn cursors all store Source.kind.
   return active[0]?.turnId;
 }
 
@@ -215,7 +230,7 @@ function parseWebMessages(
         ...(actor.userName ? { userName: actor.userName } : undefined),
       },
       message: entry.message,
-      source: "web" as const,
+      source: createWebSource(entry.message.conversationId),
     };
   });
 }
@@ -243,7 +258,12 @@ function parseResourceEventMessages(
       actor: RESOURCE_EVENT_SYSTEM_ACTOR,
       author: RESOURCE_EVENT_MESSAGE_AUTHOR,
       message,
-      source: "resource_event" as const,
+      source: createResourceEventSource({
+        eventKey: message.input.metadata.resourceEvent.eventKey,
+        eventType: message.input.metadata.resourceEvent.eventType,
+        identifier: message.input.metadata.resourceEvent.identifier,
+        namespace: message.input.metadata.resourceEvent.namespace,
+      }),
     };
   });
 }

--- a/packages/junior/src/chat/task-execution/turn-cursor.ts
+++ b/packages/junior/src/chat/task-execution/turn-cursor.ts
@@ -7,7 +7,11 @@
  * keeps resume metadata and a committed `seq` cursor into
  * `junior_conversation_events`.
  */
-import type { Destination, Source } from "@sentry/junior-plugin-api";
+import {
+  sourceSchema,
+  type Destination,
+  type Source,
+} from "@sentry/junior-plugin-api";
 import { z } from "zod";
 import { piMessageSchema, type PiMessage } from "@/chat/pi/messages";
 import { toStoredSlackActor, type Actor } from "@/chat/actor";
@@ -127,6 +131,8 @@ export interface TurnRecord {
   actors: Actor[];
   resumeReason?: TurnPauseReason;
   publishExternally?: boolean;
+  /** Input that started this Turn; absent only on stored legacy cursors. */
+  source?: Source;
   resumedFromSliceId?: number;
   turnId: string;
   sliceId: number;
@@ -235,6 +241,7 @@ const storedTurnRecordSchema = z
     lastProgressAtMs: nonNegativeNumberSchema,
     resumeReason: turnPauseReasonSchema.optional(),
     publishExternally: z.boolean().optional(),
+    source: sourceSchema.optional(),
     resumedFromSliceId: z.number().int().nonnegative().optional(),
     turnId: z.string().min(1),
     sliceId: z.number().int().nonnegative(),
@@ -345,9 +352,9 @@ async function recordConversationActivityMetadata(args: {
     conversationId: args.summary.conversationId,
   });
   const hasParent = Boolean(conversation?.parentConversationId);
-  // Nested Destination, Source, and Actor stay off Redis cursor payloads.
-  // Callers pass live values here for the SQL write. Conversations with a
-  // parent keep no Destination.
+  // Destination and Actor stay off Redis cursor payloads. Source is stored on
+  // the Turn. Callers also pass it here for the SQL Conversation write.
+  // Conversations with a parent keep no Destination.
   const destination = hasParent ? undefined : args.destination;
   // Root dual-write requires a destination on first create. Cursor-only writes
   // without destination stay Redis-only until a real root upsert lands.
@@ -361,7 +368,7 @@ async function recordConversationActivityMetadata(args: {
   // are not collapsed to local just because delivery uses a local destination.
   const activitySource = hasParent
     ? "internal"
-    : args.source?.platform === "web"
+    : args.source?.kind === "web"
       ? "web"
       : destination?.platform === "local"
         ? "local"
@@ -440,6 +447,7 @@ function materializeTurnRecord(
       errorMessage: stored.errorMessage,
       resumeReason: stored.resumeReason,
       publishExternally: stored.publishExternally,
+      source: stored.source,
       resultMessageId: stored.resultMessageId,
       resumedFromSliceId: stored.resumedFromSliceId,
       surface: stored.surface,
@@ -601,6 +609,7 @@ function buildStoredRecord(args: {
   surface?: AgentTurnSurface;
   resumeReason?: TurnPauseReason;
   publishExternally?: boolean;
+  source?: Source;
   errorMessage?: string;
   resumedFromSliceId?: number;
   traceId?: string;
@@ -626,6 +635,7 @@ function buildStoredRecord(args: {
       historyVersion: args.historyVersion,
       resumeReason: args.resumeReason,
       publishExternally: args.publishExternally,
+      source: args.source,
       resultMessageId: args.resultMessageId,
       resumedFromSliceId: args.resumedFromSliceId,
       runtimeContext:
@@ -755,6 +765,7 @@ async function updateTurnState(args: {
         historyVersion: parsed.historyVersion,
         resumeReason: args.existing.resumeReason,
         publishExternally: args.existing.publishExternally,
+        source: args.existing.source,
         resultMessageId: args.resultMessageId ?? args.existing.resultMessageId,
         resumedFromSliceId: args.existing.resumedFromSliceId,
         surface: args.existing.surface,
@@ -920,7 +931,9 @@ async function upsertTurnRecordLocked(
         errorMessage: args.errorMessage,
         lastProgressAtMs: args.lastProgressAtMs,
         resumeReason: args.resumeReason,
-        publishExternally: args.publishExternally ?? existingRecord?.publishExternally,
+        publishExternally:
+          args.publishExternally ?? existingRecord?.publishExternally,
+        source: args.source ?? existingRecord?.source,
         resultMessageId:
           args.resultMessageId ?? existingRecord?.resultMessageId,
         resumedFromSliceId: args.resumedFromSliceId,

--- a/packages/junior/src/chat/tools/event-tasks.ts
+++ b/packages/junior/src/chat/tools/event-tasks.ts
@@ -15,7 +15,7 @@ export function createEventTaskTools(
   catalog: ResourceEventCatalog,
 ): ToolRegistry {
   if (
-    context.source.platform !== "slack" ||
+    context.source.kind !== "slack" ||
     context.destination.platform !== "slack" ||
     context.actor?.platform !== "slack"
   ) {

--- a/packages/junior/src/chat/tools/index.ts
+++ b/packages/junior/src/chat/tools/index.ts
@@ -184,7 +184,7 @@ export function createTools(
     }
     // Always register public search in Slack turns. Without an action token the
     // tool stays visible and returns an honest interactive-turn limit.
-    if (context.source.platform === "slack") {
+    if (context.source.kind === "slack") {
       tools.slackPublicSearch = createSlackPublicSearchTool(
         context.slackActionToken,
       );

--- a/packages/junior/src/chat/tools/scheduled-tasks.ts
+++ b/packages/junior/src/chat/tools/scheduled-tasks.ts
@@ -13,7 +13,7 @@ function scheduledTaskToolContext(
   context: ToolRuntimeContext,
 ): SchedulerToolContext | undefined {
   if (
-    context.source.platform !== "slack" ||
+    context.source.kind !== "slack" ||
     context.destination.platform !== "slack" ||
     context.actor?.platform !== "slack" ||
     !context.resolveActorIdentity

--- a/packages/junior/src/chat/tools/search-conversation-events.ts
+++ b/packages/junior/src/chat/tools/search-conversation-events.ts
@@ -222,7 +222,7 @@ async function resolveAccessScope(
       )
     : currentConversationId;
 
-  if (context.source.platform === "slack") {
+  if (context.source.kind === "slack") {
     return {
       currentConversationId,
       currentRootConversationId,
@@ -363,7 +363,9 @@ function projectEvent(event: ConversationEvent) {
     seq: event.seq,
     history_version: event.historyVersion,
     created_at: new Date(event.createdAtMs).toISOString(),
-    ...(event.idempotencyKey ? { idempotency_key: event.idempotencyKey } : undefined),
+    ...(event.idempotencyKey
+      ? { idempotency_key: event.idempotencyKey }
+      : undefined),
     data,
   };
 }

--- a/packages/junior/src/chat/tools/types.ts
+++ b/packages/junior/src/chat/tools/types.ts
@@ -1,6 +1,7 @@
 import type { FileUpload } from "chat";
 import type {
   WebSource,
+  ResourceEventSource,
   Destination,
   Identity,
   LocalDestination,
@@ -9,6 +10,7 @@ import type {
   SlackDestination,
   SlackSource,
   Source,
+  SystemActor,
   User,
 } from "@sentry/junior-plugin-api";
 import type { McpToolManager } from "@/chat/mcp/tool-manager";
@@ -134,8 +136,17 @@ interface WebToolRuntimeContext extends BaseToolRuntimeContext {
   slackActionToken?: never;
 }
 
+interface ResourceEventToolRuntimeContext extends BaseToolRuntimeContext {
+  destination: Destination;
+  actor?: SystemActor;
+  source: ResourceEventSource;
+  slack?: never;
+  slackActionToken?: never;
+}
+
 export type ToolRuntimeContext =
   | LocalToolRuntimeContext
+  | ResourceEventToolRuntimeContext
   | SlackToolRuntimeContext
   | WebToolRuntimeContext;
 

--- a/packages/junior/src/handlers/mcp-oauth-callback.ts
+++ b/packages/junior/src/handlers/mcp-oauth-callback.ts
@@ -513,7 +513,7 @@ function mcpConversationId(
 ): string | undefined {
   if (
     authSession.destination?.platform === "local" ||
-    authSession.source?.platform === "web"
+    authSession.source?.kind === "web"
   ) {
     return authSession.conversationId;
   }
@@ -632,7 +632,7 @@ export async function GET(
       });
     }
 
-    if (authSession.source?.platform === "web" && authSession.destination) {
+    if (authSession.source?.kind === "web" && authSession.destination) {
       waitUntil(async () => {
         const turn = await getTurnRecord(
           authSession.conversationId,
@@ -684,7 +684,7 @@ export async function GET(
       // Only the CLI path should get the local-client success copy.
       local:
         authSession.destination?.platform === "local" &&
-        authSession.source?.platform !== "web",
+        authSession.source?.kind !== "web",
     });
   } catch (callbackError) {
     if (callbackError instanceof McpOAuthAttemptExpiredError) {

--- a/packages/junior/src/handlers/oauth-callback.ts
+++ b/packages/junior/src/handlers/oauth-callback.ts
@@ -762,7 +762,7 @@ export async function GET(
 
   if (
     stored.destination?.platform !== "local" &&
-    stored.source?.platform !== "web"
+    stored.source?.kind !== "web"
   ) {
     waitUntil(async () => {
       try {
@@ -778,7 +778,7 @@ export async function GET(
   }
 
   const resumesWebTurn = Boolean(
-    stored.source?.platform === "web" &&
+    stored.source?.kind === "web" &&
     stored.destination &&
     stored.resumeConversationId &&
     stored.resumeSessionId,

--- a/packages/junior/tests/component/conversation-sql-store.test.ts
+++ b/packages/junior/tests/component/conversation-sql-store.test.ts
@@ -219,7 +219,7 @@ describe("conversation SQL store", () => {
         },
         source: "slack",
         sessionSource: {
-          platform: "slack",
+          kind: "slack",
           visibility: "public",
           teamId: "T123",
           channelId: "C123",
@@ -366,7 +366,7 @@ describe("conversation SQL store", () => {
         },
         nowMs: 4_000,
         sessionSource: {
-          platform: "local",
+          kind: "local",
           visibility: "private",
           conversationId: localConversationId,
         },
@@ -706,7 +706,7 @@ describe("conversation SQL store", () => {
         destination,
         source: "slack",
         sessionSource: {
-          platform: "slack",
+          kind: "slack",
           visibility: "public",
           teamId: "T123",
           channelId: "C123",
@@ -719,7 +719,7 @@ describe("conversation SQL store", () => {
         store.get({ conversationId: CONVERSATION_ID }),
       ).resolves.toMatchObject({
         sessionSource: {
-          platform: "slack",
+          kind: "slack",
           visibility: "public",
           teamId: "T123",
           channelId: "C123",
@@ -732,7 +732,7 @@ describe("conversation SQL store", () => {
         conversationId: CONVERSATION_ID,
         destination,
         sessionSource: {
-          platform: "slack",
+          kind: "slack",
           visibility: "private",
           teamId: "T123",
           channelId: "C123",
@@ -744,7 +744,7 @@ describe("conversation SQL store", () => {
         store.get({ conversationId: CONVERSATION_ID }),
       ).resolves.toMatchObject({
         sessionSource: {
-          platform: "slack",
+          kind: "slack",
           visibility: "public",
           teamId: "T123",
           channelId: "C123",

--- a/packages/junior/tests/component/conversations/retention.test.ts
+++ b/packages/junior/tests/component/conversations/retention.test.ts
@@ -564,7 +564,7 @@ describe("retention purge job", () => {
         result: "private delegated result",
         source: {
           conversationId: "root",
-          platform: "local",
+          kind: "local",
           visibility: "private",
         },
         status: "completed",

--- a/packages/junior/tests/component/runtime/agent-run-error-path.test.ts
+++ b/packages/junior/tests/component/runtime/agent-run-error-path.test.ts
@@ -141,7 +141,7 @@ describe("executeAgentRun error path", () => {
     ).rejects.toThrow("Assistant reply generation requires a destination");
   });
 
-  it("hard-fails Actor and Source platform mismatches", async () => {
+  it("hard-fails Actor platform and Source kind mismatches", async () => {
     await expect(
       executeAgentRun({
         conversationId: LOCAL_DESTINATION.conversationId,
@@ -156,7 +156,7 @@ describe("executeAgentRun error path", () => {
         },
       }),
     ).rejects.toThrow(
-      'Actor platform "slack" does not match Source platform "local"',
+      'Actor platform "slack" does not match Source kind "local"',
     );
   });
 

--- a/packages/junior/tests/component/task-execution/checkpoint.test.ts
+++ b/packages/junior/tests/component/task-execution/checkpoint.test.ts
@@ -104,12 +104,14 @@ describe("turn checkpoint", () => {
     await upsertTurnRecord({
       conversationId: "local:ttl-split:turn",
       piMessages: [runtimeContext],
+      source: SLACK_SOURCE,
       turnId: "turn-ttl-split",
       sliceId: 1,
       state: "running",
     });
     expect(set.mock.calls.at(-1)?.[1]).toMatchObject({
       runtimeContext: [runtimeContext],
+      source: SLACK_SOURCE,
     });
     expect(set.mock.calls.at(-1)?.[1]).not.toHaveProperty("modelId");
     expect(set.mock.calls.at(-1)?.[2]).toBe(24 * 60 * 60 * 1000);
@@ -120,6 +122,10 @@ describe("turn checkpoint", () => {
     // Recovery index stays on the resume window so terminal writes cannot
     // expire unfinished sibling summaries.
     expect(appendToList.mock.calls[0]?.[2]?.ttlMs).toBe(24 * 60 * 60 * 1000);
+    const { getTurnRecord } = await import("@/chat/task-execution/turn-cursor");
+    await expect(
+      getTurnRecord("local:ttl-split:turn", "turn-ttl-split"),
+    ).resolves.toMatchObject({ source: SLACK_SOURCE });
 
     set.mockClear();
     appendToList.mockClear();
@@ -277,11 +283,11 @@ describe("turn checkpoint", () => {
       resumedFromSliceId: 1,
       resumeReason: "auth",
       publishExternally: false,
+      source: SLACK_SOURCE,
       errorMessage: "plugin auth pause",
       piMessages: [priorMessages[0]],
     });
-    // Nested routing stays off redis; SQL dual-write is the authority.
-    expect(sessionRecord).not.toHaveProperty("source");
+    // Source stays on the Turn. Destination and Actor remain live write facts.
     expect(sessionRecord).not.toHaveProperty("destination");
     expect(sessionRecord).not.toHaveProperty("actor");
   });
@@ -489,7 +495,7 @@ describe("turn checkpoint", () => {
     }
   });
 
-  it("keeps nested destination/source out of redis while dual-writing sql", async () => {
+  it("stores Source on the Turn while keeping Destination and Actor out of Redis", async () => {
     const { getStateAdapter } = await import("@/chat/state/adapter");
     const { getTurnRecord, listTurnSummaries, upsertTurnRecord } =
       await import("@/chat/task-execution/turn-cursor");
@@ -534,7 +540,7 @@ describe("turn checkpoint", () => {
       }),
     );
     expect(stored).not.toHaveProperty("destination");
-    expect(stored).not.toHaveProperty("source");
+    expect(stored).toMatchObject({ source: SLACK_SOURCE });
     expect(stored).not.toHaveProperty("actor");
 
     const summaries = await listTurnSummaries(conversationId);
@@ -543,7 +549,7 @@ describe("turn checkpoint", () => {
     expect(summaries[0]).not.toHaveProperty("source");
     expect(summaries[0]).not.toHaveProperty("actor");
 
-    // Materialized reads no longer surface nested routing/identity from redis.
+    // Materialized reads restore Source without restoring Destination or Actor.
     const record = await getTurnRecord(conversationId, turnId);
     expect(record).toMatchObject({
       conversationId,
@@ -551,7 +557,7 @@ describe("turn checkpoint", () => {
       state: "running",
     });
     expect(record).not.toHaveProperty("destination");
-    expect(record).not.toHaveProperty("source");
+    expect(record).toMatchObject({ source: SLACK_SOURCE });
     expect(record).not.toHaveProperty("actor");
 
     expect(conversationStore.recordActivity).toHaveBeenCalledWith(
@@ -627,7 +633,7 @@ describe("turn checkpoint", () => {
     const record = await getTurnRecord(conversationId, turnId);
     expect(record).toMatchObject({ schemaVersion: 2, state: "paused" });
     expect(record).not.toHaveProperty("destination");
-    expect(record).not.toHaveProperty("source");
+    expect(record).toMatchObject({ source: SLACK_SOURCE });
     expect(record).not.toHaveProperty("actor");
     expect(record).not.toHaveProperty("deprecatedFlag");
   });

--- a/packages/junior/tests/component/tool-support/pi-tool-adapter.test.ts
+++ b/packages/junior/tests/component/tool-support/pi-tool-adapter.test.ts
@@ -47,7 +47,7 @@ function actionReview(
         conversationId: "local:tool-review",
       },
       source: {
-        platform: "local",
+        kind: "local",
         visibility: "private",
         conversationId: "local:tool-review",
       },
@@ -571,7 +571,9 @@ describe("Pi tool adapter", () => {
 
     await expect(
       demoTool!.execute("tool-limit", { cadence: "weekly" }),
-    ).rejects.toThrow("Do not retry this action or an equivalent write this turn.");
+    ).rejects.toThrow(
+      "Do not retry this action or an equivalent write this turn.",
+    );
     expect(review).toHaveBeenCalledTimes(3);
     expect(onFatal).not.toHaveBeenCalled();
     expect(

--- a/packages/junior/tests/integration/acp-http.test.ts
+++ b/packages/junior/tests/integration/acp-http.test.ts
@@ -301,7 +301,7 @@ describe("remote ACP HTTP", () => {
     expect(harness.agentRuns).toHaveLength(1);
     expect(harness.agentRuns[0]).toMatchObject({
       publishExternally: false,
-      source: { platform: "web", visibility: "private" },
+      source: { kind: "web", visibility: "private" },
     });
     await expect(harness.historyTexts(sessionId)).resolves.toEqual([
       expectedFirstPromptText,

--- a/packages/junior/tests/integration/api/conversations/list.test.ts
+++ b/packages/junior/tests/integration/api/conversations/list.test.ts
@@ -215,7 +215,7 @@ describe("conversation list API", () => {
         },
         nowMs: 1_000,
         sessionSource: {
-          platform: "slack",
+          kind: "slack",
           visibility: "public",
           teamId: "T123",
           channelId: "C123",
@@ -244,7 +244,7 @@ describe("conversation list API", () => {
         },
         nowMs: 2_000,
         sessionSource: {
-          platform: "slack",
+          kind: "slack",
           visibility: "private",
           teamId: "T123",
           channelId: "D123",

--- a/packages/junior/tests/integration/conversation-turn-work.test.ts
+++ b/packages/junior/tests/integration/conversation-turn-work.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createLocalSource, createWebSource } from "@sentry/junior-plugin-api";
+import {
+  createResourceEventSource,
+  createWebSource,
+} from "@sentry/junior-plugin-api";
 import {
   appendAndEnqueueWebMessage,
   buildWebInboundMessage,
@@ -27,6 +30,7 @@ import {
   getTurnRecord,
   saveTurnCheckpoint,
 } from "@/chat/task-execution/checkpoint";
+import { turnCursorKey } from "@/chat/task-execution/turn-cursor-keys";
 import {
   closeConversationFixture,
   createConversationFixture,
@@ -555,6 +559,12 @@ describe("Conversation mailbox Turn work", () => {
 
     const messageId = message.inboundMessageId;
     const turnId = conversationTurnIdForMessage(messageId);
+    const source = createResourceEventSource({
+      eventKey: "checks-failed-1",
+      eventType: "check_suite.completed",
+      identifier: "getsentry/junior#1563",
+      namespace: "github",
+    });
     const agentRuns: AgentRun[] = [];
     let firstRun = true;
     const worker = createConversationTurnWorker(
@@ -587,6 +597,7 @@ describe("Conversation mailbox Turn work", () => {
     await expect(getTurnRecord(conversationId, turnId)).resolves.toMatchObject({
       publishExternally: false,
       resumeReason: "yield",
+      source,
       state: "paused",
     });
 
@@ -609,7 +620,7 @@ describe("Conversation mailbox Turn work", () => {
           destination,
           disabledFeatures: ["interactive-auth"],
           publishExternally: false,
-          source: createLocalSource(conversationId),
+          source,
           turnId,
         }),
       );
@@ -617,6 +628,7 @@ describe("Conversation mailbox Turn work", () => {
     }
     await expect(getTurnRecord(conversationId, turnId)).resolves.toMatchObject({
       publishExternally: false,
+      source,
       state: "completed",
     });
     const transcript = (
@@ -644,6 +656,131 @@ describe("Conversation mailbox Turn work", () => {
         text: "Handled the resource event.",
       },
     ]);
+  }, 10_000);
+
+  it("keeps legacy resource event publishing on after resume", async () => {
+    const { conversationStore, queue, state } =
+      await createConversationFixture();
+    const conversationId = "slack:C123";
+    const destination = {
+      platform: "slack" as const,
+      teamId: "T123",
+      channelId: "C123",
+    };
+    await conversationStore.recordActivity({
+      conversationId,
+      destination,
+      nowMs: 1,
+      source: "slack",
+    });
+    const message = createResourceEventInboundMessage({
+      event: {
+        eventKey: "legacy-review-requested-1",
+        eventType: "pull_request.review.requested",
+        identifier: "getsentry/junior#1563",
+        namespace: "github",
+        occurredAtMs: 2,
+        trustedSummary: "Code change review requested",
+      },
+      receivedAtMs: 2,
+      subscription: {
+        conversationId,
+        id: "legacy-resource-subscription-1",
+      },
+      text: "Code change review requested",
+    });
+    await appendAndEnqueueInboundMessage({
+      conversationStore,
+      message,
+      queue,
+      state,
+    });
+
+    const turnId = conversationTurnIdForMessage(message.inboundMessageId);
+    const source = createResourceEventSource({
+      eventKey: "legacy-review-requested-1",
+      eventType: "pull_request.review.requested",
+      identifier: "getsentry/junior#1563",
+      namespace: "github",
+    });
+    const agentRuns: AgentRun[] = [];
+    let firstRun = true;
+    const publishMessage = vi.fn(async () => ({
+      providerMessageId: "1712346.0001",
+    }));
+    const worker = createConversationTurnWorker(
+      createModelAgentRunnerForRun((run) => {
+        agentRuns.push(run);
+        if (firstRun) {
+          firstRun = false;
+          return createModelStream([
+            { type: "toolCall", name: "systemTime", arguments: {} },
+            { type: "text", text: "Review request handled." },
+          ]);
+        }
+        return createModelStream([
+          { type: "text", text: "Review request handled." },
+        ]);
+      }),
+      publishMessage,
+    );
+    const run = requireConversationTurn(worker);
+
+    await expect(
+      processConversationQueueMessage(queue.takeMessage(), {
+        conversationStore,
+        queue,
+        run,
+        softYieldAfterMs: 0,
+        state,
+      }),
+    ).resolves.toEqual({ status: "yielded" });
+    await expect(getTurnRecord(conversationId, turnId)).resolves.toMatchObject({
+      publishExternally: true,
+      source,
+      state: "paused",
+    });
+
+    const storedCursor = await state.get(turnCursorKey(conversationId, turnId));
+    if (!storedCursor || typeof storedCursor !== "object") {
+      throw new Error("Expected stored Turn cursor");
+    }
+    const {
+      publishExternally: storedPublish,
+      source: storedSource,
+      ...legacyCursor
+    } = storedCursor as Record<string, unknown>;
+    expect(storedPublish).toBe(true);
+    expect(storedSource).toEqual(source);
+    await state.set(
+      turnCursorKey(conversationId, turnId),
+      legacyCursor,
+      60_000,
+    );
+
+    await expect(
+      processConversationQueueMessage(queue.takeMessage(), {
+        conversationStore,
+        queue,
+        run,
+        state,
+      }),
+    ).resolves.toEqual({ status: "completed" });
+
+    expect(agentRuns).toHaveLength(2);
+    expect(agentRuns[0]).toEqual(
+      expect.objectContaining({
+        publishExternally: true,
+        source,
+      }),
+    );
+    expect(agentRuns[1]).toEqual(
+      expect.objectContaining({
+        publishExternally: true,
+        source: createWebSource(conversationId),
+      }),
+    );
+    expect(publishMessage).toHaveBeenCalledOnce();
   }, 10_000);
 
   it("does not claim dispatch resume wakes that share surface api", async () => {
@@ -707,7 +844,7 @@ describe("Conversation mailbox Turn work", () => {
       },
       source: "slack",
       sessionSource: {
-        platform: "slack",
+        kind: "slack",
         visibility: "public",
         teamId: "T1200",
         channelId: "C1200",
@@ -742,7 +879,7 @@ describe("Conversation mailbox Turn work", () => {
       },
       visibility: "public",
       sessionSource: {
-        platform: "slack",
+        kind: "slack",
         teamId: "T1200",
         channelId: "C1200",
         threadTs: "1712345.1200",
@@ -788,7 +925,7 @@ describe("Conversation mailbox Turn work", () => {
         destination: expect.objectContaining({ platform: "slack" }),
         location: storedConversation?.location,
         publishExternally: false,
-        source: expect.objectContaining({ platform: "web" }),
+        source: expect.objectContaining({ kind: "web" }),
       }),
     );
 

--- a/packages/junior/tests/integration/local-agent-runner.test.ts
+++ b/packages/junior/tests/integration/local-agent-runner.test.ts
@@ -584,7 +584,7 @@ describe("local agent runner", () => {
           }),
         ],
         source: {
-          platform: "local",
+          kind: "local",
           visibility: "private",
           conversationId,
         },

--- a/packages/junior/tests/integration/search-conversation-events.test.ts
+++ b/packages/junior/tests/integration/search-conversation-events.test.ts
@@ -14,7 +14,7 @@ const CURRENT_CONVERSATION_ID = "slack:C123:1700000000.100000";
 
 type SlackToolRuntimeContext = Extract<
   ToolRuntimeContext,
-  { source: { platform: "slack" } }
+  { source: { kind: "slack" } }
 >;
 
 function context(): SlackToolRuntimeContext {

--- a/packages/junior/tests/unit/handlers/mcp-oauth-callback.test.ts
+++ b/packages/junior/tests/unit/handlers/mcp-oauth-callback.test.ts
@@ -35,9 +35,7 @@ vi.mock("@/chat/runtime/thread-state", async (importOriginal) => ({
 }));
 
 vi.mock("@/chat/conversations/projection", async (importOriginal) => ({
-  ...(await importOriginal<
-    typeof import("@/chat/conversations/projection")
-  >()),
+  ...(await importOriginal<typeof import("@/chat/conversations/projection")>()),
   recordAuthenticationLinked: vi.fn(async () => undefined),
 }));
 
@@ -306,7 +304,11 @@ describe("mcp oauth callback handler", () => {
       userId: "dashboard:alice",
       conversationId: "local:web:alice",
       destination: { platform: "local", conversationId: "local:web:alice" },
-      source: { platform: "web", conversationId: "local:web:alice" },
+      source: {
+        kind: "web",
+        conversationId: "local:web:alice",
+        visibility: "private",
+      },
       sessionId: "turn-1",
       userMessage: "use MCP",
       createdAtMs: 1,

--- a/packages/junior/tests/unit/plugin-api-source.test.ts
+++ b/packages/junior/tests/unit/plugin-api-source.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { createSlackSource, sourceSchema } from "@sentry/junior-plugin-api";
+import {
+  createResourceEventSource,
+  createSlackSource,
+  sourceSchema,
+} from "@sentry/junior-plugin-api";
 
 describe("plugin source helpers", () => {
   it("accepts Slack source visibility from the runtime boundary", () => {
@@ -9,7 +13,7 @@ describe("plugin source helpers", () => {
         channelId: "C123",
         visibility: "public",
       }),
-    ).toMatchObject({ visibility: "public" });
+    ).toMatchObject({ kind: "slack", visibility: "public" });
     // Modern Slack private channels also use C-prefixed ids.
     expect(
       createSlackSource({
@@ -61,11 +65,37 @@ describe("plugin source helpers", () => {
         },
       }),
     ).toEqual({
-      platform: "slack",
+      kind: "slack",
       teamId: "T123",
       channelId: "C123",
       threadTs: "1712345.0001",
       visibility: "private",
     });
+  });
+
+  it("builds a Resource event Source from event identity", () => {
+    expect(
+      createResourceEventSource({
+        eventKey: "delivery-1",
+        eventType: "issue.updated",
+        identifier: "PROJ-123",
+        namespace: "sentry",
+      }),
+    ).toEqual({
+      kind: "resource_event",
+      eventKey: "delivery-1",
+      eventType: "issue.updated",
+      identifier: "PROJ-123",
+      namespace: "sentry",
+    });
+    expect(
+      sourceSchema.safeParse({
+        platform: "resource_event",
+        eventKey: "delivery-1",
+        eventType: "issue.updated",
+        identifier: "PROJ-123",
+        namespace: "sentry",
+      }).success,
+    ).toBe(false);
   });
 });

--- a/packages/junior/tests/unit/prompt.test.ts
+++ b/packages/junior/tests/unit/prompt.test.ts
@@ -69,7 +69,7 @@ describe("prompt builders", () => {
     );
     expect(prompt).toContain("- dispatch.actor.platform: system");
     expect(prompt).toContain("- dispatch.actor.name: scheduler");
-    expect(prompt).toContain("- source.platform: slack");
+    expect(prompt).toContain("- source.kind: slack");
     expect(prompt).toContain("- destination.channel_id: C123");
     expect(prompt).toContain(
       "- dispatch.metadata.scheduledFor: 2026-05-26T12:00:00.000Z",

--- a/packages/junior/tests/unit/runtime/source.test.ts
+++ b/packages/junior/tests/unit/runtime/source.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { normalizeSessionSource, parseSessionSource } from "@/chat/source";
 
 describe("session source", () => {
-  it("parses canonical serialized sources", () => {
+  it("normalizes a stored Source with the old discriminator", () => {
     expect(
       parseSessionSource({
         platform: "slack",
@@ -12,7 +12,7 @@ describe("session source", () => {
         threadTs: "1700000000.000100",
       }),
     ).toEqual({
-      platform: "slack",
+      kind: "slack",
       visibility: "public",
       teamId: "T123",
       channelId: "C123",
@@ -23,7 +23,7 @@ describe("session source", () => {
   it("normalizes slack sources to the session-stable thread anchor", () => {
     expect(
       normalizeSessionSource({
-        platform: "slack",
+        kind: "slack",
         visibility: "private",
         teamId: "T123",
         channelId: "C123",
@@ -31,7 +31,7 @@ describe("session source", () => {
         messageTs: "1700000000.000200",
       }),
     ).toEqual({
-      platform: "slack",
+      kind: "slack",
       visibility: "private",
       teamId: "T123",
       channelId: "C123",
@@ -42,14 +42,14 @@ describe("session source", () => {
   it("keeps channel-level slack sources without inventing a thread anchor", () => {
     expect(
       normalizeSessionSource({
-        platform: "slack",
+        kind: "slack",
         visibility: "public",
         teamId: "T123",
         channelId: "C123",
         messageTs: "1700000000.000200",
       }),
     ).toEqual({
-      platform: "slack",
+      kind: "slack",
       visibility: "public",
       teamId: "T123",
       channelId: "C123",
@@ -63,7 +63,7 @@ describe("session source", () => {
         messageTs: "1700000000.000200",
       }),
     ).toEqual({
-      platform: "slack",
+      kind: "slack",
       visibility: "public",
       teamId: "T123",
       channelId: "C123",
@@ -73,12 +73,12 @@ describe("session source", () => {
   it("normalizes local sources", () => {
     expect(
       normalizeSessionSource({
-        platform: "local",
+        kind: "local",
         visibility: "private",
         conversationId: "local:abc123:demo",
       }),
     ).toEqual({
-      platform: "local",
+      kind: "local",
       visibility: "private",
       conversationId: "local:abc123:demo",
     });

--- a/packages/junior/tests/unit/services/guardian-action-review.test.ts
+++ b/packages/junior/tests/unit/services/guardian-action-review.test.ts
@@ -23,7 +23,7 @@ const proposal: ToolActionProposal = {
       conversationId: "local:guardian-test",
     },
     source: {
-      platform: "local",
+      kind: "local",
       visibility: "private",
       conversationId: "local:guardian-test",
     },

--- a/packages/junior/tests/unit/services/turn-session-routing.test.ts
+++ b/packages/junior/tests/unit/services/turn-session-routing.test.ts
@@ -17,7 +17,7 @@ const DESTINATION = {
 } as const satisfies Destination;
 
 const SOURCE = {
-  platform: "slack",
+  kind: "slack",
   teamId: "T123",
   channelId: "C123",
   threadTs: "1712345.0001",
@@ -173,7 +173,7 @@ describe("resolveConversationRouting", () => {
           conversationId: "opaque-root",
           destination: DESTINATION,
           sessionSource: {
-            platform: "slack",
+            kind: "slack",
             teamId: "T123",
             channelId: "C123",
             visibility: "public",
@@ -190,7 +190,7 @@ describe("resolveConversationRouting", () => {
     ).resolves.toEqual({
       destination: DESTINATION,
       source: {
-        platform: "slack",
+        kind: "slack",
         teamId: "T123",
         channelId: "C123",
         visibility: "public",
@@ -208,7 +208,7 @@ describe("resolveConversationRouting", () => {
             conversationId: "local:web:abc",
           },
           sessionSource: {
-            platform: "local",
+            kind: "local",
             visibility: "private",
             conversationId: "local:web:abc",
           },
@@ -227,7 +227,7 @@ describe("resolveConversationRouting", () => {
         conversationId: "local:web:abc",
       },
       source: {
-        platform: "local",
+        kind: "local",
         visibility: "private",
         conversationId: "local:web:abc",
       },
@@ -244,7 +244,7 @@ describe("resolveConversationRouting", () => {
             conversationId: "local:web:dashboard",
           },
           sessionSource: {
-            platform: "web",
+            kind: "web",
             visibility: "public",
             conversationId: "local:web:dashboard",
           },
@@ -263,7 +263,7 @@ describe("resolveConversationRouting", () => {
         conversationId: "local:web:dashboard",
       },
       source: {
-        platform: "web",
+        kind: "web",
         visibility: "public",
         conversationId: "local:web:dashboard",
       },

--- a/packages/junior/tests/unit/slack/tool-registration.test.ts
+++ b/packages/junior/tests/unit/slack/tool-registration.test.ts
@@ -35,11 +35,11 @@ function resourceEventPlugin(enabled = true) {
   });
 }
 
-function ctx(): Extract<ToolRuntimeContext, { source: { platform: "local" } }>;
+function ctx(): Extract<ToolRuntimeContext, { source: { kind: "local" } }>;
 function ctx(
   channelId: string,
   sourceVisibility?: "private" | "public",
-): Extract<ToolRuntimeContext, { source: { platform: "slack" } }>;
+): Extract<ToolRuntimeContext, { source: { kind: "slack" } }>;
 function ctx(
   channelId?: string,
   sourceVisibility?: "private" | "public",
@@ -340,7 +340,6 @@ describe("Slack tool registration", () => {
     expect(tools).toHaveProperty("stopWatchingResources");
     expect(tools).toHaveProperty("searchConversationEvents");
   });
-
 
   it("registers image generation only when artifact persistence is available", () => {
     expect(createTools([], {}, ctx())).not.toHaveProperty("imageGenerate");

--- a/packages/junior/tests/unit/tool-support/action-review.test.ts
+++ b/packages/junior/tests/unit/tool-support/action-review.test.ts
@@ -10,7 +10,7 @@ import {
 } from "@/chat/tool-support/action-review";
 
 const LOCAL_SOURCE = {
-  platform: "local",
+  kind: "local",
   visibility: "private",
   conversationId: "local:approval-test",
 } as const;


### PR DESCRIPTION
Resource event work now keeps a first-class Source from mailbox selection through the initial Run, Turn cursor, and resumed Run. It no longer becomes a web or local Source based on the Conversation Location.

Source uses `kind` because a Resource event is not a provider platform. Actor and Destination keep `platform` because they remain provider-scoped. This is a hard cutover for internal TypeScript callers of `source.platform`.

The Source parser still accepts deployed Slack, web, and local values that use `platform` or contain the old Location copy. It normalizes those stored values before the current discriminated union, so field-level validation errors remain intact. New Resource event values must use `kind`.

Behavioral evals now create a real watch and ingest its event through Conversation work. They no longer represent Resource events as bot-authored Slack messages, so the evals exercise the same Source, Location, and Delivery path as production.

Scheduled task, Event task, Plugin dispatch, and Agent invocation Source changes remain separate slices.

Refs #1563
