### PR TITLE
ref(chat)!: add task, Plugin dispatch, and Agent invocation Sources

### DIFF
--- a/packages/junior-memory/src/agent.ts
+++ b/packages/junior-memory/src/agent.ts
@@ -302,6 +302,11 @@ function sourceLabel(source: z.output<typeof sourceSchema>): string {
       return `${source.kind}:${source.conversationId}`;
     case "resource_event":
       return `resource-event:${source.namespace}:${source.eventKey}`;
+    case "scheduled_task":
+    case "event_task":
+    case "plugin_dispatch":
+    case "agent_invocation":
+      return source.kind;
   }
 }
 

--- a/packages/junior-memory/src/process-session.ts
+++ b/packages/junior-memory/src/process-session.ts
@@ -223,8 +223,8 @@ export async function processMemorySession(
   context: PluginTaskContext,
 ): Promise<void> {
   const run = await context.run.load();
-  // TODO(dcramer): Replace this Source kind allowlist when plugin runs expose
-  // an explicit capability for passive memory extraction.
+  // TODO(dcramer): Replace this hardcoded Source check when a plugin Run can
+  // state whether passive memory extraction should run.
   if (run.source.kind !== "slack" && run.source.kind !== "web") {
     return;
   }

--- a/packages/junior-memory/src/process-session.ts
+++ b/packages/junior-memory/src/process-session.ts
@@ -223,7 +223,9 @@ export async function processMemorySession(
   context: PluginTaskContext,
 ): Promise<void> {
   const run = await context.run.load();
-  if (run.source.kind === "local" || run.source.kind === "resource_event") {
+  // TODO(dcramer): Replace this Source kind allowlist when plugin runs expose
+  // an explicit capability for passive memory extraction.
+  if (run.source.kind !== "slack" && run.source.kind !== "web") {
     return;
   }
   // Memory tool turns already own memory management or recall; do not reinterpret

--- a/packages/junior-memory/src/store.ts
+++ b/packages/junior-memory/src/store.ts
@@ -187,10 +187,18 @@ const memoryRowSchema = z
 function storedMemorySource(
   source: MemoryRuntimeContext["source"],
 ): MemorySourcePlatform {
-  if (source.kind === "resource_event") {
-    throw new Error("Resource event Source cannot own a Memory.");
+  switch (source.kind) {
+    case "slack":
+    case "local":
+    case "web":
+      return source.kind;
+    case "resource_event":
+    case "scheduled_task":
+    case "event_task":
+    case "plugin_dispatch":
+    case "agent_invocation":
+      throw new Error(`${source.kind} Source cannot own a Memory.`);
   }
-  return source.kind;
 }
 
 const memoryRecordSchema = z

--- a/packages/junior-plugin-api/README.md
+++ b/packages/junior-plugin-api/README.md
@@ -42,9 +42,10 @@ reports, and other typed hook surfaces exported by this package.
 
 - Hook context carries the active source, actor, conversation, plugin metadata,
   database, logging, and only the host capabilities required by that hook.
-- Source uses `kind` to state what produced the input, including input such as
-  a Resource event that has no provider platform. Actor and Destination keep
-  `platform` for their provider scope.
+- Source uses `kind` to state what produced the input. Resource events,
+  scheduled tasks, event tasks, Plugin dispatches, and Agent invocations have
+  no provider platform. Actor and Destination keep `platform` for their
+  provider scope.
 - Prompt hooks return bounded structured prompt messages rather than mutate the
   core prompt.
 - `formatMarkdown` is a pure text rewrite into ordinary Markdown before delivery.

--- a/packages/junior-plugin-api/README.md
+++ b/packages/junior-plugin-api/README.md
@@ -43,9 +43,8 @@ reports, and other typed hook surfaces exported by this package.
 - Hook context carries the active source, actor, conversation, plugin metadata,
   database, logging, and only the host capabilities required by that hook.
 - Source uses `kind` to state what produced the input. Resource events,
-  scheduled tasks, event tasks, Plugin dispatches, and Agent invocations have
-  no provider platform. Actor and Destination keep `platform` for their
-  provider scope.
+  scheduled tasks, event tasks, Plugin dispatches, and Agent invocations do not
+  name a provider. Actor and Destination still use `platform` to name one.
 - Prompt hooks return bounded structured prompt messages rather than mutate the
   core prompt.
 - `formatMarkdown` is a pure text rewrite into ordinary Markdown before delivery.

--- a/packages/junior-plugin-api/src/context.ts
+++ b/packages/junior-plugin-api/src/context.ts
@@ -34,6 +34,13 @@ export type SlackSource = Extract<Source, { kind: "slack" }>;
 export type LocalSource = Extract<Source, { kind: "local" }>;
 export type WebSource = Extract<Source, { kind: "web" }>;
 export type ResourceEventSource = Extract<Source, { kind: "resource_event" }>;
+export type ScheduledTaskSource = Extract<Source, { kind: "scheduled_task" }>;
+export type EventTaskSource = Extract<Source, { kind: "event_task" }>;
+export type PluginDispatchSource = Extract<Source, { kind: "plugin_dispatch" }>;
+export type AgentInvocationSource = Extract<
+  Source,
+  { kind: "agent_invocation" }
+>;
 export type SourceVisibility = z.output<typeof sourceVisibilitySchema>;
 
 export type Destination = z.output<typeof destinationSchema>;
@@ -129,9 +136,18 @@ export interface ResourceEventInvocationContext extends BaseInvocationContext {
 
 export type InvocationContext =
   | LocalInvocationContext
-  | ResourceEventInvocationContext
   | SlackInvocationContext
-  | WebInvocationContext;
+  | WebInvocationContext
+  | (BaseInvocationContext & {
+      destination: Destination;
+      actor?: SystemActor;
+      source:
+        | AgentInvocationSource
+        | EventTaskSource
+        | PluginDispatchSource
+        | ResourceEventSource
+        | ScheduledTaskSource;
+    });
 
 /** Build a normalized Slack source from runtime-owned Slack coordinates. */
 export function createSlackSource(input: {
@@ -209,6 +225,11 @@ export function getSourceKey(source: Source): string | undefined {
     }
     case "resource_event":
       return `resource-event:${source.namespace}:${source.eventKey}`;
+    case "scheduled_task":
+    case "event_task":
+    case "plugin_dispatch":
+    case "agent_invocation":
+      return undefined;
   }
 }
 

--- a/packages/junior-plugin-api/src/context.ts
+++ b/packages/junior-plugin-api/src/context.ts
@@ -129,7 +129,7 @@ export interface WebInvocationContext extends BaseInvocationContext {
 export interface ResourceEventInvocationContext extends BaseInvocationContext {
   /** Existing conversation destination used for tool context. */
   destination: Destination;
-  actor?: SystemActor;
+  actor?: Actor;
   /** Runtime-owned Resource event Source for this invocation. */
   source: ResourceEventSource;
 }
@@ -140,7 +140,7 @@ export type InvocationContext =
   | WebInvocationContext
   | (BaseInvocationContext & {
       destination: Destination;
-      actor?: SystemActor;
+      actor?: Actor;
       source:
         | AgentInvocationSource
         | EventTaskSource

--- a/packages/junior-plugin-api/src/schemas.ts
+++ b/packages/junior-plugin-api/src/schemas.ts
@@ -121,11 +121,35 @@ export const resourceEventSourceSchema = z
   })
   .strict();
 
+/** Runtime-owned Scheduled task input Source. */
+export const scheduledTaskSourceSchema = z
+  .object({ kind: z.literal("scheduled_task") })
+  .strict();
+
+/** Runtime-owned Event task input Source. */
+export const eventTaskSourceSchema = z
+  .object({ kind: z.literal("event_task") })
+  .strict();
+
+/** Runtime-owned Plugin dispatch input Source. */
+export const pluginDispatchSourceSchema = z
+  .object({ kind: z.literal("plugin_dispatch") })
+  .strict();
+
+/** Runtime-owned Agent invocation input Source. */
+export const agentInvocationSourceSchema = z
+  .object({ kind: z.literal("agent_invocation") })
+  .strict();
+
 const currentSourceSchema = z.discriminatedUnion("kind", [
   slackSourceSchema,
   localSourceSchema,
   webSourceSchema,
   resourceEventSourceSchema,
+  scheduledTaskSourceSchema,
+  eventTaskSourceSchema,
+  pluginDispatchSourceSchema,
+  agentInvocationSourceSchema,
 ]);
 
 function normalizeStoredSource(value: unknown): unknown {
@@ -320,6 +344,5 @@ export const dispatchOptionsSchema = z
     input: nonBlankStringSchema.pipe(z.string().max(32_000)),
     metadata: dispatchMetadataSchema.optional(),
     replyAttribution: replyAttributionSchema.optional(),
-    source: sourceSchema,
   })
   .strict();

--- a/packages/junior-plugin-api/src/tools.ts
+++ b/packages/junior-plugin-api/src/tools.ts
@@ -1,14 +1,11 @@
 import type {
   Actor,
   Identity,
-  LocalInvocationContext,
-  ResourceEventInvocationContext,
+  InvocationContext,
   PluginContext,
   PluginEmbedder,
   PluginModel,
-  SlackInvocationContext,
   User,
-  WebInvocationContext,
 } from "./context";
 import type { PluginCredentialSubject } from "./credentials";
 import type { PluginAnnotations } from "./annotations";
@@ -508,8 +505,8 @@ export function definePluginTool<
 
 export interface SlackToolRegistrationHookContext {
   /**
-   * Capabilities of the source Slack conversation exposed to this plugin.
-   * Recomputed from `source.channelId`, not from `destination`.
+   * Capabilities of the Slack Conversation Location exposed to this plugin.
+   * Recomputed from Location, not from Source or Destination.
    */
   channelCapabilities: {
     canAddReactions: boolean;
@@ -568,28 +565,8 @@ interface BaseToolRegistrationHookContext extends PluginContext {
   workspaces: PluginWorkspaceToolContext;
 }
 
-interface SlackToolRegistrationContext
-  extends BaseToolRegistrationHookContext, SlackInvocationContext {
-  slack: SlackToolRegistrationHookContext;
-}
-
-interface LocalToolRegistrationContext
-  extends BaseToolRegistrationHookContext, LocalInvocationContext {
-  slack?: never;
-}
-
-interface WebToolRegistrationContext
-  extends BaseToolRegistrationHookContext, WebInvocationContext {
-  slack?: never;
-}
-
-interface ResourceEventToolRegistrationContext
-  extends BaseToolRegistrationHookContext, ResourceEventInvocationContext {
-  slack?: never;
-}
-
-export type ToolRegistrationHookContext =
-  | LocalToolRegistrationContext
-  | ResourceEventToolRegistrationContext
-  | SlackToolRegistrationContext
-  | WebToolRegistrationContext;
+export type ToolRegistrationHookContext = BaseToolRegistrationHookContext &
+  InvocationContext & {
+    /** Slack capabilities when the Conversation has a Slack Location. */
+    slack?: SlackToolRegistrationHookContext;
+  };

--- a/packages/junior-plugin-api/src/tools.ts
+++ b/packages/junior-plugin-api/src/tools.ts
@@ -505,8 +505,8 @@ export function definePluginTool<
 
 export interface SlackToolRegistrationHookContext {
   /**
-   * Capabilities of the Slack Conversation Location exposed to this plugin.
-   * Recomputed from Location, not from Source or Destination.
+   * What Slack tools can do in the Conversation Location.
+   * Computed from Location, not from Source or Destination.
    */
   channelCapabilities: {
     canAddReactions: boolean;
@@ -567,6 +567,6 @@ interface BaseToolRegistrationHookContext extends PluginContext {
 
 export type ToolRegistrationHookContext = BaseToolRegistrationHookContext &
   InvocationContext & {
-    /** Slack capabilities when the Conversation has a Slack Location. */
+    /** Slack tool details when the Conversation has a Slack Location. */
     slack?: SlackToolRegistrationHookContext;
   };

--- a/packages/junior/src/chat/agent-dispatch/context.ts
+++ b/packages/junior/src/chat/agent-dispatch/context.ts
@@ -31,7 +31,7 @@ function bindDispatchCredentialSubject(
 ): BoundDispatchOptions {
   const { credentialSubject, ...baseOptions } = options;
   if (!credentialSubject) {
-    return baseOptions;
+    return { ...baseOptions, source: { kind: "plugin_dispatch" } };
   }
   if ("binding" in credentialSubject) {
     throw new Error("Dispatch credentialSubject binding is runtime-owned");
@@ -55,6 +55,7 @@ function bindDispatchCredentialSubject(
   return {
     ...baseOptions,
     credentialSubject: boundSubject,
+    source: { kind: "plugin_dispatch" },
   };
 }
 
@@ -155,6 +156,7 @@ export async function dispatchEventTask(args: {
   const options: BoundDispatchOptions = {
     ...unboundOptions,
     ...(boundSubject ? { credentialSubject: boundSubject } : undefined),
+    source: { kind: "event_task" },
   };
   return await dispatch({
     conversationWorkQueue: args.conversationWorkQueue,
@@ -192,6 +194,7 @@ export async function dispatchScheduledTask(args: {
   const options: BoundDispatchOptions = {
     ...unboundOptions,
     ...(boundSubject ? { credentialSubject: boundSubject } : undefined),
+    source: { kind: "scheduled_task" },
   };
   return await dispatch({
     conversationWorkQueue: args.conversationWorkQueue,

--- a/packages/junior/src/chat/agent-dispatch/types.ts
+++ b/packages/junior/src/chat/agent-dispatch/types.ts
@@ -1,7 +1,10 @@
 import type {
   DispatchOptions,
   DestinationVisibility,
+  EventTaskSource,
+  PluginDispatchSource,
   ReplyAttribution,
+  ScheduledTaskSource,
   Source,
   SlackDestination,
 } from "@sentry/junior-plugin-api";
@@ -31,6 +34,7 @@ export interface BoundDispatchOptions extends Omit<
   "credentialSubject"
 > {
   credentialSubject?: CredentialSubject;
+  source: EventTaskSource | PluginDispatchSource | ScheduledTaskSource;
 }
 
 export interface DispatchRecord {

--- a/packages/junior/src/chat/agent-dispatch/validation.ts
+++ b/packages/junior/src/chat/agent-dispatch/validation.ts
@@ -67,26 +67,6 @@ function dispatchOptionsErrorMessage(
   if (hasIssueUnderPath(issues, ["destination", "channelId"])) {
     return "Dispatch destination channelId must be a Slack channel id";
   }
-  if (
-    issues.some(
-      (issue) =>
-        issue.code === "unrecognized_keys" && issue.path[0] === "source",
-    )
-  ) {
-    return "Dispatch source must not include unknown fields";
-  }
-  if (hasIssueAtPath(issues, ["source"])) {
-    return "Dispatch Source kind is required";
-  }
-  if (hasIssueUnderPath(issues, ["source", "teamId"])) {
-    return "Dispatch source teamId must be a Slack team id";
-  }
-  if (hasIssueUnderPath(issues, ["source", "channelId"])) {
-    return "Dispatch source channelId must be a Slack channel id";
-  }
-  if (hasIssueUnderPath(issues, ["source", "conversationId"])) {
-    return "Dispatch source conversationId must be a local conversation id";
-  }
   if (hasIssueUnderPath(issues, ["idempotencyKey"])) {
     const tooLong = issues.some(
       (issue) => issue.path[0] === "idempotencyKey" && issue.code === "too_big",
@@ -162,7 +142,7 @@ export function validateDispatchOptions(
 
 /** Verify runtime-owned access requirements for delegated dispatch credentials. */
 export async function verifyDispatchCredentialSubjectAccess(
-  options: BoundDispatchOptions,
+  options: Pick<BoundDispatchOptions, "credentialSubject" | "destination">,
   plugin: string,
 ): Promise<void> {
   if (!options.credentialSubject) {

--- a/packages/junior/src/chat/agent-invocations/spawn.ts
+++ b/packages/junior/src/chat/agent-invocations/spawn.ts
@@ -41,7 +41,6 @@ export function bindSpawnAgent(
         ...(input.reasoningLevel
           ? { reasoningLevel: input.reasoningLevel }
           : undefined),
-        source: run.source,
       },
       { ...options, queue },
     );

--- a/packages/junior/src/chat/agent-invocations/store.ts
+++ b/packages/junior/src/chat/agent-invocations/store.ts
@@ -122,8 +122,7 @@ function sameCreateInput(
     JSON.stringify(invocation.credentialContext) ===
       JSON.stringify(input.credentialContext) &&
     JSON.stringify(invocation.destination) ===
-      JSON.stringify(input.destination) &&
-    JSON.stringify(invocation.source) === JSON.stringify(input.source)
+      JSON.stringify(input.destination)
   );
 }
 
@@ -303,7 +302,7 @@ export async function createAgentInvocation(
         input: input.input,
         actor: input.actor,
         credentialContext: input.credentialContext ?? null,
-        source: input.source,
+        source: { kind: "agent_invocation" },
         destination: input.destination,
         reasoningLevel: input.reasoningLevel ?? null,
         status: "pending",

--- a/packages/junior/src/chat/agent-invocations/types.ts
+++ b/packages/junior/src/chat/agent-invocations/types.ts
@@ -74,7 +74,6 @@ export const createAgentInvocationSchema = z
     input: exactStringSchema,
     parentConversationId: exactStringSchema,
     reasoningLevel: z.enum(TURN_REASONING_LEVELS).optional(),
-    source: sourceSchema,
   })
   .strict();
 

--- a/packages/junior/src/chat/agent/index.ts
+++ b/packages/junior/src/chat/agent/index.ts
@@ -227,7 +227,12 @@ export async function executeAgentRun(
   const userActor = actor && "userId" in actor ? actor : undefined;
   const runLogContext: LogContext = {
     conversationId: run.conversationId,
-    platform: run.source.kind,
+    platform:
+      run.source.kind === "slack" ||
+      run.source.kind === "web" ||
+      run.source.kind === "local"
+        ? run.source.kind
+        : undefined,
     messageConversationId:
       run.source.kind === "slack"
         ? run.conversationId

--- a/packages/junior/src/chat/agent/prompt.ts
+++ b/packages/junior/src/chat/agent/prompt.ts
@@ -459,7 +459,12 @@ export async function assemblePrompt(args: {
   resumedFromSessionRecord: boolean;
   run: Pick<
     AgentRun,
-    "source" | "destination" | "dispatch" | "slackConversation"
+    | "source"
+    | "destination"
+    | "dispatch"
+    | "slackConversation"
+    | "location"
+    | "delivery"
   >;
   spanContext: LogContext;
   turnId: string;
@@ -501,12 +506,16 @@ export async function assemblePrompt(args: {
     shouldPromptAgent &&
     !replayedPrompt &&
     !hasRuntimeTurnContext(promptHistoryMessages);
+  const platform =
+    args.run.delivery && args.run.location?.provider === "slack"
+      ? "slack"
+      : "local";
   const systemPromptContributions =
-    await getPluginSystemPromptContributions(source);
+    await getPluginSystemPromptContributions(platform);
   const pluginSystemPrompt = buildPluginSystemPromptContributions(
     systemPromptContributions,
   );
-  const baseInstructions = [buildSystemPrompt({ source }), pluginSystemPrompt]
+  const baseInstructions = [buildSystemPrompt(platform), pluginSystemPrompt]
     .filter((section): section is string => Boolean(section))
     .join("\n\n");
   const pluginUserPromptContributions =

--- a/packages/junior/src/chat/agent/tools.ts
+++ b/packages/junior/src/chat/agent/tools.ts
@@ -16,7 +16,6 @@ import type {
   PluginDispatchSource,
   ResourceEventSource,
   ScheduledTaskSource,
-  SystemActor,
 } from "@sentry/junior-plugin-api";
 import type { FileUpload } from "chat";
 import { createUserTokenStore } from "@/chat/capabilities/factory";
@@ -152,7 +151,7 @@ type ToolRuntimeRoute =
       "actor" | "destination" | "source"
     >
   | {
-      actor?: SystemActor;
+      actor?: Actor;
       destination: Destination;
       source:
         | AgentInvocationSource
@@ -206,7 +205,7 @@ function resolveToolRuntimeRoute(args: {
     case "agent_invocation":
       return {
         destination,
-        actor: args.actor?.platform === "system" ? args.actor : undefined,
+        actor: args.actor,
         source: args.run.source,
       };
   }

--- a/packages/junior/src/chat/agent/tools.ts
+++ b/packages/junior/src/chat/agent/tools.ts
@@ -9,6 +9,15 @@
  * here so the run parks before prompting.
  */
 import type { AgentTool } from "@earendil-works/pi-agent-core";
+import type {
+  AgentInvocationSource,
+  Destination,
+  EventTaskSource,
+  PluginDispatchSource,
+  ResourceEventSource,
+  ScheduledTaskSource,
+  SystemActor,
+} from "@sentry/junior-plugin-api";
 import type { FileUpload } from "chat";
 import { createUserTokenStore } from "@/chat/capabilities/factory";
 import {
@@ -142,10 +151,16 @@ type ToolRuntimeRoute =
       Extract<ToolRuntimeContext, { source: { kind: "web" } }>,
       "actor" | "destination" | "source"
     >
-  | Pick<
-      Extract<ToolRuntimeContext, { source: { kind: "resource_event" } }>,
-      "actor" | "destination" | "source"
-    >;
+  | {
+      actor?: SystemActor;
+      destination: Destination;
+      source:
+        | AgentInvocationSource
+        | EventTaskSource
+        | PluginDispatchSource
+        | ResourceEventSource
+        | ScheduledTaskSource;
+    };
 
 /** Resolve provider-specific tool routing without changing turn delivery. */
 function resolveToolRuntimeRoute(args: {
@@ -185,6 +200,10 @@ function resolveToolRuntimeRoute(args: {
         source: args.run.source,
       };
     case "resource_event":
+    case "scheduled_task":
+    case "event_task":
+    case "plugin_dispatch":
+    case "agent_invocation":
       return {
         destination,
         actor: args.actor?.platform === "system" ? args.actor : undefined,
@@ -331,7 +350,13 @@ export async function wireAgentTools(
   );
   const commonToolRuntimeContext = {
     conversationId: args.run.conversationId,
-    ...(args.run.location ? { locationId: args.run.location.id } : undefined),
+    ...(args.run.location
+      ? {
+          location: args.run.location,
+          locationId: args.run.location.id,
+        }
+      : undefined),
+    conversationPrivacy: args.conversationPrivacy,
     userText: args.userInput,
     configuration: args.configurationValues,
     egress: createPluginEgress({

--- a/packages/junior/src/chat/agent/types.ts
+++ b/packages/junior/src/chat/agent/types.ts
@@ -361,7 +361,8 @@ export function assertRunConsistency(
     case "event_task":
     case "plugin_dispatch":
     case "agent_invocation":
-      break;
+      // These Sources do not identify the Actor's platform.
+      return;
   }
 
   const actor = run.dispatch?.actor ?? run.actor;

--- a/packages/junior/src/chat/agent/types.ts
+++ b/packages/junior/src/chat/agent/types.ts
@@ -357,6 +357,10 @@ export function assertRunConsistency(
       break;
     }
     case "resource_event":
+    case "scheduled_task":
+    case "event_task":
+    case "plugin_dispatch":
+    case "agent_invocation":
       break;
   }
 

--- a/packages/junior/src/chat/agent/types.ts
+++ b/packages/junior/src/chat/agent/types.ts
@@ -403,6 +403,8 @@ export function surfaceFromRun(
   if (run.surface) {
     return run.surface;
   }
+  // TODO(dcramer): Remove Source-based inference after every work owner and
+  // deployed Turn checkpoint provides surface.
   if (run.source.kind === "slack") {
     return "slack";
   }

--- a/packages/junior/src/chat/event-tasks/ingest.ts
+++ b/packages/junior/src/chat/event-tasks/ingest.ts
@@ -6,7 +6,6 @@
  */
 import { createHash } from "node:crypto";
 import {
-  createSlackSource,
   RESOURCE_EVENT_SUMMARY_MAX_LENGTH,
   RESOURCE_EVENT_TEXT_MAX_LENGTH,
   resourceEventSchema,
@@ -112,11 +111,6 @@ export async function ingestEventTasks(
           input: eventInput(task, event),
           metadata: { eventTaskId: task.id },
           replyAttribution: replyAttribution(task),
-          source: createSlackSource({
-            teamId: task.destination.teamId,
-            channelId: task.destination.channelId,
-            visibility: task.destinationVisibility,
-          }),
         },
       });
       if (dispatch.status === "created") {

--- a/packages/junior/src/chat/plugins/agent-hooks.ts
+++ b/packages/junior/src/chat/plugins/agent-hooks.ts
@@ -17,6 +17,7 @@ import type {
   PluginOperationalReportContent,
   PluginOperationalTone,
   PluginRouteApp,
+  Platform,
   ResourceEvent,
   SlackConversationLink,
   PluginRegistration,
@@ -204,6 +205,10 @@ function pluginInvocationContext(
         source: context.source,
       };
     case "resource_event":
+    case "scheduled_task":
+    case "event_task":
+    case "plugin_dispatch":
+    case "agent_invocation":
       return {
         ...common,
         actor: context.actor?.platform === "system" ? context.actor : undefined,
@@ -451,7 +456,7 @@ export function applyPluginFormatMarkdown(text: string): string {
 
 /** Collect stable plugin prompt contributions for the static system prompt. */
 export async function getPluginSystemPromptContributions(
-  source: ToolRuntimeContext["source"],
+  platform: Platform,
 ): Promise<PluginPromptContributionContext[]> {
   const contributions: PluginPromptContributionContext[] = [];
   let totalChars = 0;
@@ -464,8 +469,7 @@ export async function getPluginSystemPromptContributions(
     try {
       const pluginContributions = await hook({
         ...systemPromptPluginContext(plugin),
-        // Plugin system prompts only distinguish Slack vs non-Slack surfaces.
-        platform: source.kind === "slack" ? "slack" : "local",
+        platform,
       });
       const result =
         systemPromptMessageArraySchema.safeParse(pluginContributions);
@@ -615,7 +619,7 @@ export function getPluginTools(
     const slackToolContext = getSlackToolContext(context);
     const credentialSubject = slackToolContext
       ? createSlackDirectCredentialSubject({
-          channelId: slackToolContext.sourceChannelId,
+          channelId: slackToolContext.locationChannelId,
           teamId: slackToolContext.teamId,
           userId: slackToolContext.actor?.userId,
         })
@@ -627,7 +631,7 @@ export function getPluginTools(
       slackToolContext
         ? {
             channelCapabilities: resolveChannelCapabilities(
-              slackToolContext.sourceChannelId,
+              slackToolContext.locationChannelId,
             ),
             ...(dashboardConversationUrl
               ? { conversationLink: { url: dashboardConversationUrl } }
@@ -694,6 +698,7 @@ export function getPluginTools(
       annotations,
       conversationId: context.conversationId,
       locationId: context.locationId,
+      ...(slackContext ? { slack: slackContext } : undefined),
       userText: context.userText,
       embedder: createPluginEmbedder(pluginName),
       egress: context.egress,
@@ -722,7 +727,6 @@ export function getPluginTools(
           actor:
             context.actor?.platform === "slack" ? context.actor : undefined,
           destination: context.destination,
-          slack: slackContext!,
           source: context.source,
         };
         break;
@@ -749,6 +753,10 @@ export function getPluginTools(
         };
         break;
       case "resource_event":
+      case "scheduled_task":
+      case "event_task":
+      case "plugin_dispatch":
+      case "agent_invocation":
         pluginContext = {
           ...common,
           actor:

--- a/packages/junior/src/chat/plugins/agent-hooks.ts
+++ b/packages/junior/src/chat/plugins/agent-hooks.ts
@@ -211,7 +211,7 @@ function pluginInvocationContext(
     case "agent_invocation":
       return {
         ...common,
-        actor: context.actor?.platform === "system" ? context.actor : undefined,
+        actor: context.actor,
         destination: context.destination,
         source: context.source,
       };
@@ -759,8 +759,7 @@ export function getPluginTools(
       case "agent_invocation":
         pluginContext = {
           ...common,
-          actor:
-            context.actor?.platform === "system" ? context.actor : undefined,
+          actor: context.actor,
           destination: context.destination,
           source: context.source,
         };

--- a/packages/junior/src/chat/plugins/task-runner.ts
+++ b/packages/junior/src/chat/plugins/task-runner.ts
@@ -7,6 +7,7 @@
  */
 import type {
   Actor,
+  Location,
   PluginRegistration,
   PluginRunContext,
   PluginRunTranscriptEntry,
@@ -14,7 +15,8 @@ import type {
   PluginTaskContext,
 } from "@sentry/junior-plugin-api";
 import { pluginRunContextSchema } from "@sentry/junior-plugin-api";
-import { getDb } from "@/chat/db";
+import { getConversationStore, getDb } from "@/chat/db";
+import type { ConversationPrivacy } from "@/chat/conversation-privacy";
 import { createPluginLogger } from "@/chat/plugins/logging";
 import { createPluginConversationEvents } from "@/chat/plugins/conversation-events";
 import { createPluginEmbedder, createPluginModel } from "@/chat/plugins/model";
@@ -55,7 +57,6 @@ import {
 } from "./task-queue";
 import { getStateAdapter } from "@/chat/state/adapter";
 import type { Lock } from "chat";
-import type { SessionSource } from "@/chat/source";
 
 const PLUGIN_TASK_LOCK_TTL_MS = 5 * 60 * 1000;
 
@@ -207,7 +208,7 @@ function turnMessagesWithProvenance(
 
 /** Recover the Slack context author identity from a persisted thread message. */
 function slackContextAuthor(
-  source: { teamId: string },
+  location: { teamId: string },
   message: ConversationMessage,
 ): Actor | undefined {
   const userId = message.author?.userId?.trim();
@@ -216,7 +217,7 @@ function slackContextAuthor(
   }
   return {
     platform: "slack",
-    teamId: source.teamId,
+    teamId: location.teamId,
     userId,
     ...(message.author?.userName
       ? { userName: message.author.userName }
@@ -258,27 +259,19 @@ function messageExistedAtRunCompletion(
 /**
  * Project bounded public-thread context into the run transcript.
  *
- * Prior public Slack messages are durable conversation evidence a completed run
- * may have acted on, so passive consumers can cite them. They are always
- * context authority (never instruction), and only public Slack Conversations
- * contribute; private and local Conversations add nothing here.
+ * Prior public Slack messages from the current Conversation are durable
+ * evidence a completed run may have acted on, so passive consumers can cite
+ * them. They are always context authority (never instruction), and private or
+ * local Conversations add nothing here.
  */
 async function loadConversationContextTranscriptEntries(
   record: TurnRecord,
-  source: SessionSource,
+  location: Location | undefined,
+  visibility: ConversationPrivacy | undefined,
   runActor: Actor | undefined,
 ): Promise<PluginRunTranscriptEntry[]> {
-  // TODO(dcramer): Read Location and visibility directly after plugin tasks no
-  // longer depend on turn-session-routing and its legacy session Source.
-  switch (source.kind) {
-    case "slack":
-      if (source.visibility === "private") {
-        return [];
-      }
-      break;
-    case "web":
-    case "local":
-      return [];
+  if (location?.provider !== "slack" || visibility !== "public") {
+    return [];
   }
   const state = await getPersistedThreadState(record.conversationId);
   const conversation = coerceThreadConversationState(state);
@@ -298,7 +291,7 @@ async function loadConversationContextTranscriptEntries(
     if (!text) {
       continue;
     }
-    const author = slackContextAuthor(source, message);
+    const author = slackContextAuthor(location, message);
     entries.push({
       type: "message",
       role: "user",
@@ -345,8 +338,10 @@ async function loadPluginRun(
   if (record.state !== "completed") {
     throw new Error("Completed plugin task session record is not completed");
   }
+  const conversationStore = getConversationStore();
   const routing = await resolveConversationRouting({
     conversationId: params.conversationId,
+    conversationStore,
   });
   if (!routing) {
     throw new Error(
@@ -359,6 +354,9 @@ async function loadPluginRun(
   if (!source) {
     throw new Error("Completed plugin task session record is missing Source");
   }
+  const conversation = await conversationStore.get({
+    conversationId: params.conversationId,
+  });
   // The Turn Actor owns the run.
   // TODO(dcramer): Remove the provenance and dispatch Actor fallbacks after no
   // deployed Turn cursor can omit Actor.
@@ -382,9 +380,12 @@ async function loadPluginRun(
       .map((entry) => entry.text),
   );
   const contextEntries = (
-    source.kind === "slack" || source.kind === "web" || source.kind === "local"
-      ? await loadConversationContextTranscriptEntries(record, source, runActor)
-      : []
+    await loadConversationContextTranscriptEntries(
+      record,
+      conversation?.location,
+      conversation?.visibility,
+      runActor,
+    )
   ).filter(
     (entry) => entry.type !== "message" || !runMessageTexts.has(entry.text),
   );

--- a/packages/junior/src/chat/plugins/task-runner.ts
+++ b/packages/junior/src/chat/plugins/task-runner.ts
@@ -30,7 +30,7 @@ import {
   stripRuntimeTurnContext,
 } from "@/chat/pi/transcript";
 import { getPersistedThreadState } from "@/chat/runtime/thread-state";
-import { resolveTurnSessionRouting } from "@/chat/services/turn-session-routing";
+import { resolveConversationRouting } from "@/chat/services/turn-session-routing";
 import { getDispatchRecord } from "@/chat/agent-dispatch/store";
 import { readActorIdentity } from "@/chat/plugins/viewer";
 import { coerceThreadConversationState } from "@/chat/state/conversation";
@@ -345,12 +345,20 @@ async function loadPluginRun(
   if (record.state !== "completed") {
     throw new Error("Completed plugin task session record is not completed");
   }
-  const routing = await resolveTurnSessionRouting({
+  const routing = await resolveConversationRouting({
     conversationId: params.conversationId,
   });
+  if (!routing) {
+    throw new Error(
+      `Conversation ${params.conversationId} is missing durable routing metadata`,
+    );
+  }
   // TODO(dcramer): Remove the session Source fallback after every deployed
   // Turn cursor stores Source.
   const source = record.source ?? routing.source;
+  if (!source) {
+    throw new Error("Completed plugin task session record is missing Source");
+  }
   // The Turn Actor owns the run.
   // TODO(dcramer): Remove the provenance and dispatch Actor fallbacks after no
   // deployed Turn cursor can omit Actor.
@@ -374,11 +382,9 @@ async function loadPluginRun(
       .map((entry) => entry.text),
   );
   const contextEntries = (
-    await loadConversationContextTranscriptEntries(
-      record,
-      routing.source,
-      runActor,
-    )
+    source.kind === "slack" || source.kind === "web" || source.kind === "local"
+      ? await loadConversationContextTranscriptEntries(record, source, runActor)
+      : []
   ).filter(
     (entry) => entry.type !== "message" || !runMessageTexts.has(entry.text),
   );

--- a/packages/junior/src/chat/plugins/task-runner.ts
+++ b/packages/junior/src/chat/plugins/task-runner.ts
@@ -55,6 +55,7 @@ import {
 } from "./task-queue";
 import { getStateAdapter } from "@/chat/state/adapter";
 import type { Lock } from "chat";
+import type { SessionSource } from "@/chat/source";
 
 const PLUGIN_TASK_LOCK_TTL_MS = 5 * 60 * 1000;
 
@@ -259,15 +260,16 @@ function messageExistedAtRunCompletion(
  *
  * Prior public Slack messages are durable conversation evidence a completed run
  * may have acted on, so passive consumers can cite them. They are always
- * context authority (never instruction), and only public Slack sources
- * contribute; private and local sources add nothing here.
+ * context authority (never instruction), and only public Slack Conversations
+ * contribute; private and local Conversations add nothing here.
  */
 async function loadConversationContextTranscriptEntries(
   record: TurnRecord,
-  source: PluginRunContext["source"],
+  source: SessionSource,
   runActor: Actor | undefined,
 ): Promise<PluginRunTranscriptEntry[]> {
-  // Prior conversation evidence is a Slack public-channel concern only.
+  // TODO(dcramer): Read Location and visibility directly after plugin tasks no
+  // longer depend on turn-session-routing and its legacy session Source.
   switch (source.kind) {
     case "slack":
       if (source.visibility === "private") {
@@ -276,7 +278,6 @@ async function loadConversationContextTranscriptEntries(
       break;
     case "web":
     case "local":
-    case "resource_event":
       return [];
   }
   const state = await getPersistedThreadState(record.conversationId);
@@ -347,6 +348,9 @@ async function loadPluginRun(
   const routing = await resolveTurnSessionRouting({
     conversationId: params.conversationId,
   });
+  // TODO(dcramer): Remove the session Source fallback after every deployed
+  // Turn cursor stores Source.
+  const source = record.source ?? routing.source;
   // The Turn Actor owns the run.
   // TODO(dcramer): Remove the provenance and dispatch Actor fallbacks after no
   // deployed Turn cursor can omit Actor.
@@ -389,7 +393,7 @@ async function loadPluginRun(
     actors: record.actors,
     ...(runActor ? { actor: runActor } : undefined),
     runId: record.turnId,
-    source: routing.source,
+    source,
     transcript: [...contextEntries, ...runEntries],
   });
 }

--- a/packages/junior/src/chat/prompt.ts
+++ b/packages/junior/src/chat/prompt.ts
@@ -702,7 +702,7 @@ const STATIC_SYSTEM_PROMPTS: Record<PromptPlatform, string> = {
   slack: buildStaticSystemPrompt("slack"),
 };
 
-/** Return byte-stable platform instructions shared by every Conversation and Turn. */
+/** Return the fixed instructions shared by every Conversation and Turn. */
 export function buildSystemPrompt(platform: PromptPlatform): string {
   return STATIC_SYSTEM_PROMPTS[platform];
 }

--- a/packages/junior/src/chat/prompt.ts
+++ b/packages/junior/src/chat/prompt.ts
@@ -468,6 +468,11 @@ function formatSourceLines(source: Source): string[] {
         `- source.identifier: ${escapeXml(source.identifier)}`,
         `- source.event_type: ${escapeXml(source.eventType)}`,
       ];
+    case "scheduled_task":
+    case "event_task":
+    case "plugin_dispatch":
+    case "agent_invocation":
+      return [`- source.kind: ${source.kind}`];
   }
 }
 
@@ -697,11 +702,8 @@ const STATIC_SYSTEM_PROMPTS: Record<PromptPlatform, string> = {
   slack: buildStaticSystemPrompt("slack"),
 };
 
-/** Return byte-stable platform instructions shared by every conversation and turn. */
-export function buildSystemPrompt(params: { source: Source }): string {
-  // web/dashboard turns use the local (non-Slack) instruction surface.
-  const platform: PromptPlatform =
-    params.source.kind === "slack" ? "slack" : "local";
+/** Return byte-stable platform instructions shared by every Conversation and Turn. */
+export function buildSystemPrompt(platform: PromptPlatform): string {
   return STATIC_SYSTEM_PROMPTS[platform];
 }
 

--- a/packages/junior/src/chat/scheduled-tasks/heartbeat.ts
+++ b/packages/junior/src/chat/scheduled-tasks/heartbeat.ts
@@ -1,8 +1,6 @@
 import {
-  createSlackSource,
   type Dispatch,
   type ReplyAttribution,
-  type Source,
 } from "@sentry/junior-plugin-api";
 import {
   dispatchScheduledTask,
@@ -96,14 +94,6 @@ function replyAttribution(task: ScheduledTask): ReplyAttribution {
         label: "Scheduled task",
         detail: `Every ${recurrence.interval} ${frequency.unit}s`,
       };
-}
-
-function dispatchSource(task: ScheduledTask): Source {
-  return createSlackSource({
-    teamId: task.destination.teamId,
-    channelId: task.destination.channelId,
-    visibility: task.conversationAccess.visibility,
-  });
 }
 
 function shouldSkipRun(
@@ -430,7 +420,6 @@ export async function runScheduledTaskHeartbeat(args: {
           input: buildDispatchInput(task),
           metadata,
           replyAttribution: replyAttribution(task),
-          source: dispatchSource(task),
         },
       });
     } catch (error) {

--- a/packages/junior/src/chat/scheduled-tasks/tool-support.ts
+++ b/packages/junior/src/chat/scheduled-tasks/tool-support.ts
@@ -162,6 +162,8 @@ export function getConversationAccess(
   destination: SlackDestination,
   source: SlackSource | undefined,
 ): ScheduledTaskConversationAccess {
+  // TODO(dcramer): Read Conversation visibility after Scheduled tasks no longer
+  // require Slack Source. Source describes the input, not the Conversation.
   if (isDmChannel(destination.channelId)) {
     return { audience: "direct", visibility: "private" };
   }

--- a/packages/junior/src/chat/scheduled-tasks/tool-support.ts
+++ b/packages/junior/src/chat/scheduled-tasks/tool-support.ts
@@ -162,8 +162,9 @@ export function getConversationAccess(
   destination: SlackDestination,
   source: SlackSource | undefined,
 ): ScheduledTaskConversationAccess {
-  // TODO(dcramer): Read Conversation visibility after Scheduled tasks no longer
-  // require Slack Source. Source describes the input, not the Conversation.
+  // TODO(dcramer): Read stored Conversation visibility when users can create
+  // Scheduled tasks from web and other Conversations. Then this function will
+  // not need Slack Source.
   if (isDmChannel(destination.channelId)) {
     return { audience: "direct", visibility: "private" };
   }

--- a/packages/junior/src/chat/services/turn-session-routing.ts
+++ b/packages/junior/src/chat/services/turn-session-routing.ts
@@ -5,11 +5,7 @@
  * parent reads through that relation. Later Turns and mailbox wakes use the
  * same Destination so tools stay consistent for the whole Conversation.
  */
-import type {
-  Destination,
-  SlackDestination,
-  Source,
-} from "@sentry/junior-plugin-api";
+import type { Destination, SlackDestination } from "@sentry/junior-plugin-api";
 import type {
   Conversation,
   ConversationStore,
@@ -24,12 +20,12 @@ export interface TurnSessionRouting {
   destination: Destination;
   location?: Location;
   /** Present when the conversation already stores a session source. */
-  source?: Source;
+  source?: SessionSource;
 }
 
 /** Conversation data with a required Destination and Source. */
 export type RequiredTurnSessionRouting = TurnSessionRouting & {
-  source: Source;
+  source: SessionSource;
 };
 
 async function loadConversationChain(

--- a/packages/junior/src/chat/slack/tool-support/context.ts
+++ b/packages/junior/src/chat/slack/tool-support/context.ts
@@ -1,5 +1,4 @@
 import type { ToolRuntimeContext } from "@/chat/tools/types";
-import type { SlackDestination } from "@sentry/junior-plugin-api";
 import type { SlackSource } from "@sentry/junior-plugin-api";
 import type { SlackActor } from "@/chat/actor";
 import {
@@ -14,45 +13,56 @@ import {
 } from "@/chat/slack/timestamp";
 
 export interface SlackToolContext {
-  destination: SlackDestination;
-  source: SlackSource;
   actor?: SlackActor;
   destinationChannelId: SlackChannelId;
+  locationChannelId: SlackChannelId;
+  messageChannelId?: SlackChannelId;
   messageTs?: SlackMessageTs;
-  sourceChannelId: SlackChannelId;
   teamId: SlackTeamId;
   threadTs?: SlackMessageTs;
 }
 
-/** Resolve Slack-specific tool context from the active source/destination/actor. */
+/** Resolve Slack tool context from the Conversation Location. */
 export function getSlackToolContext(
   context: ToolRuntimeContext,
 ): SlackToolContext | undefined {
-  if (context.source.kind !== "slack") {
-    return undefined;
-  }
-  if (context.destination.platform !== "slack") {
-    throw new TypeError("Slack source requires a Slack destination");
-  }
+  // TODO(dcramer): Remove the Slack Source fallback after every deployed
+  // Conversation that came from Slack has a stored Location.
+  const source: SlackSource | undefined =
+    context.source.kind === "slack" ? context.source : undefined;
+  const location =
+    context.location?.provider === "slack"
+      ? context.location
+      : source
+        ? {
+            provider: "slack" as const,
+            teamId: source.teamId,
+            channelId: source.channelId,
+            threadTs: source.threadTs,
+          }
+        : undefined;
+  if (!location) return undefined;
+
   const destinationChannelId = parseSlackChannelReferenceId(
-    context.destination.channelId,
+    context.destination.platform === "slack"
+      ? context.destination.channelId
+      : location.channelId,
   );
-  const sourceChannelId = parseSlackChannelReferenceId(
-    context.source.channelId,
-  );
-  const teamId = parseSlackTeamId(context.source.teamId);
-  if (!destinationChannelId || !sourceChannelId || !teamId) {
+  const locationChannelId = parseSlackChannelReferenceId(location.channelId);
+  const teamId = parseSlackTeamId(location.teamId);
+  if (!destinationChannelId || !locationChannelId || !teamId) {
     return undefined;
   }
 
   return {
-    destination: context.destination,
-    source: context.source,
     actor: context.actor?.platform === "slack" ? context.actor : undefined,
     destinationChannelId,
-    messageTs: parseSlackMessageTs(context.source.messageTs),
-    sourceChannelId,
+    locationChannelId,
+    messageChannelId: source
+      ? parseSlackChannelReferenceId(source.channelId)
+      : undefined,
+    messageTs: parseSlackMessageTs(source?.messageTs),
     teamId,
-    threadTs: parseSlackMessageTs(context.source.threadTs),
+    threadTs: parseSlackMessageTs(location.threadTs),
   };
 }

--- a/packages/junior/src/chat/slack/tools/channel-join.ts
+++ b/packages/junior/src/chat/slack/tools/channel-join.ts
@@ -35,7 +35,7 @@ export function createSlackChannelJoinTool(context: SlackToolContext) {
       const access = await checkSlackChannelReadAccess({
         currentChannelIds: [
           context.destinationChannelId,
-          context.sourceChannelId,
+          context.locationChannelId,
         ],
         targetChannelId: target.channelId,
         teamId: context.teamId,

--- a/packages/junior/src/chat/slack/tools/channel-list-messages.ts
+++ b/packages/junior/src/chat/slack/tools/channel-list-messages.ts
@@ -130,7 +130,7 @@ export function createSlackChannelListMessagesTool(context: SlackToolContext) {
       const access = await checkSlackChannelReadAccess({
         currentChannelIds: [
           context.destinationChannelId,
-          context.sourceChannelId,
+          context.locationChannelId,
         ],
         targetChannelId,
         teamId: context.teamId,

--- a/packages/junior/src/chat/slack/tools/message-add-reaction.ts
+++ b/packages/junior/src/chat/slack/tools/message-add-reaction.ts
@@ -21,8 +21,7 @@ export function createSlackMessageAddReactionTool(
       openWorldHint: true,
       readOnlyHint: false,
     },
-    description:
-      "Add an emoji reaction to the current inbound Slack message.",
+    description: "Add an emoji reaction to the current inbound Slack message.",
     inputSchema: z.object({
       emoji: z
         .string()
@@ -34,11 +33,11 @@ export function createSlackMessageAddReactionTool(
     }),
     outputSchema: juniorToolOutputSchema,
     execute: async ({ emoji }) => {
-      const targetChannelId = context.sourceChannelId;
+      const targetChannelId = context.messageChannelId;
       const targetMessageTs = context.messageTs;
-      if (!targetMessageTs) {
+      if (!targetChannelId || !targetMessageTs) {
         throw new ToolInputError(
-          "No active message timestamp is available for reactions.",
+          "No active Slack message is available for reactions.",
         );
       }
       const normalizedEmoji = normalizeSlackEmojiName(emoji);

--- a/packages/junior/src/chat/slack/tools/send-files.ts
+++ b/packages/junior/src/chat/slack/tools/send-files.ts
@@ -7,7 +7,6 @@ import { uploadFilesToConversation } from "@/chat/slack/outbound";
 import type { SlackToolContext } from "@/chat/slack/tool-support/context";
 import { z } from "zod";
 import { zodTool } from "@/chat/tool-support/zod-tool";
-import { ToolInputError } from "@/chat/tools/execution/tool-input-error";
 import { createOperationKey } from "@/chat/tools/idempotency";
 import {
   sandboxFileReferenceSchema,
@@ -107,22 +106,14 @@ export function createSendFilesTool(
     outputSchema: sendFilesResultSchema,
     execute: async ({ files }, options) => {
       const filesToSend = normalizeFiles(files);
-      const activeChannelId = context.sourceChannelId;
-      if (!activeChannelId) {
-        throw new ToolInputError("No active Slack conversation is available.");
-      }
+      const activeChannelId = context.locationChannelId;
       const threadTs = context.threadTs ?? context.messageTs;
-      if (!threadTs) {
-        throw new ToolInputError(
-          "No active Slack conversation timestamp is available.",
-        );
-      }
       const materializedFiles = await Promise.all(
         filesToSend.map((file) => materializeFile(file)),
       );
       const operationKey = createOperationKey("sendFiles", {
         channel_id: activeChannelId,
-        thread_ts: threadTs,
+        thread_ts: threadTs ?? null,
         files: fileOperationInput(materializedFiles),
       });
       const cached = state.getOperationResult<CachedSendFiles>(operationKey);
@@ -134,7 +125,9 @@ export function createSendFilesTool(
           await recordAttachmentsDelivered({
             attachments: cached.delivered,
             conversationId: attachments.conversationId,
-            ...(cached.toolCallId ? { toolCallId: cached.toolCallId } : undefined),
+            ...(cached.toolCallId
+              ? { toolCallId: cached.toolCallId }
+              : undefined),
           });
         }
         return sendFilesResultSchema.parse({
@@ -158,7 +151,7 @@ export function createSendFilesTool(
       await uploadFilesToConversation({
         channelId: activeChannelId,
         files: uploads,
-        threadTs,
+        ...(threadTs ? { threadTs } : undefined),
       });
       const delivered: DeliveredAttachment[] = stored.map(
         (attachment, index) => {
@@ -183,13 +176,17 @@ export function createSendFilesTool(
       state.setOperationResult(operationKey, {
         delivered,
         result: response,
-        ...(options.toolCallId ? { toolCallId: options.toolCallId } : undefined),
+        ...(options.toolCallId
+          ? { toolCallId: options.toolCallId }
+          : undefined),
       } satisfies CachedSendFiles);
       if (attachments && delivered.length > 0) {
         await recordAttachmentsDelivered({
           attachments: delivered,
           conversationId: attachments.conversationId,
-          ...(options.toolCallId ? { toolCallId: options.toolCallId } : undefined),
+          ...(options.toolCallId
+            ? { toolCallId: options.toolCallId }
+            : undefined),
         });
       }
       return response;

--- a/packages/junior/src/chat/slack/tools/thread-read.ts
+++ b/packages/junior/src/chat/slack/tools/thread-read.ts
@@ -89,11 +89,7 @@ export function createSlackThreadReadTool(context: SlackToolContext) {
       readOnlyHint: true,
     },
     inputSchema: z.object({
-      url: z
-        .string()
-        .min(1)
-        .describe("Slack message archive URL.")
-        .optional(),
+      url: z.string().min(1).describe("Slack message archive URL.").optional(),
       channel_id: slackChannelRefParam.optional(),
       ts: slackTimestampParam(
         "Slack message timestamp. May be the thread root or any message in the thread.",
@@ -148,7 +144,7 @@ export function createSlackThreadReadTool(context: SlackToolContext) {
       const access = await checkSlackChannelReadAccess({
         currentChannelIds: [
           context.destinationChannelId,
-          context.sourceChannelId,
+          context.locationChannelId,
         ],
         targetChannelId: channelId,
         teamId: context.teamId,

--- a/packages/junior/src/chat/source.ts
+++ b/packages/junior/src/chat/source.ts
@@ -1,16 +1,16 @@
 import { sourceSchema, type Source } from "@sentry/junior-plugin-api";
 
-/** Source coordinates reduced to the stable locator for one conversation. */
+// TODO(dcramer): Delete SessionSource and this module after resume and SQL
+// Location reads no longer use Conversation.sessionSource.
+/** Legacy Source coordinates stored as a Conversation locator. */
 export type SessionSource =
   | Extract<Source, { kind: "web" }>
   | Extract<Source, { kind: "local" }>
   | Omit<Extract<Source, { kind: "slack" }>, "messageTs">;
 
 /**
- * Normalize a turn Source into the session-stable locator persisted on a
- * conversation. Drops per-message timestamps. Threaded Slack turns keep their
- * thread anchor; channel-level turns (scheduled/event dispatch) keep the
- * channel locator without inventing a threadTs.
+ * Normalize a Turn Source into the legacy locator stored on a Conversation.
+ * System Sources do not contain a Conversation Location.
  */
 export function normalizeSessionSource(
   value: Source | undefined,
@@ -32,7 +32,13 @@ export function normalizeSessionSource(
       conversationId: value.conversationId,
     };
   }
-  if (value.kind === "resource_event") {
+  if (
+    value.kind === "resource_event" ||
+    value.kind === "scheduled_task" ||
+    value.kind === "event_task" ||
+    value.kind === "plugin_dispatch" ||
+    value.kind === "agent_invocation"
+  ) {
     return undefined;
   }
   const threadTs = value.threadTs?.trim();

--- a/packages/junior/src/chat/source.ts
+++ b/packages/junior/src/chat/source.ts
@@ -2,14 +2,14 @@ import { sourceSchema, type Source } from "@sentry/junior-plugin-api";
 
 // TODO(dcramer): Delete SessionSource and this module after resume and SQL
 // Location reads no longer use Conversation.sessionSource.
-/** Legacy Source coordinates stored as a Conversation locator. */
+/** Legacy provider Source fields stored on a Conversation. */
 export type SessionSource =
   | Extract<Source, { kind: "web" }>
   | Extract<Source, { kind: "local" }>
   | Omit<Extract<Source, { kind: "slack" }>, "messageTs">;
 
 /**
- * Normalize a Turn Source into the legacy locator stored on a Conversation.
+ * Normalize a Turn Source into legacy provider fields stored on a Conversation.
  * System Sources do not contain a Conversation Location.
  */
 export function normalizeSessionSource(
@@ -51,7 +51,7 @@ export function normalizeSessionSource(
   };
 }
 
-/** Parse a serialized Source into the stable locator stored on a conversation. */
+/** Parse a serialized Source into legacy provider fields stored on a Conversation. */
 export function parseSessionSource(value: unknown): SessionSource | undefined {
   const parsed = sourceSchema.safeParse(value);
   return parsed.success ? normalizeSessionSource(parsed.data) : undefined;

--- a/packages/junior/src/chat/tools/event-tasks.ts
+++ b/packages/junior/src/chat/tools/event-tasks.ts
@@ -14,10 +14,9 @@ export function createEventTaskTools(
   context: ToolRuntimeContext,
   catalog: ResourceEventCatalog,
 ): ToolRegistry {
-  // TODO(dcramer): Let users manage Event tasks from web and other Junior
-  // Conversations. Remove these Slack checks when task storage can identify
-  // its Conversation and User without Slack-only fields. Location provides
-  // Slack context; the work owner decides Delivery.
+  // TODO(dcramer): Let users manage Event tasks from web and other
+  // Conversations. Remove these checks when Event tasks no longer require a
+  // Slack Destination or Slack creator.
   if (
     context.source.kind !== "slack" ||
     context.destination.platform !== "slack" ||

--- a/packages/junior/src/chat/tools/event-tasks.ts
+++ b/packages/junior/src/chat/tools/event-tasks.ts
@@ -14,6 +14,10 @@ export function createEventTaskTools(
   context: ToolRuntimeContext,
   catalog: ResourceEventCatalog,
 ): ToolRegistry {
+  // TODO(dcramer): Let users manage Event tasks from web and other Junior
+  // Conversations. Remove these Slack checks when task storage can identify
+  // its Conversation and User without Slack-only fields. Location provides
+  // Slack context; the work owner decides Delivery.
   if (
     context.source.kind !== "slack" ||
     context.destination.platform !== "slack" ||

--- a/packages/junior/src/chat/tools/index.ts
+++ b/packages/junior/src/chat/tools/index.ts
@@ -83,11 +83,11 @@ export function createTools(
 ) {
   const state = createToolState();
   const slackContext = getSlackToolContext(context);
-  const slackSourceCapabilities = slackContext
-    ? resolveChannelCapabilities(slackContext.sourceChannelId)
+  const slackLocationCapabilities = slackContext
+    ? resolveChannelCapabilities(slackContext.locationChannelId)
     : undefined;
   const canSendFilesToActiveConversation = Boolean(
-    slackContext && slackSourceCapabilities?.canSendFiles,
+    slackContext && slackLocationCapabilities?.canSendFiles,
   );
   const resourceEventCatalog = getResourceEventCatalog();
   const tools: ToolRegistry = {
@@ -171,7 +171,7 @@ export function createTools(
     tools.slackCanvasWrite = createSlackCanvasWriteTool(state);
     tools.slackThreadRead = createSlackThreadReadTool(slackContext);
     tools.slackChannelJoin = createSlackChannelJoinTool(slackContext);
-    if (slackContext.source.visibility === "public") {
+    if (context.conversationPrivacy === "public") {
       tools.searchConversationMessages =
         createSlackConversationMessageSearchTool(
           {
@@ -206,8 +206,8 @@ export function createTools(
     const outputCapabilities = outputChannelId
       ? resolveChannelCapabilities(outputChannelId)
       : undefined;
-    const rawChannelCapabilities = resolveChannelCapabilities(
-      slackContext.sourceChannelId,
+    const locationCapabilities = resolveChannelCapabilities(
+      slackContext.locationChannelId,
     );
     if (outputCapabilities?.canCreateCanvas) {
       tools.slackCanvasCreate = createSlackCanvasCreateTool(
@@ -216,7 +216,7 @@ export function createTools(
       );
     }
 
-    if (rawChannelCapabilities.canSendFiles) {
+    if (locationCapabilities.canSendFiles) {
       tools.sendFiles = createSendFilesTool(
         slackContext,
         state,
@@ -236,7 +236,10 @@ export function createTools(
     tools.slackChannelListMessages =
       createSlackChannelListMessagesTool(slackContext);
 
-    if (rawChannelCapabilities.canAddReactions) {
+    if (
+      context.source.kind === "slack" &&
+      locationCapabilities.canAddReactions
+    ) {
       tools.addReaction = createSlackMessageAddReactionTool(
         slackContext,
         state,

--- a/packages/junior/src/chat/tools/scheduled-tasks.ts
+++ b/packages/junior/src/chat/tools/scheduled-tasks.ts
@@ -12,10 +12,9 @@ import type { ToolRuntimeContext } from "@/chat/tools/types";
 function scheduledTaskToolContext(
   context: ToolRuntimeContext,
 ): SchedulerToolContext | undefined {
-  // TODO(dcramer): Let users manage Scheduled tasks from web and other Junior
-  // Conversations. Remove these Slack checks when task storage can identify
-  // its Conversation and User without Slack-only fields. Location provides
-  // Slack context; the work owner decides Delivery.
+  // TODO(dcramer): Let users manage Scheduled tasks from web and other
+  // Conversations. Remove these checks when Scheduled tasks no longer require
+  // a Slack Destination or Slack creator.
   if (
     context.source.kind !== "slack" ||
     context.destination.platform !== "slack" ||

--- a/packages/junior/src/chat/tools/scheduled-tasks.ts
+++ b/packages/junior/src/chat/tools/scheduled-tasks.ts
@@ -12,6 +12,10 @@ import type { ToolRuntimeContext } from "@/chat/tools/types";
 function scheduledTaskToolContext(
   context: ToolRuntimeContext,
 ): SchedulerToolContext | undefined {
+  // TODO(dcramer): Let users manage Scheduled tasks from web and other Junior
+  // Conversations. Remove these Slack checks when task storage can identify
+  // its Conversation and User without Slack-only fields. Location provides
+  // Slack context; the work owner decides Delivery.
   if (
     context.source.kind !== "slack" ||
     context.destination.platform !== "slack" ||

--- a/packages/junior/src/chat/tools/search-conversation-events.ts
+++ b/packages/junior/src/chat/tools/search-conversation-events.ts
@@ -222,6 +222,18 @@ async function resolveAccessScope(
       )
     : currentConversationId;
 
+  if (context.location?.provider === "slack") {
+    return {
+      currentConversationId,
+      currentRootConversationId,
+      provider: "slack",
+      providerTenantId: context.location.teamId,
+    };
+  }
+
+  // TODO(dcramer): Remove the Source and Destination fallbacks after every
+  // deployed Slack Conversation has a stored Location and AgentRun no longer
+  // has Destination.
   if (context.source.kind === "slack") {
     return {
       currentConversationId,

--- a/packages/junior/src/chat/tools/types.ts
+++ b/packages/junior/src/chat/tools/types.ts
@@ -1,15 +1,20 @@
 import type { FileUpload } from "chat";
 import type {
+  AgentInvocationSource,
+  EventTaskSource,
   WebSource,
   ResourceEventSource,
   Destination,
   Identity,
+  Location,
   LocalDestination,
   LocalSource,
+  PluginDispatchSource,
   PluginEgress,
   SlackDestination,
   SlackSource,
   Source,
+  ScheduledTaskSource,
   SystemActor,
   User,
 } from "@sentry/junior-plugin-api";
@@ -25,6 +30,7 @@ import type { GeneratedArtifactFileRef } from "@/chat/tools/sandbox/file-uploads
 import type { SpawnAgent } from "@/chat/agent/types";
 import type { AttachmentStorage } from "@/chat/attachments/storage";
 import type { Workspace } from "@/chat/workspaces/types";
+import type { ConversationPrivacy } from "@/chat/conversation-privacy";
 
 interface HandoffControl {
   /** Non-empty catalog of configured targets. */
@@ -87,7 +93,13 @@ interface BaseToolRuntimeContext {
    */
   conversationId: string;
   /** Location associated with this Conversation. */
+  location?: Location;
+  // TODO(dcramer): Remove locationId after memory and plugin contexts read
+  // Location directly.
+  /** Legacy Location identity used by memory and plugin contexts. */
   locationId?: string;
+  /** Stored Conversation visibility used by tools. */
+  conversationPrivacy?: ConversationPrivacy;
 
   /** Runtime-owned default outbound destination for this invocation. */
   destination: Destination;
@@ -124,7 +136,6 @@ interface LocalToolRuntimeContext extends BaseToolRuntimeContext {
   destination: LocalDestination;
   actor?: LocalActor;
   source: LocalSource;
-  slack?: never;
   slackActionToken?: never;
 }
 
@@ -132,23 +143,24 @@ interface WebToolRuntimeContext extends BaseToolRuntimeContext {
   destination: Destination;
   actor?: WebActor;
   source: WebSource;
-  slack?: never;
-  slackActionToken?: never;
-}
-
-interface ResourceEventToolRuntimeContext extends BaseToolRuntimeContext {
-  destination: Destination;
-  actor?: SystemActor;
-  source: ResourceEventSource;
-  slack?: never;
   slackActionToken?: never;
 }
 
 export type ToolRuntimeContext =
   | LocalToolRuntimeContext
-  | ResourceEventToolRuntimeContext
   | SlackToolRuntimeContext
-  | WebToolRuntimeContext;
+  | WebToolRuntimeContext
+  | (BaseToolRuntimeContext & {
+      destination: Destination;
+      actor?: SystemActor;
+      source:
+        | AgentInvocationSource
+        | EventTaskSource
+        | PluginDispatchSource
+        | ResourceEventSource
+        | ScheduledTaskSource;
+      slackActionToken?: never;
+    });
 
 export interface ToolState {
   getOperationResult: <T>(operationKey: string) => T | undefined;

--- a/packages/junior/src/chat/tools/types.ts
+++ b/packages/junior/src/chat/tools/types.ts
@@ -15,7 +15,6 @@ import type {
   SlackSource,
   Source,
   ScheduledTaskSource,
-  SystemActor,
   User,
 } from "@sentry/junior-plugin-api";
 import type { McpToolManager } from "@/chat/mcp/tool-manager";
@@ -152,7 +151,7 @@ export type ToolRuntimeContext =
   | WebToolRuntimeContext
   | (BaseToolRuntimeContext & {
       destination: Destination;
-      actor?: SystemActor;
+      actor?: Actor;
       source:
         | AgentInvocationSource
         | EventTaskSource

--- a/packages/junior/tests/component/agent-dispatch-worker.test.ts
+++ b/packages/junior/tests/component/agent-dispatch-worker.test.ts
@@ -1,5 +1,4 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { createSlackSource } from "@sentry/junior-plugin-api";
 import {
   createOrGetDispatch,
   getDispatchConversationId,
@@ -38,10 +37,7 @@ async function createDispatch(idempotencyKey: string) {
         destinationVisibility: "private",
         idempotencyKey,
         input: "Post the scheduled digest.",
-        source: createSlackSource({
-          ...destination,
-          visibility: "private",
-        }),
+        source: { kind: "scheduled_task" },
       },
       plugin: "scheduler",
     })

--- a/packages/junior/tests/component/agent-invocation-worker.test.ts
+++ b/packages/junior/tests/component/agent-invocation-worker.test.ts
@@ -20,7 +20,6 @@ import {
 import type { ConversationWorkerContext } from "@/chat/task-execution/worker";
 import { neverRunAgentRunner } from "../fixtures/agent-runner";
 import { createConfiguredJuniorSqlFixture } from "../fixtures/sql";
-import { createLocalSource } from "@sentry/junior-plugin-api";
 const PARENT_CONVERSATION_ID = "local:test:component-parent-agent";
 const DESTINATION = {
   conversationId: PARENT_CONVERSATION_ID,
@@ -32,7 +31,6 @@ const INVOCATION_INPUT = {
   input: "Summarize the durable task.",
   parentConversationId: PARENT_CONVERSATION_ID,
   reasoningLevel: "medium" as const,
-  source: createLocalSource(PARENT_CONVERSATION_ID),
 };
 
 async function prepareParentConversation() {
@@ -100,7 +98,7 @@ describe("agent invocation worker", () => {
         ] as PiMessage[],
         turnId,
         sliceId: 1,
-        source: INVOCATION_INPUT.source,
+        source: { kind: "agent_invocation" },
         state: "running",
         surface: "internal",
       });

--- a/packages/junior/tests/component/plugins/plugin-tasks.test.ts
+++ b/packages/junior/tests/component/plugins/plugin-tasks.test.ts
@@ -173,7 +173,6 @@ describe("plugin background tasks", () => {
     await getConversationStore().recordActivity({
       conversationId: runConversationId,
       destination: runDestination,
-      sessionSource: createLocalSource(runConversationId),
       source: "internal",
     });
     await upsertTurnRecord({

--- a/packages/junior/tests/component/plugins/plugin-tasks.test.ts
+++ b/packages/junior/tests/component/plugins/plugin-tasks.test.ts
@@ -383,19 +383,8 @@ describe("plugin background tasks", () => {
     const channelId = "C123";
     const slackConversationId = "slack:C123:1700000000.000000";
     const slackSessionId = "slack-session-context";
-    const alice = {
-      platform: "slack",
-      teamId,
-      userId: "U_ALICE",
-      userName: "alice",
-    } as const;
-    const source = createSlackSource({
-      teamId,
-      channelId,
-      visibility: "public",
-      messageTs: "1700000000.000100",
-      threadTs: "1700000000.000000",
-    });
+    const runActor = { platform: "system", name: "scheduler" } as const;
+    const source = { kind: "scheduled_task" } as const;
     const loadedRuns: PluginRunContext[] = [];
     const queue = new PluginTaskQueueTestAdapter();
     const { setPlugins } = await import("@/chat/plugins/agent-hooks");
@@ -419,6 +408,14 @@ describe("plugin background tasks", () => {
         },
       }),
     ]);
+
+    const { getConversationStore } = await import("@/chat/db");
+    await getConversationStore().recordActivity({
+      conversationId: slackConversationId,
+      destination: { platform: "slack", teamId, channelId },
+      source: "scheduler",
+      visibility: "public",
+    });
 
     await seedVisibleMessages(slackConversationId, [
       {
@@ -447,7 +444,7 @@ describe("plugin background tasks", () => {
       turnId: slackSessionId,
       sliceId: 1,
       source,
-      actor: alice,
+      actor: runActor,
       state: "completed",
       surface: "slack",
       turnStartMessageIndex: 0,
@@ -483,7 +480,7 @@ describe("plugin background tasks", () => {
         type: "message",
         role: "user",
         text: "Deploy the release now.",
-        provenance: { authority: "instruction", actor: alice },
+        provenance: { authority: "instruction", actor: runActor },
         isRunActor: true,
       },
     ]);
@@ -531,6 +528,14 @@ describe("plugin background tasks", () => {
         },
       }),
     ]);
+
+    const { getConversationStore } = await import("@/chat/db");
+    await getConversationStore().recordActivity({
+      conversationId: slackConversationId,
+      destination: { platform: "slack", teamId, channelId },
+      source: "slack",
+      visibility: "public",
+    });
 
     vi.useFakeTimers({ now: completionMs });
     await upsertTurnRecord({
@@ -671,24 +676,13 @@ describe("plugin background tasks", () => {
     });
   });
 
-  it("adds no context transcript entries for private Slack sources", async () => {
+  it("adds no context transcript entries for private Slack Conversations", async () => {
     const teamId = "T123";
     const channelId = "D123";
     const slackConversationId = "slack:D123:1700000000.000000";
     const slackSessionId = "slack-session-private";
-    const alice = {
-      platform: "slack",
-      teamId,
-      userId: "U_ALICE",
-      userName: "alice",
-    } as const;
-    const source = createSlackSource({
-      teamId,
-      channelId,
-      visibility: "private",
-      messageTs: "1700000000.000100",
-      threadTs: "1700000000.000000",
-    });
+    const runActor = { platform: "system", name: "scheduler" } as const;
+    const source = { kind: "scheduled_task" } as const;
     const loadedRuns: PluginRunContext[] = [];
     const queue = new PluginTaskQueueTestAdapter();
     const { setPlugins } = await import("@/chat/plugins/agent-hooks");
@@ -717,6 +711,14 @@ describe("plugin background tasks", () => {
       }),
     ]);
 
+    const { getConversationStore } = await import("@/chat/db");
+    await getConversationStore().recordActivity({
+      conversationId: slackConversationId,
+      destination: { platform: "slack", teamId, channelId },
+      source: "scheduler",
+      visibility: "private",
+    });
+
     await persistThreadStateById(slackConversationId, {
       conversation: coerceThreadConversationState({
         conversation: {
@@ -743,7 +745,7 @@ describe("plugin background tasks", () => {
       turnId: slackSessionId,
       sliceId: 1,
       source,
-      actor: alice,
+      actor: runActor,
       state: "completed",
       surface: "slack",
       turnStartMessageIndex: 0,

--- a/packages/junior/tests/component/plugins/plugin-tasks.test.ts
+++ b/packages/junior/tests/component/plugins/plugin-tasks.test.ts
@@ -144,7 +144,8 @@ describe("plugin background tasks", () => {
       ...destination,
       conversationId: runConversationId,
     };
-    const runSource = createLocalSource(runConversationId);
+    const runSource = { kind: "plugin_dispatch" } as const;
+    const runActor = { name: "plugin", platform: "system" } as const;
     const queue = new PluginTaskQueueTestAdapter();
     const loadedRuns: PluginRunContext[] = [];
     const { setPlugins } = await import("@/chat/plugins/agent-hooks");
@@ -168,6 +169,13 @@ describe("plugin background tasks", () => {
         },
       }),
     ]);
+    const { getConversationStore } = await import("@/chat/db");
+    await getConversationStore().recordActivity({
+      conversationId: runConversationId,
+      destination: runDestination,
+      sessionSource: createLocalSource(runConversationId),
+      source: "internal",
+    });
     await upsertTurnRecord({
       conversationId: runConversationId,
       destination: runDestination,
@@ -209,12 +217,7 @@ describe("plugin background tasks", () => {
       turnId: runSessionId,
       sliceId: 1,
       source: runSource,
-      actor: {
-        fullName: "Local CLI",
-        platform: "local",
-        userId: "local-cli",
-        userName: "local",
-      },
+      actor: runActor,
       state: "completed",
       surface: "internal",
       turnStartMessageIndex: 2,
@@ -236,14 +239,7 @@ describe("plugin background tasks", () => {
         destination: runDestination,
         runId: runSessionId,
         // Exposed from the full-run provenance: the single instruction author.
-        actors: [
-          {
-            fullName: "Local CLI",
-            platform: "local",
-            userId: "local-cli",
-            userName: "local",
-          },
-        ],
+        actors: [runActor],
         transcript: [
           {
             type: "message",
@@ -251,12 +247,7 @@ describe("plugin background tasks", () => {
             text: "I prefer pull request summaries with test evidence.",
             provenance: {
               authority: "instruction",
-              actor: {
-                fullName: "Local CLI",
-                platform: "local",
-                userId: "local-cli",
-                userName: "local",
-              },
+              actor: runActor,
             },
             isRunActor: true,
           },
@@ -272,12 +263,7 @@ describe("plugin background tasks", () => {
             text: "Understood.",
           },
         ],
-        actor: {
-          fullName: "Local CLI",
-          platform: "local",
-          userId: "local-cli",
-          userName: "local",
-        },
+        actor: runActor,
         source: runSource,
       }),
     ]);

--- a/packages/junior/tests/fixtures/agent-dispatch.ts
+++ b/packages/junior/tests/fixtures/agent-dispatch.ts
@@ -1,9 +1,6 @@
-import {
-  createSlackSource,
-  type ReplyAttribution,
-  type Source,
-} from "@sentry/junior-plugin-api";
+import type { ReplyAttribution } from "@sentry/junior-plugin-api";
 import { createOrGetDispatch } from "@/chat/agent-dispatch/store";
+import type { BoundDispatchOptions } from "@/chat/agent-dispatch/types";
 import { createConversationWork } from "@/chat/app/conversation-work";
 import { createJuniorSlackAdapter } from "@/chat/slack/adapter";
 import type { CredentialSubject } from "@/chat/credentials/context";
@@ -42,7 +39,7 @@ export async function createAgentDispatchWorkHarness(agentRunner: AgentRunner) {
 export async function createAgentDispatchTestRecord(
   idempotencyKey: string,
   credentialSubject?: CredentialSubject,
-  source?: Source,
+  source?: BoundDispatchOptions["source"],
   replyAttribution?: ReplyAttribution,
   input = "Post the scheduled digest.",
 ) {
@@ -56,12 +53,7 @@ export async function createAgentDispatchTestRecord(
         idempotencyKey,
         input,
         ...(replyAttribution ? { replyAttribution } : undefined),
-        source:
-          source ??
-          createSlackSource({
-            ...agentDispatchTestDestination,
-            visibility: "private",
-          }),
+        source: source ?? { kind: "scheduled_task" },
       },
       plugin: "scheduler",
     })

--- a/packages/junior/tests/integration/agent-dispatch-recovery.test.ts
+++ b/packages/junior/tests/integration/agent-dispatch-recovery.test.ts
@@ -1,5 +1,4 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { createSlackSource } from "@sentry/junior-plugin-api";
 import {
   getDispatchConversationId,
   getDispatchRecord,
@@ -107,11 +106,7 @@ describe("agent dispatch recovery", () => {
           signature: "v1=test",
         },
       },
-      createSlackSource({
-        teamId: "T123",
-        channelId: "C123",
-        visibility: "private",
-      }),
+      undefined,
       { label: "Scheduled task", detail: "Weekly" },
     );
     const agentRunner = createModelAgentRunner(
@@ -168,7 +163,7 @@ describe("agent dispatch recovery", () => {
         plugin: dispatch.plugin,
         replyAttribution: dispatch.replyAttribution,
       },
-      source: dispatch.source,
+      source: { kind: "scheduled_task" },
       surface: "api",
     });
     expect(resumedRun?.instruction.text).toBe(dispatch.input);

--- a/packages/junior/tests/integration/agent-dispatch-work.test.ts
+++ b/packages/junior/tests/integration/agent-dispatch-work.test.ts
@@ -97,10 +97,9 @@ describe("agent dispatch conversation work", () => {
       undefined,
       { label: "Scheduled task", detail: "Weekly" },
     );
-    const modelStream = vi.fn(
+    const agentRunner = createModelAgentRunner(
       createModelStream([{ type: "text", text: "Scheduled digest" }]),
     );
-    const agentRunner = createModelAgentRunner(modelStream);
     const run = vi.spyOn(agentRunner, "run");
     const {
       queue,
@@ -152,9 +151,6 @@ describe("agent dispatch conversation work", () => {
       surface: "api",
       disabledFeatures: ["interactive-auth"],
     });
-    expect(modelStream.mock.calls[0]?.[1].systemPrompt).toContain(
-      "You are a Slack-based helper assistant.",
-    );
   });
 
   it("projects a previously delivered reply without running the agent again", async () => {

--- a/packages/junior/tests/integration/agent-dispatch-work.test.ts
+++ b/packages/junior/tests/integration/agent-dispatch-work.test.ts
@@ -97,9 +97,10 @@ describe("agent dispatch conversation work", () => {
       undefined,
       { label: "Scheduled task", detail: "Weekly" },
     );
-    const agentRunner = createModelAgentRunner(
+    const modelStream = vi.fn(
       createModelStream([{ type: "text", text: "Scheduled digest" }]),
     );
+    const agentRunner = createModelAgentRunner(modelStream);
     const run = vi.spyOn(agentRunner, "run");
     const {
       queue,
@@ -147,9 +148,13 @@ describe("agent dispatch conversation work", () => {
           detail: "Weekly",
         },
       },
+      source: { kind: "scheduled_task" },
       surface: "api",
       disabledFeatures: ["interactive-auth"],
     });
+    expect(modelStream.mock.calls[0]?.[1].systemPrompt).toContain(
+      "You are a Slack-based helper assistant.",
+    );
   });
 
   it("projects a previously delivered reply without running the agent again", async () => {

--- a/packages/junior/tests/integration/agent-invocation-concurrency.test.ts
+++ b/packages/junior/tests/integration/agent-invocation-concurrency.test.ts
@@ -1,6 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { StreamFn } from "@earendil-works/pi-agent-core";
-import { createLocalSource } from "@sentry/junior-plugin-api";
 import type { AgentRun } from "@/chat/agent/types";
 import { AgentInvocationLimitError } from "@/chat/agent-invocations/errors";
 import {
@@ -35,7 +34,6 @@ const baseInput = {
   destination,
   input: "Do the delegated work.",
   parentConversationId,
-  source: createLocalSource(parentConversationId),
 };
 
 function taskModel(request: AgentRun): StreamFn {

--- a/packages/junior/tests/integration/agent-invocation-work.test.ts
+++ b/packages/junior/tests/integration/agent-invocation-work.test.ts
@@ -312,7 +312,7 @@ describe("agent invocation conversation work", () => {
       expect(child).not.toHaveProperty("sessionSource");
       expect(child).not.toHaveProperty("visibility");
       let observedVisibility: ReturnType<typeof getCurrentConversationPrivacy>;
-      const modelStream = vi.fn(
+      const agentRunner = createModelAgentRunner(
         createModelStream([
           {
             type: "text",
@@ -323,7 +323,6 @@ describe("agent invocation conversation work", () => {
           },
         ]),
       );
-      const agentRunner = createModelAgentRunner(modelStream);
       const run = vi.spyOn(agentRunner, "run");
       const fallbackWorker = vi.fn(async () => ({
         status: "completed" as const,
@@ -425,12 +424,6 @@ describe("agent invocation conversation work", () => {
         runId: created.invocationId,
       });
       expect(run.mock.calls[0]?.[0].delivery).toBeUndefined();
-      expect(modelStream.mock.calls[0]?.[1].systemPrompt).toContain(
-        "You are a helper assistant.",
-      );
-      expect(modelStream.mock.calls[0]?.[1].systemPrompt).not.toContain(
-        "Slack-based",
-      );
       expect(observedVisibility).toBe("public");
       expect(fallbackWorker).not.toHaveBeenCalled();
     } finally {

--- a/packages/junior/tests/integration/agent-invocation-work.test.ts
+++ b/packages/junior/tests/integration/agent-invocation-work.test.ts
@@ -64,6 +64,11 @@ const slackSource = createSlackSource({
 });
 const slackInvocationInput = {
   ...invocationInput,
+  actor: {
+    platform: "slack",
+    teamId: "T123",
+    userId: "U123",
+  } as const,
   destination: slackDestination,
   parentConversationId: slackParentConversationId,
 };

--- a/packages/junior/tests/integration/agent-invocation-work.test.ts
+++ b/packages/junior/tests/integration/agent-invocation-work.test.ts
@@ -49,7 +49,6 @@ const invocationInput = {
   input: "Summarize the durable task.",
   parentConversationId,
   reasoningLevel: "medium" as const,
-  source: createLocalSource(parentConversationId),
 };
 const slackParentConversationId = "slack:C123:1712345.0001";
 const slackDestination = {
@@ -67,7 +66,6 @@ const slackInvocationInput = {
   ...invocationInput,
   destination: slackDestination,
   parentConversationId: slackParentConversationId,
-  source: slackSource,
 };
 
 async function prepareParentConversation() {
@@ -263,7 +261,6 @@ describe("agent invocation conversation work", () => {
         input: "Inspect the failing checks.",
         parentConversationId,
         reasoningLevel: "high",
-        source: createLocalSource(parentConversationId),
       });
       expect(queue.sentRecords()).toHaveLength(1);
       await expect(
@@ -315,7 +312,7 @@ describe("agent invocation conversation work", () => {
       expect(child).not.toHaveProperty("sessionSource");
       expect(child).not.toHaveProperty("visibility");
       let observedVisibility: ReturnType<typeof getCurrentConversationPrivacy>;
-      const agentRunner = createModelAgentRunner(
+      const modelStream = vi.fn(
         createModelStream([
           {
             type: "text",
@@ -326,6 +323,7 @@ describe("agent invocation conversation work", () => {
           },
         ]),
       );
+      const agentRunner = createModelAgentRunner(modelStream);
       const run = vi.spyOn(agentRunner, "run");
       const fallbackWorker = vi.fn(async () => ({
         status: "completed" as const,
@@ -422,11 +420,17 @@ describe("agent invocation conversation work", () => {
           channelId: "C123",
           threadTs: "1712345.0001",
         },
-        source: slackInvocationInput.source,
+        source: { kind: "agent_invocation" },
         surface: "internal",
         runId: created.invocationId,
       });
       expect(run.mock.calls[0]?.[0].delivery).toBeUndefined();
+      expect(modelStream.mock.calls[0]?.[1].systemPrompt).toContain(
+        "You are a helper assistant.",
+      );
+      expect(modelStream.mock.calls[0]?.[1].systemPrompt).not.toContain(
+        "Slack-based",
+      );
       expect(observedVisibility).toBe("public");
       expect(fallbackWorker).not.toHaveBeenCalled();
     } finally {
@@ -644,7 +648,7 @@ describe("agent invocation conversation work", () => {
         ] as PiMessage[],
         turnId: getAgentInvocationTurnId(created.invocationId),
         sliceId: 1,
-        source: invocationInput.source,
+        source: { kind: "agent_invocation" },
         state: "completed",
         surface: "internal",
       });

--- a/packages/junior/tests/integration/event-tasks.test.ts
+++ b/packages/junior/tests/integration/event-tasks.test.ts
@@ -315,7 +315,7 @@ describe("event tasks", () => {
       ).resolves.toMatchObject({
         destination: { channelId },
         destinationVisibility,
-        source: { channelId, visibility: sourceVisibility },
+        source: { kind: "event_task" },
       });
     },
   );

--- a/packages/junior/tests/integration/heartbeat.test.ts
+++ b/packages/junior/tests/integration/heartbeat.test.ts
@@ -1,9 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
-  createSlackSource,
   defineJuniorPlugin,
   type Destination,
-  type Source,
 } from "@sentry/junior-plugin-api";
 import { eq } from "drizzle-orm";
 import { createHeartbeatContext } from "@/chat/agent-dispatch/context";
@@ -47,19 +45,6 @@ const SLACK_DESTINATION = {
   teamId: "T123",
   channelId: "C123",
 } satisfies Destination;
-const SLACK_SOURCE = createSlackSource({
-  ...SLACK_DESTINATION,
-  visibility: "private",
-}) satisfies Source;
-
-function slackDmSource(channelId = "D123"): Source {
-  return createSlackSource({
-    teamId: "T123",
-    channelId,
-    visibility: "private",
-  });
-}
-
 let conversationWorkQueue = createConversationWorkQueueTestAdapter();
 
 function createTestHeartbeatContext(
@@ -466,7 +451,6 @@ describe("plugin heartbeat", () => {
       destinationVisibility: "private",
       input: "Run the scheduled task.",
       metadata: { runId: "run-1" },
-      source: SLACK_SOURCE,
     });
 
     await expect(schedulerCtx.agent.get(result.id)).resolves.toEqual({
@@ -484,7 +468,7 @@ describe("plugin heartbeat", () => {
       input: "Run the scheduled task.",
       destination: { channelId: "C123" },
       metadata: { runId: "run-1" },
-      source: { channelId: "C123" },
+      source: { kind: "plugin_dispatch" },
     });
   });
 
@@ -522,7 +506,6 @@ describe("plugin heartbeat", () => {
         destination: SLACK_DESTINATION,
         destinationVisibility: "private",
         input: "Run the scheduled task.",
-        source: SLACK_SOURCE,
       });
     }
 
@@ -532,7 +515,6 @@ describe("plugin heartbeat", () => {
         destination: SLACK_DESTINATION,
         destinationVisibility: "private",
         input: "Run the scheduled task.",
-        source: SLACK_SOURCE,
       }),
     ).rejects.toThrow("Plugin heartbeat exceeded the dispatch limit");
   });
@@ -559,7 +541,6 @@ describe("plugin heartbeat", () => {
           },
           destinationVisibility: "private",
           input: "Run the scheduled task.",
-          source: SLACK_SOURCE,
         }),
       ).rejects.toThrow("Dispatch destination teamId must be a Slack team id");
     }
@@ -570,7 +551,6 @@ describe("plugin heartbeat", () => {
         destination: SLACK_DESTINATION,
         destinationVisibility: "private",
         input: "Run the scheduled task.",
-        source: SLACK_SOURCE,
       }),
     ).resolves.toMatchObject({ status: "created" });
   });
@@ -600,7 +580,6 @@ describe("plugin heartbeat", () => {
         },
         destinationVisibility: "private",
         input: "Run the scheduled task.",
-        source: slackDmSource(),
       }),
     ).rejects.toThrow("Dispatch credentialSubject binding is runtime-owned");
     expect(getCapturedSlackApiCalls("conversations.info")).toHaveLength(0);
@@ -622,7 +601,6 @@ describe("plugin heartbeat", () => {
       },
       destinationVisibility: "private",
       input: "Run the scheduled task.",
-      source: slackDmSource(),
     });
 
     await expect(getDispatchRecord(result.id)).resolves.toMatchObject({
@@ -691,13 +669,7 @@ describe("plugin heartbeat", () => {
     );
     expect(dispatchRecord?.destination).toEqual(SLACK_DESTINATION);
     expect(dispatchRecord?.destinationVisibility).toBe("public");
-    expect(dispatchRecord?.source).toEqual(
-      createSlackSource({
-        teamId: "T123",
-        channelId: "C123",
-        visibility: "public",
-      }),
-    );
+    expect(dispatchRecord?.source).toEqual({ kind: "scheduled_task" });
     expect(dispatchRecord?.metadata).toMatchObject({
       runId: `sched_plugin_1:${TEST_RUN_AT_MS}`,
       schedule: "Once at noon",

--- a/packages/junior/tests/integration/search-conversation-events.test.ts
+++ b/packages/junior/tests/integration/search-conversation-events.test.ts
@@ -1,4 +1,3 @@
-import { createSlackSource } from "@sentry/junior-plugin-api";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   closeDb,
@@ -12,12 +11,7 @@ import { juniorConversationEvents } from "@/db/schema";
 
 const CURRENT_CONVERSATION_ID = "slack:C123:1700000000.100000";
 
-type SlackToolRuntimeContext = Extract<
-  ToolRuntimeContext,
-  { source: { kind: "slack" } }
->;
-
-function context(): SlackToolRuntimeContext {
+function context(): ToolRuntimeContext {
   return {
     conversationId: CURRENT_CONVERSATION_ID,
     destination: {
@@ -25,12 +19,14 @@ function context(): SlackToolRuntimeContext {
       teamId: "T123",
       channelId: "C123",
     },
-    source: createSlackSource({
+    location: {
+      id: "location:T123:C123",
+      provider: "slack",
       teamId: "T123",
       channelId: "C123",
       threadTs: "1700000000.100000",
-      visibility: "public",
-    }),
+    },
+    source: { kind: "scheduled_task" },
     egress: {
       async fetch() {
         return new Response("ok");

--- a/packages/junior/tests/integration/slack-channel-tools.test.ts
+++ b/packages/junior/tests/integration/slack-channel-tools.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from "vitest";
-import { createSlackSource } from "@sentry/junior-plugin-api";
 import { createSlackChannelJoinTool } from "@/chat/slack/tools/channel-join";
 import { createSlackChannelListMessagesTool } from "@/chat/slack/tools/channel-list-messages";
 import { createSlackMessageAddReactionTool } from "@/chat/slack/tools/message-add-reaction";
@@ -37,14 +36,16 @@ function createToolState(): ToolState {
 type ContextOverrides = Omit<
   Partial<SlackToolContext>,
   | "destinationChannelId"
+  | "messageChannelId"
   | "messageTs"
-  | "sourceChannelId"
+  | "locationChannelId"
   | "teamId"
   | "threadTs"
 > & {
   destinationChannelId?: string;
+  messageChannelId?: string;
   messageTs?: string;
-  sourceChannelId?: string;
+  locationChannelId?: string;
   teamId?: string;
   threadTs?: string;
 };
@@ -77,17 +78,18 @@ function createContext(
   _userText: string,
   overrides: ContextOverrides = {},
 ): SlackToolContext {
-  const sourceChannelId = requireSlackChannelId(
-    overrides.sourceChannelId ?? "C123",
+  const locationChannelId = requireSlackChannelId(
+    overrides.locationChannelId ?? "C123",
   );
   const destinationChannelId =
     overrides.destinationChannelId !== undefined
       ? requireSlackChannelId(overrides.destinationChannelId)
-      : sourceChannelId;
+      : locationChannelId;
   const teamId = requireSlackTeamId(overrides.teamId ?? "T123");
   const {
-    sourceChannelId: _sourceChannelId,
+    locationChannelId: _locationChannelId,
     destinationChannelId: _destinationChannelId,
+    messageChannelId: overrideMessageChannelId,
     messageTs: overrideMessageTs,
     teamId: _teamId,
     threadTs: overrideThreadTs,
@@ -100,21 +102,12 @@ function createContext(
     ? requireSlackMessageTs(overrideThreadTs)
     : undefined;
   return {
-    destination: {
-      platform: "slack",
-      teamId,
-      channelId: destinationChannelId,
-    },
-    source: createSlackSource({
-      teamId,
-      channelId: sourceChannelId,
-      messageTs,
-
-      visibility: "private",
-    }),
     destinationChannelId,
+    locationChannelId,
+    messageChannelId: requireSlackChannelId(
+      overrideMessageChannelId ?? locationChannelId,
+    ),
     messageTs,
-    sourceChannelId,
     teamId,
     ...(threadTs ? { threadTs } : undefined),
     ...rest,
@@ -151,9 +144,9 @@ async function executeTool<TInput>(
 }
 
 describe("slack channel tools", () => {
-  it("uses source coordinates for sendFiles and destination context for channel reads", async () => {
+  it("uses Location for sendFiles and Destination for channel reads", async () => {
     const context = createContext("share this in the current channel", {
-      sourceChannelId: "D123",
+      locationChannelId: "D123",
       destinationChannelId: "C0SHARED",
     });
     queueSlackApiResponse("conversations.history", {
@@ -391,7 +384,7 @@ describe("slack channel tools", () => {
     });
     const tool = createSlackChannelListMessagesTool(
       createContext("list other channel", {
-        sourceChannelId: "C123",
+        locationChannelId: "C123",
       }),
     );
 
@@ -420,7 +413,8 @@ describe("slack channel tools", () => {
       }),
     });
     const tool = createSlackChannelListMessagesTool(
-      createContext("list private channel"));
+      createContext("list private channel"),
+    );
 
     await expect(
       executeTool(tool, { channel_id: "C0PRIVATE" }),
@@ -674,8 +668,12 @@ describe("slack channel tools", () => {
       }),
     });
     const tool = createSlackChannelListMessagesTool(
-      createContext("history after join"));
-    const result = await executeTool(tool, { channel_id: "C0JOINME", limit: 5 });
+      createContext("history after join"),
+    );
+    const result = await executeTool(tool, {
+      channel_id: "C0JOINME",
+      limit: 5,
+    });
     expect(result).toMatchObject({
       channel_id: "C0JOINME",
       joined_channel: true,
@@ -684,5 +682,4 @@ describe("slack channel tools", () => {
     expect(getCapturedSlackApiCalls("conversations.join")).toHaveLength(1);
     expect(getCapturedSlackApiCalls("conversations.history")).toHaveLength(2);
   });
-
 });

--- a/packages/junior/tests/integration/slack-send-files.test.ts
+++ b/packages/junior/tests/integration/slack-send-files.test.ts
@@ -1,6 +1,5 @@
 import { eq } from "drizzle-orm";
 import { afterEach, describe, expect, it } from "vitest";
-import { createSlackSource } from "@sentry/junior-plugin-api";
 import type { AttachmentStorage } from "@/chat/attachments/storage";
 import { migrateSchema } from "@/chat/conversations/sql/migrations";
 import {
@@ -36,13 +35,13 @@ type ContextOverrides = Omit<
   Partial<SlackToolContext>,
   | "destinationChannelId"
   | "messageTs"
-  | "sourceChannelId"
+  | "locationChannelId"
   | "teamId"
   | "threadTs"
 > & {
   destinationChannelId?: string;
   messageTs?: string;
-  sourceChannelId?: string;
+  locationChannelId?: string;
   teamId?: string;
   threadTs?: string;
 };
@@ -69,16 +68,16 @@ function createContext(
   _userText: string,
   overrides: ContextOverrides = {},
 ): SlackToolContext {
-  const sourceChannelId = requireSlackChannelId(
-    overrides.sourceChannelId ?? "C123",
+  const locationChannelId = requireSlackChannelId(
+    overrides.locationChannelId ?? "C123",
   );
   const destinationChannelId =
     overrides.destinationChannelId !== undefined
       ? requireSlackChannelId(overrides.destinationChannelId)
-      : sourceChannelId;
+      : locationChannelId;
   const teamId = requireSlackTeamId(overrides.teamId ?? "T123");
   const {
-    sourceChannelId: _sourceChannelId,
+    locationChannelId: _locationChannelId,
     destinationChannelId: _destinationChannelId,
     messageTs: overrideMessageTs,
     teamId: _teamId,
@@ -92,20 +91,9 @@ function createContext(
     ? requireSlackMessageTs(overrideThreadTs)
     : undefined;
   return {
-    destination: {
-      platform: "slack",
-      teamId,
-      channelId: destinationChannelId,
-    },
-    source: createSlackSource({
-      teamId,
-      channelId: sourceChannelId,
-      messageTs,
-      visibility: "private",
-    }),
     destinationChannelId,
     messageTs,
-    sourceChannelId,
+    locationChannelId,
     teamId,
     ...(threadTs ? { threadTs } : undefined),
     ...rest,
@@ -130,9 +118,11 @@ function createMaterializeFile(files: Record<string, Buffer> = {}) {
     readSandboxFileUpload(sandbox, input);
 }
 
-async function executeTool<
-  TInput,
->(tool: any, input: TInput, options: { toolCallId?: string } = {}) {
+async function executeTool<TInput>(
+  tool: any,
+  input: TInput,
+  options: { toolCallId?: string } = {},
+) {
   if (typeof tool?.execute !== "function") {
     throw new Error("tool execute function missing");
   }
@@ -199,9 +189,9 @@ describe("Slack sendFiles", () => {
     });
   });
 
-  it("uses source thread coordinates for thread delivery in assistant-context turns", async () => {
+  it("uses the Conversation Location thread when Destination differs", async () => {
     const context = createContext("attach this here", {
-      sourceChannelId: "D123",
+      locationChannelId: "D123",
       destinationChannelId: "CSHARED",
       threadTs: "1700000000.321",
     });
@@ -226,6 +216,27 @@ describe("Slack sendFiles", () => {
       channel_id: "D123",
       thread_ts: "1700000000.321",
     });
+  });
+
+  it("uploads files to a channel-level Conversation Location", async () => {
+    const context = createContext("attach the report");
+    delete context.messageTs;
+    const tool = createSendFilesTool(
+      context,
+      createToolState(),
+      createMaterializeFile({
+        "/tmp/report.txt": Buffer.from("report body"),
+      }),
+    );
+
+    await executeTool(tool, {
+      files: [{ path: "/tmp/report.txt" }],
+    });
+
+    const params = getCapturedSlackApiCalls("files.completeUploadExternal")[0]
+      ?.params;
+    expect(params).toMatchObject({ channel_id: "C123" });
+    expect(params).not.toHaveProperty("thread_ts");
   });
 
   it("uploads files into the current Slack thread", async () => {

--- a/packages/junior/tests/integration/slack-thread-read.test.ts
+++ b/packages/junior/tests/integration/slack-thread-read.test.ts
@@ -1,5 +1,4 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { createSlackSource } from "@sentry/junior-plugin-api";
 import { closeDb, getConversationStore } from "@/chat/db";
 import { createSlackThreadReadTool } from "@/chat/slack/tools/thread-read";
 import type { SlackToolContext } from "@/chat/slack/tool-support/context";
@@ -17,10 +16,10 @@ import {
 
 type ContextOverrides = Omit<
   Partial<SlackToolContext>,
-  "destinationChannelId" | "sourceChannelId" | "teamId"
+  "destinationChannelId" | "locationChannelId" | "teamId"
 > & {
   destinationChannelId?: string;
-  sourceChannelId?: string;
+  locationChannelId?: string;
   teamId?: string;
 };
 
@@ -41,36 +40,23 @@ function requireSlackTeamId(value: string) {
 }
 
 function createContext(overrides: ContextOverrides = {}): SlackToolContext {
-  const sourceChannelId = requireSlackChannelId(
-    overrides.sourceChannelId ?? "C0CURRENT",
+  const locationChannelId = requireSlackChannelId(
+    overrides.locationChannelId ?? "C0CURRENT",
   );
   const destinationChannelId =
     overrides.destinationChannelId !== undefined
       ? requireSlackChannelId(overrides.destinationChannelId)
-      : sourceChannelId;
+      : locationChannelId;
   const teamId = requireSlackTeamId(overrides.teamId ?? "T123");
   const {
-    sourceChannelId: _sourceChannelId,
+    locationChannelId: _locationChannelId,
     destinationChannelId: _destinationChannelId,
     teamId: _teamId,
     ...rest
   } = overrides;
   return {
-    destination: overrides.destination ?? {
-      platform: "slack",
-      teamId,
-      channelId: destinationChannelId,
-    },
-    source:
-      overrides.source ??
-      createSlackSource({
-        teamId,
-        channelId: sourceChannelId,
-
-        visibility: "private",
-      }),
     destinationChannelId,
-    sourceChannelId,
+    locationChannelId,
     teamId,
     ...rest,
   };
@@ -218,7 +204,7 @@ describe("slackThreadRead", () => {
       }),
     });
 
-    const tool = createTool({ sourceChannelId: "G0PRIVATE" });
+    const tool = createTool({ locationChannelId: "G0PRIVATE" });
     const result = await executeTool(tool, {
       channel_id: "G0PRIVATE",
       ts: "1700000000.100000",
@@ -250,7 +236,7 @@ describe("slackThreadRead", () => {
     });
 
     const tool = createTool({
-      sourceChannelId: "D0DM",
+      locationChannelId: "D0DM",
       destinationChannelId: "G0PRIVATE",
     });
     const result = await executeTool(tool, {
@@ -273,7 +259,7 @@ describe("slackThreadRead", () => {
         isGroup: true,
       }),
     });
-    const tool = createTool({ sourceChannelId: "D0DM" });
+    const tool = createTool({ locationChannelId: "D0DM" });
     await expect(
       executeTool(tool, {
         channel_id: "G0PRIVATE",
@@ -292,7 +278,7 @@ describe("slackThreadRead", () => {
         isGroup: true,
       }),
     });
-    const tool = createTool({ sourceChannelId: "C0CURRENT" });
+    const tool = createTool({ locationChannelId: "C0CURRENT" });
     await expect(
       executeTool(tool, {
         url: "https://sentry.slack.com/archives/G0OTHER/p1700000000100000",
@@ -342,7 +328,7 @@ describe("slackThreadRead", () => {
       }),
     });
 
-    const tool = createTool({ sourceChannelId: "C0CURRENT" });
+    const tool = createTool({ locationChannelId: "C0CURRENT" });
     const result = await executeTool(tool, {
       url: "https://sentry.slack.com/archives/C0UNCONFIRMED/p1700000000100000",
     });
@@ -363,7 +349,7 @@ describe("slackThreadRead", () => {
       }),
     });
 
-    const tool = createTool({ sourceChannelId: "C0CURRENT" });
+    const tool = createTool({ locationChannelId: "C0CURRENT" });
     await expect(
       executeTool(tool, {
         url: "https://sentry.slack.com/archives/C0UNCONFIRMED/p1700000000100000",
@@ -390,7 +376,7 @@ describe("slackThreadRead", () => {
       error: "channel_not_found",
     });
 
-    const tool = createTool({ sourceChannelId: "C0CURRENT" });
+    const tool = createTool({ locationChannelId: "C0CURRENT" });
     await expect(
       executeTool(tool, {
         url: "https://sentry.slack.com/archives/C0STALE/p1700000000100000",

--- a/packages/junior/tests/integration/tool-idempotency.test.ts
+++ b/packages/junior/tests/integration/tool-idempotency.test.ts
@@ -18,11 +18,6 @@ import {
   queueSlackApiError,
   queueSlackApiResponse,
 } from "../msw/handlers/slack-api";
-import {
-  createSlackSource,
-} from "@sentry/junior-plugin-api";
-
-
 function createToolState(): ToolState {
   const operationResultCache = new Map<string, unknown>();
 
@@ -57,19 +52,8 @@ function slackContext(channelId: string): SlackToolContext {
   const parsedChannelId = requireSlackChannelId(channelId);
   const teamId = requireSlackTeamId("T123");
   return {
-    destination: {
-      platform: "slack" as const,
-      teamId,
-      channelId: parsedChannelId,
-    },
-    source: createSlackSource({
-      teamId,
-      channelId: parsedChannelId,
-
-      visibility: "private",
-    }),
     destinationChannelId: parsedChannelId,
-    sourceChannelId: parsedChannelId,
+    locationChannelId: parsedChannelId,
     teamId,
   };
 }
@@ -196,15 +180,9 @@ describe("tool idempotency", () => {
     });
 
     const sharedChannelId = requireSlackChannelId("C0SHARED");
-    const teamId = requireSlackTeamId("T123");
     const tool = createSlackCanvasCreateTool(
       {
         ...slackContext("D123"),
-        destination: {
-          platform: "slack" as const,
-          teamId,
-          channelId: sharedChannelId,
-        },
         destinationChannelId: sharedChannelId,
       },
       createToolState(),
@@ -231,7 +209,7 @@ describe("tool idempotency", () => {
     const state = createToolState();
     const tool = createSlackCanvasCreateTool(
       // @ts-expect-error non-overlapping boundary cast; rule forbids as-unknown-as chains
-      (LOCAL_CONTEXT) as SlackToolContext,
+      LOCAL_CONTEXT as SlackToolContext,
       state,
     );
 

--- a/packages/junior/tests/unit/plugin-api-source.test.ts
+++ b/packages/junior/tests/unit/plugin-api-source.test.ts
@@ -98,4 +98,15 @@ describe("plugin source helpers", () => {
       }).success,
     ).toBe(false);
   });
+
+  it("accepts Scheduled task, event task, Plugin dispatch, and Agent invocation Sources", () => {
+    for (const kind of [
+      "scheduled_task",
+      "event_task",
+      "plugin_dispatch",
+      "agent_invocation",
+    ] as const) {
+      expect(sourceSchema.parse({ kind })).toEqual({ kind });
+    }
+  });
 });

--- a/packages/junior/tests/unit/plugins/agent-hooks.test.ts
+++ b/packages/junior/tests/unit/plugins/agent-hooks.test.ts
@@ -286,7 +286,7 @@ describe("agent plugin hooks", () => {
     ]);
     try {
       await expect(
-        getPluginSystemPromptContributions(LOCAL_SOURCE),
+        getPluginSystemPromptContributions("local"),
       ).resolves.toEqual([
         { id: "systemPrompt:0", pluginName: "a-demo", text: "A contribution" },
         { id: "systemPrompt:0", pluginName: "z-demo", text: "Z contribution" },
@@ -313,7 +313,7 @@ describe("agent plugin hooks", () => {
     ]);
     try {
       await expect(
-        getPluginSystemPromptContributions(LOCAL_SOURCE),
+        getPluginSystemPromptContributions("local"),
       ).resolves.toEqual([]);
     } finally {
       setPlugins(previous);
@@ -856,7 +856,7 @@ describe("agent plugin hooks", () => {
     try {
       expect(() =>
         getPluginTools({
-        conversationId: LOCAL_DESTINATION.conversationId,
+          conversationId: LOCAL_DESTINATION.conversationId,
           destination: LOCAL_DESTINATION,
           egress: TEST_EGRESS,
           source: LOCAL_SOURCE,
@@ -1966,11 +1966,18 @@ describe("getPluginTools channel resolution", () => {
     });
   });
 
-  it("computes channelCapabilities from source channelId", () => {
+  it("computes channelCapabilities from the Conversation Location", () => {
     // DM channel: canvas and reactions yes, standalone channel-post no
     const ctx = capturePluginContext({
       conversationId: "slack:DDM:1712345.0001",
       source: slackSource("DDM"),
+      location: {
+        id: "location:T123:DDM",
+        provider: "slack",
+        teamId: "T123",
+        channelId: "DDM",
+        threadTs: "1712345.0001",
+      },
       destination: {
         platform: "slack",
         teamId: "T123",
@@ -1982,6 +1989,25 @@ describe("getPluginTools channel resolution", () => {
     expect(ctx.slack?.channelCapabilities.canCreateCanvas).toBe(true);
     expect(ctx.slack?.channelCapabilities.canAddReactions).toBe(true);
     expect(ctx.slack?.channelCapabilities.canPostToChannel).toBe(false);
+  });
+
+  it("exposes Slack context for system work in a Slack Conversation", () => {
+    const ctx = capturePluginContext({
+      conversationId: "agent-dispatch:dispatch-1",
+      source: { kind: "scheduled_task" },
+      destination: SLACK_DESTINATION,
+      location: {
+        id: "location:T123:DDM",
+        provider: "slack",
+        teamId: "T123",
+        channelId: "DDM",
+      },
+      egress: TEST_EGRESS,
+      workspace: {} as any,
+    });
+
+    expect(ctx.source).toEqual({ kind: "scheduled_task" });
+    expect(ctx.slack?.channelCapabilities.canCreateCanvas).toBe(true);
   });
 
   it("creates a direct credential subject when channelId is a DM", () => {

--- a/packages/junior/tests/unit/plugins/agent-hooks.test.ts
+++ b/packages/junior/tests/unit/plugins/agent-hooks.test.ts
@@ -1991,10 +1991,11 @@ describe("getPluginTools channel resolution", () => {
     expect(ctx.slack?.channelCapabilities.canPostToChannel).toBe(false);
   });
 
-  it("exposes Slack context for system work in a Slack Conversation", () => {
+  it("exposes Slack context and Actor for an Agent invocation", () => {
     const ctx = capturePluginContext({
-      conversationId: "agent-dispatch:dispatch-1",
-      source: { kind: "scheduled_task" },
+      conversationId: "agent-invocation:invocation-1",
+      source: { kind: "agent_invocation" },
+      actor: TEST_ACTOR,
       destination: SLACK_DESTINATION,
       location: {
         id: "location:T123:DDM",
@@ -2006,7 +2007,8 @@ describe("getPluginTools channel resolution", () => {
       workspace: {} as any,
     });
 
-    expect(ctx.source).toEqual({ kind: "scheduled_task" });
+    expect(ctx.source).toEqual({ kind: "agent_invocation" });
+    expect(ctx.actor).toEqual(TEST_ACTOR);
     expect(ctx.slack?.channelCapabilities.canCreateCanvas).toBe(true);
   });
 

--- a/packages/junior/tests/unit/runtime/agent-dispatch-validation.test.ts
+++ b/packages/junior/tests/unit/runtime/agent-dispatch-validation.test.ts
@@ -24,12 +24,6 @@ const validOptions = {
   },
   destinationVisibility: "private" as const,
   input: "Run the scheduled task.",
-  source: createSlackSource({
-    teamId: "T123",
-    channelId: "C123",
-
-    visibility: "private",
-  }),
 };
 
 function createPluginCredentialSubject(
@@ -153,27 +147,17 @@ describe("agent dispatch validation", () => {
     ).toThrow("Dispatch destination channelId must be a Slack channel id");
   });
 
-  it("rejects malformed dispatch source payloads", () => {
+  it("rejects a plugin-provided Source", () => {
     expect(() =>
       validateDispatchOptions({
         ...validOptions,
-        source: {
-          ...validOptions.source,
-          threadTs: "1700000000.000",
-          unexpected: "field",
-        },
+        source: createSlackSource({
+          teamId: "T123",
+          channelId: "C123",
+          visibility: "private",
+        }),
       }),
-    ).toThrow("Dispatch source must not include unknown fields");
-
-    expect(() =>
-      validateDispatchOptions({
-        ...validOptions,
-        source: {
-          ...validOptions.source,
-          teamId: "not-a-team",
-        },
-      }),
-    ).toThrow("Dispatch source teamId must be a Slack team id");
+    ).toThrow("Dispatch options must not include unknown fields");
   });
 
   it("rejects multiline dispatch metadata", () => {
@@ -227,7 +211,11 @@ describe("agent dispatch validation", () => {
       idempotencyKey: "run-1",
       input: "Run the scheduled task.",
       plugin: "scheduler",
-      source: validOptions.source,
+      source: createSlackSource({
+        teamId: "T123",
+        channelId: "C123",
+        visibility: "private",
+      }),
       status: "pending",
       updatedAtMs: Date.parse("2026-05-26T12:00:00.000Z"),
     };

--- a/packages/junior/tests/unit/slack/slack-message-add-reaction-tool.test.ts
+++ b/packages/junior/tests/unit/slack/slack-message-add-reaction-tool.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it, vi } from "vitest";
-import { createSlackSource } from "@sentry/junior-plugin-api";
 import { createSlackMessageAddReactionTool } from "@/chat/slack/tools/message-add-reaction";
 import { ToolInputError } from "@/chat/tools/execution/tool-input-error";
 import type { SlackToolContext } from "@/chat/slack/tool-support/context";
@@ -26,21 +25,10 @@ if (!TEST_TEAM_ID) {
 }
 
 const TEST_SLACK_CONTEXT: SlackToolContext = {
-  destination: {
-    platform: "slack",
-    teamId: TEST_TEAM_ID,
-    channelId: TEST_CHANNEL_ID,
-  },
-  source: createSlackSource({
-    teamId: TEST_TEAM_ID,
-    channelId: TEST_CHANNEL_ID,
-    messageTs: TEST_MESSAGE_TS,
-
-    visibility: "private",
-  }),
   destinationChannelId: TEST_CHANNEL_ID,
+  locationChannelId: TEST_CHANNEL_ID,
+  messageChannelId: TEST_CHANNEL_ID,
   messageTs: TEST_MESSAGE_TS,
-  sourceChannelId: TEST_CHANNEL_ID,
   teamId: TEST_TEAM_ID,
 };
 

--- a/packages/junior/tests/unit/slack/tool-registration.test.ts
+++ b/packages/junior/tests/unit/slack/tool-registration.test.ts
@@ -59,6 +59,8 @@ function ctx(
 
   return {
     conversationId: `slack:${channelId}:1700000000.100000`,
+    conversationPrivacy:
+      sourceVisibility ?? (channelId.startsWith("C") ? "public" : "private"),
     slackActionToken: actionToken,
     destination: {
       platform: "slack" as const,
@@ -71,6 +73,13 @@ function ctx(
       visibility:
         sourceVisibility ?? (channelId.startsWith("C") ? "public" : "private"),
     }),
+    location: {
+      id: `location:T123:${channelId}`,
+      provider: "slack",
+      teamId: "T123",
+      channelId,
+      threadTs: "1700000000.100000",
+    },
     egress: noopEgress,
     workspace: noopSandbox,
   };
@@ -169,7 +178,7 @@ describe("Slack tool registration", () => {
     expect(tools).toHaveProperty("slackChannelJoin");
   });
 
-  it("does not register conversation search for a source-confirmed private C channel", () => {
+  it("does not register conversation search for a private Conversation", () => {
     const tools = createTools([], {}, ctx("C12345", "private"));
 
     expect(tools).not.toHaveProperty("searchConversationMessages");
@@ -197,6 +206,25 @@ describe("Slack tool registration", () => {
     expect(tools).toHaveProperty("sendFiles");
     expect(tools).toHaveProperty("slackChannelListMessages");
     expect(tools).toHaveProperty("slackThreadRead");
+  });
+
+  it("registers Slack tools for system work in a Slack Conversation", () => {
+    const tools = createTools(
+      [],
+      {},
+      {
+        ...ctx("C12345"),
+        actor: { platform: "system", name: "scheduler" },
+        source: { kind: "scheduled_task" },
+        slackActionToken: undefined,
+      },
+    );
+
+    expect(tools).toHaveProperty("slackThreadRead");
+    expect(tools).toHaveProperty("slackChannelListMessages");
+    expect(tools).toHaveProperty("sendFiles");
+    expect(tools).not.toHaveProperty("slackPublicSearch");
+    expect(tools).not.toHaveProperty("addReaction");
   });
 
   it("registers delivery tools from assistant context channel in DM turns", () => {


### PR DESCRIPTION
Scheduled tasks, Event tasks, Plugin dispatches, and Agent invocations now set
the Source that caused each Turn. They no longer copy a Slack Source or the
parent Run's Source. Plugin background tasks use the Source saved on the Turn.

Slack tools use the Conversation Location and visibility. Actions on the
current Slack message still require a Slack Source. Slack reply instructions
require Delivery and a Slack Location. This lets scheduled Slack work reply to
Slack while an Agent invocation can use Slack tools without sending its result
to Slack.

Plugin dispatch callers must stop passing `source`; Junior now sets Plugin
dispatch Source. Legacy session Source and Destination reads remain only for
deployed data. TODOs state when to remove them. Scheduled task and Event task
tools still require Slack when users manage them. TODOs state that these tools
should later work from web and other Conversations.

Refs #1563
