### PR TITLE
ref(chat): store Actor on the Turn

### DIFF
--- a/TERMINOLOGY.md
+++ b/TERMINOLOGY.md
@@ -42,6 +42,8 @@ Canonical words used across Junior's code and documentation.
 - **Actor**: the runtime participant for one source invocation. Actor ids are
   provider-scoped and are not canonical user ids. An Actor may keep provider
   fields that the agent or tools need. Those fields do not select the runtime.
+  A Turn stores the Actor selected from the input that started it. Steering
+  inputs keep their own Actors.
 - **Resource event**: one normalized change identified by namespace, identifier,
   event type, and an idempotency key. Plugins and core can publish them.
   A Resource event can wake a Conversation. Location stays on that

--- a/packages/junior/src/chat/actor.ts
+++ b/packages/junior/src/chat/actor.ts
@@ -275,7 +275,7 @@ export function toStoredSlackActor(actor: SlackActor): StoredSlackActor {
 
 /** Resolve a Slack resume actor from stored profile data and the active actor. */
 export function createSlackResumeActor(args: {
-  actor?: UserActor;
+  actor?: Actor;
   teamId: string;
   userId: string;
 }): SlackActor {

--- a/packages/junior/src/chat/actor.ts
+++ b/packages/junior/src/chat/actor.ts
@@ -273,7 +273,12 @@ export function toStoredSlackActor(actor: SlackActor): StoredSlackActor {
   };
 }
 
-/** Resolve a Slack resume actor from stored profile data and the active actor. */
+/**
+ * Resolve a Slack resume actor from stored profile data and the active actor.
+ *
+ * TODO(dcramer): Require Actor and remove ID-only construction after no
+ * deployed Turn cursor can omit Actor.
+ */
 export function createSlackResumeActor(args: {
   actor?: Actor;
   teamId: string;

--- a/packages/junior/src/chat/agent-dispatch/README.md
+++ b/packages/junior/src/chat/agent-dispatch/README.md
@@ -16,9 +16,10 @@ adapter owns destination delivery.
 - A dispatch uses one isolated conversation and one stable turn across all runs
   and execution slices.
 
-The mailbox carries no credential authority. Every run rebuilds actor,
-credential subject, source, destination, and plugin metadata from the dispatch
-record.
+The mailbox carries no credential authority. The first Run reads Actor,
+credential subject, Source, Destination, and plugin metadata from the dispatch
+record. The Turn saves Actor for later Runs. The dispatch record remains the
+authority for the other facts until their owning contract changes.
 
 ## Lifecycle
 

--- a/packages/junior/src/chat/plugins/task-runner.ts
+++ b/packages/junior/src/chat/plugins/task-runner.ts
@@ -347,8 +347,9 @@ async function loadPluginRun(
   const routing = await resolveTurnSessionRouting({
     conversationId: params.conversationId,
   });
-  // The Turn Actor owns the run. The later fallbacks cover deployed cursors
-  // written before Turn Actor persistence.
+  // The Turn Actor owns the run.
+  // TODO(dcramer): Remove the provenance and dispatch Actor fallbacks after no
+  // deployed Turn cursor can omit Actor.
   const runActor =
     record.actor ??
     record.actors[0] ??

--- a/packages/junior/src/chat/plugins/task-runner.ts
+++ b/packages/junior/src/chat/plugins/task-runner.ts
@@ -347,10 +347,10 @@ async function loadPluginRun(
   const routing = await resolveTurnSessionRouting({
     conversationId: params.conversationId,
   });
-  // Singular run.actor comes from committed instruction provenance, or the
-  // dispatch record for system-only runs. Optional only for legacy actor-less
-  // records (plugins must fail closed on authority-sensitive work).
+  // The Turn Actor owns the run. The later fallbacks cover deployed cursors
+  // written before Turn Actor persistence.
   const runActor =
+    record.actor ??
     record.actors[0] ??
     (record.dispatchId
       ? (await getDispatchRecord(record.dispatchId))?.actor

--- a/packages/junior/src/chat/resource-events/actor.ts
+++ b/packages/junior/src/chat/resource-events/actor.ts
@@ -2,8 +2,8 @@
  * System Actor for resource-event Turns.
  *
  * Resource-event mailbox Messages are not from a person. They use this Actor
- * for credentials and attribution. Mailbox input stores the author ID. Resume
- * rebuilds the same Actor from the saved Turn input.
+ * for credentials and attribution. The Turn saves this Actor for resume.
+ * Mailbox input keeps the author ID for deployed cursors without Actor.
  */
 import type { Actor } from "@/chat/actor";
 
@@ -35,8 +35,8 @@ export const RESOURCE_EVENT_SYSTEM_ACTOR = {
 /**
  * Whether a saved Message started a resource-event Turn.
  *
- * TODO(dcramer): Delete this marker check after resumes read Source.kind from
- * the Turn checkpoint. `eventType` only supports saved synthetic Slack input.
+ * TODO(dcramer): Delete this marker check after deployed Turn cursors all store
+ * Source and Actor. `eventType` only supports saved synthetic Slack input.
  */
 export function isResourceEventConversationMessage(message: {
   author?: { userId?: string };

--- a/packages/junior/src/chat/task-execution/README.md
+++ b/packages/junior/src/chat/task-execution/README.md
@@ -12,9 +12,9 @@ accept the result.
 checkpoint and is private to this module.
 
 `turn-wake.ts` wakes paused turns. `paused-turn.ts` runs them under the
-conversation lease. SQL conversation events store history. The Redis turn
-cursor stores only the data that is needed to resume a turn, including the
-Source that started it.
+conversation lease. SQL conversation events store history. The Redis Turn
+cursor stores only the data that is needed to resume a Turn, including the
+Source and Actor that started it.
 
 The reliability rules are small:
 
@@ -43,6 +43,8 @@ Runtime and Redis status is `paused`. SQL free-text / enum rows may still say
   `interrupt` or `defer` mailbox delivery, and the legacy
   `publishExternally` field. The worker keeps different publish choices in
   separate Turns and saves the selected choice as the Turn's `publish` fact.
+- A Turn cursor saves the Source and Actor selected from the input that started
+  the Turn. Steering input keeps its own Actor in message provenance.
 - A queue message identifies the conversation to wake. The stored work controls
   delivery. A provider conversation stores its destination. Child work without
   a destination gets its authority from its stored agent invocation.

--- a/packages/junior/src/chat/task-execution/conversation-turn.ts
+++ b/packages/junior/src/chat/task-execution/conversation-turn.ts
@@ -224,11 +224,12 @@ export function createConversationTurnWorker(
         );
       }
       resumedResourceEvent = isResourceEventConversationMessage(userMessage);
-      // Resume has no new input. Restore Source from the Turn and Actor from
-      // the saved instruction until Actor is also a first-class Turn field.
+      // Resume has no new input. Restore Source and Actor from the Turn.
+      // Deployed cursors without these fields still use the saved Message.
       turnInputFacts = turnInputFactsFromConversationMessage(userMessage, {
         conversationId: context.conversationId,
         location: storedConversation?.location,
+        savedActor: savedTurn?.actor,
         savedSource: savedTurn?.source,
         visibility: storedConversation?.visibility,
       });

--- a/packages/junior/src/chat/task-execution/conversation-turn.ts
+++ b/packages/junior/src/chat/task-execution/conversation-turn.ts
@@ -225,7 +225,8 @@ export function createConversationTurnWorker(
       }
       resumedResourceEvent = isResourceEventConversationMessage(userMessage);
       // Resume has no new input. Restore Source and Actor from the Turn.
-      // Deployed cursors without these fields still use the saved Message.
+      // TODO(dcramer): Remove the saved Message fallback after no deployed Turn
+      // cursor can omit Source or Actor.
       turnInputFacts = turnInputFactsFromConversationMessage(userMessage, {
         conversationId: context.conversationId,
         location: storedConversation?.location,

--- a/packages/junior/src/chat/task-execution/mailbox-turn.ts
+++ b/packages/junior/src/chat/task-execution/mailbox-turn.ts
@@ -39,7 +39,12 @@ export type TurnInputFacts = Pick<
   "actor" | "author" | "source"
 >;
 
-/** Restore Turn input facts, with saved Message fallback for legacy cursors. */
+/**
+ * Restore Turn input facts, with saved Message fallback for legacy cursors.
+ *
+ * TODO(dcramer): Remove Actor and Source reconstruction from the saved Message
+ * after no deployed Turn cursor can omit either field.
+ */
 export function turnInputFactsFromConversationMessage(
   message: ConversationMessage,
   args: {

--- a/packages/junior/src/chat/task-execution/mailbox-turn.ts
+++ b/packages/junior/src/chat/task-execution/mailbox-turn.ts
@@ -39,19 +39,20 @@ export type TurnInputFacts = Pick<
   "actor" | "author" | "source"
 >;
 
-/** Restore the Turn input facts kept on one saved Message. */
+/** Restore Turn input facts, with saved Message fallback for legacy cursors. */
 export function turnInputFactsFromConversationMessage(
   message: ConversationMessage,
   args: {
     conversationId: string;
     location?: Location;
+    savedActor?: Actor;
     savedSource?: Source;
     visibility?: ConversationPrivacy;
   },
 ): TurnInputFacts | undefined {
   if (isResourceEventConversationMessage(message)) {
     return {
-      actor: RESOURCE_EVENT_SYSTEM_ACTOR,
+      actor: args.savedActor ?? RESOURCE_EVENT_SYSTEM_ACTOR,
       author: message.author ?? RESOURCE_EVENT_MESSAGE_AUTHOR,
       // Stored Turns written before Source was saved can only restore the old
       // provider stand-in from the Conversation.
@@ -65,10 +66,12 @@ export function turnInputFactsFromConversationMessage(
           : createLocalSource(args.conversationId)),
     };
   }
-  const actor = createActor(message.author, {
-    platform: "web",
-    userId: message.author?.userId,
-  });
+  const actor =
+    args.savedActor ??
+    createActor(message.author, {
+      platform: "web",
+      userId: message.author?.userId,
+    });
   if (actor?.platform !== "web") {
     return undefined;
   }

--- a/packages/junior/src/chat/task-execution/paused-turn.ts
+++ b/packages/junior/src/chat/task-execution/paused-turn.ts
@@ -254,14 +254,12 @@ async function resolveSlackResumeUserActor(args: {
  * Resolve the Actor and credentials for a resumed Turn.
  *
  * Sources, in order:
- * 1. Actor and credentials supplied by dispatch or OAuth.
- * 2. Resource event markers.
- * 3. Slack author and team.
- *
- * Do not read the Actor from the Turn checkpoint. Use supplied credentials when
- * present. Otherwise, derive them from the Actor.
+ * 1. Actor saved on the Turn.
+ * 2. Actor and credentials supplied by dispatch or OAuth.
+ * 3. Legacy Resource event or Slack Message data.
  */
 async function resolveResumeExecutionIdentity(args: {
+  actor?: Actor;
   conversationId: string;
   routingContext?: PausedTurnOptions["routingContext"];
   teamId: string;
@@ -278,6 +276,7 @@ async function resolveResumeExecutionIdentity(args: {
   // credential subject.
   if (routing?.credentialContext) {
     const actor =
+      args.actor ??
       routing.dispatch?.actor ??
       routing.actor ??
       (!("type" in routing.credentialContext.actor)
@@ -288,7 +287,7 @@ async function resolveResumeExecutionIdentity(args: {
       : undefined;
   }
 
-  let actor: Actor | undefined = routing?.actor;
+  let actor: Actor | undefined = args.actor ?? routing?.actor;
   if (!actor && isResourceEventConversationMessage(args.userMessage)) {
     actor = RESOURCE_EVENT_SYSTEM_ACTOR;
   }
@@ -450,6 +449,7 @@ async function runPausedTurnInContext(
         }
 
         const identity = await resolveResumeExecutionIdentity({
+          actor: activeTurn.actor,
           conversationId: payload.conversationId,
           routingContext: options.routingContext,
           teamId: destination.teamId,

--- a/packages/junior/src/chat/task-execution/paused-turn.ts
+++ b/packages/junior/src/chat/task-execution/paused-turn.ts
@@ -257,6 +257,9 @@ async function resolveSlackResumeUserActor(args: {
  * 1. Actor saved on the Turn.
  * 2. Actor and credentials supplied by dispatch or OAuth.
  * 3. Legacy Resource event or Slack Message data.
+ *
+ * TODO(dcramer): Remove the routing and Message Actor fallbacks after no
+ * deployed Turn cursor can omit Actor.
  */
 async function resolveResumeExecutionIdentity(args: {
   actor?: Actor;

--- a/packages/junior/src/chat/task-execution/turn-cursor.ts
+++ b/packages/junior/src/chat/task-execution/turn-cursor.ts
@@ -108,7 +108,12 @@ interface ConversationMessageProjection {
 }
 
 export interface TurnRecord {
-  /** Actor that started this Turn; absent only on stored legacy cursors. */
+  /**
+   * Actor that started this Turn; absent only on stored legacy cursors.
+   *
+   * TODO(dcramer): Make this field required after no deployed Turn cursor can
+   * omit Actor.
+   */
   actor?: Actor;
   channelName?: string;
   schemaVersion: 2;
@@ -235,6 +240,7 @@ const storedTurnSummarySchema = z
 /** Full resume cursor stored for one turn. */
 const storedTurnRecordSchema = z
   .object({
+    // TODO(dcramer): Require Actor after no deployed Turn cursor can omit it.
     actor: actorSchema.optional(),
     schemaVersion: z.literal(TURN_CURSOR_SCHEMA_VERSION),
     version: z.number().int().nonnegative(),

--- a/packages/junior/src/chat/task-execution/turn-cursor.ts
+++ b/packages/junior/src/chat/task-execution/turn-cursor.ts
@@ -8,6 +8,7 @@
  * `junior_conversation_events`.
  */
 import {
+  actorSchema,
   sourceSchema,
   type Destination,
   type Source,
@@ -107,6 +108,8 @@ interface ConversationMessageProjection {
 }
 
 export interface TurnRecord {
+  /** Actor that started this Turn; absent only on stored legacy cursors. */
+  actor?: Actor;
   channelName?: string;
   schemaVersion: 2;
   version: number;
@@ -232,6 +235,7 @@ const storedTurnSummarySchema = z
 /** Full resume cursor stored for one turn. */
 const storedTurnRecordSchema = z
   .object({
+    actor: actorSchema.optional(),
     schemaVersion: z.literal(TURN_CURSOR_SCHEMA_VERSION),
     version: z.number().int().nonnegative(),
     conversationId: z.string().min(1),
@@ -426,6 +430,7 @@ function materializeTurnRecord(
       ? restoreRuntimeContext(piProjection, stored.runtimeContext)
       : piProjection;
   return {
+    ...definedProps({ actor: stored.actor }),
     schemaVersion: stored.schemaVersion,
     version: stored.version,
     conversationId: stored.conversationId,
@@ -594,6 +599,7 @@ export async function getTurnRecordForResume(
 
 /** Build the storage record that advances optimistic resume versioning. */
 function buildStoredRecord(args: {
+  actor?: Actor;
   conversationId: string;
   dispatchId?: string;
   dispatchOutcome?: AgentDispatchOutcome;
@@ -629,6 +635,7 @@ function buildStoredRecord(args: {
     updatedAtMs: nowMs,
     committedSeq: args.committedSeq,
     ...definedProps({
+      actor: args.actor,
       dispatchId: args.dispatchId,
       dispatchOutcome: args.dispatchOutcome,
       errorMessage: args.errorMessage,
@@ -735,6 +742,7 @@ async function updateTurnState(args: {
   }
 
   return await setStoredRecord({
+    actor: args.existing.actor,
     fence: args.fence,
     piMessages: args.existing.piMessages,
     piMessageProvenance: args.existing.piMessageProvenance,
@@ -750,6 +758,7 @@ async function updateTurnState(args: {
       turnStartMessageIndex: args.existing.turnStartMessageIndex,
     }),
     record: buildStoredRecord({
+      actor: args.existing.actor,
       conversationId: args.existing.conversationId,
       turnId: args.existing.turnId,
       sliceId: args.existing.sliceId,
@@ -845,8 +854,8 @@ async function upsertTurnRecordLocked(
   // Attribute new user input to the turn's actor as an instruction; the event
   // store reuses committed provenance for the unchanged prefix and defaults the
   // rest to context. Platform-neutral so local identities are preserved too.
-  // Execution actor is not stored in Redis — callers pass it live for SQL
-  // dual-write and fresh instruction attribution only.
+  // The Turn keeps the starting Actor. New instruction provenance can still
+  // record other Actors that steer the same Turn.
   const instructionActor = args.actor;
   const commit = await commitMessages({
     conversationId: args.conversationId,
@@ -895,7 +904,7 @@ async function upsertTurnRecordLocked(
       : commit.messageSeqs.filter((seq) => seq <= turnStartSeq).length);
 
   return await setStoredRecord({
-    actor: args.actor,
+    actor: existingRecord?.actor ?? args.actor,
     fence,
     conversationStore: args.conversationStore,
     destination: args.destination,
@@ -917,6 +926,7 @@ async function upsertTurnRecordLocked(
     ...definedProps({ indexTtlMs: args.ttlMs }),
     turnStartMessageIndex,
     record: buildStoredRecord({
+      actor: existingRecord?.actor ?? args.actor,
       conversationId: args.conversationId,
       turnId: args.turnId,
       sliceId: args.sliceId,

--- a/packages/junior/src/handlers/mcp-oauth-callback.ts
+++ b/packages/junior/src/handlers/mcp-oauth-callback.ts
@@ -351,6 +351,7 @@ async function resumeAuthorizedMcpTurn(args: {
       let actor: Actor;
       try {
         actor = createSlackResumeActor({
+          actor: lockedSessionRecord.actor,
           teamId: destination.teamId,
           userId: authSession.userId,
         });

--- a/packages/junior/src/handlers/oauth-callback.ts
+++ b/packages/junior/src/handlers/oauth-callback.ts
@@ -378,6 +378,7 @@ async function resumeOAuthSessionRecordTurn(
       let actor: Actor;
       try {
         actor = createSlackResumeActor({
+          actor: lockedSessionRecord.actor,
           teamId: destination.teamId,
           userId: lockedUserMessage.author.userId,
         });

--- a/packages/junior/tests/component/task-execution/checkpoint.test.ts
+++ b/packages/junior/tests/component/task-execution/checkpoint.test.ts
@@ -292,7 +292,8 @@ describe("turn checkpoint", () => {
       errorMessage: "plugin auth pause",
       piMessages: [priorMessages[0]],
     });
-    // This legacy-shaped fixture omits Actor. Source still survives the update.
+    // TODO(dcramer): Remove this legacy fixture after no deployed Turn cursor
+    // can omit Actor.
     expect(sessionRecord).not.toHaveProperty("destination");
     expect(sessionRecord).not.toHaveProperty("actor");
   });

--- a/packages/junior/tests/component/task-execution/checkpoint.test.ts
+++ b/packages/junior/tests/component/task-execution/checkpoint.test.ts
@@ -21,6 +21,11 @@ const SLACK_SOURCE = createSlackSource({
   threadTs: "1700000000.001",
   visibility: "private",
 }) satisfies Source;
+const SLACK_ACTOR = {
+  platform: "slack",
+  teamId: "T123",
+  userId: "U123",
+} as const;
 
 function userMessage(text: string): PiMessage {
   return {
@@ -287,7 +292,7 @@ describe("turn checkpoint", () => {
       errorMessage: "plugin auth pause",
       piMessages: [priorMessages[0]],
     });
-    // Source stays on the Turn. Destination and Actor remain live write facts.
+    // This legacy-shaped fixture omits Actor. Source still survives the update.
     expect(sessionRecord).not.toHaveProperty("destination");
     expect(sessionRecord).not.toHaveProperty("actor");
   });
@@ -299,15 +304,10 @@ describe("turn checkpoint", () => {
     const { getConversationStore } = await import("@/chat/db");
     const stateAdapter = getStateAdapter();
     const set = vi.spyOn(stateAdapter, "set");
-    const actor = {
-      platform: "slack",
-      teamId: "T123",
-      userId: "U123",
-    } as const;
     const usage = { inputTokens: 7, outputTokens: 3 };
 
     await upsertTurnRecord({
-      actor,
+      actor: SLACK_ACTOR,
       channelName: "runtime-team",
       conversationId: "slack:C123:ops-bag",
       cumulativeDurationMs: 1_500,
@@ -332,6 +332,7 @@ describe("turn checkpoint", () => {
     ]) {
       expect(redisRecord).not.toHaveProperty(field);
     }
+    expect(redisRecord).toMatchObject({ actor: SLACK_ACTOR });
     await expect(
       getConversationStore().get({ conversationId: "slack:C123:ops-bag" }),
     ).resolves.toMatchObject({
@@ -495,7 +496,7 @@ describe("turn checkpoint", () => {
     }
   });
 
-  it("stores Source on the Turn while keeping Destination and Actor out of Redis", async () => {
+  it("stores Source and Actor on the Turn while keeping Destination out of Redis", async () => {
     const { getStateAdapter } = await import("@/chat/state/adapter");
     const { getTurnRecord, listTurnSummaries, upsertTurnRecord } =
       await import("@/chat/task-execution/turn-cursor");
@@ -516,6 +517,7 @@ describe("turn checkpoint", () => {
     };
 
     await upsertTurnRecord({
+      actor: SLACK_ACTOR,
       conversationId,
       conversationStore,
       destination: SLACK_DESTINATION,
@@ -540,8 +542,10 @@ describe("turn checkpoint", () => {
       }),
     );
     expect(stored).not.toHaveProperty("destination");
-    expect(stored).toMatchObject({ source: SLACK_SOURCE });
-    expect(stored).not.toHaveProperty("actor");
+    expect(stored).toMatchObject({
+      actor: SLACK_ACTOR,
+      source: SLACK_SOURCE,
+    });
 
     const summaries = await listTurnSummaries(conversationId);
     expect(summaries).toHaveLength(1);
@@ -549,7 +553,7 @@ describe("turn checkpoint", () => {
     expect(summaries[0]).not.toHaveProperty("source");
     expect(summaries[0]).not.toHaveProperty("actor");
 
-    // Materialized reads restore Source without restoring Destination or Actor.
+    // Materialized reads restore Source and Actor without restoring Destination.
     const record = await getTurnRecord(conversationId, turnId);
     expect(record).toMatchObject({
       conversationId,
@@ -557,8 +561,10 @@ describe("turn checkpoint", () => {
       state: "running",
     });
     expect(record).not.toHaveProperty("destination");
-    expect(record).toMatchObject({ source: SLACK_SOURCE });
-    expect(record).not.toHaveProperty("actor");
+    expect(record).toMatchObject({
+      actor: SLACK_ACTOR,
+      source: SLACK_SOURCE,
+    });
 
     expect(conversationStore.recordActivity).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -633,8 +639,10 @@ describe("turn checkpoint", () => {
     const record = await getTurnRecord(conversationId, turnId);
     expect(record).toMatchObject({ schemaVersion: 2, state: "paused" });
     expect(record).not.toHaveProperty("destination");
-    expect(record).toMatchObject({ source: SLACK_SOURCE });
-    expect(record).not.toHaveProperty("actor");
+    expect(record).toMatchObject({
+      actor: SLACK_ACTOR,
+      source: SLACK_SOURCE,
+    });
     expect(record).not.toHaveProperty("deprecatedFlag");
   });
 
@@ -830,17 +838,17 @@ describe("turn checkpoint", () => {
 
     const record = await getTurnRecord(conversationId, sessionId);
     expect(record).toMatchObject({
+      actor,
       piMessages: [userMessage],
       state: "paused",
     });
-    expect(record).not.toHaveProperty("actor");
 
     const stateAdapter = getStateAdapter();
     await stateAdapter.connect();
     const stored = await stateAdapter.get(
       turnCursorKey(conversationId, sessionId),
     );
-    expect(stored).not.toHaveProperty("actor");
+    expect(stored).toMatchObject({ actor });
 
     await expect(
       getConversationStore().get({ conversationId }),
@@ -900,7 +908,7 @@ describe("turn checkpoint", () => {
       turnStartMessageIndex: 1,
       piMessages: [previousQuestion, currentQuestion],
     });
-    expect(scoped).not.toHaveProperty("actor");
+    expect(scoped).toMatchObject({ actor: SLACK_ACTOR });
     const projection = await loadConversationProjection({
       conversationId: "conversation-turn-scope",
     });
@@ -1025,7 +1033,7 @@ describe("turn checkpoint", () => {
       "conversation-multi-actor",
       "turn-multi-actor",
     );
-    expect(record).not.toHaveProperty("actor");
+    expect(record).toMatchObject({ actor: alice });
     expect(record?.piMessageProvenance).toEqual([
       { authority: "instruction", actor: alice },
       { authority: "instruction", actor: bob },

--- a/packages/junior/tests/integration/agent-continue-slack.test.ts
+++ b/packages/junior/tests/integration/agent-continue-slack.test.ts
@@ -328,7 +328,7 @@ describe("paused turn Slack integration", () => {
     ).resolves.toBeUndefined();
   });
 
-  it("resumes and delivers when the continuation record is missing stored actor profile data", async () => {
+  it("restores the Turn Actor when the saved Message has no profile data", async () => {
     const conversationId = "slack:C123:1712345.0008";
     const sessionId = "turn_msg_8";
     const sessionRecord = await turnSessionStoreModule.upsertTurnRecord({
@@ -349,9 +349,12 @@ describe("paused turn Slack integration", () => {
       resumedFromSliceId: 1,
       errorMessage: "Agent turn timed out",
       actor: {
+        email: "alice@example.com",
+        fullName: "Alice Example",
         platform: "slack",
         teamId: SLACK_DESTINATION.teamId,
         userId: "U123",
+        userName: "alice",
       },
     });
 
@@ -399,9 +402,12 @@ describe("paused turn Slack integration", () => {
     expect(agentRuns[0]).toMatchObject({
       instruction: { text: "resume this request" },
       actor: {
+        email: "alice@example.com",
+        fullName: "Alice Example",
         platform: "slack",
         teamId: "T123",
         userId: "U123",
+        userName: "alice",
       },
     });
   });

--- a/packages/junior/tests/integration/conversation-turn-work.test.ts
+++ b/packages/junior/tests/integration/conversation-turn-work.test.ts
@@ -595,6 +595,7 @@ describe("Conversation mailbox Turn work", () => {
       }),
     ).resolves.toEqual({ status: "yielded" });
     await expect(getTurnRecord(conversationId, turnId)).resolves.toMatchObject({
+      actor: RESOURCE_EVENT_SYSTEM_ACTOR,
       publishExternally: false,
       resumeReason: "yield",
       source,
@@ -627,6 +628,7 @@ describe("Conversation mailbox Turn work", () => {
       expect(run.authorization).toBeUndefined();
     }
     await expect(getTurnRecord(conversationId, turnId)).resolves.toMatchObject({
+      actor: RESOURCE_EVENT_SYSTEM_ACTOR,
       publishExternally: false,
       source,
       state: "completed",

--- a/packages/junior/tests/integration/mcp-oauth-callback.test.ts
+++ b/packages/junior/tests/integration/mcp-oauth-callback.test.ts
@@ -504,9 +504,12 @@ describe("mcp oauth callback integration", () => {
           context: expect.stringContaining("You need the budget by Friday."),
         }),
         actor: {
+          email: "stored@example.com",
+          fullName: "Stored User",
           platform: "slack",
           teamId: "T123",
           userId: "U123",
+          userName: "stored-user",
         },
         destination: SLACK_DESTINATION,
         location: expect.objectContaining({

--- a/packages/junior/tests/integration/oauth-callback.test.ts
+++ b/packages/junior/tests/integration/oauth-callback.test.ts
@@ -377,9 +377,12 @@ describe("oauth callback integration", () => {
           context: expect.stringContaining("You need the budget by Friday."),
         }),
         actor: {
+          email: "stored@example.com",
+          fullName: "Stored User",
           platform: "slack",
           teamId: "T123",
           userId: "U123",
+          userName: "stored-user",
         },
         destination: SLACK_DESTINATION,
         location: expect.objectContaining({


### PR DESCRIPTION
Turns now store the Actor selected from the input that started them. Mailbox, paused Slack, OAuth, and MCP OAuth resumes restore that saved Actor. Plugin tasks also use it. Profile and authority no longer depend on rebuilding identity from Conversation or Message data.

Steering input still keeps its own Actors in Message provenance. Cursors written by deployed workers may omit Actor, so resume keeps the existing Message and dispatch fallbacks only for those records. The `publish` cutover and remaining Source kinds stay separate.

Refs #1563
